### PR TITLE
Add OpenSSF Best Practices badge and reporting guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,15 @@ Thanks for your interest in bdinfo-rs — a memory-safe, zero-C-dependency Rust
 Blu-ray disc analyzer. This guide covers how to build, what CI expects, and the
 handful of house rules that keep the project's guarantees intact.
 
+## Reporting issues
+
+- **Bugs and feature requests:** open an issue on the
+  [tracker](https://github.com/agentjp/bdinfo-rs/issues). A disc structure or
+  report excerpt that reproduces the problem helps a lot.
+- **Security vulnerabilities:** report privately via
+  [GitHub Security Advisories](https://github.com/agentjp/bdinfo-rs/security/advisories/new),
+  not a public issue.
+
 ## Building
 
 No C toolchain, no system libraries, no extra steps — the same on Windows,

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![codeql](https://github.com/agentjp/bdinfo-rs/actions/workflows/codeql.yml/badge.svg)](https://github.com/agentjp/bdinfo-rs/actions/workflows/codeql.yml)
 [![fuzz](https://github.com/agentjp/bdinfo-rs/actions/workflows/fuzz.yml/badge.svg)](https://github.com/agentjp/bdinfo-rs/actions/workflows/fuzz.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/agentjp/bdinfo-rs/badge)](https://scorecard.dev/viewer/?uri=github.com/agentjp/bdinfo-rs)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13304/badge)](https://www.bestpractices.dev/projects/13304)
 [![release](https://img.shields.io/github/v/release/agentjp/bdinfo-rs?include_prereleases&sort=semver)](https://github.com/agentjp/bdinfo-rs/releases)
 [![MSRV](https://img.shields.io/badge/MSRV-1.96-blue)](rust-toolchain.toml)
 [![license](https://img.shields.io/badge/license-LGPL--2.1--only-blue)](LICENSE)


### PR DESCRIPTION
- Adds the **OpenSSF Best Practices** badge (project now **passing**, https://www.bestpractices.dev/projects/13304) to the README badge row, next to the Scorecard badge.
- Adds a short **Reporting issues** section to CONTRIBUTING.md (bug tracker + private security reporting via GitHub Security Advisories) — the only thing the existing guide was missing.