### PR TITLE
Clear the GitHub Actions deprecation and audit warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
 
       - name: Build
         run: cargo build --workspace --locked
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
 
       - name: Install action-validator
         run: cargo install action-validator --locked
@@ -100,7 +100,7 @@ jobs:
       - name: Install pinned nightly rustfmt
         run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component rustfmt
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
 
       - name: Install gate tools
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
@@ -151,7 +151,7 @@ jobs:
       - name: Install pinned nightly with llvm-tools
         run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
 
       - name: Install coverage tools
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
@@ -176,7 +176,7 @@ jobs:
         with:
           fetch-depth: 0   # need the base branch to diff the PR against
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
 
       - name: Install mutation tools
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,22 +85,22 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -142,15 +142,15 @@ jobs:
           pattern: digest-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -203,7 +203,7 @@ jobs:
 
       - name: Attest the SBOM for the image
         if: ${{ !github.event.repository.private }}
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.digest.outputs.digest }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install pinned nightly
         run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: fuzz
 
@@ -87,7 +87,7 @@ jobs:
       - name: Install pinned nightly
         run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: fuzz
 

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,10 @@ ignore = []
 
 [licenses]
 version = 2
+# Several allowed licenses below aren't present in our tiny dependency tree today.
+# Keep them pre-approved (so a routine dep bump pulling a common permissive license
+# doesn't fail audit) instead of warning on each currently-unused allow entry.
+unused-allowed-license = "allow"
 # Allowlist — permissive licenses only. A dependency whose SPDX expression
 # isn't satisfied here is a hard error.
 allow = [


### PR DESCRIPTION
Clears the deprecation/audit warnings surfaced by recent workflow runs. Each change was checked against the live action releases.

## docker.yml
- **Node 20 deprecation** — bumped the four Docker actions to their Node 24 majors: `setup-buildx-action` v3→v4, `login-action` v3→v4, `metadata-action` v5→v6, `build-push-action` v6→v7. Each major bump is "Node 24 + internal ESM refactor + removal of already-deprecated inputs we don't use" per their changelogs; our usage is unaffected.
- **`actions/attest-sbom` deprecated** — migrated the image SBOM attestation to `actions/attest`. The latest `attest-sbom` is now just a wrapper that prints the deprecation banner; `actions/attest` exposes the identical `subject-name`/`subject-digest`/`sbom-path`/`push-to-registry` inputs, so it's a 1:1 swap with no permission changes.

## deny.toml
- Set `unused-allowed-license = "allow"` to silence the `license-not-encountered` warnings. Six permissive licenses (BSD-2/3, CC0, ISC, MPL-2.0, Zlib) aren't in the current dependency tree; keeping them pre-approved avoids a routine dep bump failing audit, and is safer than trimming entries that may be used on a platform the local check doesn't see. Verified `cargo deny check licenses` → `licenses ok`.

## ci.yml / fuzz.yml
- Bumped `Swatinem/rust-cache` to v2.9.1 (freshness). The `punycode` DEP0040 line it emits comes from Node deep inside the action's bundle and is an ecosystem-wide deprecation we can't fix directly; it may persist and is harmless.

## Deliberately left as-is
- cargo-vet's "default toolchain implicitly overridden" (rustup correctly honoring our pinned toolchain) and its yanked-dep notices (cargo-vet's *own* locked build deps, not ours — it ships no prebuilt binary past v0.10.0, so it's built from source). Both are benign tool-install noise.