### PR TITLE
Add package-manager publishing (crates.io, Homebrew, WinGet, Scoop, AUR, deb/rpm)

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -48,6 +48,11 @@ jobs:
   aur:
     name: AUR (bdinfo-rs-bin)
     runs-on: ubuntu-latest
+    # ON HOLD (2026-06-19): aur.archlinux.org account registration is currently
+    # disabled, so there is no AUR account/package to push to yet. Re-enable by
+    # setting the repo variable AUR_ENABLED=true (after registering the account and
+    # the AUR_SSH_KEY public key) — no code change needed; the secret is already set.
+    if: ${{ vars.AUR_ENABLED == 'true' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,156 @@
+name: packages
+
+# Fan-out package publishing, fired AFTER release.yml has published the GitHub
+# Release (the `released` event carries the uploaded archives + checksums, and it
+# does NOT fire for prereleases — stable-only, matching Homebrew's default). Every
+# job runs on a Linux runner; every action is SHA-pinned.
+#
+# Channels handled ELSEWHERE (not here):
+#   - Homebrew  -> release.yml (cargo-dist homebrew publish job)
+#   - crates.io -> publish-crates.yml (OIDC)
+#   - Scoop     -> the agentjp/scoop-bucket repo (Excavator auto-update bot)
+#
+# Secrets required (configure before the first release, or the jobs fail):
+#   WINGET_TOKEN - classic PAT (public_repo) on the bot account that forked winget-pkgs
+#   AUR_SSH_KEY  - private SSH key whose public half is on the aur.archlinux.org account
+#
+# NOTE: the deb/rpm jobs repackage the prebuilt musl binaries and are validated on
+# the first real release; tweak the cargo-deb / cargo-generate-rpm invocation here
+# (not the binary) if a path needs adjusting.
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: read
+
+env:
+  VERSION: ${{ github.event.release.tag_name }}
+
+jobs:
+  # ── Windows: WinGet (Microsoft community repo) ─────────────────────────────
+  winget:
+    name: WinGet
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submit the new version to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: agentjp.bdinfo-rs
+          # Both windows-msvc .zip archives (x64 + arm64); excludes the .sha256 sidecars.
+          installers-regex: '-pc-windows-msvc\.zip$'
+          # The bot account that holds the fork of microsoft/winget-pkgs.
+          fork-user: agentjp-bot
+          token: ${{ secrets.WINGET_TOKEN }}
+
+  # ── Arch Linux: AUR (-bin, repackages the prebuilt musl binary) ────────────
+  aur:
+    name: AUR (bdinfo-rs-bin)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Render the PKGBUILD for this version
+        shell: bash
+        run: |
+          ver="${VERSION#v}"
+          mkdir -p build/aur
+          sed "s/__PKGVER__/${ver}/g" packaging/aur/PKGBUILD.template > build/aur/PKGBUILD
+          cat build/aur/PKGBUILD
+
+      - name: Publish to the AUR
+        uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
+        with:
+          pkgname: bdinfo-rs-bin
+          pkgbuild: build/aur/PKGBUILD
+          updpkgsums: true # download the release tarballs and write real sha256sums
+          test: true # build the package in an Arch container before pushing
+          commit_username: bdinfo-rs CI
+          commit_email: bdinfo-rs@users.noreply.github.com
+          commit_message: Update to ${{ github.event.release.tag_name }}
+          ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
+
+  # ── Debian/Ubuntu: .deb attached to the release (x64 + arm64) ──────────────
+  deb:
+    name: .deb (${{ matrix.triple }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh release upload
+    strategy:
+      fail-fast: false
+      matrix:
+        triple: [x86_64-unknown-linux-musl, aarch64-unknown-linux-musl]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install cargo-deb
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        with:
+          tool: cargo-deb
+
+      - name: Stage the prebuilt binary + completion/man assets
+        shell: bash
+        run: |
+          gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" -p "bdinfo-rs-${{ matrix.triple }}.tar.gz" -D dl
+          tar xzf "dl/bdinfo-rs-${{ matrix.triple }}.tar.gz" -C dl
+          d="dl/bdinfo-rs-${{ matrix.triple }}"
+          mkdir -p "target/${{ matrix.triple }}/release" release-assets crates/bdinfo-rs/release-assets
+          cp "$d/bdinfo-rs" "target/${{ matrix.triple }}/release/bdinfo-rs"
+          for f in bdinfo-rs.1 bdinfo-rs.bash _bdinfo-rs bdinfo-rs.fish; do
+            cp "$d/$f" release-assets/
+            cp "$d/$f" crates/bdinfo-rs/release-assets/
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the .deb
+        run: cargo deb --no-build --no-strip --target ${{ matrix.triple }} -p bdinfo-rs
+
+      - name: Upload the .deb to the release
+        shell: bash
+        run: gh release upload "$VERSION" target/${{ matrix.triple }}/debian/*.deb --repo "$GITHUB_REPOSITORY" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Fedora/RHEL: .rpm attached to the release (x64 + arm64) ────────────────
+  rpm:
+    name: .rpm (${{ matrix.triple }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh release upload
+    strategy:
+      fail-fast: false
+      matrix:
+        triple: [x86_64-unknown-linux-musl, aarch64-unknown-linux-musl]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install cargo-generate-rpm
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        with:
+          tool: cargo-generate-rpm
+
+      - name: Stage the prebuilt binary + completion/man assets
+        shell: bash
+        run: |
+          gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" -p "bdinfo-rs-${{ matrix.triple }}.tar.gz" -D dl
+          tar xzf "dl/bdinfo-rs-${{ matrix.triple }}.tar.gz" -C dl
+          d="dl/bdinfo-rs-${{ matrix.triple }}"
+          mkdir -p "target/${{ matrix.triple }}/release" release-assets crates/bdinfo-rs/release-assets
+          cp "$d/bdinfo-rs" "target/${{ matrix.triple }}/release/bdinfo-rs"
+          for f in bdinfo-rs.1 bdinfo-rs.bash _bdinfo-rs bdinfo-rs.fish; do
+            cp "$d/$f" release-assets/
+            cp "$d/$f" crates/bdinfo-rs/release-assets/
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the .rpm
+        run: cargo generate-rpm -p crates/bdinfo-rs --target ${{ matrix.triple }}
+
+      - name: Upload the .rpm to the release
+        shell: bash
+        run: gh release upload "$VERSION" target/${{ matrix.triple }}/generate-rpm/*.rpm --repo "$GITHUB_REPOSITORY" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,63 @@
+name: publish-crates
+
+# Publish bdinfo-rs-core then bdinfo-rs to crates.io on a vX.Y.Z tag, using
+# crates.io Trusted Publishing (OIDC): a short-lived, repo/workflow-scoped token is
+# minted at run time and revoked afterwards, so NO long-lived CARGO_REGISTRY_TOKEN
+# is stored. `cargo publish --workspace` (stable since Rust 1.90; the pinned
+# toolchain is 1.96) resolves the dependency order, publishing the library first.
+#
+# Bootstrap: Trusted Publishing requires the crate to already exist, so the FIRST
+# publish of each crate is done by hand; this workflow takes over for every tag
+# afterwards. Configure the trusted publisher on crates.io for BOTH crates ->
+# repository agentjp/bdinfo-rs, workflow `publish-crates.yml`.
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-crates-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: cargo publish --workspace (crates.io)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # mint the short-lived crates.io OIDC token
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+
+      # cargo publishes whatever version is in Cargo.toml, not the tag — fail fast
+      # if a tag was cut that does not match (mirrors the guard in docker.yml).
+      - name: Verify the tag matches the workspace version
+        shell: pwsh
+        run: |
+          $tag = '${{ github.ref_name }}'
+          if ($tag -notmatch '^v(?<base>\d+\.\d+\.\d+)(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$') {
+            throw "Tag '$tag' is not vMAJOR.MINOR.PATCH[-prerelease]"
+          }
+          $base = $Matches['base']
+          $inWp = $false; $crate = $null
+          foreach ($line in (Get-Content Cargo.toml)) {
+            if ($line -match '^\[workspace\.package\]') { $inWp = $true; continue }
+            if ($line -match '^\[') { $inWp = $false; continue }
+            if ($inWp -and $line -match '^version\s*=\s*"([^"]+)"') { $crate = $Matches[1]; break }
+          }
+          if (-not $crate) { throw 'No [workspace.package] version found in Cargo.toml' }
+          if ($base -ne $crate) { throw "Tag $tag (base $base) does not match workspace version $crate" }
+
+      - name: Authenticate to crates.io (Trusted Publishing / OIDC)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
+
+      - name: Publish both crates (core first)
+        run: cargo publish --workspace --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,14 +303,61 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+  publish-homebrew-formula:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PLAN: ${{ needs.plan.outputs.val }}
+      GITHUB_USER: "axo bot"
+      GITHUB_EMAIL: "admin+bot@axo.dev"
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: true
+          repository: "agentjp/homebrew-tap"
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      # So we have access to the formula
+      - name: Fetch homebrew formulae
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: artifacts-*
+          path: Formula/
+          merge-multiple: true
+      # This is extra complex because you can make your Formula name not match your app name
+      # so we need to find releases with a *.rb file, and publish with that filename.
+      - name: Commit formula files
+        run: |
+          git config --global user.name "${GITHUB_USER}"
+          git config --global user.email "${GITHUB_EMAIL}"
+
+          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
+            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
+            name=$(echo "$filename" | sed "s/\.rb$//")
+            version=$(echo "$release" | jq .app_version --raw-output)
+
+            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+            brew update
+            # We avoid reformatting user-provided data such as the app description and homepage.
+            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
+
+            git add "Formula/${filename}"
+            git commit -m "${name} ${version}"
+          done
+          git push
+
   announce:
     needs:
       - plan
       - host
+      - publish-homebrew-formula
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -40,11 +40,42 @@ One honest caveat: all of this is best-effort. I've thrown a lot at it, proptest
 
 ## Install
 
-Prebuilt static binaries for Windows, Linux, and macOS (x64 and arm64) are attached
-to every [release](https://github.com/agentjp/bdinfo-rs/releases). Two ways to get
-one — both deliver the same single static binary:
+`bdinfo-rs` is one small static binary — no runtime, no install. Pick whichever
+channel fits your platform; every one delivers the same binary.
 
-**Install script** — downloads the right binary for your platform and puts it on `PATH`:
+### Package managers
+
+```sh
+# Rust — from crates.io (compiles from source)
+cargo install bdinfo-rs
+# …or fetch the prebuilt binary instead of compiling
+cargo binstall bdinfo-rs
+
+# macOS / Linux — Homebrew
+brew install agentjp/tap/bdinfo-rs
+
+# Windows — WinGet
+winget install agentjp.bdinfo-rs
+
+# Windows — Scoop
+scoop bucket add agentjp https://github.com/agentjp/scoop-bucket
+scoop install bdinfo-rs
+
+# Arch Linux (AUR) — with an AUR helper such as paru or yay
+paru -S bdinfo-rs-bin
+```
+
+**Debian/Ubuntu (`.deb`) and Fedora/RHEL (`.rpm`)** packages for x64 and arm64 are
+attached to every [release](https://github.com/agentjp/bdinfo-rs/releases):
+
+```sh
+sudo apt install ./bdinfo-rs_*_amd64.deb     # Debian/Ubuntu
+sudo dnf install ./bdinfo-rs-*.x86_64.rpm    # Fedora/RHEL
+```
+
+### Install script
+
+Downloads the right prebuilt binary for your platform and puts it on `PATH`:
 
 ```sh
 # Linux / macOS
@@ -56,8 +87,10 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/agentjp/bdinfo-rs/relea
 powershell -ExecutionPolicy Bypass -c "irm https://github.com/agentjp/bdinfo-rs/releases/latest/download/bdinfo-rs-installer.ps1 | iex"
 ```
 
-**Manual download** — grab the archive for your platform (named by Rust target triple,
-e.g. `bdinfo-rs-x86_64-unknown-linux-musl.tar.gz` or `bdinfo-rs-aarch64-pc-windows-msvc.zip`),
+### Manual download
+
+Grab the archive for your platform (named by Rust target triple, e.g.
+`bdinfo-rs-x86_64-unknown-linux-musl.tar.gz` or `bdinfo-rs-aarch64-pc-windows-msvc.zip`),
 extract it, and run the binary — no install step. Verify a download against the
 attached aggregate `sha256.sum`, or the per-archive `.sha256` sidecar.
 
@@ -88,8 +121,8 @@ collected into a `WARNING` block and the rest is scanned (exit code 3).
 Every release archive ships ready-to-install shell completion scripts — for **bash**,
 **zsh**, **fish**, and **PowerShell** — and a **`bdinfo-rs.1`** man page, all generated
 from the CLI itself so they always match the binary's flags and help text. Package
-managers (Homebrew, apt, Scoop/Chocolatey, AUR) drop them into the standard locations
-automatically; to install one by hand from an extracted archive:
+managers (Homebrew, the `.deb`/`.rpm` packages, and the AUR package) drop them into the
+standard locations automatically; to install one by hand from an extracted archive:
 
 ```sh
 # bash  — system-wide, or source it from your ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -60,9 +60,6 @@ winget install agentjp.bdinfo-rs
 # Windows — Scoop
 scoop bucket add agentjp https://github.com/agentjp/scoop-bucket
 scoop install bdinfo-rs
-
-# Arch Linux (AUR) — with an AUR helper such as paru or yay
-paru -S bdinfo-rs-bin
 ```
 
 **Debian/Ubuntu (`.deb`) and Fedora/RHEL (`.rpm`)** packages for x64 and arm64 are
@@ -121,8 +118,8 @@ collected into a `WARNING` block and the rest is scanned (exit code 3).
 Every release archive ships ready-to-install shell completion scripts — for **bash**,
 **zsh**, **fish**, and **PowerShell** — and a **`bdinfo-rs.1`** man page, all generated
 from the CLI itself so they always match the binary's flags and help text. Package
-managers (Homebrew, the `.deb`/`.rpm` packages, and the AUR package) drop them into the
-standard locations automatically; to install one by hand from an extracted archive:
+managers (Homebrew and the `.deb`/`.rpm` packages) drop them into the standard
+locations automatically; to install one by hand from an extracted archive:
 
 ```sh
 # bash  — system-wide, or source it from your ~/.bashrc

--- a/crates/bdinfo-rs/Cargo.toml
+++ b/crates/bdinfo-rs/Cargo.toml
@@ -31,6 +31,57 @@ workspace = true
 [package.metadata.cargo-machete]
 ignored = ["clap_complete", "clap_mangen"]
 
+# cargo-binstall: fetch the prebuilt archives this repo already ships (cargo-dist
+# names them `bdinfo-rs-<target-triple>.<ext>`, with NO version in the filename)
+# instead of compiling from source. Each archive wraps its files in a
+# `bdinfo-rs-<triple>/` directory, so `bin-dir` reaches inside it. Windows ships
+# `.zip`; every other target ships `.tar.gz` (the `tgz` default + per-target
+# overrides below).
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ name }-{ target }/{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-fmt = "zip"
+
+# cargo-deb (`.deb` packaging). The `packages.yml` deb job runs `cargo deb
+# --no-build --target <triple>` over the prebuilt musl binary it stages at
+# `target/<triple>/release/bdinfo-rs` — cargo-deb special-cases the `target/release/`
+# asset prefix to that path and derives the Debian arch from `--target`. The
+# completion/man assets are staged under the crate's `release-assets/`. The static
+# musl binary has no shared-library deps, so `depends` is emptied.
+[package.metadata.deb]
+maintainer = "bdinfo-rs contributors <bdinfo-rs@users.noreply.github.com>"
+section = "utils"
+priority = "optional"
+depends = ""
+extended-description = "A memory-safe, statically-linked command-line Blu-ray disc analyzer — a drop-in replacement for the classic BDInfo report tool. Scans BDMV folders and .iso images and renders the classic per-stream video/audio technical report."
+assets = [
+    ["target/release/bdinfo-rs", "usr/bin/", "755"],
+    ["release-assets/bdinfo-rs.1", "usr/share/man/man1/", "644"],
+    ["release-assets/bdinfo-rs.bash", "usr/share/bash-completion/completions/bdinfo-rs", "644"],
+    ["release-assets/_bdinfo-rs", "usr/share/zsh/site-functions/", "644"],
+    ["release-assets/bdinfo-rs.fish", "usr/share/fish/vendor_completions.d/", "644"],
+]
+
+# cargo-generate-rpm (`.rpm` packaging). The `packages.yml` rpm job mirrors the deb
+# job: it rewrites the `target/release/` asset prefix to `target/<triple>/release/`
+# under `--target` and derives the arch from the triple. `auto-req = "no"` because
+# the static musl binary pulls in no shared-library requirements.
+[package.metadata.generate-rpm]
+auto-req = "no"
+assets = [
+    { source = "target/release/bdinfo-rs", dest = "/usr/bin/bdinfo-rs", mode = "755" },
+    { source = "release-assets/bdinfo-rs.1", dest = "/usr/share/man/man1/bdinfo-rs.1", mode = "644" },
+    { source = "release-assets/bdinfo-rs.bash", dest = "/usr/share/bash-completion/completions/bdinfo-rs", mode = "644" },
+    { source = "release-assets/_bdinfo-rs", dest = "/usr/share/zsh/site-functions/_bdinfo-rs", mode = "644" },
+    { source = "release-assets/bdinfo-rs.fish", dest = "/usr/share/fish/vendor_completions.d/bdinfo-rs.fish", mode = "644" },
+]
+
 [dependencies]
 bdinfo-rs-core = { workspace = true }
 clap = { workspace = true }

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -82,8 +82,17 @@ fail-fast = true
 # curl|sh + irm|iex fetching installers, served from the GitHub Release. They
 # reference the dist-generated archive names, so the archives are kept at dist's
 # default `<pkg>-<target-triple>.<ext>` names (no friendly-name rename).
-installers = ["shell", "powershell"]
+installers = ["shell", "powershell", "homebrew"]
 hosting = ["github"]
+
+# Homebrew: publish a BINARY formula (it fetches the prebuilt .tar.gz archives —
+# no source build, no macOS runner) to our own tap on each STABLE release. One
+# formula covers macOS (Intel + Apple Silicon) and Linuxbrew. dist's homebrew
+# publish job pushes to the tap using the `HOMEBREW_TAP_TOKEN` repo secret (a
+# fine-grained PAT scoped to the tap repo, Contents:read/write). The tap repo is
+# named `homebrew-tap`; users tap it as `agentjp/tap`.
+tap = "agentjp/homebrew-tap"
+publish-jobs = ["homebrew"]
 
 # A reusable workflow wired in at the start of CI (before any build): it fails the
 # whole release unless the tagged commit is an ancestor of origin/master. dist

--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -1,0 +1,32 @@
+# Maintainer: bdinfo-rs CI <bdinfo-rs@users.noreply.github.com>
+#
+# Template for the AUR `bdinfo-rs-bin` package. The `packages.yml` aur job seds
+# __PKGVER__ to the release version, then KSXGitHub/github-actions-deploy-aur runs
+# `updpkgsums` (filling in the real per-arch sha256sums) and pushes it to the AUR.
+# This repackages the prebuilt static-musl release tarballs — no compilation.
+pkgname=bdinfo-rs-bin
+_pkgname=bdinfo-rs
+pkgver=__PKGVER__
+pkgrel=1
+pkgdesc='Memory-safe command-line Blu-ray disc analyzer — a drop-in replacement for BDInfo'
+arch=('x86_64' 'aarch64')
+url='https://github.com/agentjp/bdinfo-rs'
+license=('LGPL-2.1-only')
+provides=('bdinfo-rs')
+conflicts=('bdinfo-rs')
+source_x86_64=("${_pkgname}-${pkgver}-x86_64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}-x86_64-unknown-linux-musl.tar.gz")
+source_aarch64=("${_pkgname}-${pkgver}-aarch64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}-aarch64-unknown-linux-musl.tar.gz")
+sha256sums_x86_64=('SKIP')
+sha256sums_aarch64=('SKIP')
+
+package() {
+    # Each release tarball extracts to a `bdinfo-rs-<triple>/` directory; CARCH is
+    # x86_64 or aarch64, matching the `<carch>-unknown-linux-musl` triple.
+    local _dir="${srcdir}/${_pkgname}-${CARCH}-unknown-linux-musl"
+    install -Dm755 "${_dir}/bdinfo-rs" "${pkgdir}/usr/bin/bdinfo-rs"
+    install -Dm644 "${_dir}/bdinfo-rs.1" "${pkgdir}/usr/share/man/man1/bdinfo-rs.1"
+    install -Dm644 "${_dir}/bdinfo-rs.bash" "${pkgdir}/usr/share/bash-completion/completions/bdinfo-rs"
+    install -Dm644 "${_dir}/_bdinfo-rs" "${pkgdir}/usr/share/zsh/site-functions/_bdinfo-rs"
+    install -Dm644 "${_dir}/bdinfo-rs.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/bdinfo-rs.fish"
+    install -Dm644 "${_dir}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
Wires `bdinfo-rs` into the major package managers, all tag-driven and SHA-pinned, on top of the existing cargo-dist release pipeline + GHCR image. Nothing publishes until a tag is pushed.

## What this adds
- **crates.io** — `publish-crates.yml`: on a `v*` tag, mints a short-lived OIDC token (`rust-lang/crates-io-auth-action`, no stored secret) and runs `cargo publish --workspace` (core before bin). Unlocks `cargo install` + the library + `cargo binstall` + `mise`.
- **cargo-binstall** — `[package.metadata.binstall]` pointed at the prebuilt archives (`bdinfo-rs-<triple>.<ext>`, binary inside the `bdinfo-rs-<triple>/` subdir; per-target `.zip`/`.tar.gz`).
- **Homebrew (own tap)** — enabled in `dist-workspace.toml` (`installers += homebrew`, `tap`, `publish-jobs`); `release.yml` regenerated. Binary formula, reuses the `.tar.gz` archives, covers macOS Intel/ARM + Linuxbrew, runs on the Linux release job. Needs `HOMEBREW_TAP_TOKEN`.
- **WinGet** — `packages.yml` job via `vedantmgoyal9/winget-releaser` (Komac self-hashes; ubuntu). Needs `WINGET_TOKEN` on a bot account that forked `microsoft/winget-pkgs`.
- **AUR (`bdinfo-rs-bin`)** — `packages.yml` job via `KSXGitHub/github-actions-deploy-aur` + `packaging/aur/PKGBUILD.template` (repackages the musl tarballs, `updpkgsums` + build test). Needs `AUR_SSH_KEY`.
- **.deb / .rpm** — `packages.yml` jobs repackage the prebuilt musl binaries with `cargo-deb` / `cargo-generate-rpm` (x64 + arm64) and attach them to the release. `GITHUB_TOKEN` only. (`[package.metadata.deb]` / `[package.metadata.generate-rpm]` added.)
- **Scoop** — handled in a separate `agentjp/scoop-bucket` repo (Excavator auto-update); not in this tree.
- README "Install" section documents every channel.

## Notes
- Every new action is SHA-pinned; the Homebrew job reuses dist's already-pinned checkout/download-artifact, so `dist generate --check` stays green.
- `packages.yml` fires on `release: released` (stable only) so the assets/checksums exist first.
- The deb/rpm repackaging paths are validated on the first real release — fixups, if any, are workflow-only.

## Requires before the next release tag
Bot account + `agentjp/homebrew-tap` + `agentjp/scoop-bucket` + AUR account; secrets `HOMEBREW_TAP_TOKEN`, `WINGET_TOKEN`, `AUR_SSH_KEY`; first manual crates.io publish + Trusted Publisher config; one-time WinGet first submission. (Full checklist tracked separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)