### PR TITLE
Cut 1.0.1: version bump, changelog, and BDInfoCLI-ng link fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-20
+
+Distribution and documentation only — the analyzer and its report output are
+unchanged from 1.0.0 (the binary is byte-for-byte identical; no `src/` changes).
+
 ### Added
 
 - **Install by name on Linux**: `apt install bdinfo-rs` (Debian/Ubuntu) and
@@ -77,5 +82,6 @@ which of these are visible on a normal disc.
 - AC-3 low-sample-rate frame-size shift.
 - DTS core 1536 kbps bitrate.
 
-[Unreleased]: https://github.com/agentjp/bdinfo-rs/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/agentjp/bdinfo-rs/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/agentjp/bdinfo-rs/releases/tag/v1.0.1
 [1.0.0]: https://github.com/agentjp/bdinfo-rs/releases/tag/v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bdinfo-rs-core",
  "clap",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proptest",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["crates/bdinfo-rs-core", "crates/bdinfo-rs"]
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.96"
 # LGPL (unlike GPL) permits use from other applications.
@@ -118,7 +118,7 @@ private_intra_doc_links = "allow"
 
 [workspace.dependencies]
 # Internal (version + path so bdinfo-rs is publishable to crates.io).
-bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "1.0.0" }
+bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "1.0.1" }
 # External (pinned to latest stable minor; deny.toml forbids wildcards).
 clap = { version = "4.6", features = ["derive"] }
 proptest = "1.11"

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ full‑length feature, its scanner CPU‑bound far below disk speed.
 start‑order rotated per disc, wall‑clock end to end — Intel Core Ultra 9 285K · NVMe SSD ·
 47 GB RAM · Windows 11. Reference builds: uniqproject =
 [UniqProject BDInfo](https://github.com/UniqProject/BDInfo) 0.8.0.1b; tetrahydroc =
-[BDInfoCLI](https://github.com/tetrahydroc/BDInfoCLI) (.NET 8), which ships with a
+[BDInfoCLI‑ng](https://github.com/tetrahydroc/BDInfoCLI-ng) (.NET 8), which ships with a
 2 GB GC heap cap that aborts on large UHD streams — it was given unrestricted heap so it
 could complete the scan and be timed.</sub>
 
@@ -303,7 +303,7 @@ megabytes**:
 | Tool | Installed on disk | Runtime |
 |---|--:|:--|
 | **bdinfo-rs** | **≈ 1 MB** | none |
-| BDInfoCLI (tetrahydroc) | 33.7 MB | .NET 8, bundled |
+| BDInfoCLI‑ng (tetrahydroc) | 33.7 MB | .NET 8, bundled |
 | BDInfo (uniqproject) | 54.1 MB | .NET + Skia, bundled |
 
 That's roughly **34–54× smaller** — one file you can drop on a USB stick, commit to a
@@ -312,7 +312,7 @@ repo, or bake into a `FROM scratch` container, with no runtime to carry along.
 <sub>On-disk size of a complete install, measured on Windows x64: the size-optimized
 `bdinfo-rs` release binary vs. the self-contained publishes of
 [UniqProject BDInfo](https://github.com/UniqProject/BDInfo) 0.8.0.1b and
-[BDInfoCLI](https://github.com/tetrahydroc/BDInfoCLI) (.NET 8). The Linux musl and
+[BDInfoCLI‑ng](https://github.com/tetrahydroc/BDInfoCLI-ng) (.NET 8). The Linux musl and
 macOS binaries are in the same ≈1 MB ballpark.</sub>
 
 ## 📚 Library
@@ -368,7 +368,7 @@ each layer:
 
 - **Report & analysis** — ported from [UniqProject BDInfo](https://github.com/UniqProject/BDInfo),
   the classic .NET tool, as the baseline.
-- **Console flow** — the CLI follows [BDInfoCLI](https://github.com/tetrahydroc/BDInfoCLI)
+- **Console flow** — the CLI follows [BDInfoCLI-ng](https://github.com/tetrahydroc/BDInfoCLI-ng)
   (tetrahydroc), the command-line BDInfo.
 - **Codec correctness** — edge cases cross-checked against
   [libbluray](https://code.videolan.org/videolan/libbluray) and [FFmpeg](https://ffmpeg.org/)


### PR DESCRIPTION
Cuts the **1.0.1** release prep. The apt/dnf-by-name publishing, per-release install verification, Homebrew smoke test, and Scorecard annotation that were originally developed on this branch **already landed via #12**, so this PR has been rebuilt on top of current `master` to contain only the genuinely-remaining changes:

- **Bump the workspace version** to 1.0.1 (`Cargo.toml` + the internal `bdinfo-rs-core` pin + `Cargo.lock`).
- **Add the `[1.0.1]` CHANGELOG section** (stamps the Unreleased distribution/docs notes into a release section + link refs).
- **Fix the 3 remaining `BDInfoCLI` → `BDInfoCLI-ng` links** in the README footprint/credits section that `48f479d` missed.

No `src/` changes — the analyzer and its byte-exact report output are unchanged from 1.0.0.

> History note: this branch was reorganized in place (reset to `master`, three clean commits, force-pushed) to drop ~17 now-redundant commits that duplicated #12 plus temporary smoke-test scaffolding.