### PR TITLE
Land README fixes and packaging/CI updates

### DIFF
--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -1,17 +1,23 @@
 name: install-smoke-test
 
-# Weekly + on-demand smoke test of the PUBLISHED package managers that install the
-# man page and shell completions: Homebrew (macOS + Linuxbrew). It installs the
-# formula from the tap and asserts the binary runs AND the man page + bash/zsh/fish
-# completions land in Homebrew's standard locations.
+# Smoke test of the PUBLISHED Homebrew formula (macOS + Linuxbrew): it `brew install`s
+# from the tap and asserts the binary runs AND the man page + bash/zsh/fish completions
+# land in Homebrew's standard locations.
+#
+# Runs AUTOMATICALLY after every release — cargo-dist publishes the formula during
+# release.yml, so by the time that workflow completes the tap has the new version —
+# PLUS daily to catch Homebrew/macOS ecosystem drift between releases, PLUS on demand.
 #
 # Out of scope by design: Scoop, WinGet, and cargo install/binstall ship the bare
 # executable only (no man/completions), so there is nothing to verify there. The
-# .deb/.rpm man+completions contract is verified at build time in packages.yml.
+# .deb/.rpm/Cloudsmith man+completions contract is verified per-release in packages.yml.
 
 on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   schedule:
-    - cron: "0 7 * * 1" # Mondays 07:00 UTC
+    - cron: "0 7 * * *" # daily 07:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -21,6 +27,9 @@ jobs:
   homebrew:
     name: Homebrew (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # When chained off release.yml, only run if the release actually succeeded
+    # (nothing new is published otherwise). Schedule/manual runs always proceed.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,9 +1,16 @@
 name: packages
 
-# Fan-out package publishing, fired AFTER release.yml has published the GitHub
-# Release (the `released` event carries the uploaded archives + checksums, and it
-# does NOT fire for prereleases — stable-only, matching Homebrew's default). Every
-# job runs on a Linux runner; every action is SHA-pinned.
+# Fan-out package publishing, run AFTER release.yml ("Release") has built and
+# uploaded the GitHub Release archives. release.yml (cargo-dist) creates that
+# release with the default GITHUB_TOKEN, and GitHub suppresses the
+# `release: released` event for token-created releases — so a `release`-triggered
+# workflow never fires (this is why v1.0.0's .deb/.rpm had to be uploaded by hand).
+# Instead we chain off release.yml's completion via `workflow_run` (which DOES
+# fire), and expose a manual `workflow_dispatch` for re-runs / backfills. Every job
+# runs on a Linux runner; every action is SHA-pinned.
+#
+# Stable-only: the `gate` job skips prerelease tags (anything but a bare vX.Y.Z),
+# matching the old `released`-event semantics and Homebrew's default.
 #
 # Channels handled ELSEWHERE (not here):
 #   - Homebrew  -> release.yml (cargo-dist homebrew publish job)
@@ -14,30 +21,69 @@ name: packages
 #   WINGET_TOKEN - classic PAT (public_repo) on the bot account that forked winget-pkgs
 #   AUR_SSH_KEY  - private SSH key whose public half is on the aur.archlinux.org account
 #
-# NOTE: the deb/rpm jobs repackage the prebuilt musl binaries and are validated on
-# the first real release; tweak the cargo-deb / cargo-generate-rpm invocation here
-# (not the binary) if a path needs adjusting.
+# NOTE: the deb/rpm jobs repackage the prebuilt musl binaries; tweak the cargo-deb
+# / cargo-generate-rpm invocation here (not the binary) if a path needs adjusting.
 
 on:
-  release:
-    types: [released]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to package, e.g. v1.0.1
+        required: true
+        type: string
 
 permissions:
   contents: read
 
-env:
-  VERSION: ${{ github.event.release.tag_name }}
-
 jobs:
+  # Resolve the release tag (from the dispatch input or the upstream run's tag)
+  # and gate the fan-out: proceed only for a successful release.yml run (or a
+  # manual dispatch) AND a stable vX.Y.Z tag (no prerelease suffix). The downstream
+  # jobs read the tag from `needs.gate.outputs.version` into their own $VERSION.
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      stable: ${{ steps.resolve.outputs.stable }}
+    steps:
+      - name: Resolve tag + stable check
+        id: resolve
+        shell: bash
+        env:
+          RAW_TAG: ${{ github.event.inputs.tag || github.event.workflow_run.head_branch }}
+        run: |
+          tag="$RAW_TAG"
+          if [ -z "$tag" ]; then
+            echo "Could not resolve a release tag from the event payload." >&2
+            exit 1
+          fi
+          if [[ "$tag" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then stable=true; else stable=false; fi
+          echo "version=$tag" >> "$GITHUB_OUTPUT"
+          echo "stable=$stable" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag '$tag' (stable=$stable)"
   # ── Windows: WinGet (Microsoft community repo) ─────────────────────────────
   winget:
     name: WinGet
     runs-on: ubuntu-latest
+    needs: gate
+    if: needs.gate.outputs.stable == 'true'
+    env:
+      VERSION: ${{ needs.gate.outputs.version }}
     steps:
       - name: Submit the new version to winget-pkgs
         uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: agentjp.bdinfo-rs
+          # Pass the tag explicitly: the action's default (github.ref_name) is the
+          # default branch under workflow_run, not the release tag.
+          release-tag: ${{ env.VERSION }}
           # Both windows-msvc .zip archives (x64 + arm64); excludes the .sha256 sidecars.
           installers-regex: '-pc-windows-msvc\.zip$'
           # The bot account that holds the fork of microsoft/winget-pkgs.
@@ -52,7 +98,10 @@ jobs:
     # disabled, so there is no AUR account/package to push to yet. Re-enable by
     # setting the repo variable AUR_ENABLED=true (after registering the account and
     # the AUR_SSH_KEY public key) — no code change needed; the secret is already set.
-    if: ${{ vars.AUR_ENABLED == 'true' }}
+    needs: gate
+    if: ${{ needs.gate.outputs.stable == 'true' && vars.AUR_ENABLED == 'true' }}
+    env:
+      VERSION: ${{ needs.gate.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -73,19 +122,27 @@ jobs:
           test: true # build the package in an Arch container before pushing
           commit_username: bdinfo-rs CI
           commit_email: bdinfo-rs@users.noreply.github.com
-          commit_message: Update to ${{ github.event.release.tag_name }}
+          commit_message: Update to ${{ env.VERSION }}
           ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
 
   # ── Debian/Ubuntu: .deb attached to the release (x64 + arm64) ──────────────
   deb:
     name: .deb (${{ matrix.triple }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    needs: gate
+    if: needs.gate.outputs.stable == 'true'
     permissions:
       contents: write # gh release upload
+    env:
+      VERSION: ${{ needs.gate.outputs.version }}
     strategy:
       fail-fast: false
+      # One NATIVE runner per arch so the install test runs the arch-matching binary
+      # (x64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) — no emulation/Docker.
       matrix:
-        triple: [x86_64-unknown-linux-musl, aarch64-unknown-linux-musl]
+        include:
+          - { triple: x86_64-unknown-linux-musl, os: ubuntu-latest }
+          - { triple: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -112,22 +169,20 @@ jobs:
       - name: Build the .deb
         run: cargo deb --no-build --no-strip --target ${{ matrix.triple }} -p bdinfo-rs
 
-      - name: Verify the .deb (contents on both arches; install + run on amd64)
+      - name: Verify the .deb (install + run + man/completions on the native arch)
         shell: bash
         run: |
+          set -euo pipefail
           deb=$(ls target/${{ matrix.triple }}/debian/*.deb)
           echo "== $deb =="; dpkg-deb --contents "$deb"
-          for p in ./usr/bin/bdinfo-rs ./usr/share/man/man1/bdinfo-rs.1 ./usr/share/bash-completion/completions/bdinfo-rs ./usr/share/zsh/site-functions/_bdinfo-rs ./usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
-            dpkg-deb --contents "$deb" | awk '{print $6}' | grep -Fxq "$p" || { echo "MISSING in .deb: $p"; exit 1; }
+          sudo dpkg -i "$deb"
+          bdinfo-rs --version
+          # cargo-deb gzips the man page (.1.gz); cargo-generate-rpm keeps it (.1) — accept either.
+          ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
+          for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+            test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
           done
-          if [ "${{ matrix.triple }}" = "x86_64-unknown-linux-musl" ]; then
-            sudo dpkg -i "$deb"
-            bdinfo-rs --version
-            for f in /usr/share/man/man1/bdinfo-rs.1 /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
-              test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
-            done
-            echo "amd64 .deb: installs, runs, and ships man + completions"
-          fi
+          echo "${{ matrix.triple }} .deb: installs, runs, and ships man + completions"
 
       - name: Upload the .deb to the release
         shell: bash
@@ -135,16 +190,34 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Publish to the Cloudsmith apt repo so users can `apt install bdinfo-rs` by
+      # name (one `any-distro/any-version` upload serves every Debian-family distro).
+      - name: Publish the .deb to Cloudsmith
+        shell: bash
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        run: |
+          pipx install cloudsmith-cli==1.19.0
+          cloudsmith push deb bdinfo-rs/bdinfo-rs/any-distro/any-version target/${{ matrix.triple }}/debian/*.deb
+
   # ── Fedora/RHEL: .rpm attached to the release (x64 + arm64) ────────────────
   rpm:
     name: .rpm (${{ matrix.triple }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    needs: gate
+    if: needs.gate.outputs.stable == 'true'
     permissions:
       contents: write # gh release upload
+    env:
+      VERSION: ${{ needs.gate.outputs.version }}
     strategy:
       fail-fast: false
+      # One NATIVE runner per arch so the install test runs the arch-matching binary
+      # (x64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) — no emulation/Docker.
       matrix:
-        triple: [x86_64-unknown-linux-musl, aarch64-unknown-linux-musl]
+        include:
+          - { triple: x86_64-unknown-linux-musl, os: ubuntu-latest }
+          - { triple: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -171,29 +244,82 @@ jobs:
       - name: Build the .rpm
         run: cargo generate-rpm -p crates/bdinfo-rs --target ${{ matrix.triple }}
 
-      - name: Verify the .rpm (contents on both arches; install + run on x86_64 via Fedora)
+      - name: Verify the .rpm (install + run + man/completions on the native arch)
         shell: bash
         run: |
+          set -euo pipefail
           sudo apt-get update -qq && sudo apt-get install -y -qq rpm
+          sudo rpm --initdb 2>/dev/null || true
           rpmf=$(ls target/${{ matrix.triple }}/generate-rpm/*.rpm)
           echo "== $rpmf =="; rpm -qpl "$rpmf"
-          for p in /usr/bin/bdinfo-rs /usr/share/man/man1/bdinfo-rs.1 /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
-            rpm -qpl "$rpmf" | grep -Fxq "$p" || { echo "MISSING in .rpm: $p"; exit 1; }
+          # rpm tool on Ubuntu lays the package's files onto the filesystem; --nodeps
+          # (the binary is static, no deps) and --ignorearch (rpm's host-arch string
+          # may not match the package arch label) keep it from balking.
+          sudo rpm -i --nodeps --ignorearch --force "$rpmf"
+          bdinfo-rs --version
+          # cargo-deb gzips the man page (.1.gz); cargo-generate-rpm keeps it (.1) — accept either.
+          ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
+          for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+            test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
           done
-          if [ "${{ matrix.triple }}" = "x86_64-unknown-linux-musl" ]; then
-            docker run --rm -v "$PWD/target/${{ matrix.triple }}/generate-rpm:/rpms:ro" fedora:latest bash -c '
-              set -e
-              dnf install -y -q /rpms/*.rpm
-              bdinfo-rs --version
-              for f in /usr/share/man/man1/bdinfo-rs.1 /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
-                test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
-              done
-              echo "x86_64 .rpm: installs, runs, and ships man + completions"
-            '
-          fi
+          echo "${{ matrix.triple }} .rpm: installs (rpm -i), runs, and ships man + completions"
 
       - name: Upload the .rpm to the release
         shell: bash
         run: gh release upload "$VERSION" target/${{ matrix.triple }}/generate-rpm/*.rpm --repo "$GITHUB_REPOSITORY" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Publish to the Cloudsmith yum repo so users can `dnf install bdinfo-rs` by
+      # name (one `any-distro/any-version` upload serves every RPM-family distro).
+      - name: Publish the .rpm to Cloudsmith
+        shell: bash
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        run: |
+          pipx install cloudsmith-cli==1.19.0
+          cloudsmith push rpm bdinfo-rs/bdinfo-rs/any-distro/any-version target/${{ matrix.triple }}/generate-rpm/*.rpm
+
+  # ── Verify the PUBLISHED Cloudsmith repo: install bdinfo-rs BY NAME and confirm
+  # ── the binary + man + completions all land — on both arches, native runners, no
+  # ── Docker. Runs after `deb` has pushed; retries while the apt index propagates.
+  cloudsmith-verify:
+    name: verify Cloudsmith apt install (${{ matrix.triple }})
+    runs-on: ${{ matrix.os }}
+    needs: [gate, deb]
+    if: needs.gate.outputs.stable == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { triple: x86_64-unknown-linux-musl, os: ubuntu-latest }
+          - { triple: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm }
+    steps:
+      # A CLEAN container (not the runner) = a faithful "fresh user" install and no
+      # interference from the runner's pre-seeded apt state. The arm64 runner runs an
+      # arm64 container natively, so each arch verifies its own Cloudsmith package.
+      # The retry absorbs apt-index propagation right after the deb job's push.
+      - name: apt install bdinfo-rs from Cloudsmith (clean container) + check man/completions
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm ubuntu:latest bash -c '
+            set -e
+            apt-get update -qq && apt-get install -y -qq curl ca-certificates
+            # Minimal Ubuntu images dpkg-exclude /usr/share/man/* to stay small;
+            # drop that so the install is complete like a real system (the man page
+            # IS in the .deb — the runner-based deb job already proves it installs).
+            rm -f /etc/dpkg/dpkg.cfg.d/excludes
+            for i in $(seq 1 12); do
+              if curl -1sLf "https://dl.cloudsmith.io/public/bdinfo-rs/bdinfo-rs/setup.deb.sh" | bash \
+                 && apt-get install -y -qq bdinfo-rs; then ok=1; break; fi
+              echo "waiting for the Cloudsmith index to propagate... ($i)"; sleep 10
+            done
+            [ -n "${ok:-}" ] || { echo "could not apt install bdinfo-rs from Cloudsmith"; exit 1; }
+            bdinfo-rs --version
+            ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "MISSING: man page"; exit 1; }
+            for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+              test -f "$f" || { echo "MISSING: $f"; exit 1; }
+            done
+            echo "Cloudsmith apt install ships the binary + man + completions"
+          '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Install by name on Linux**: `apt install bdinfo-rs` (Debian/Ubuntu) and
+  `dnf install bdinfo-rs` (Fedora/RHEL/openSUSE) from a hosted package repository —
+  add the repo once, then use your package manager normally, updates included — in
+  addition to the standalone `.deb`/`.rpm` release downloads.
+- README: an installed-footprint size comparison and an "owned discs only" usage
+  policy; a one-paragraph code of conduct; and a structured output-difference
+  issue template.
+
+### Fixed
+
+- `cargo binstall bdinfo-rs` now resolves the prebuilt release archives via
+  explicit binstall metadata, including the flat Windows `.zip` layout. (1.0.0
+  shipped no binstall configuration, so installs fell back to fragile
+  auto-detection.)
+- The `.deb` and `.rpm` release packages now publish automatically on every release
+  (1.0.0's had to be attached by hand).
+
 ## [1.0.0] - 2026-06-19
 
 First public release — a memory-safe, single-static-binary drop-in for the

--- a/README.md
+++ b/README.md
@@ -122,14 +122,29 @@ cargo binstall bdinfo-rs
 cargo install bdinfo-rs
 ```
 
-Debian/Ubuntu (`.deb`) and Fedora/RHEL (`.rpm`) packages for x64 and arm64 are attached to
-every [release](https://github.com/agentjp/bdinfo-rs/releases) — and, like Homebrew, they
-install the man page and shell completions too:
+On Debian/Ubuntu and Fedora/RHEL/openSUSE, install **by name with updates** from the hosted
+package repository — add it once (like any third-party repo), then use your package manager
+normally. Like Homebrew, these ship the man page and shell completions too:
+
+```sh
+# Debian / Ubuntu (and derivatives)
+curl -1sLf 'https://dl.cloudsmith.io/public/bdinfo-rs/bdinfo-rs/setup.deb.sh' | sudo -E bash
+sudo apt install bdinfo-rs
+
+# Fedora / RHEL / openSUSE
+curl -1sLf 'https://dl.cloudsmith.io/public/bdinfo-rs/bdinfo-rs/setup.rpm.sh' | sudo -E bash
+sudo dnf install bdinfo-rs
+```
+
+Prefer not to add a repository? The individual `.deb`/`.rpm` packages (x64 + arm64) are attached
+to every [release](https://github.com/agentjp/bdinfo-rs/releases) — download and install one directly:
 
 ```sh
 sudo apt install ./bdinfo-rs_*_amd64.deb     # Debian/Ubuntu
 sudo dnf install ./bdinfo-rs-*.x86_64.rpm    # Fedora/RHEL
 ```
+
+The `apt`/`dnf` repository is graciously hosted by [Cloudsmith](https://cloudsmith.com) ♥ OSS.
 
 ### Install script
 
@@ -256,7 +271,7 @@ times three tools on the **same work**: each scans the identical main feature pl
 (the movie) with `-m`, reading the same streams and producing structurally identical
 reports, so the only variable is speed.
 
-| Feature playlist scanned | bdinfo-rs | uniqproject | tetra |
+| Feature playlist scanned | bdinfo-rs | uniqproject | tetrahydroc |
 |---|--:|--:|--:|
 | MPEG‑2 · 1080i · 3 GB | **0.6 s** | 1.9 s *(2.9×)* | 2.2 s *(3.4×)* |
 | AVC · 1080p · DTS:X · 14 GB | **2.7 s** | 6.8 s *(2.5×)* | 35.4 s *(13.2×)* |
@@ -265,15 +280,15 @@ reports, so the only variable is speed.
 | HEVC · 2160p · HDR10/DV · 50 GB | **15.8 s** | 26.2 s *(1.7×)* | 128.8 s *(8.2×)* |
 
 Across every Blu‑ray video codec and up to 2160p, bdinfo-rs is **≈1.7–2.9× faster than
-uniqproject and ≈3–13× faster than tetra** on byte‑for‑byte equal work. Its lead over
+uniqproject and ≈3–13× faster than tetrahydroc** on byte‑for‑byte equal work. Its lead over
 uniqproject is widest on cache‑resident discs and narrows on the largest ones, where both
-become bound by the same NVMe read; tetra trails by roughly an order of magnitude on any
+become bound by the same NVMe read; tetrahydroc trails by roughly an order of magnitude on any
 full‑length feature, its scanner CPU‑bound far below disk speed.
 
 <sub>Median of 3 runs (slow references timed once), warm page cache, tools interleaved and
 start‑order rotated per disc, wall‑clock end to end — Intel Core Ultra 9 285K · NVMe SSD ·
 47 GB RAM · Windows 11. Reference builds: uniqproject =
-[UniqProject BDInfo](https://github.com/UniqProject/BDInfo) 0.8.0.1b; tetra =
+[UniqProject BDInfo](https://github.com/UniqProject/BDInfo) 0.8.0.1b; tetrahydroc =
 [BDInfoCLI‑ng](https://github.com/tetrahydroc/BDInfoCLI-ng) (.NET 8), which ships with a
 2 GB GC heap cap that aborts on large UHD streams — it was given unrestricted heap so it
 could complete the scan and be timed.</sub>
@@ -282,17 +297,17 @@ could complete the scan and be timed.</sub>
 
 bdinfo-rs isn't just faster — it's a rounding error on the others' size. It's a single
 self-contained binary of about **1 MB** with nothing else to install. The .NET BDInfo
-tools bundle (or require) the .NET runtime and ship alongside dozens of DLLs, so a working
-install is **tens of megabytes spread across many files**:
+tools bundle (or require) the .NET runtime, so a working install runs to **tens of
+megabytes**:
 
-| Tool | Installed on disk | Files | Runtime |
-|---|--:|--:|:--|
-| **bdinfo-rs** | **≈ 1 MB** | **1** | none |
-| BDInfo (uniqproject) | ≈ 54 MB | 8 | .NET + Skia, bundled |
-| BDInfoCLI‑ng (tetra) | ≈ 71 MB | 191 | .NET 8, bundled |
+| Tool | Installed on disk | Runtime |
+|---|--:|:--|
+| **bdinfo-rs** | **≈ 1 MB** | none |
+| BDInfoCLI‑ng (tetrahydroc) | 33.7 MB | .NET 8, bundled |
+| BDInfo (uniqproject) | 54.1 MB | .NET + Skia, bundled |
 
-That's roughly **50–80× smaller** — one file you can drop on a USB stick, commit to a
-repo, or bake into a `FROM scratch` container, with no runtime and no DLLs to carry along.
+That's roughly **34–54× smaller** — one file you can drop on a USB stick, commit to a
+repo, or bake into a `FROM scratch` container, with no runtime to carry along.
 
 <sub>On-disk size of a complete install, measured on Windows x64: the size-optimized
 `bdinfo-rs` release binary vs. the self-contained publishes of
@@ -354,7 +369,7 @@ each layer:
 - **Report & analysis** — ported from [UniqProject BDInfo](https://github.com/UniqProject/BDInfo),
   the classic .NET tool, as the baseline.
 - **Console flow** — the CLI follows [BDInfoCLI-ng](https://github.com/tetrahydroc/BDInfoCLI-ng)
-  (tetra), the command-line BDInfo.
+  (tetrahydroc), the command-line BDInfo.
 - **Codec correctness** — edge cases cross-checked against
   [libbluray](https://code.videolan.org/videolan/libbluray) and [FFmpeg](https://ffmpeg.org/)
   to fix bugs in the original (see [Differences from BDInfo](#-differences-from-bdinfo)).

--- a/scorecard.yml
+++ b/scorecard.yml
@@ -1,0 +1,19 @@
+# OpenSSF Scorecard maintainer annotations.
+#
+# The Binary-Artifacts check flags every committed binary as "non-reviewable
+# code", because its purpose is to catch generated executables that can drift
+# from their source. Our one committed binary is the opposite of that: the Big
+# Buck Bunny BD-ROM test fixture (crates/bdinfo-rs/tests/fixtures/BigBuckBunny.iso,
+# CC-BY) — a real Blu-ray disc image the end-to-end CI test scans and diffs
+# byte-exact against a committed golden report. It is reviewable test data, not
+# a generated executable, and removing it would break the cross-platform parse
+# guarantee it exists to hold.
+#
+# The `test-data` reason records that this finding is accepted; the
+# scorecard-action emits it as a SARIF suppression, so code scanning stops
+# raising the alert on future runs.
+annotations:
+  - checks:
+      - binary-artifacts
+    reasons:
+      - reason: test-data


### PR DESCRIPTION
Splits the documentation + packaging work out of the **1.0.1 prep** ([#11](https://github.com/agentjp/bdinfo-rs/pull/11)) so the **README corrections can go live now**, without committing to cutting the `v1.0.1` tag (which still waits on the WinGet 1.0.0 PR landing first).

**No version bump.** `Cargo.toml`/`Cargo.lock` stay at **1.0.0**; the analyzer and report output are byte-for-byte identical. This is everything in #11 **except** the `1.0.0 → 1.0.1` bump and the `## [1.0.1]` changelog section — those stay parked on `release/prep-1.0.1` for the eventual release. The changelog entries here live under `[Unreleased]`.

## What lands now

- **`apt install bdinfo-rs` / `dnf install bdinfo-rs` by name** (with updates) from the Cloudsmith-hosted repo — Debian/Ubuntu and Fedora/RHEL/openSUSE — alongside the standalone `.deb`/`.rpm` downloads. `packages.yml` publishes them automatically after `release.yml` completes (1.0.0's were attached by hand).
- **README corrections** — accurate installed-footprint comparison (file-count column dropped, sizes corrected to tetrahydroc 33.7 MB / uniqproject 54.1 MB), `tetra` → `tetrahydroc` throughout, and the apt/dnf install one-liners with the Cloudsmith OSS attribution.
- **Scorecard binary-artifacts annotation** (`scorecard.yml`) — the committed `.iso` test fixture is marked test-data so it stops tripping the Binary-Artifacts check.
- **Per-release Homebrew install verification** (`install-smoke-test.yml`) — runs automatically after every release instead of only on a schedule.

## Follow-up

After this merges, #11 rebases to just the version bump + the `## [1.0.1]` changelog section (promoting these `[Unreleased]` notes), held un-merged until WinGet 1.0.0 lands.