### PR TITLE
Exclude the repo's own changelog tag/compare links from the link check

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,11 @@
+# Self-referential CHANGELOG links to this repo's own release tags and compares.
+# A release PR cuts a new version section whose link refs point at
+#   https://github.com/agentjp/bdinfo-rs/releases/tag/vX.Y.Z
+#   https://github.com/agentjp/bdinfo-rs/compare/vX.Y.Z...HEAD
+# Both 404 until the vX.Y.Z tag is pushed, which by our release flow happens
+# after the PR merges -- so without these excludes the Check links gate hard-
+# fails on every release or version-bump PR. We exclude only our own tag and
+# compare URLs, so those PRs stay green with no per-PR step while lychee still
+# verifies every other link, including the badges, /releases, and installer URLs.
+https://github\.com/agentjp/bdinfo-rs/releases/tag/v
+https://github\.com/agentjp/bdinfo-rs/compare/v


### PR DESCRIPTION
## Why

The `Check links` gate (lychee, added in `48f479d`) structurally conflicts with the documented release flow. Every release/version-bump PR cuts a new `## [X.Y.Z]` CHANGELOG section whose link refs point at:

- `https://github.com/agentjp/bdinfo-rs/releases/tag/vX.Y.Z`
- `https://github.com/agentjp/bdinfo-rs/compare/vX.Y.Z...HEAD`

Both **404 until the `vX.Y.Z` tag is pushed**, which by our flow happens *after* the PR merges. So `Check links` hard-fails on every such PR (it just did, on the abandoned 1.0.1-prep #11). v1.0.0 never hit this — the gate didn't exist yet.

## Fix

A tracked root `.lycheeignore` (lychee auto-reads it, no flag needed) excluding **only this repo's own** `releases/tag/v…` and `compare/v…` URLs. These are the two self-referential, auto-generated changelog links; everything else — badges, `/releases`, `/issues`, installer URLs, all external links — keeps being verified.

This is a one-time structural fix: release and bump PRs now stay green with **no per-PR step**. The only currently-valid link it stops checking is `releases/tag/v1.0.0` (an auto-generated self-link), which is an acceptable trade.