### PR TITLE
Add a taplo TOML format and lint gate and reformat the tracked TOML

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -59,7 +59,7 @@ vt = "vet --locked"
 #
 # Linux: musl = fully static, no glibc — the literal "drop a file, it runs".
 [target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=+crt-static"]   # (musl default; explicit)
+rustflags = ["-C", "target-feature=+crt-static"] # (musl default; explicit)
 [target.aarch64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=+crt-static"]
 # Windows: statically link the UCRT so the .exe needs no VC++ redist. (System

--- a/.github/workflows/toml.yml
+++ b/.github/workflows/toml.yml
@@ -1,0 +1,41 @@
+name: toml
+
+# TOML formatting + lint gate (taplo): every tracked TOML — the Cargo manifests,
+# the gate configs (clippy/deny/nextest/mutants/typos), dist-workspace.toml — must
+# match `taplo fmt` and pass `taplo lint`, against the committed taplo.toml. Mirrors
+# the local gate's `tp` step. Cargo.lock and the cargo-vet-managed
+# supply-chain/*.toml are excluded in taplo.toml so taplo never fights a generator.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: toml-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  taplo:
+    name: lint TOML (taplo)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install taplo (prebuilt, no from-source compile)
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        with:
+          tool: taplo-cli
+
+      # taplo auto-discovers taplo.toml (include/exclude + formatting). --check
+      # fails on any unformatted file; --diff prints exactly what differs.
+      - name: Check formatting (taplo fmt --check)
+        run: taplo fmt --check --diff
+
+      - name: Lint (taplo lint)
+        run: taplo lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,12 @@ documentation = "https://docs.rs/bdinfo-rs-core"
 # (deny vs warn) only changes whether a bare `cargo check` is noisy.
 # ---------------------------------------------------------------------------
 [workspace.lints.rust]
-unsafe_code = "forbid"                  # memory safety is the product guarantee.
+unsafe_code = "forbid" # memory safety is the product guarantee.
 # `cargo llvm-cov` sets cfg(coverage)/cfg(coverage_nightly) when instrumenting;
 # register them so the `#[cfg_attr(coverage_nightly, …)]` coverage-exclusion
 # attributes don't trip `unexpected_cfgs` under the `-D warnings` gate.
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
-missing_docs = "warn"                   # every public item carries a doc.
+missing_docs = "warn" # every public item carries a doc.
 missing_debug_implementations = "deny"
 unreachable_pub = "deny"
 unused_crate_dependencies = "deny"
@@ -49,7 +49,7 @@ trivial_numeric_casts = "deny"
 elided_lifetimes_in_paths = "deny"
 single_use_lifetimes = "deny"
 redundant_lifetimes = "deny"
-non_ascii_idents = "deny"               # parser hygiene / homoglyph safety.
+non_ascii_idents = "deny" # parser hygiene / homoglyph safety.
 keyword_idents_2024 = "deny"
 unused_lifetimes = "deny"
 unit_bindings = "deny"
@@ -93,7 +93,7 @@ panic = "warn"
 unwrap_used = "warn"
 expect_used = "warn"
 unwrap_in_result = "warn"
-exit = "warn"                           # CLI uses ExitCode, never process::exit.
+exit = "warn" # CLI uses ExitCode, never process::exit.
 mem_forget = "warn"
 clone_on_ref_ptr = "warn"
 rc_buffer = "warn"
@@ -136,12 +136,12 @@ roxmltree = "0.21"
 # ---------------------------------------------------------------------------
 # Release = the shipped single static binary: tuned for size.
 [profile.release]
-opt-level = "s"   # optimize for size (the product is one small drop-and-run binary)
+opt-level = "s" # optimize for size (the product is one small drop-and-run binary)
 lto = true
 codegen-units = 1
-panic = "abort"   # drop unwind tables (smaller). The CLI aborts on the panics the
-                  # gate already forbids on input; tests/coverage use the test
-                  # profile, so this only affects the shipped binary.
+panic = "abort" # drop unwind tables (smaller). The CLI aborts on the panics the
+# gate already forbids on input; tests/coverage use the test
+# profile, so this only affects the shipped binary.
 strip = true
 
 # Dedicated profile for `cargo mt` (cargo-mutants): inherits `test` (same

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -5,7 +5,7 @@
 # Cargo.toml as `[profile.dist]` (dist builds with `--profile dist`).
 
 [workspace]
-members = ["cargo:."]   # pull in the whole Cargo workspace rooted here
+members = ["cargo:."] # pull in the whole Cargo workspace rooted here
 
 [dist]
 # Pin dist itself (reproducibility): the generated CI installs exactly this

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 # compiler — reproducible gate across machines and CI. rustup reads this and
 # installs the version + components on demand. Bump deliberately.
 [toolchain]
-channel = "1.96.0"  # latest stable (2026-05-25)
+channel = "1.96.0" # latest stable (2026-05-25)
 # clippy + rustfmt for the lint/format gate; llvm-tools-preview ships the
 # profdata/profcov binaries cargo-llvm-cov shells out to (the `cov` alias
 # fails on a fresh machine without it).

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,30 @@
+# taplo configuration — TOML formatter + linter, enforced by the `toml` CI job and
+# the local gate (scripts/compliance.ps1 `tp` step). The formatting options below
+# are tuned to match the repo's existing hand-formatting, so the one-time baseline
+# reformat normalizes only spacing/commas and never re-flows the author's chosen
+# array line breaks.
+include = ["**/*.toml"]
+# Cargo.lock is generated (and is a .lock, not a .toml — never matched anyway);
+# supply-chain/{audits,config}.toml are written by cargo-vet — leave both to their
+# generators so taplo never fights them. target/ holds throwaway build artifacts.
+exclude = ["Cargo.lock", "supply-chain/**", "target/**"]
+
+[formatting]
+# 4-space indent matches the repo's multi-line arrays (e.g. dist-workspace targets,
+# deny.toml allow, the mutants exclude_re).
+indent_string = "    "
+# Don't column-align trailing comments: aligning to the widest sibling in a block
+# shoves short entries' comments far right (and is inconsistent). One space before
+# every `#` is uniform and the smallest, most predictable normalization.
+align_comments = false
+# Preserve the author's line breaks: never auto-expand a single-line array or
+# auto-collapse a multi-line one. This keeps deliberate layouts (a one-line
+# skip_calls list, a multi-line deb `assets` array of arrays) exactly as written.
+array_auto_expand = false
+array_auto_collapse = false
+# Never reorder keys or array entries — order is semantic here (license precedence,
+# target order, lint grouping) and reordering would be churn plus a real risk.
+reorder_keys = false
+reorder_arrays = false
+# Wide enough that nothing wraps on width alone (array re-flow is already off).
+column_width = 120

--- a/typos.toml
+++ b/typos.toml
@@ -17,20 +17,20 @@ clpi = "clpi"
 clipinf = "clipinf"
 ssif = "ssif"
 mpls = "mpls"
-indx = "indx"   # index.bdmv magic "INDX0300" (UHD detection)
-cll = "cll"     # MaxCLL — HDR maximum content light level
-ue = "ue"       # ue(v): unsigned Exp-Golomb code (H.264/H.265 syntax notation)
-compre = "compre"  # AC-3 BSI syntax element (compression-gain-word exists flag)
+indx = "indx" # index.bdmv magic "INDX0300" (UHD detection)
+cll = "cll" # MaxCLL — HDR maximum content light level
+ue = "ue" # ue(v): unsigned Exp-Golomb code (H.264/H.265 syntax notation)
+compre = "compre" # AC-3 BSI syntax element (compression-gain-word exists flag)
 
 [files]
 # Skip build output, local-only trees, generated data, and binaries.
 extend-exclude = [
     "target/",
     "fuzz/target/",
-    "fuzz/corpus/",  # raw-byte seed fixtures (garbage/boundary inputs), not text
+    "fuzz/corpus/", # raw-byte seed fixtures (garbage/boundary inputs), not text
 
     "docs/",
-    "scratch/",  # local research + notes (also gitignored)
+    "scratch/", # local research + notes (also gitignored)
     # Real-disc test fixtures: the golden reports are locked BDInfo output (domain
     # jargon, not prose) and the README credits the CC-BY source; the disc bytes are
     # binary. Spell-checking any of it is all false positives.


### PR DESCRIPTION
Adds [taplo](https://taplo.tamasfe.dev/) as a TOML formatting + lint gate, mirroring the other quality gates (`zizmor`, `link-check`). Every tracked TOML must match `taplo fmt` and pass `taplo lint`.

## The gate (`toml.yml`)
- Installs taplo prebuilt via `taiki-e/install-action`; runs `taplo fmt --check --diff` + `taplo lint` on push/PR; hard-fails. SHA-pinned, `contents: read`, `persist-credentials: false` (passes the zizmor gate). New required check: **`lint TOML (taplo)`**.

## Config (`taplo.toml`) — tuned to minimize churn
The formatting options match the repo's existing hand-formatting so the one-time baseline reformat is **pure spacing normalization**, never a re-flow:
- `indent_string` = 4 spaces (the repo's multi-line-array indent).
- `array_auto_expand` / `array_auto_collapse` = **false** — preserve the author's line breaks (a one-line `skip_calls`, a multi-line deb `assets` array of arrays stay exactly as written; defaults would explode/collapse them).
- `align_comments` = false — one space before every `#` (uniform; the default shoves short entries' comments far right to align with a long sibling).
- `reorder_keys` / `reorder_arrays` = false — order is semantic (license precedence, target order).
- `column_width` = 120.
- **Excludes** `Cargo.lock` (generated) and the cargo-vet-managed `supply-chain/*.toml` (+ `target/`), so taplo never fights a generator.

## Baseline reformat
The same PR runs `taplo fmt` once: **5 files, 17 lines, all comment-spacing** (collapsing hand-aligned multi-space-before-`#` to one space). Zero value changes — verified `cargo build` clean and `dist generate --check` still passes (the reformat touched `dist-workspace.toml` whitespace only).

Local gate + tooling docs updated out-of-band (gitignored cockpit: `compliance.ps1` `tp` step + `taplo fmt` under `-Fix`, `setup.ps1`, `CLAUDE.md`). Full local gate green.
