### PR TITLE
Embed the dependency manifest in shipped binaries via cargo-auditable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,8 @@ jobs:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
+      - name: Install cargo-auditable
+        run: ${{ matrix.install_cargo_auditable.run }}
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@
 # CI gets a multi-arch image by building each arch on its own native runner.
 
 # --- build: compile the static musl binary --------------------------------
+# `cargo auditable build` (not plain `cargo build`) embeds the dependency tree in
+# the binary's `.dep-v0` section, so the GHCR image is auditable by the same tools
+# as the release binaries (`cargo audit bin`, trivy, grype) — matching the
+# cargo-auditable=true that release.yml's dist build uses. Pure Rust, no C, no
+# runtime dep: the FROM-scratch static guarantee is unchanged.
 FROM rust:1.96-slim@sha256:3b05f7c617a200c41c3506097f0d15fc193a1c93bfd8f141007b47cac8f95d3c AS build
 ARG TARGETARCH
 WORKDIR /src
@@ -19,7 +24,8 @@ RUN set -eux; \
       *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
     esac; \
     rustup target add "$target"; \
-    cargo build --release -p bdinfo-rs --target "$target" --locked; \
+    cargo install cargo-auditable --locked; \
+    cargo auditable build --release -p bdinfo-rs --target "$target" --locked; \
     cp "target/$target/release/bdinfo-rs" /bdinfo-rs
 
 # --- runtime: the binary, alone -------------------------------------------

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -76,6 +76,20 @@ checksum = "sha256"
 # only — satisfied). dist 0.32 emits actions/attest@v4.
 github-attestations = true
 
+# Embed the dependency tree (a Zlib-compressed JSON in the `.dep-v0` linker
+# section) into every shipped binary via cargo-auditable, so a CONSUMER can audit
+# the distributed artifact itself — `cargo audit bin`, `rust-audit-info`, trivy,
+# grype, osv-scanner — closing the loop our build-time cargo-deny/cargo-vet don't:
+# those check the source we build, this lets downstream re-check the binary. dist
+# runs `cargo auditable build`/`cargo auditable zigbuild` instead of plain
+# `cargo build`, and the generated release.yml installs cargo-auditable on each
+# runner (the `need_cargo_auditable` matrix step). Requires dist >= 0.32 — that
+# release lifted the prior cargo-auditable⊕zigbuild mutual exclusion, so our two
+# musl (zigbuild) targets get the section too, not just the cargo-build ones. The
+# embedded section is allocated data, not debuginfo, so `strip = true` keeps it;
+# it adds no runtime dep and no C, so the single-static-binary guarantee holds.
+cargo-auditable = true
+
 # Abort the whole run if any single target fails to build.
 fail-fast = true
 


### PR DESCRIPTION
## What

Embed the dependency tree into every shipped `bdinfo-rs` binary via [cargo-auditable](https://github.com/rust-secure-code/cargo-auditable), so downstream consumers and scanners can audit the *distributed artifact itself* for known vulnerabilities — `cargo audit bin`, `rust-audit-info`, trivy, grype, osv-scanner. This closes the consumer-side supply-chain loop that our build-time `cargo-deny` / `cargo-vet` gates don't cover: those check the source we build; this lets anyone re-check the binary.

## How

- `dist-workspace.toml`: set `cargo-auditable = true` in `[dist]`. dist then runs `cargo auditable build` / `cargo auditable zigbuild` instead of plain `cargo build`, embedding a Zlib-compressed JSON dep tree in the binary's `.dep-v0` linker section.
- `release.yml`: regenerated with `dist generate` (not hand-edited) — adds one `Install cargo-auditable` step per build runner. `dist generate --check` stays green.
- `Dockerfile`: the GHCR image builds via plain `cargo build` (not dist), so it's wired separately — install cargo-auditable in the build stage and switch to `cargo auditable build`, so the `FROM scratch` image binary is auditable too.

## Why this is safe here

- **dist 0.32.0** (our pinned version) is exactly the release that lifted the prior cargo-auditable ⊕ cargo-zigbuild mutual exclusion, so the two musl targets get the section too — all six targets are covered (the four `cargo build` targets incl. native win-arm64, and the two zigbuild musl targets).
- **No new GitHub Action** is introduced (the install is a `run:` step), so nothing new to SHA-pin.
- **Static-binary guarantee intact**: cargo-auditable is a build-time wrapper that injects a data section; it adds no runtime dependency and no C. `Cargo.lock` is unchanged (no new crates), so `cargo-deny`/`cdeps` are unaffected.

## Verification (local, dist profile with `strip = true`)

- Built `cargo auditable build --profile dist` and confirmed `rust-audit-info` reads the full dependency tree back out of the **stripped** binary (`format:1`) — `strip` + `lto` + `panic=abort` all preserve the section.
- **Size delta: +1,024 bytes (+0.11%)** on the win-x64 binary.
- `taplo` (TOML), `action-validator` + `ryl` (YAML), and `zizmor` (workflow security — "No findings") all pass on the changed files.
