### PR TITLE
Polish: exact action pins + ref-version-mismatch, and follow-ups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,22 +1,6 @@
-# Keep the build context tiny — the image build only needs the workspace
-# sources. Excluding docs/CI also keeps edits to them from busting the
-# (expensive) cargo build layer cache.
-/target
-.git
-.github
-.gitignore
-fuzz
-scripts
-.config
-discs
-scratch
-docs
-donotread
-mutants.out
-mutants.out.old
-*.log
-proptest-regressions
-Dockerfile
-.dockerignore
-README.md
-LICENSE
+# The image build needs only the staged binaries (bin/<arch>/bdinfo-rs) — there is
+# no compile step. The Dockerfile is read by BuildKit directly, not through this
+# context, so excluding everything but bin/ keeps the build context tiny (the repo
+# also carries a multi-MB fuzz seed corpus the COPY never touches).
+*
+!bin/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,20 @@
-# Dependabot — grouped + monthly, deliberately frugal: updates arrive as ONE
-# grouped cargo PR and ONE grouped GitHub-Actions PR per month, not a trickle.
-# Security advisories are NOT throttled by this cadence: Dependabot security
-# updates (enabled repo-side) and the audit.yml workflow react to RustSec /
-# GitHub advisories immediately.
+# Dependabot — grouped + daily: updates arrive as ONE grouped cargo PR and ONE
+# grouped GitHub-Actions PR per day, and only when a member actually has an
+# update (a grouped PR is opened solely when there is something to bump), so a
+# quiet day is silent. Security advisories are NOT throttled by this cadence:
+# Dependabot security updates (enabled repo-side) and the audit.yml workflow
+# react to RustSec / GitHub advisories immediately.
+#
+# There is deliberately no `docker` ecosystem: the Dockerfile is `FROM scratch`
+# (it ships the prebuilt release binary, no base image), so there is no image
+# tag or digest for Dependabot to bump. The docker GitHub Actions used by
+# docker.yml are covered by the github-actions ecosystem below.
 version: 2
 updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: monthly
+      interval: daily
     groups:
       cargo-dependencies:
         patterns: ["*"]
@@ -17,20 +23,8 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: monthly
+      interval: daily
     groups:
       github-actions:
-        patterns: ["*"]
-    labels: [dependencies, ci]
-
-  # The Dockerfile build base (`rust:<ver>-slim@sha256:...`): Dependabot refreshes
-  # the digest and proposes newer tags. The version-freshness job separately
-  # asserts the tag stays in lockstep with the stable Rust pin.
-  - package-ecosystem: docker
-    directory: "/"
-    schedule:
-      interval: monthly
-    groups:
-      docker:
         patterns: ["*"]
     labels: [dependencies, ci]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,7 +6,7 @@ name: audit
 #   - the license allowlist (deps must be permissive)
 #   - the no-C-dependencies bans (cc/cmake/bindgen/… → guards the static binary)
 #   - crates.io-only sources (no git / unknown registries)
-# Runs on every push/PR and weekly, so a newly-disclosed CVE surfaces between
+# Runs on every push/PR and daily, so a newly-disclosed CVE surfaces between
 # pushes too.
 
 on:
@@ -14,7 +14,7 @@ on:
     branches: [master]
   pull_request:
   schedule:
-    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+    - cron: "0 6 * * *"   # daily 06:00 UTC
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,12 +29,12 @@ jobs:
     name: cargo deny check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install cargo-deny (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-deny
 
@@ -49,7 +49,7 @@ jobs:
     name: cargo vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
           - macos-15-intel     # x86_64-apple-darwin
           - macos-15           # aarch64-apple-darwin
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build
         run: cargo build --workspace --locked
@@ -67,11 +67,11 @@ jobs:
     name: lint YAML (action-validator + ryl)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install action-validator + ryl
         run: |
@@ -96,7 +96,7 @@ jobs:
     name: release workflow in sync (dist generate --check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -120,7 +120,7 @@ jobs:
     name: lint (clippy, fmt, typos, doc, deps, semver)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0   # semver-checks needs the v* baseline tag
           persist-credentials: false
@@ -128,10 +128,10 @@ jobs:
       - name: Install pinned nightly rustfmt
         run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component rustfmt
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install gate tools
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-machete,cargo-shear,cargo-semver-checks,typos
 
@@ -174,17 +174,17 @@ jobs:
     name: coverage (100% lines/regions/functions)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install pinned nightly with llvm-tools
         run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install coverage tools
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-llvm-cov,cargo-nextest
 
@@ -202,15 +202,15 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0   # need the base branch to diff the PR against
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install mutation tools
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-mutants,cargo-nextest
 
@@ -243,11 +243,11 @@ jobs:
           - {os: macos-15-intel, target: ""}
           - {os: macos-15, target: ""}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       # "Install" the way a user would: build from source and drop the binary in a
       # bin dir — exactly what `cargo install bdinfo-rs` does off crates.io. On Linux
@@ -296,11 +296,11 @@ jobs:
           - {os: ubuntu-latest, target: x86_64-unknown-linux-musl}
           - {os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       # Build the actual shipped artifact: the fully static musl release binary.
       # Pure-Rust (no C deps), so the musl target needs no C toolchain.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,15 +28,15 @@ jobs:
         # rust: the crates; actions: the workflow files themselves.
         language: [rust, actions]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,8 +9,8 @@ on:
     branches: [master]
   pull_request:
   schedule:
-    # Wednesdays 06:00 UTC — picks up new queries shipped in CodeQL releases.
-    - cron: "0 6 * * 3"
+    # Daily 06:00 UTC — picks up new queries shipped in CodeQL releases.
+    - cron: "0 6 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,11 +15,11 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: low
           comment-summary-in-pr: on-failure

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
     name: verify tag matches crate version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0   # ancestry check against master needs history
           persist-credentials: false
@@ -84,26 +84,26 @@ jobs:
             runner: ubuntu-24.04-arm
             arch: arm64
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -120,7 +120,7 @@ jobs:
           $digest = $env:DIGEST -replace '^sha256:', ''
           New-Item -ItemType File "$dir/$digest" | Out-Null
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digest-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -139,25 +139,25 @@ jobs:
       id-token: write       # sigstore signing for the attestations
       attestations: write   # record them in the GitHub attestation store
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digest-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -192,7 +192,7 @@ jobs:
       # private repo, where they would need GitHub Enterprise — as release.yml does.
       - name: Attest build provenance for the image
         if: ${{ !github.event.repository.private }}
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.digest.outputs.digest }}
@@ -203,7 +203,7 @@ jobs:
       # actually contains.
       - name: Generate the dependency SBOM
         if: ${{ !github.event.repository.private }}
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: .
           format: spdx-json
@@ -212,7 +212,7 @@ jobs:
 
       - name: Attest the SBOM for the image
         if: ${{ !github.event.repository.private }}
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.digest.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,23 +1,33 @@
 name: docker
 
-# Push a `vX.Y.Z` tag and a multi-arch image is published to the GitHub Container
-# Registry, versioned in lock-step with the binaries `release.yml` cuts from the
-# same tag. The runtime image is `FROM scratch` + the static musl binary (see the
-# Dockerfile), so there is nothing in it to emulate: each arch is built on its OWN
-# native runner, pushed by digest, and the two are stitched into one manifest list.
-# A tag resolves to that list, and `docker pull` auto-selects the caller's arch.
-# The manifest list also gets a signed SLSA provenance + SBOM attestation, free on
-# public repos — the same supply-chain trail release.yml attaches to the binaries.
+# Publish the multi-arch GHCR image AFTER the Release completes. The image ships
+# the EXACT static musl binary cargo-dist already built, checksummed, and attested
+# in release.yml: docker.yml downloads it from the published Release and packages it
+# `FROM scratch` (see the Dockerfile). So the binary in the image is byte-for-byte
+# the one users download — same SHA-256, same Sigstore attestation — not a separate
+# rebuild we would have to prove equivalent. There is no compile here, just a COPY.
+#
+# Triggered by release.yml FINISHING (workflow_run), not the tag push: that fires
+# only once the whole release has uploaded its assets, so the download never races
+# the upload. `workflow_dispatch` re-publishes the image for a given tag by hand
+# (e.g. if only the image push failed while the release itself is fine).
 #
 # Tags published for a release v1.2.3:  1.2.3, 1.2, 1, latest.
-# A `-pre.N` rehearsal tag publishes only the exact 1.2.3-pre.N — never latest.
+# A `-pre.N` rehearsal tag publishes only the exact 1.2.3-pre.N — never latest
+# (docker/metadata-action omits the rolling + latest tags for prereleases).
 #
-# Assumes a public repo (free arm64 runners + GHCR). The package inherits the
+# Assumes a public repo (free arm64 build minutes + GHCR). The package inherits the
 # repo's visibility; flip it to public once in the repo's package settings.
 
-on:
-  push:
-    tags: ["v*"]
+on:  # zizmor: ignore[dangerous-triggers] runs only after our own Release; checks out the released tag, never untrusted PR code
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to (re)publish the image for, e.g. v1.2.3"
+        required: true
 
 permissions:
   contents: read
@@ -27,66 +37,64 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  # ── Gate: the tag must be honest before anything is built (mirrors release.yml)
-  verify:
-    name: verify tag matches crate version
+  publish:
+    name: publish multi-arch image
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0   # ancestry check against master needs history
-          persist-credentials: false
-
-      - name: Parse the tag, compare to [workspace.package] version
-        shell: pwsh
-        run: |
-          $tag = $env:GITHUB_REF_NAME
-          if ($tag -notmatch '^v(?<ver>(?<base>\d+\.\d+\.\d+)(?:-(?<pre>[0-9A-Za-z][0-9A-Za-z.-]*))?)$') {
-            throw "Tag '$tag' is not vMAJOR.MINOR.PATCH[-prerelease]"
-          }
-          $base = $Matches['base']
-
-          # The version under [workspace.package] in the root Cargo.toml.
-          $inWp = $false; $crate = $null
-          foreach ($line in (Get-Content Cargo.toml)) {
-            if ($line -match '^\[workspace\.package\]') { $inWp = $true; continue }
-            if ($line -match '^\[') { $inWp = $false; continue }
-            if ($inWp -and $line -match '^version\s*=\s*"([^"]+)"') { $crate = $Matches[1]; break }
-          }
-          if (-not $crate) { throw 'No [workspace.package] version found in Cargo.toml' }
-          if ($base -ne $crate) {
-            throw "Tag $tag (base $base) does not match the workspace crate version $crate"
-          }
-
-          # The tagged commit must already be on master (i.e. gated by CI).
-          git merge-base --is-ancestor $env:GITHUB_SHA origin/master
-          if ($LASTEXITCODE -ne 0) { throw "Tagged commit $env:GITHUB_SHA is not on master" }
-
-  # ── Build: one NATIVE runner per arch, each pushed to GHCR by digest ───────
-  # No QEMU: a native runner links the matching arch directly (the `scratch`
-  # image runs nothing at build time). The image is pushed untagged, by digest;
-  # the merge job below applies the human tags to the assembled manifest list.
-  build:
-    name: build (${{ matrix.platform }})
-    needs: verify
-    runs-on: ${{ matrix.runner }}
+    # Skip unless the triggering Release succeeded (a failed release published
+    # nothing to package). A manual dispatch always proceeds.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            arch: amd64
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            arch: arm64
+      contents: read        # checkout the tagged source (Dockerfile + Cargo.lock)
+      packages: write       # push the image + attestations to GHCR
+      id-token: write       # sigstore signing for the attestations
+      attestations: write   # record them in the GitHub attestation store
     steps:
+      # The tag is the upstream Release run's branch (a tag push, so head_branch is
+      # the tag name), or the manual input. Validated to a vX.Y.Z[-pre] tag so a
+      # stray trigger fails loudly instead of building a mislabelled image.
+      - name: Resolve the release tag
+        id: tag
+        shell: pwsh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_TAG: ${{ github.event.workflow_run.head_branch }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          $tag = if ($env:EVENT_NAME -eq 'workflow_dispatch') { $env:DISPATCH_TAG } else { $env:WORKFLOW_RUN_TAG }
+          if ($tag -notmatch '^v\d+\.\d+\.\d+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$') {
+            throw "Not a release tag: '$tag' (expected vMAJOR.MINOR.PATCH[-prerelease])"
+          }
+          "tag=$tag" >> $env:GITHUB_OUTPUT
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ steps.tag.outputs.tag }}
           persist-credentials: false
+
+      # Pull the two musl archives dist attached to the Release and unpack just the
+      # binary into bin/<arch>/, the path the Dockerfile COPYs per TARGETARCH. dist
+      # wraps unix archives in a `<pkg>-<triple>/` dir, hence --strip-components=1.
+      - name: Download the released musl binaries and stage them per arch
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          New-Item -ItemType Directory -Force dl | Out-Null
+          gh release download $env:TAG --repo $env:REPO --pattern '*-unknown-linux-musl.tar.gz' --dir dl
+          if ($LASTEXITCODE -ne 0) { throw "gh release download failed for $env:TAG" }
+          $arches = [ordered]@{
+            'x86_64-unknown-linux-musl'  = 'amd64'
+            'aarch64-unknown-linux-musl' = 'arm64'
+          }
+          foreach ($triple in $arches.Keys) {
+            $arch = $arches[$triple]
+            New-Item -ItemType Directory -Force "bin/$arch" | Out-Null
+            tar -xzf "dl/bdinfo-rs-$triple.tar.gz" -C "bin/$arch" --strip-components=1 "bdinfo-rs-$triple/bdinfo-rs"
+            if ($LASTEXITCODE -ne 0) { throw "extract failed for $triple" }
+          }
+          Get-ChildItem -Recurse bin | Select-Object FullName, Length | Format-Table -AutoSize
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
@@ -100,93 +108,33 @@ jobs:
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # {{version}} = 1.2.3 (the `v` is dropped by Docker convention). The
+          # rolling 1.2 / 1 tags and `latest` apply to stable releases only —
+          # metadata-action omits them for a `-pre.N` prerelease. value= feeds the
+          # resolved tag because github.ref is the default branch on a workflow_run,
+          # not the tag.
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.tag.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag.outputs.tag }}
+            type=semver,pattern={{major}},value=${{ steps.tag.outputs.tag }}
 
-      - name: Build and push by digest
+      # No RUN in the Dockerfile, so a single multi-platform build needs no QEMU and
+      # emits the manifest list directly; outputs.digest is that list's digest.
+      - name: Build and push the multi-arch image
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export the digest
-        shell: pwsh
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          $dir = "${env:RUNNER_TEMP}/digests"
-          New-Item -ItemType Directory -Force $dir | Out-Null
-          $digest = $env:DIGEST -replace '^sha256:', ''
-          New-Item -ItemType File "$dir/$digest" | Out-Null
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: digest-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  # ── Merge: stitch the per-arch digests into one tagged manifest list, then
-  #    attest its provenance + SBOM (mirrors the binary attestation in release.yml).
-  merge:
-    name: publish manifest list
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read        # checkout (the Cargo.lock the SBOM is built from)
-      packages: write       # push the manifest list + attestations to GHCR
-      id-token: write       # sigstore signing for the attestations
-      attestations: write   # record them in the GitHub attestation store
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digest-*
-          merge-multiple: true
-
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        id: meta
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # {{version}} = 1.2.3 (the `v` is dropped by Docker convention); the
-          # rolling 1.2 / 1 tags and `latest` are applied to releases only, never
-          # to a `-pre.N` prerelease (metadata-action's default latest=auto).
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-
-      - name: Create the manifest list and push
-        working-directory: ${{ runner.temp }}/digests
-        shell: pwsh
-        run: |
-          $meta = $env:DOCKER_METADATA_OUTPUT_JSON | ConvertFrom-Json
-          $tags = $meta.tags | ForEach-Object { '-t', $_ }
-          $refs = Get-ChildItem -File | ForEach-Object { "${env:REGISTRY}/${env:IMAGE_NAME}@sha256:$($_.Name)" }
-          docker buildx imagetools create $tags $refs
-
-      - name: Capture the manifest-list digest
-        id: digest
-        shell: pwsh
-        env:
-          META_VERSION: ${{ steps.meta.outputs.version }}
-        run: |
-          $ref = "${env:REGISTRY}/${env:IMAGE_NAME}:${env:META_VERSION}"
-          $digest = "$(docker buildx imagetools inspect $ref --format '{{.Manifest.Digest}}')".Trim()
-          "digest=$digest" >> $env:GITHUB_OUTPUT
+          # Disable BuildKit's own provenance/SBOM attestations: they add
+          # `unknown/unknown` entries to the manifest list (changing the digest) and
+          # duplicate the GitHub Sigstore attestations attached below, which mirror
+          # the ones release.yml puts on the binaries. Keep the list to the 2 arches.
+          provenance: false
+          sbom: false
 
       # Attestations are free on public repos (Sigstore public-good); skipped on a
       # private repo, where they would need GitHub Enterprise — as release.yml does.
@@ -195,12 +143,12 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.digest.outputs.digest }}
+          subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
       # The image is `FROM scratch`: no OS packages to scan, so the SBOM is built
-      # from Cargo.lock — the crates compiled into the binary, i.e. what the image
-      # actually contains.
+      # from Cargo.lock at the tagged commit — the crates compiled into the binary,
+      # i.e. what the image actually contains.
       - name: Generate the dependency SBOM
         if: ${{ !github.event.repository.private }}
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -215,7 +163,7 @@ jobs:
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.digest.outputs.digest }}
+          subject-digest: ${{ steps.build.outputs.digest }}
           sbom-path: ${{ runner.temp }}/sbom.spdx.json
           push-to-registry: true
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -51,14 +51,14 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install pinned nightly
         run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: fuzz
           # Restore/save the cache only outside release runs: the replay job runs on
@@ -68,7 +68,7 @@ jobs:
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-fuzz
 
@@ -89,14 +89,14 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install pinned nightly
         run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: fuzz
           # Restore/save the cache only outside release runs: the replay job runs on
@@ -106,7 +106,7 @@ jobs:
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-fuzz
 
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashes
           path: fuzz/artifacts/

--- a/.github/workflows/guard-ancestor.yml
+++ b/.github/workflows/guard-ancestor.yml
@@ -19,7 +19,7 @@ jobs:
     name: tagged commit must be on master
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0   # ancestry check needs full history
           persist-credentials: false

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,20 +28,20 @@ jobs:
     name: Check links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       # Persist lychee's response cache so reruns only re-check day-old links.
       - name: Restore the lychee cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .lycheecache
           key: lychee-${{ github.run_id }}
           restore-keys: lychee-
 
       - name: Check links
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           # Whole repo; skip the generated lockfile and the binary fuzz seed
           # corpus (the binary disc fixtures are skipped automatically by their

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -3,7 +3,7 @@ name: link-check
 # Stale-link guard: lychee verifies every URL and relative/file link across the
 # repo (README, CHANGELOG, DIFFERENCES, CONTRIBUTING, the issue templates, the
 # Cargo/audit metadata, and the doc-comment URLs in src). Runs on every push/PR
-# like the other quality gates, plus weekly to catch links that rot after merge
+# like the other quality gates, plus daily to catch links that rot after merge
 # (external pages move without touching our code). Cheap: lychee caches its
 # results and only re-checks day-old links; a residual rate-limit (429) is
 # accepted rather than failed, so an external host can't red-X an unrelated push.
@@ -13,7 +13,7 @@ on:
     branches: [master]
   pull_request:
   schedule:
-    - cron: "0 7 * * 3"   # Wednesdays 07:00 UTC — catch post-merge rot
+    - cron: "0 7 * * *"   # daily 07:00 UTC — catch post-merge rot
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -103,7 +103,7 @@ jobs:
     env:
       VERSION: ${{ needs.gate.outputs.version }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -146,12 +146,12 @@ jobs:
           - {triple: x86_64-unknown-linux-musl, os: ubuntu-latest}
           - {triple: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install cargo-deb
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-deb
 
@@ -223,12 +223,12 @@ jobs:
           - {triple: x86_64-unknown-linux-musl, os: ubuntu-latest}
           - {triple: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install cargo-generate-rpm
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-generate-rpm
 

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
       id-token: write # mint the short-lived crates.io OIDC token
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Authenticate to crates.io (Trusted Publishing / OIDC)
         id: auth
-        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
       - name: Publish both crates (core first)
         run: cargo publish --workspace --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -81,7 +81,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -126,7 +126,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -152,7 +152,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -168,7 +168,7 @@ jobs:
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
       - name: Attest
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
@@ -185,7 +185,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -202,19 +202,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -232,7 +232,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts-build-global
           path: |
@@ -252,19 +252,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -277,14 +277,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-*
           path: artifacts
@@ -317,14 +317,14 @@ jobs:
       GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true
           repository: "agentjp/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-*
           path: Formula/
@@ -364,7 +364,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,7 @@ on:
   # Re-score when branch protection changes (Scorecard reads those settings).
   branch_protection_rule:
   schedule:
-    - cron: "0 6 * * 2"   # Tuesdays 06:00 UTC
+    - cron: "0 6 * * *"   # daily 06:00 UTC
   push:
     branches: [master]
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,7 @@ jobs:
       id-token: write          # publish results to the OpenSSF API
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -38,13 +38,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/toml.yml
+++ b/.github/workflows/toml.yml
@@ -30,7 +30,10 @@ jobs:
       - name: Install taplo (prebuilt, no from-source compile)
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
-          tool: taplo-cli
+          # Pinned (not latest) so a new taplo can't reformat/relint the tree and
+          # red-X an unrelated PR; version-freshness watches it against crates.io
+          # and the bump stays deliberate, like rustfmt's nightly pin.
+          tool: taplo-cli@0.10.0
 
       # taplo auto-discovers taplo.toml (include/exclude + formatting). --check
       # fails on any unformatted file; --diff prints exactly what differs.

--- a/.github/workflows/toml.yml
+++ b/.github/workflows/toml.yml
@@ -23,12 +23,12 @@ jobs:
     name: lint TOML (taplo)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install taplo (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: taplo-cli
 

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -6,10 +6,13 @@ name: version-freshness
 #   - cargo-dist (dist-workspace.toml `cargo-dist-version` AND the `cargo-dist@X`
 #     install in ci.yml — the two must stay equal),
 #   - cargo-vet (the `--version` pin in audit.yml),
-#   - the Dockerfile `rust:<ver>-slim` build base (must track the stable pin).
-# (Cargo deps/dev-deps, GitHub Action SHAs, and the Dockerfile digest are already
-# auto-bumped by Dependabot — cargo + github-actions + docker ecosystems — so they
-# are deliberately NOT re-checked here.)
+#   - ryl (the `cargo install ryl --version` pin in ci.yml's YAML-lint job).
+# (Cargo deps/dev-deps and GitHub Action SHAs are already auto-bumped by
+# Dependabot — cargo + github-actions ecosystems — so they are deliberately NOT
+# re-checked here. The other gate tools — taplo, zizmor, action-validator,
+# cargo-{machete,shear,semver-checks,llvm-cov,nextest,mutants,deny}, typos — are
+# installed at LATEST every run, so they self-update and have no pin to rot. The
+# Dockerfile is `FROM scratch`, so there is no build-base tag to track either.)
 #
 # This daily ~1-minute job compares each silently-rotting pin to its upstream
 # latest (and cross-checks the pins that must agree); when anything is stale or
@@ -58,6 +61,19 @@ jobs:
             return $null
           }
 
+          # The latest stable version of a crates.io crate (the source `cargo
+          # install <crate> --version X` resolves against — more authoritative
+          # than GitHub releases, which a crate may not publish), or $null on
+          # failure. crates.io rejects requests without a User-Agent.
+          function Latest-CratesIo($crate) {
+            try {
+              $resp = Invoke-RestMethod -Uri "https://crates.io/api/v1/crates/$crate" `
+                -Headers @{ 'User-Agent' = 'bdinfo-rs-version-freshness (github actions)' } -ErrorAction Stop
+              return $resp.crate.max_stable_version
+            }
+            catch { return $null }
+          }
+
           # --- Rust stable: rust-toolchain.toml vs rust-lang/rust ---------------
           $stablePin = Read-Pin 'rust-toolchain.toml' '^channel\s*=\s*"([0-9.]+)"'
           if (-not $stablePin) { throw 'No pinned stable channel in rust-toolchain.toml' }
@@ -101,17 +117,19 @@ jobs:
             $problems += "- cargo-vet pin ``$vetPin`` (audit.yml) is behind the latest release ``$vetLatest``"
           }
 
-          # --- Dockerfile build base must track the stable pin -----------------
-          # (Dependabot's docker ecosystem refreshes the digest + proposes newer
-          # tags; this just asserts the tag stays in lockstep with the toolchain.)
-          $dockerRust = Read-Pin 'Dockerfile' 'FROM rust:([0-9.]+)'
-          if (-not $dockerRust) { throw 'No `FROM rust:<version>` base image in Dockerfile' }
-          $stableMajorMinor = ($stablePin -split '\.')[0..1] -join '.'
-          if ($dockerRust -ne $stableMajorMinor) {
-            $problems += "- Dockerfile base ``rust:$dockerRust-slim`` does not match the stable Rust pin ``$stablePin`` (rust-toolchain.toml) — bump the tag to ``rust:$stableMajorMinor-slim``"
+          # --- ryl: ci.yml YAML-lint pin vs crates.io --------------------------
+          # ryl is pinned (`cargo install ryl --version X`) so the YAML lint stays
+          # reproducible; nothing else watches it, so check it here like cargo-vet.
+          $rylPin = Read-Pin '.github/workflows/ci.yml' 'cargo install ryl --version ([0-9.]+)'
+          if (-not $rylPin) { throw 'No `cargo install ryl --version` pin in ci.yml' }
+          $rylLatest = Latest-CratesIo 'ryl'
+          if (-not $rylLatest) {
+            $problems += '- could not query the latest ryl release (crates.io)'
+          } elseif ([version]$rylLatest -gt [version]$rylPin) {
+            $problems += "- ryl pin ``$rylPin`` (ci.yml) is behind the latest release ``$rylLatest``"
           }
 
-          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  docker-rust: $dockerRust"
+          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  ryl: $rylPin (latest $rylLatest)"
           if ($problems.Count -eq 0) { Write-Host 'All pinned versions are fresh and consistent.'; exit 0 }
 
           $title = 'Pinned versions are stale'

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -30,7 +30,7 @@ jobs:
     name: compare pinned versions to upstream
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -6,10 +6,13 @@ name: version-freshness
 #   - cargo-dist (dist-workspace.toml `cargo-dist-version` AND the `cargo-dist@X`
 #     install in ci.yml — the two must stay equal),
 #   - cargo-vet (the `--version` pin in audit.yml),
-#   - ryl (the `cargo install ryl --version` pin in ci.yml's YAML-lint job).
+#   - ryl (the `cargo install ryl --version` pin in ci.yml's YAML-lint job),
+#   - taplo (the `tool: taplo-cli@X` pin in toml.yml — a formatter, pinned like
+#     rustfmt so a new release can't reformat/relint the tree out from under a PR).
 # (Cargo deps/dev-deps and GitHub Action SHAs are already auto-bumped by
 # Dependabot — cargo + github-actions ecosystems — so they are deliberately NOT
-# re-checked here. The other gate tools — taplo, zizmor, action-validator,
+# re-checked here. The remaining gate tools — zizmor (a security linter, kept at
+# latest on purpose so new vuln checks land immediately), action-validator,
 # cargo-{machete,shear,semver-checks,llvm-cov,nextest,mutants,deny}, typos — are
 # installed at LATEST every run, so they self-update and have no pin to rot. The
 # Dockerfile is `FROM scratch`, so there is no build-base tag to track either.)
@@ -88,7 +91,7 @@ jobs:
           $nightlyPin = Read-Pin '.github/workflows/ci.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
           if (-not $nightlyPin) { throw 'No NIGHTLY pin in ci.yml' }
           $nightlyAgeDays = [int]((Get-Date) - [datetime]::ParseExact($nightlyPin, 'yyyy-MM-dd', $null)).TotalDays
-          if ($nightlyAgeDays -gt 90) {
+          if ($nightlyAgeDays -gt 30) {
             $problems += "- nightly pin ``nightly-$nightlyPin`` (ci.yml NIGHTLY + scripts/_common.ps1) is $nightlyAgeDays days old"
           }
 
@@ -129,7 +132,19 @@ jobs:
             $problems += "- ryl pin ``$rylPin`` (ci.yml) is behind the latest release ``$rylLatest``"
           }
 
-          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  ryl: $rylPin (latest $rylLatest)"
+          # --- taplo: toml.yml `tool: taplo-cli@X` pin vs crates.io -------------
+          # Pinned like ryl so the TOML format/lint stays reproducible; nothing
+          # else watches it.
+          $taploPin = Read-Pin '.github/workflows/toml.yml' 'tool:\s*taplo-cli@([0-9.]+)'
+          if (-not $taploPin) { throw 'No `tool: taplo-cli@<version>` pin in toml.yml' }
+          $taploLatest = Latest-CratesIo 'taplo-cli'
+          if (-not $taploLatest) {
+            $problems += '- could not query the latest taplo release (crates.io taplo-cli)'
+          } elseif ([version]$taploLatest -gt [version]$taploPin) {
+            $problems += "- taplo pin ``$taploPin`` (toml.yml) is behind the latest release ``$taploLatest``"
+          }
+
+          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  ryl: $rylPin (latest $rylLatest)  taplo: $taploPin (latest $taploLatest)"
           if ($problems.Count -eq 0) { Write-Host 'All pinned versions are fresh and consistent.'; exit 0 }
 
           $title = 'Pinned versions are stale'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -31,12 +31,12 @@ jobs:
     name: zizmor (workflow security)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install zizmor (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: zizmor
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ name: zizmor
 # poisoning, dangerous triggers, credential persistence, and more. Runs the FULL
 # audit set online — the GITHUB_TOKEN enables the impostor-commit /
 # known-vulnerable-actions checks that need the GitHub API — and hard-fails on any
-# finding, like the other quality gates. Weekly too, so a newly-disclosed
+# finding, like the other quality gates. Daily too, so a newly-disclosed
 # vulnerable action surfaces between pushes. The only accepted residuals live in
 # .github/zizmor.yml (the cargo-dist-generated release.yml, which cannot be
 # hand-edited) and inline (the two architecturally-required workflow_run triggers);
@@ -16,7 +16,7 @@ on:
     branches: [master]
   pull_request:
   schedule:
-    - cron: "0 7 * * 4"   # Thursdays 07:00 UTC — catch newly-disclosed action vulns
+    - cron: "0 7 * * *"   # daily 07:00 UTC — catch newly-disclosed action vulns
   workflow_dispatch:
 
 permissions:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -6,6 +6,10 @@
 # Each is an accepted, structural residual of cargo-dist's own template, scoped to
 # release.yml by rule id (whole-file, since regeneration shifts line numbers).
 # Findings in every hand-maintained workflow are fixed in place, not ignored.
+#
+# ref-version-mismatch is intentionally NOT suppressed: every SHA pin carries the
+# EXACT immutable tag it resolves to (`# vX.Y.Z`, not a moving major `# vN`), so a
+# pin's comment can never drift from its hash and Dependabot bumps both together.
 rules:
   # cargo-dist hardcodes a top-level `contents: write` (needed to upload release
   # assets); it is not tightenable without editing the generated file.
@@ -28,11 +32,3 @@ rules:
   template-injection:
     ignore:
       - release.yml
-  # The online run still does the security-critical impostor-commit check, but
-  # ref-version-mismatch wants each pin's comment to name the EXACT tag the SHA
-  # resolves to (e.g. `# v2.82.0`). This repo deliberately pins `<sha> # vN` (the
-  # major line), a convention documented in CLAUDE.md and kept by Dependabot, so a
-  # patch bump never churns the comment. Disabled rather than re-pinned to exact
-  # tags on ~40 actions (which would also fight the dist-generated release.yml).
-  ref-version-mismatch:
-    disable: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,26 @@
-# bdinfo-rs is one fully-static, zero-C-dependency musl binary, so the runtime
-# image is literally just that binary on `scratch`: no libc, no shell, no OS —
+# bdinfo-rs ships as one fully-static, zero-C-dependency musl binary, so the
+# runtime image is literally that binary on `scratch`: no libc, no shell, no OS —
 # a ~2 MB image with nothing to patch and no attack surface beyond the binary.
 #
-# The build stage runs on the *target* platform and builds that arch's musl
-# binary natively (the matching system linker handles the static link; Rust adds
-# no C of its own). So `docker build` works as-is on amd64 and arm64 hosts, and
-# CI gets a multi-arch image by building each arch on its own native runner.
-
-# --- build: compile the static musl binary --------------------------------
-# `cargo auditable build` (not plain `cargo build`) embeds the dependency tree in
-# the binary's `.dep-v0` section, so the GHCR image is auditable by the same tools
-# as the release binaries (`cargo audit bin`, trivy, grype) — matching the
-# cargo-auditable=true that release.yml's dist build uses. Pure Rust, no C, no
-# runtime dep: the FROM-scratch static guarantee is unchanged.
-FROM rust:1.96-slim@sha256:3b05f7c617a200c41c3506097f0d15fc193a1c93bfd8f141007b47cac8f95d3c AS build
-ARG TARGETARCH
-WORKDIR /src
-COPY . .
-RUN set -eux; \
-    case "$TARGETARCH" in \
-      amd64) target=x86_64-unknown-linux-musl  ;; \
-      arm64) target=aarch64-unknown-linux-musl ;; \
-      *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
-    esac; \
-    rustup target add "$target"; \
-    cargo install cargo-auditable --locked; \
-    cargo auditable build --release -p bdinfo-rs --target "$target" --locked; \
-    cp "target/$target/release/bdinfo-rs" /bdinfo-rs
-
-# --- runtime: the binary, alone -------------------------------------------
+# The image ships the EXACT binary the release pipeline already cut, not a separate
+# rebuild: docker.yml downloads the published `*-unknown-linux-musl.tar.gz` archives
+# from the GitHub Release and stages each arch's binary under `bin/<arch>/` before
+# this build. So the binary inside the image is byte-for-byte the one users
+# download — same SHA-256, same cargo-auditable `.dep-v0` section, covered by the
+# SAME Sigstore attestation — with nothing to "prove equivalent" because it IS the
+# same artifact. cargo-dist owns that binary (release.yml); here we only package it.
+#
+# There is no build stage and no RUN: the image only COPYs a prebuilt binary, so a
+# single `docker buildx --platform linux/amd64,linux/arm64` build needs no QEMU and
+# emits the multi-arch manifest list directly. TARGETARCH is the buildx-provided
+# per-platform arch (`amd64` | `arm64`), so each platform copies its own binary.
+#
+# Build a local image from a checkout by staging a binary first, then building that
+# one arch, e.g.:
+#   cargo build --release -p bdinfo-rs
+#   mkdir -p bin/amd64 && cp target/release/bdinfo-rs bin/amd64/bdinfo-rs
+#   docker build --platform linux/amd64 .
 FROM scratch
-COPY --from=build /bdinfo-rs /bdinfo-rs
+ARG TARGETARCH
+COPY bin/${TARGETARCH}/bdinfo-rs /bdinfo-rs
 ENTRYPOINT ["/bdinfo-rs"]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -130,14 +130,17 @@ host = "aarch64-pc-windows-msvc"
 # Pin every action dist emits to a full-length commit SHA so the GENERATED
 # release.yml satisfies Scorecard's pinned-dependencies check — without detaching
 # from dist (the `dist generate --check` drift guard in ci.yml stays green because
-# this IS what dist now generates). The trailing `# vN` rides along in the value
-# (dist renders `{name}@{value}` verbatim) so the pins read like the rest of the
-# repo and Dependabot tracks them. Each pin is dist 0.32's own default major
-# (checkout v6, upload-artifact v7, download-artifact v8, attest v4): we stay on
-# dist's tested versions and just pin them — checkout v7 now matches the
-# hand-maintained workflows, so the whole repo tracks one SHA.
+# this IS what dist now generates). The trailing comment names the EXACT immutable
+# tag the SHA resolves to (`# vX.Y.Z`, not the moving major `# vN`): it rides along
+# in the value (dist renders `{name}@{value}` verbatim) so release.yml satisfies
+# zizmor's ref-version-mismatch audit like the hand-maintained workflows, and a
+# stale pin can never make the comment lie (an exact tag is immutable, a moving
+# major is not). Dependabot bumps the SHA and the comment together. The SHA is
+# still dist 0.32's own default major line (checkout v7, upload-artifact v7,
+# download-artifact v8, attest v4) — we only made the comment exact; checkout v7
+# matches the hand-maintained workflows, so the whole repo tracks one SHA.
 [dist.github-action-commits]
-"actions/checkout" = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7"
-"actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7"
-"actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
-"actions/attest" = "59d89421af93a897026c735860bf21b6eb4f7b26 # v4"
+"actions/checkout" = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0"
+"actions/upload-artifact" = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"
+"actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1"
+"actions/attest" = "59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0"


### PR DESCRIPTION
Rolling polish branch — pins, distribution hygiene, and CI cadence. Six commits, merged once green.

## Done

### 1. Pin every action to its exact release tag + enable zizmor `ref-version-mismatch`
- Every SHA-pinned action now carries the **exact immutable tag** it resolves to (`# vX.Y.Z`) instead of the moving major (`# vN`). An exact tag can never drift from its hash, so the pin comment stays honest for good and Dependabot bumps the SHA and comment together. (Moving-major comments pass only while upstream hasn't moved the major tag — latent CI breakage; exact tags are immune.)
- Resolved each pin against GitHub (e.g. `actions/checkout` → `# v7.0.0`, `taiki-e/install-action` → `# v2.82.0`, `docker/build-push-action` → `# v7.2.0`). Pins with no more-specific tag are left as-is (`winget-releaser # v2`, `Homebrew/actions/setup-homebrew # master`).
- The four dist-managed pins were updated in `dist-workspace.toml` `[dist.github-action-commits]` and `release.yml` was regenerated with `dist generate` (drift guard `dist generate --check` stays green).
- Removed `ref-version-mismatch: disable: true` from `.github/zizmor.yml`; the audit is now enforced. `zizmor .github/workflows` reports **0 findings**.

### 2. Ship the released binary in the Docker image instead of rebuilding it
- The image previously **recompiled** the binary inside the Dockerfile (`cargo auditable build`), a second build separate from the released artifact — not byte-identical (no reproducible-build controls) and outside dist's Sigstore attestation chain.
- Now `docker.yml` downloads the published `*-unknown-linux-musl.tar.gz` archives from the Release and packages them `FROM scratch`. The image binary is **byte-for-byte** the one users download — same SHA-256, same cargo-auditable `.dep-v0`, covered by the **same** attestation. Nothing to prove equivalent because it *is* the same artifact.
- `Dockerfile`: 34 → ~5 lines (no toolchain, no `RUN`). `docker.yml`: ~227 lines / 3 jobs → one job. A single `buildx --platform amd64,arm64` emits the manifest list directly (no QEMU, no per-arch runners, no digest-merge job, no redundant `verify` job — release.yml already gates tag==version + on-master). `.dockerignore` slimmed to the staged binary only.
- Triggered via `workflow_run: ["Release"]` (race-free — fires after assets upload), plus `workflow_dispatch` for manual re-publish. BuildKit's own provenance/SBOM disabled so the GitHub Sigstore attestations (matching release.yml) are the single source.

**Note:** the Docker build only runs on a real release tag, so this PR's CI exercises the lint/security gates (zizmor/yaml/taplo — all green) but not the image build itself. The multi-arch `FROM scratch` + `TARGETARCH` build was smoke-tested locally with buildx.

### 3. Run every scheduled workflow on a daily cron
- `audit`, `codeql`, `scorecard`, `link-check`, and `zizmor` moved from weekly to daily (`0 6/7 * * *`); `version-freshness` and `install-smoke-test` were already daily. Every gate that runs on a *schedule* (independent of push / PR / release) now runs daily, so a newly-disclosed CVE, action vuln, broken link, or stale pin surfaces within a day instead of up to a week.

### 4. Switch Dependabot to daily + drop the dead docker ecosystem
- `cargo` and `github-actions` ecosystems → `interval: daily` (still grouped: at most one PR per ecosystem per day, and only when a member actually has an update).
- Removed the `docker` ecosystem entry: the `FROM scratch` Dockerfile (§2) has no base image or digest to bump; the docker GitHub Actions in `docker.yml` are covered by the `github-actions` ecosystem.

### 5. Make version-freshness cover every live pin + tighten the nightly nag
- Added checks for the two silently-rotting pins nothing watched: **ryl** (`cargo install ryl --version` in `ci.yml`) and **taplo** (now pinned `tool: taplo-cli@0.10.0` in `toml.yml`), both compared against crates.io. taplo had been floating on latest — a formatter that could reformat/relint the tree and red-X an unrelated PR; it's now pinned like rustfmt and watched.
- Removed the obsolete `FROM rust:<ver>` Dockerfile-base check — it `throw`s every run now that the image is `FROM scratch` (§2).
- Tightened the nightly-staleness threshold from **90 → 30 days**.
- Resulting coverage: cargo deps + Action SHAs → Dependabot; Rust stable/nightly, cargo-dist (×2, cross-checked), cargo-vet, ryl, taplo → version-freshness; the remaining gate tools install at latest (self-updating, nothing to rot); zizmor floats deliberately (a security linter — newest vuln checks should land immediately).
