### PR TITLE
Bump taiki-e/install-action from 2.82.0 to 2.82.2

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Install cargo-deny (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-deny
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install gate tools
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-machete,cargo-shear,cargo-semver-checks,typos
 
@@ -184,7 +184,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install coverage tools
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-llvm-cov,cargo-nextest
 
@@ -210,7 +210,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install mutation tools
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-mutants,cargo-nextest
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -68,7 +68,7 @@ jobs:
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-fuzz
 
@@ -106,7 +106,7 @@ jobs:
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-fuzz
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -151,7 +151,7 @@ jobs:
           persist-credentials: false
 
       - name: Install cargo-deb
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-deb
 
@@ -228,7 +228,7 @@ jobs:
           persist-credentials: false
 
       - name: Install cargo-generate-rpm
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-generate-rpm
 

--- a/.github/workflows/toml.yml
+++ b/.github/workflows/toml.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Install taplo (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           # Pinned (not latest) so a new taplo can't reformat/relint the tree and
           # red-X an unrelated PR; version-freshness watches it against crates.io

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Install zizmor (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: zizmor
 


### PR DESCRIPTION
Bumps `taiki-e/install-action` from 2.82.0 to 2.82.2 across the six hand-maintained workflows (audit, ci, fuzz, packages, toml, zizmor), SHA-pinned with the exact immutable tag comment. The cargo-dist-generated `release.yml` does not use this action, so there is no `dist-workspace.toml` pin to sync. Recreated as a signed commit in place of Dependabot #19.