### PR TITLE
Print help and exit 0 when run with no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Running `bdinfo-rs` with no arguments now prints the help and exits 0, instead
+  of clap's missing-argument usage error (exit 2). Invoking it with an actual but
+  invalid argument still reports a usage error. This makes a bare run friendlier
+  (such as a double-clicked binary) and lets package-manager install validators
+  that smoke-run the executable see a clean exit.
+
 ### Added
 
 - **Install by name on Linux**: `apt install bdinfo-rs` (Debian/Ubuntu) and

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -51,6 +51,7 @@ use bdinfo_rs_core::error::{BdError, ScanError};
 use bdinfo_rs_core::report::text;
 use bdinfo_rs_core::vfs::fs::FsDir;
 use bdinfo_rs_core::vfs::udf::source::{PathIso, UdfSource};
+use clap::CommandFactory as _;
 use crossterm::style::Stylize as _;
 use crossterm::{Command as _, cursor, terminal};
 
@@ -62,6 +63,18 @@ use crossterm::{Command as _, cursor, terminal};
 include!("cli.rs");
 
 fn main() -> ExitCode {
+    // A bare invocation (no arguments at all) prints the help to stdout and
+    // exits 0, rather than letting clap reject the missing required BD_PATH with
+    // a usage error on stderr (exit 2). Treating "no arguments" as a help request
+    // is friendlier for a double-clicked binary, and keeps package-manager
+    // install validators that smoke-run the executable from reading a clean run
+    // as a failure. Any actual argument still parses normally — a missing or bad
+    // path remains the usual exit-2 usage error. `args_os` (not `args`) so a
+    // non-UTF-8 argument can't panic this check.
+    if std::env::args_os().nth(1).is_none() {
+        let _ = Cli::command().print_long_help().is_ok();
+        return ExitCode::SUCCESS;
+    }
     ExitCode::from(run(&Cli::parse()))
 }
 

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -46,6 +46,20 @@ fn help_shows_the_normalized_surface_and_exits_zero() {
     }
 }
 
+#[test]
+fn no_arguments_print_help_and_exit_zero() {
+    // A bare invocation is treated as a help request: the long help goes to
+    // stdout and the process exits 0 (not clap's exit-2 usage error), with
+    // nothing on stderr. Any actual argument still parses — see
+    // `a_subcommand_style_invocation_is_just_a_bad_path` for the exit-2 path.
+    let output = bdinfo_rs().output().expect("spawn bdinfo-rs");
+    assert!(output.status.success(), "no-args exits 0: {:?}", output.status.code());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Usage:"), "no-args prints usage: {stdout}");
+    assert!(stdout.contains("<BD_PATH>"), "no-args prints help: {stdout}");
+    assert!(output.stderr.is_empty(), "no error output on a help request: {:?}", output.stderr);
+}
+
 /// A valid zero-item `*.mpls` (magic `MPLS0300`, one empty `PlayList`, no marks)
 /// — enough for the scan to emit its playlist row.
 fn empty_mpls() -> Vec<u8> {


### PR DESCRIPTION
## What

Running `bdinfo-rs` with **no arguments** now prints the help to stdout and exits **0**, instead of clap's missing-`BD_PATH` usage error on stderr (exit **2**). Any actual-but-invalid argument (bad flag, nonexistent path) still reports the usual usage error / exit 2 — only the truly-empty invocation changes.

## Why

A bare run is friendlier (e.g. a double-clicked binary shows usage instead of flashing an error), and — the motivating reason — package-manager install validators that smoke-run the executable no longer read a clean run as a failure.

winget's validation pipeline installs the portable and runs `bdinfo-rs.exe`; exit 2 trips its executable check and forces a manual moderator waiver on **every** release. clap-based CLIs that require an argument (e.g. `sharkdp.hyperfine`, `chmln.sd`) hit exactly this and are merged only via a `Waived-Validation-Executable-Error` moderator action. Exiting 0 on a bare run removes that friction for all future releases.

## How

- `main()` intercepts an empty argv (`std::env::args_os().nth(1).is_none()`) before clap parsing, prints the long help, and returns `ExitCode::SUCCESS`. The `Cli` struct is unchanged, so `--help`/`--version` (already exit 0) and every parse-level test are untouched.

## Tests / gate

- New end-to-end test `no_arguments_print_help_and_exit_zero` (asserts exit 0, `Usage:`/`<BD_PATH>` on stdout, empty stderr).
- Core gate green: 100% lines/regions/functions, branches 97.84%; scoped `cargo mutants --in-diff` on the change = 1 mutant, 0 missed.
- Verified on the release binary: no-args→0, bad-path→2, `--version`/`--help`→0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)