### PR TITLE
ci: bump ryl pin to 0.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install action-validator + ryl
         run: |
           cargo install action-validator --locked
-          cargo install ryl --version 0.20.0 --locked
+          cargo install ryl --version 0.21.0 --locked
 
       - name: Schema-validate the workflow YAML (action-validator)
         run: |


### PR DESCRIPTION
The daily version-freshness check (#24) flagged the ryl YAML-lint pin
in `ci.yml` as behind its latest crates.io release.

- Bumps `cargo install ryl --version` from `0.20.0` to `0.21.0` in the
  `yaml` job (the action-validator + ryl lint).

No Rust source changed — CI-tooling-only. Validated locally with
action-validator, ryl (YAML well-formedness), and zizmor (no findings).

Closes #24