### PR TITLE
chore(release): prepare the 1.0.1 release

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -72,8 +72,15 @@ jobs:
   winget:
     name: WinGet
     runs-on: ubuntu-latest
+    # GATED OFF (2026-06-23): winget-releaser UPDATES an existing package — it bases
+    # the new manifest on the package's prior version already in microsoft/winget-pkgs.
+    # The first submission (agentjp.bdinfo-rs 1.0.0) is still an open New-Package PR
+    # awaiting manual moderator review, so an auto-update now would fail (no base
+    # manifest) and could jump ahead of that pending PR. Re-enable by setting the repo
+    # variable WINGET_ENABLED=true once 1.0.0 has merged into winget-pkgs master — no
+    # code change needed; the WINGET_TOKEN secret is already set.
     needs: gate
-    if: needs.gate.outputs.stable == 'true'
+    if: ${{ needs.gate.outputs.stable == 'true' && vars.WINGET_ENABLED == 'true' }}
     env:
       VERSION: ${{ needs.gate.outputs.version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,34 +12,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      heading shape used below, which cargo-dist parses for the GitHub Release notes. See
      CONTRIBUTING.md § "Cutting a release". -->
 
-## [Unreleased]
+## [v1.0.1](https://github.com/agentjp/bdinfo-rs/compare/v1.0.0...218dab463b7973086ae318e8d38da945787dd458) (2026-06-22)
 
-### Changed
+### Features
 
-- Running `bdinfo-rs` with no arguments now prints the help and exits 0, instead
-  of clap's missing-argument usage error (exit 2). Invoking it with an actual but
-  invalid argument still reports a usage error. This makes a bare run friendlier
-  (such as a double-clicked binary) and lets package-manager install validators
-  that smoke-run the executable see a clean exit.
+* **packaging:** install by name on Linux — `apt install bdinfo-rs` (Debian/Ubuntu)
+  and `dnf install bdinfo-rs` (Fedora/RHEL/openSUSE) from a hosted package
+  repository, in addition to the standalone `.deb`/`.rpm` release downloads.
 
-### Added
+### Bug Fixes
 
-- **Install by name on Linux**: `apt install bdinfo-rs` (Debian/Ubuntu) and
-  `dnf install bdinfo-rs` (Fedora/RHEL/openSUSE) from a hosted package repository —
-  add the repo once, then use your package manager normally, updates included — in
-  addition to the standalone `.deb`/`.rpm` release downloads.
-- README: an installed-footprint size comparison and an "owned discs only" usage
-  policy; a one-paragraph code of conduct; and a structured output-difference
-  issue template.
-
-### Fixed
-
-- `cargo binstall bdinfo-rs` now resolves the prebuilt release archives via
-  explicit binstall metadata, including the flat Windows `.zip` layout. (1.0.0
-  shipped no binstall configuration, so installs fell back to fragile
-  auto-detection.)
-- The `.deb` and `.rpm` release packages now publish automatically on every release
-  (1.0.0's had to be attached by hand).
+* **cli:** running `bdinfo-rs` with no arguments now prints the help and exits 0
+  instead of clap's missing-argument usage error (exit 2); an actual but invalid
+  argument still reports a usage error. Friendlier for a double-clicked binary and
+  for package-manager install validators that smoke-run the executable.
+* **packaging:** `cargo binstall bdinfo-rs` now resolves the prebuilt release
+  archives via explicit binstall metadata, including the flat Windows `.zip` layout
+  (1.0.0 shipped no binstall configuration).
+* **packaging:** the `.deb` and `.rpm` release packages now publish automatically
+  on every release (1.0.0's had to be attached by hand).
 
 ## [1.0.0] - 2026-06-19
 
@@ -92,5 +83,4 @@ which of these are visible on a normal disc.
 - AC-3 low-sample-rate frame-size shift.
 - DTS core 1536 kbps bitrate.
 
-[Unreleased]: https://github.com/agentjp/bdinfo-rs/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/agentjp/bdinfo-rs/releases/tag/v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bdinfo-rs-core",
  "clap",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proptest",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["crates/bdinfo-rs-core", "crates/bdinfo-rs"]
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.96"
 # LGPL (unlike GPL) permits use from other applications.
@@ -118,7 +118,7 @@ private_intra_doc_links = "allow"
 
 [workspace.dependencies]
 # Internal (version + path so bdinfo-rs is publishable to crates.io).
-bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "1.0.0" }
+bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "1.0.1" }
 # External (pinned to latest stable minor; deny.toml forbids wildcards).
 clap = { version = "4.6", features = ["derive"] }
 proptest = "1.11"


### PR DESCRIPTION
Prepares the 1.0.1 release. Merging this does **not** publish anything — pushing the `v1.0.1` tag after merge triggers the release pipeline.

### Changes

- **version**: `[workspace.package]` 1.0.0 → 1.0.1 (both crates inherit; the internal `bdinfo-rs-core` pin and `Cargo.lock` move in lock-step).
- **changelog**: add the `[v1.0.1]` section. This is the first release straddling the convco adoption, so the section is convco's mechanical output with the pre-convco user-facing commits folded in by hand (apt/dnf install-by-name, the no-args help/exit-0 behavior, the binstall metadata fix, and automatic `.deb`/`.rpm` publishing).
- **packaging**: gate the WinGet auto-update job behind a new `WINGET_ENABLED` repo variable (mirrors `AUR_ENABLED`). `winget-releaser` updates an existing package, but `agentjp.bdinfo-rs` 1.0.0 is still an open New-Package PR in winget-pkgs, so auto-updating now would fail. Set `WINGET_ENABLED=true` once 1.0.0 merges to re-enable.

The local gate (`scripts/compliance.ps1`) is green.
