### PR TITLE
ci(release): add the man page and shell completions to the Homebrew formula

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,93 @@
+name: homebrew
+
+# Custom dist PUBLISH job, wired via `publish-jobs = ["./homebrew"]` in
+# dist-workspace.toml. It REPLACES dist's built-in `homebrew` publish job (removed
+# from publish-jobs) while dist still GENERATES the formula (the `homebrew`
+# installer stays in `installers`, and dist attaches the generated `.rb` to the
+# GitHub Release).
+#
+# WHY THIS EXISTS: dist's generated formula (templates/installer/homebrew.rb.j2)
+# installs ONLY the binary and dumps the man page + shell completions into pkgshare
+# — its `def install` has no `man1.install` / `*_completion.install`, and the
+# homebrew installer config exposes no way to add them (only `tap` and `formula`).
+# So we take dist's own generated formula, add the four install lines, and push it
+# to the tap ourselves: ONE commit per release, reusing dist's correct multi-arch
+# url/sha generation. Nothing else dist does changes.
+#
+# dist regenerates only the CALL to this workflow in release.yml (passing `plan`
+# and `secrets: inherit`), never this file, so it survives `dist generate --check`.
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        description: The dist release plan (JSON), passed by dist.
+        required: true
+        type: string
+
+permissions:
+  contents: read # read the release to download dist's generated formula
+
+jobs:
+  homebrew:
+    name: publish the Homebrew formula (with man page + completions)
+    runs-on: ubuntu-latest
+    env:
+      # GITHUB_TOKEN downloads the formula from THIS repo's release; the push to
+      # the tap uses HOMEBREW_TAP_TOKEN (the checkout credentials), not this.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PLAN: ${{ inputs.plan }}
+    steps:
+      # Check out the TAP repo (not this one) with a token that can push to it.
+      # persist-credentials stays true so the formula commit below can push.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: agentjp/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          persist-credentials: true # zizmor: ignore[artipacked] the token MUST persist to push the formula commit
+
+      - name: Add the man page + shell completions to dist's formula, then push
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "bdinfo-rs CI"
+          git config user.email "bdinfo-rs@users.noreply.github.com"
+          export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+
+          # dist attached the generated formula to the release; one *.rb per release
+          # that produced one (we ship exactly one). Compact JSON has no internal
+          # spaces, so word-splitting the loop is safe (this mirrors dist's own job).
+          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
+            filename=$(echo "$release" | jq --raw-output '.artifacts[] | select(endswith(".rb"))')
+            name=$(echo "$filename" | sed 's/\.rb$//')
+            version=$(echo "$release" | jq --raw-output '.app_version')
+
+            # Pull dist's just-generated formula from the release into the tap.
+            gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --pattern "$filename" --dir Formula --clobber
+            f="Formula/${filename}"
+
+            # dist installs only the binary; add the man page + the bash/zsh/fish
+            # completions to the standard Homebrew dirs (the archive ships all of
+            # them). Idempotent: a re-run that already has them is a no-op.
+            if ! grep -q 'man1.install' "$f"; then
+              awk '{ print }
+                   /^    install_binary_aliases!$/ {
+                     print "    man1.install \"bdinfo-rs.1\""
+                     print "    bash_completion.install \"bdinfo-rs.bash\" => \"bdinfo-rs\""
+                     print "    zsh_completion.install \"_bdinfo-rs\""
+                     print "    fish_completion.install \"bdinfo-rs.fish\""
+                   }' "$f" > "$f.patched"
+              mv "$f.patched" "$f"
+            fi
+            # Fail the release loudly rather than push a man-less formula if dist's
+            # template ever changes the anchor line above.
+            grep -q 'man1.install' "$f" || { echo "::error::could not inject man1.install — dist's formula template changed; update homebrew.yml"; exit 1; }
+
+            # Canonicalize like dist does (non-fatal; our lines are standard idioms).
+            brew update
+            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "$f" || true
+
+            git add "$f"
+            git commit -m "${name} ${version}"
+          done
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,61 +305,28 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
-  publish-homebrew-formula:
+  custom-homebrew:
     needs:
       - plan
       - host
-    runs-on: "ubuntu-22.04"
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PLAN: ${{ needs.plan.outputs.val }}
-      GITHUB_USER: "axo bot"
-      GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: true
-          repository: "agentjp/homebrew-tap"
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-      # So we have access to the formula
-      - name: Fetch homebrew formulae
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: artifacts-*
-          path: Formula/
-          merge-multiple: true
-      # This is extra complex because you can make your Formula name not match your app name
-      # so we need to find releases with a *.rb file, and publish with that filename.
-      - name: Commit formula files
-        run: |
-          git config --global user.name "${GITHUB_USER}"
-          git config --global user.email "${GITHUB_EMAIL}"
-
-          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
-            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
-            name=$(echo "$filename" | sed "s/\.rb$//")
-            version=$(echo "$release" | jq .app_version --raw-output)
-
-            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
-            brew update
-            # We avoid reformatting user-provided data such as the app description and homepage.
-            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
-
-            git add "Formula/${filename}"
-            git commit -m "${name} ${version}"
-          done
-          git push
+    uses: ./.github/workflows/homebrew.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    # publish jobs get escalated permissions
+    permissions:
+      "contents": "read"
 
   announce:
     needs:
       - plan
       - host
-      - publish-homebrew-formula
+      - custom-homebrew
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.custom-homebrew.result == 'skipped' || needs.custom-homebrew.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -99,14 +99,19 @@ fail-fast = true
 installers = ["shell", "powershell", "homebrew"]
 hosting = ["github"]
 
-# Homebrew: publish a BINARY formula (it fetches the prebuilt .tar.gz archives —
-# no source build, no macOS runner) to our own tap on each STABLE release. One
-# formula covers macOS (Intel + Apple Silicon) and Linuxbrew. dist's homebrew
-# publish job pushes to the tap using the `HOMEBREW_TAP_TOKEN` repo secret (a
-# fine-grained PAT scoped to the tap repo, Contents:read/write). The tap repo is
-# named `homebrew-tap`; users tap it as `agentjp/tap`.
+# Homebrew: dist GENERATES a BINARY formula (it fetches the prebuilt .tar.gz
+# archives — no source build, no macOS runner) covering macOS (Intel + Apple
+# Silicon) and Linuxbrew, from our own tap; users tap it as `agentjp/tap`. The
+# PUSH is our own job (`./homebrew`), NOT dist's built-in `homebrew` publisher:
+# dist's formula installs only the binary and never the man page / shell
+# completions (its templates/installer/homebrew.rb.j2 has no man1.install and the
+# homebrew installer config exposes no way to add it). So `./homebrew` takes dist's
+# generated formula, adds those four install lines, and pushes to the tap with the
+# `HOMEBREW_TAP_TOKEN` secret — one commit, reusing dist's multi-arch url/sha
+# generation. Keeping `homebrew` in `installers` (above) keeps the formula
+# generation; only the publisher is swapped. See .github/workflows/homebrew.yml.
 tap = "agentjp/homebrew-tap"
-publish-jobs = ["homebrew"]
+publish-jobs = ["./homebrew"]
 
 # A reusable workflow wired in at the start of CI (before any build): it fails the
 # whole release unless the tagged commit is an ancestor of origin/master. dist
@@ -115,6 +120,13 @@ publish-jobs = ["homebrew"]
 plan-jobs = ["./guard-ancestor"]
 
 [dist.github-custom-job-permissions.guard-ancestor]
+contents = "read"
+
+# The custom ./homebrew publish job only needs to read THIS repo's release (to
+# download dist's generated formula); the push to the tap uses HOMEBREW_TAP_TOKEN,
+# not GITHUB_TOKEN. This OVERRIDES dist's default publish-job grant (id-token +
+# packages write), which the job does not use.
+[dist.github-custom-job-permissions.homebrew]
 contents = "read"
 
 [dist.github-custom-runners.aarch64-pc-windows-msvc]


### PR DESCRIPTION
## Problem

cargo-dist's generated Homebrew formula installs only the binary — its `def install` has no `man1.install` / `*_completion.install` (confirmed in dist's `templates/installer/homebrew.rb.j2`; the homebrew installer config exposes only `tap` and `formula`, no way to add install steps). So the man page + shell completions land in `pkgshare` instead of the standard dirs, and `install-smoke-test` (a real `brew install` that checks for them) fails. dist regenerates and force-pushes the formula on every release, so any hand-patch to the tap is clobbered each time.

## Fix

Own only the formula *publish*, reusing dist's *generation*:

- dist still generates the formula (the `homebrew` installer stays in `installers`) and attaches the `.rb` to the GitHub Release.
- `publish-jobs = ["homebrew"]` → `["./homebrew"]`: a small reusable workflow (`.github/workflows/homebrew.yml`) replaces dist's built-in homebrew publisher. It downloads dist's generated formula, injects the four `man1.install` / completion lines (idempotent; fails loudly if dist's anchor line ever changes), runs `brew style`, and pushes to the tap — **one commit per release, same as today**, reusing dist's correct multi-arch url/sha generation.
- `[dist.github-custom-job-permissions.homebrew]` scopes the job to `contents: read` (it reads the release to fetch the formula; the tap push uses `HOMEBREW_TAP_TOKEN`).

Nothing else dist does changes — binaries, archives, checksums, Sigstore attestations, the GitHub Release, and the shell/powershell installers are untouched. `dist generate --check` stays green.

## Notes

- Pure CI/config change — no version bump, no tag, nothing published by merging this.
- The 1.0.1 tap formula was already hand-fixed, so current `brew install agentjp/tap/bdinfo-rs` users already get the man page; this stops the regression on every future release.
- The injection was verified against the real v1.0.1 generated formula (the four lines land correctly after `install_binary_aliases!`); `install-smoke-test` does the end-to-end `brew install` check on the next release.
