### PR TITLE
build(fuzz): sync the fuzz lockfile to bdinfo-rs-core 1.0.1

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "roxmltree",
  "thiserror",


### PR DESCRIPTION
The fuzz workspace is excluded from the root workspace and keeps its own `Cargo.lock`, which pins `bdinfo-rs-core` by path. The 1.0.1 version bump (PR #26) refreshed the root `Cargo.lock` but left this one at `1.0.0`, so every cargo resolve of the fuzz workspace rewrote the line back to `1.0.1` and it kept surfacing as a stray local modification.

This commits the `1.0.1` update so the lockfile is honest and stops re-dirtying.

`fuzz.yml` resolves the workspace without `--locked`, so CI was unaffected by the staleness (it bumped the version fresh each run). Verified consistent with `cargo metadata --manifest-path fuzz/Cargo.toml --locked`.
