### PR TITLE
ci: clean up GitHub Actions warnings

### DIFF
--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -37,6 +37,20 @@ jobs:
     steps:
       - uses: Homebrew/actions/setup-homebrew@6315ef70a8bfcd2c71104383846591ac113ace33 # master
 
+      # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
+      # check then warns about them on every brew command. We install bdinfo-rs by its
+      # fully-qualified name (which trusts only that item), so those taps are unrelated noise
+      # — trust them to silence it. Scoped to the two named taps ON PURPOSE: if the image
+      # later pre-taps a new one we WANT that warning, so we never blanket-disable the
+      # feature. Tolerant: those taps don't exist on the Linux runner. (The lone remaining
+      # "Sandbox unavailable" warning on Linux is left deliberately — it's an honest signal
+      # that self-resolves when the runner gains a usable sandbox; HOMEBREW_NO_SANDBOX_LINUX
+      # would force-disable it forever and hide that, for a binary formula with nothing to
+      # sandbox.)
+      - name: Trust the runner's pre-tapped third-party taps
+        shell: bash
+        run: for tap in aws/tap azure/bicep; do brew trust "$tap" 2>/dev/null || true; done
+
       - name: Install bdinfo-rs from the tap
         run: brew install agentjp/tap/bdinfo-rs
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -193,7 +193,11 @@ jobs:
           for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
             test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
           done
-          echo "${{ matrix.triple }} .deb: installs, runs, and ships man + completions"
+          # Debian carries NO License field in control metadata — the license lives only in
+          # the DEP-5 copyright, which is what license scanners (Cloudsmith) read. Assert the
+          # copyright installed AND carries the machine-readable License short-name.
+          grep -q '^License: LGPL-2.1-only' /usr/share/doc/bdinfo-rs/copyright || { echo "NOT INSTALLED: DEP-5 copyright License field"; exit 1; }
+          echo "${{ matrix.triple }} .deb: installs, runs, and ships man + completions + DEP-5 copyright"
 
       - name: Upload the .deb to the release
         shell: bash

--- a/crates/bdinfo-rs/Cargo.toml
+++ b/crates/bdinfo-rs/Cargo.toml
@@ -63,6 +63,15 @@ bin-dir = "{ bin }{ binary-ext }"
 # asset prefix to that path and derives the Debian arch from `--target`. The
 # completion/man assets are staged under the crate's `release-assets/`. The static
 # musl binary has no shared-library deps, so `depends` is emptied.
+#
+# Debian packages carry NO license field in their `control` metadata — by policy the
+# license lives only in the DEP-5 `/usr/share/doc/<pkg>/copyright` file. cargo-deb
+# auto-generates a MINIMAL header-only copyright (no `Files:` stanza), which license
+# scanners/registries (e.g. Cloudsmith) skip → "no license data" (the .rpm is fine
+# because RPM has a first-class `License:` tag). So we ship our own complete, machine-
+# readable `debian/copyright` (header + `Files: *` `License: LGPL-2.1-only` stanza +
+# the license paragraph) as the canonical-path asset; cargo-deb uses it verbatim
+# instead of generating one. The path is resolved relative to this crate dir.
 [package.metadata.deb]
 maintainer = "bdinfo-rs contributors <bdinfo-rs@users.noreply.github.com>"
 section = "utils"
@@ -71,6 +80,7 @@ depends = ""
 extended-description = "A memory-safe, statically-linked command-line Blu-ray disc analyzer — a drop-in replacement for the classic BDInfo report tool. Scans BDMV folders and .iso images and renders the classic per-stream video/audio technical report."
 assets = [
     ["target/release/bdinfo-rs", "usr/bin/", "755"],
+    ["debian/copyright", "usr/share/doc/bdinfo-rs/copyright", "644"],
     ["release-assets/bdinfo-rs.1", "usr/share/man/man1/", "644"],
     ["release-assets/bdinfo-rs.bash", "usr/share/bash-completion/completions/bdinfo-rs", "644"],
     ["release-assets/_bdinfo-rs", "usr/share/zsh/site-functions/", "644"],

--- a/crates/bdinfo-rs/debian/copyright
+++ b/crates/bdinfo-rs/debian/copyright
@@ -1,0 +1,20 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: bdinfo-rs
+Source: https://github.com/agentjp/bdinfo-rs
+
+Files: *
+Copyright: bdinfo-rs contributors
+License: LGPL-2.1-only
+
+License: LGPL-2.1-only
+ bdinfo-rs is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License version 2.1 as published
+ by the Free Software Foundation.
+ .
+ bdinfo-rs is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ details.
+ .
+ On Debian systems, the complete text of the GNU Lesser General Public License
+ version 2.1 can be found in "/usr/share/common-licenses/LGPL-2.1".


### PR DESCRIPTION
Batches small fixes surfaced while reviewing the Actions runs and the Cloudsmith repo. More may follow on this branch before merge.

## `install-smoke-test.yml` — Homebrew tap-trust warnings (`91513b6`)

The `macos-15` runner image ships `aws/tap` and `azure/bicep` pre-tapped, so Homebrew's new tap-trust check warns about them on **every** `brew` command. They are unrelated to our install — we install by the fully-qualified `agentjp/tap/bdinfo-rs` name, which trusts only that item, so the install itself is unaffected now and when tap-trust becomes the default in Homebrew 5.2/6.0.

The new step trusts those two named taps to silence the noise. It is scoped to the two known taps on purpose: if a future runner image pre-taps a new one, we **want** that warning to surface rather than blanket-disabling the feature.

The single remaining `Sandbox unavailable: building without sandboxing` warning on the Linux runner is left **deliberately** — it is an honest signal that self-resolves the moment the runner image gains a usable bubblewrap sandbox, and `HOMEBREW_NO_SANDBOX_LINUX` would force-disable the sandbox forever and hide that change.

## `.deb` — license shown as "No license data" on Cloudsmith (`703d4ee`)

Cloudsmith showed the two `.deb` packages as **No license data** while the two `.rpm`s correctly showed `LGPL-2.1-only`. This is genuine but structural, not a licensing problem:

- **RPM** has a first-class `License:` tag — `cargo-generate-rpm` fills it from `Cargo.toml`, so Cloudsmith reads it.
- **DEB** has **no** license field in its `control` metadata (by Debian policy); the license lives only in the DEP-5 `/usr/share/doc/<pkg>/copyright` file.

Inspecting the published `bdinfo-rs_1.0.1-1_amd64.deb` confirmed `cargo-deb` writes a **minimal, header-only** copyright (just `Format`/`Upstream-Name`/`Source`/`Copyright`/`License`, no `Files: *` stanza). DEP-5 license scanners read the license from a `Files:` paragraph and treat the bare header `License:` as an optional summary, so Cloudsmith found nothing → empty.

Fix: ship a complete, machine-readable `crates/bdinfo-rs/debian/copyright` (header + `Files: *` `License: LGPL-2.1-only` stanza + the license paragraph pointing at `/usr/share/common-licenses/LGPL-2.1`) as the canonical-path asset. `cargo-deb` uses a user-provided copyright verbatim instead of generating one (verified locally with cargo-deb 3.7.0 by rebuilding the real crate's `.deb` and extracting it). The deb verify step now asserts the copyright and its `License:` field install.

Note: this corrects the artifact going forward — the next release's `.deb` will carry the license. The already-published `1.0.1` `.deb` on Cloudsmith stays "no license data" until a `.deb` with the new copyright is pushed.
