### PR TITLE
ci: silence Homebrew tap-trust warnings in the install smoke test

### DIFF
--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -37,6 +37,20 @@ jobs:
     steps:
       - uses: Homebrew/actions/setup-homebrew@6315ef70a8bfcd2c71104383846591ac113ace33 # master
 
+      # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
+      # check then warns about them on every brew command. We install bdinfo-rs by its
+      # fully-qualified name (which trusts only that item), so those taps are unrelated noise
+      # — trust them to silence it. Scoped to the two named taps ON PURPOSE: if the image
+      # later pre-taps a new one we WANT that warning, so we never blanket-disable the
+      # feature. Tolerant: those taps don't exist on the Linux runner. (The lone remaining
+      # "Sandbox unavailable" warning on Linux is left deliberately — it's an honest signal
+      # that self-resolves when the runner gains a usable sandbox; HOMEBREW_NO_SANDBOX_LINUX
+      # would force-disable it forever and hide that, for a binary formula with nothing to
+      # sandbox.)
+      - name: Trust the runner's pre-tapped third-party taps
+        shell: bash
+        run: for tap in aws/tap azure/bicep; do brew trust "$tap" 2>/dev/null || true; done
+
       - name: Install bdinfo-rs from the tap
         run: brew install agentjp/tap/bdinfo-rs
 


### PR DESCRIPTION
Silences the Homebrew tap-trust warnings on the `install-smoke-test` runs.

The `macos-15` runner image ships `aws/tap` and `azure/bicep` pre-tapped, so Homebrew's new tap-trust check warns about them on **every** `brew` command. They are unrelated to our install — we install by the fully-qualified `agentjp/tap/bdinfo-rs` name, which trusts only that item, so the install itself is unaffected now and when tap-trust becomes the default in Homebrew 5.2/6.0.

The new step trusts those two named taps to silence the noise. It is scoped to the two known taps on purpose: if a future runner image pre-taps a new one, we **want** that warning to surface rather than blanket-disabling the feature.

The single remaining `Sandbox unavailable: building without sandboxing` warning on the Linux runner is left **deliberately** — it is an honest signal that self-resolves the moment the runner image gains a usable bubblewrap sandbox, and `HOMEBREW_NO_SANDBOX_LINUX` would force-disable the sandbox forever and hide that change.
