### PR TITLE
ci: make Dependabot emit conventional commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,14 @@ updates:
       cargo-dependencies:
         patterns: ["*"]
     labels: [dependencies]
+    # master is squash-merged and the conventional gate (conventional.yml) lints
+    # the PR title AND every commit, so Dependabot's default "Bump ..." subject is
+    # rejected. Emit a Conventional Commit instead — `build(deps): bump ...` (cargo
+    # deps are build inputs; the deps/deps-dev scope comes from include: scope).
+    # `build` is a no-bump type, so a dependency PR never drives a release on its own.
+    commit-message:
+      prefix: build
+      include: scope
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -28,3 +36,8 @@ updates:
       github-actions:
         patterns: ["*"]
     labels: [dependencies, ci]
+    # Same reason as cargo above: produce `ci(deps): bump ...` so the squash subject
+    # and the commit both pass the conventional gate. `ci` is a no-bump type too.
+    commit-message:
+      prefix: ci
+      include: scope


### PR DESCRIPTION
## Why

PR #32 is the first Dependabot PR opened after the conventional-commit gate
(`conventional.yml`) landed (#23, on master at 19:18 the same day #19 was merged at
01:57). That gate lints **both** the PR title (the squash subject) and every commit
in the PR. Dependabot's default subject — `Bump the github-actions group with 2
updates` — is not a Conventional Commit, so `convco check` fails and the merge is
blocked. The bumps themselves are fine; only the message format is rejected.

## What

Configure `commit-message` for both ecosystems in `dependabot.yml`:

- cargo → `prefix: build`, `include: scope` → `build(deps): bump ...`
- github-actions → `prefix: ci`, `include: scope` → `ci(deps): bump ...`

Both `build` and `ci` are no-bump types, so a dependency PR never drives a release
on its own. The `deps` scope is already in the repo's scope allowlist.

After this lands, `@dependabot recreate` on #32 regenerates it with a conventional
subject + commit so it passes the gate, and every future Dependabot PR is
conventional by construction.