### PR TITLE
ci(deps): bump Homebrew/actions/setup-homebrew to current master

### DIFF
--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: [macos-15, ubuntu-latest]
     steps:
-      - uses: Homebrew/actions/setup-homebrew@6315ef70a8bfcd2c71104383846591ac113ace33 # master
+      - uses: Homebrew/actions/setup-homebrew@841d750a0ed9262d3c3ca31f2173974696bc261a # master
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its


### PR DESCRIPTION
Upstream `Homebrew/actions` `master` advanced 6 commits past the pinned SHA, so zizmor's `ref-version-mismatch` audit (run online with a token) flags the `# master` comment as no longer matching the pinned commit. This turned the `zizmor (workflow security)` required check red on master's daily runs (2026-06-25 onward) and on every open PR.

`Homebrew/actions` publishes no tags, so `# master` is the only available ref (per the documented "stays as-is" pinning exception). This re-pins to the current `master` tip and keeps the `# master` comment.

- old: `6315ef70a8bfcd2c71104383846591ac113ace33`
- new: `841d750a0ed9262d3c3ca31f2173974696bc261a` (current `Homebrew/actions` master)

Verified locally: `zizmor .github/workflows` now reports no findings.