### PR TITLE
ci: freeze the Homebrew action SHA and watch it in version-freshness

### DIFF
--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -35,7 +35,18 @@ jobs:
       matrix:
         os: [macos-15, ubuntu-latest]
     steps:
-      - uses: Homebrew/actions/setup-homebrew@841d750a0ed9262d3c3ca31f2173974696bc261a # master
+      # Homebrew/actions publishes NO version tags, so this pin cannot carry an
+      # immutable `# vX.Y.Z` like every other action in the repo. The SHA is a
+      # deliberate FREEZE of a reviewed master commit — never "track latest". We
+      # therefore exempt only this line from zizmor's ref-version-mismatch, which
+      # would otherwise resolve a `# master` comment against the live branch HEAD and
+      # red-X every PR each time Homebrew pushes to master. It stays SHA-pinned, so
+      # Scorecard pinned-dependencies and zizmor's unpinned-uses are still satisfied.
+      # Staying current is out-of-band, not a blocking check: version-freshness.yml
+      # nags (files an issue) when Homebrew master moves past this SHA, and the bump
+      # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
+      # releases, and this repo has none).
+      - uses: Homebrew/actions/setup-homebrew@841d750a0ed9262d3c3ca31f2173974696bc261a # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -10,10 +10,15 @@ name: version-freshness
 #   - taplo (the `tool: taplo-cli@X` pin in toml.yml — a formatter, pinned like
 #     rustfmt so a new release can't reformat/relint the tree out from under a PR),
 #   - convco (the `tool: convco@X` pin in conventional.yml — pinned because its
-#     output drives a reproducible changelog/version format, like taplo/rustfmt).
+#     output drives a reproducible changelog/version format, like taplo/rustfmt),
+#   - the Homebrew/actions/setup-homebrew SHA (install-smoke-test.yml) — the ONE
+#     action SHA watched here: it pins a TAGLESS repo's `master`, so Dependabot
+#     (which bumps toward releases) can't move it, and zizmor's ref-version-mismatch
+#     is inline-ignored for it; without this nag nothing would tell us it drifted.
 # (Cargo deps/dev-deps and GitHub Action SHAs are already auto-bumped by
 # Dependabot — cargo + github-actions ecosystems — so they are deliberately NOT
-# re-checked here. The remaining gate tools — zizmor (a security linter, kept at
+# re-checked here, EXCEPT the one tagless branch-pinned action noted above that
+# Dependabot cannot bump. The remaining gate tools — zizmor (a security linter, kept at
 # latest on purpose so new vuln checks land immediately), action-validator,
 # cargo-{machete,shear,semver-checks,llvm-cov,nextest,mutants,deny}, typos — are
 # installed at LATEST every run, so they self-update and have no pin to rot. The
@@ -158,7 +163,23 @@ jobs:
             $problems += "- convco pin ``$convcoPin`` (conventional.yml) is behind the latest release ``$convcoLatest``"
           }
 
-          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  ryl: $rylPin (latest $rylLatest)  taplo: $taploPin (latest $taploLatest)  convco: $convcoPin (latest $convcoLatest)"
+          # --- Homebrew/actions/setup-homebrew: install-smoke-test.yml vs master HEAD ---
+          # SHA-pinned to a TAGLESS repo's master branch, so Dependabot can't bump it
+          # (no release to target) and zizmor's ref-version-mismatch is inline-ignored
+          # on that line. Watch it here instead: nag (don't fail CI) when Homebrew
+          # master moves past the frozen SHA, so re-pinning stays a deliberate edit.
+          $brewPin = Read-Pin '.github/workflows/install-smoke-test.yml' 'setup-homebrew@([0-9a-f]{40})'
+          if (-not $brewPin) { throw 'No Homebrew/actions/setup-homebrew SHA pin in install-smoke-test.yml' }
+          $brewHead = gh api repos/Homebrew/actions/branches/master --jq '.commit.sha' 2>$null
+          if ($LASTEXITCODE -ne 0 -or -not $brewHead) {
+            $problems += '- could not query Homebrew/actions master HEAD (GitHub API)'
+          } elseif ($brewPin -ne $brewHead) {
+            $problems += "- Homebrew/actions/setup-homebrew pin ``$($brewPin.Substring(0, 12))`` (install-smoke-test.yml) is behind master HEAD ``$($brewHead.Substring(0, 12))`` — re-pin deliberately (the repo ships no tags, so the SHA is frozen on purpose)"
+          }
+          $brewPinShort = if ($brewPin) { $brewPin.Substring(0, 12) } else { '?' }
+          $brewHeadShort = if ($brewHead) { $brewHead.Substring(0, 12) } else { '?' }
+
+          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  ryl: $rylPin (latest $rylLatest)  taplo: $taploPin (latest $taploLatest)  convco: $convcoPin (latest $convcoLatest)  brew: $brewPinShort (head $brewHeadShort)"
           if ($problems.Count -eq 0) { Write-Host 'All pinned versions are fresh and consistent.'; exit 0 }
 
           $title = 'Pinned versions are stale'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,9 +7,14 @@
 # release.yml by rule id (whole-file, since regeneration shifts line numbers).
 # Findings in every hand-maintained workflow are fixed in place, not ignored.
 #
-# ref-version-mismatch is intentionally NOT suppressed: every SHA pin carries the
-# EXACT immutable tag it resolves to (`# vX.Y.Z`, not a moving major `# vN`), so a
-# pin's comment can never drift from its hash and Dependabot bumps both together.
+# ref-version-mismatch is intentionally NOT suppressed in this config: every SHA
+# pin carries the EXACT immutable tag it resolves to (`# vX.Y.Z`, not a moving
+# major `# vN`), so a pin's comment can never drift from its hash and Dependabot
+# bumps both together. The ONE exception is handled inline, not here:
+# Homebrew/actions/setup-homebrew (install-smoke-test.yml) pins a TAGLESS repo's
+# `master`, so it cannot carry an immutable tag — it is frozen at a reviewed SHA
+# and exempted with an on-line `# zizmor: ignore[ref-version-mismatch]`, while
+# version-freshness.yml watches it for upstream movement.
 rules:
   # cargo-dist hardcodes a top-level `contents: write` (needed to upload release
   # assets); it is not tightenable without editing the generated file.


### PR DESCRIPTION
## Problem

`Homebrew/actions/setup-homebrew` was pinned as `@<sha> # master` — a self-contradiction: the SHA *freezes* a commit, but the `# master` comment *labels it a moving branch*. zizmor's `ref-version-mismatch` (run online) resolves that comment against Homebrew/actions' live `master` HEAD and fails the moment the pinned SHA diverges — i.e. every time Homebrew pushes to master. That reddens the required `zizmor (workflow security)` check on every open PR and on master's own daily run, until someone manually re-pins (which just resets the clock).

Nothing caught it early: `version-freshness` delegates action SHAs to Dependabot, and Dependabot can't bump this one because `Homebrew/actions` publishes **no release tags** (Dependabot bumps toward releases). It's the only branch-pinned action in the repo.

## Fix — freeze + watch (no disruption, stay current)

1. **`install-smoke-test.yml`** — exempt only that line with an inline `# zizmor: ignore[ref-version-mismatch]`, dropping the misleading `# master`. The SHA stays frozen at a reviewed commit, so Scorecard pinned-dependencies and zizmor's `unpinned-uses` are still satisfied; it no longer red-Xs PRs.
2. **`version-freshness.yml`** — add a daily check comparing the pinned SHA against Homebrew/actions' live `master` HEAD, folded into the existing "Pinned versions are stale" issue. It *notifies*, never blocks, and the bump becomes a deliberate edit — matching the workflow's existing "human-reviewed bump" philosophy.
3. **`zizmor.yml`** — document the single inline exception so the config's "ref-version-mismatch is never suppressed" note stays accurate.

Verified locally: `zizmor .github/workflows` reports no findings, the new freshness check reads the pin + queries the live HEAD + reports fresh/stale correctly, and action-validator + ryl pass.