### PR TITLE
ci: explain release.yml drift when dist generate --check fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,29 @@ jobs:
       - name: Check release.yml is in sync with dist-workspace.toml
         run: dist generate --check
 
+      # Make the drift self-explanatory (no token / no extra permission — just an
+      # annotation). The usual cause is a Dependabot bump of an action that appears
+      # in the GENERATED release.yml (checkout, upload-/download-artifact, attest):
+      # it edits release.yml but cannot edit dist-workspace.toml, so the pins drift.
+      - name: Explain the drift if the check failed
+        if: failure()
+        run: |
+          echo "::group::release.yml is out of sync with dist-workspace.toml"
+          drift=0
+          for a in actions/checkout actions/upload-artifact actions/download-artifact actions/attest; do
+            rel=$(grep -oP "uses:\s*${a}@\K[0-9a-f]{40}\s*#\s*\S+" .github/workflows/release.yml | head -1)
+            cfg=$(grep -oP "\"${a}\"\s*=\s*\"\K[^\"]+" dist-workspace.toml | head -1)
+            if [ -n "$rel" ] && [ "$rel" != "$cfg" ]; then
+              echo "::error::dist-workspace.toml pin stale for ${a} — set:  \"${a}\" = \"${rel}\""
+              drift=1
+            fi
+          done
+          if [ "$drift" -eq 0 ]; then
+            echo "::error::release.yml differs from dist generate output, but not via a tracked action pin — run 'dist generate' locally and inspect the diff."
+          fi
+          echo "Fix: run 'pwsh scripts/dist-sync.ps1 -Pr <this-PR> -Push' (cockpit helper), or paste the line(s) above into dist-workspace.toml and run 'dist generate', then commit on this branch."
+          echo "::endgroup::"
+
   # The quality gate mirrored from the local runner. The gate commands are the
   # tracked cargo aliases in .cargo/config.toml (ck/lt/mc/dc + cov); clippy.toml +
   # typos.toml are tracked so clippy/typos behave identically. Format uses the


### PR DESCRIPTION
The cargo-dist-generated `release.yml` shares four actions with `dist-workspace.toml` (`checkout`, `upload-`/`download-artifact`, `attest`). When Dependabot bumps one of them it edits `release.yml` directly but can't touch `dist-workspace.toml [dist.github-action-commits]`, so `dist generate --check` fails with cargo-dist's generic "out of sync" message — leaving the cause non-obvious.

This adds a zero-permission `if: failure()` step (just a `::error::` annotation — no token, no PR comment, no added permission) that, on drift, prints the exact `dist-workspace.toml` pin to set for whichever action drifted, plus the one-command fix.

Paired with the local cockpit helper `scripts/dist-sync.ps1` (mirrors the pin, runs `dist generate`, optionally fetches the PR branch and commits+pushes) and a "Handling Dependabot PRs" runbook in the local cockpit doc — both gitignored, not in this PR.

Verified locally: zizmor, action-validator, and ryl all pass on `ci.yml`; the diagnostic's grep logic correctly reports no drift in sync and the precise stale pin under simulated drift.