### PR TITLE
build(deps): refresh lockfiles and allow transitive Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,15 @@ updates:
     groups:
       cargo-dependencies:
         patterns: ["*"]
+    # Bump INDIRECT (transitive) deps too, not just the direct ones named in
+    # Cargo.toml. Dependabot's default version-update policy is direct-only
+    # (transitive deps move solely on a security advisory), so routine
+    # transitive-only Cargo.lock patch bumps (quote/syn/cc/memchr/wasip2…) drift
+    # silently between direct-dep PRs — neither this nor version-freshness.yml
+    # (which delegates cargo to Dependabot) would catch them. `all` = direct +
+    # indirect, folded into the same grouped PR.
+    allow:
+      - dependency-type: "all"
     labels: [dependencies]
     # master is squash-merged and the conventional gate (conventional.yml) lints
     # the PR title AND every commit, so Dependabot's default "Bump ..." subject is
@@ -54,6 +63,11 @@ updates:
     groups:
       wasm-cargo-dependencies:
         patterns: ["*"]
+    # Transitive deps too (see the root cargo entry): direct-only is the default,
+    # so the wasm-bindgen / js-sys / web-sys transitive tree would otherwise miss
+    # routine patch bumps. `all` = direct + indirect, in the same grouped PR.
+    allow:
+      - dependency-type: "all"
     labels: [dependencies]
     commit-message:
       prefix: build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,9 +381,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "proc-macro2"
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -133,9 +133,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -170,9 +170,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -135,6 +135,10 @@ criteria = "safe-to-deploy"
 version = "1.11.0"
 criteria = "safe-to-run"
 
+[[exemptions.quote]]
+version = "1.0.46"
+criteria = "safe-to-deploy"
+
 [[exemptions.r-efi]]
 version = "5.3.0"
 criteria = "safe-to-run"


### PR DESCRIPTION
## What

A dependency-maintenance sweep (run locally to "force update everything and see what still works").

**Two commits:**

1. `build(deps): bump transitive crates to latest compatible versions` — `cargo update` across both workspaces. No direct-dep floor was behind its latest published version, so only transitive patches moved:
   - root: `quote 1.0.45 -> 1.0.46`
   - fuzz: `cc 1.2.63 -> 1.2.65`, `memchr 2.8.1 -> 2.8.2`, `quote 1.0.45 -> 1.0.46`, `syn 2.0.117 -> 2.0.118`, `wasip2 1.0.3 -> 1.0.4`

2. `ci(deps): allow transitive dependency updates in Dependabot` — add `allow: dependency-type: "all"` to both cargo entries. The default version-update policy is direct-only (transitive deps move solely on a security advisory), which is exactly why the patch bumps in commit 1 had drifted silently — neither Dependabot nor `version-freshness.yml` (which delegates cargo to Dependabot) was watching them. `all` folds indirect deps into the same grouped PR.

## Not changed

- Stable Rust, cargo-dist, npm devDeps, and every direct cargo dep were already at their latest — nothing to bump.
- The CI nightly pin was left as-is (deliberate pin, still under the 30-day freshness threshold).
- Security coverage is unchanged: `audit.yml` + Dependabot security updates already react to advisories regardless of dependency type.

## Verification

Core gate green locally before pushing: 100% lines/regions/functions, 97.84% branches, all 881 tests passing. The Dependabot YAML change is `ryl`-clean.