### PR TITLE
fix(wasm): make the scan Worker spawn detectable by Vite and webpack

### DIFF
--- a/crates/bdinfo-rs-wasm/Cargo.toml
+++ b/crates/bdinfo-rs-wasm/Cargo.toml
@@ -30,10 +30,10 @@ wasm-bindgen = "0.2"
 # WebReader/WebFile FileReaderSync seam + scan_files/build_web_tree), so they are
 # wasm-only — a native `cargo build` / parity build never compiles them.
 # `File`/`Blob`/`FileReaderSync` back the streaming `scan_files` seam: synchronous
-# byte-offset reads in a Worker (no JSPI/Asyncify); `console` is the scan log.
+# byte-offset reads in a Worker (no JSPI/Asyncify).
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Blob", "File", "FileReaderSync", "console"] }
+web-sys = { version = "0.3", features = ["Blob", "File", "FileReaderSync"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -1021,10 +1021,7 @@ pub fn run_iso_report(reader: Box<dyn IsoReader>) -> String {
 #[wasm_bindgen]
 #[must_use]
 pub fn scan_report(data: &[u8]) -> String {
-    let report = run_report(data);
-    #[cfg(target_arch = "wasm32")]
-    web_sys::console::log_1(&format!("bdinfo-rs-wasm: rendered {} bytes", report.len()).into());
-    report
+    run_report(data)
 }
 
 /// The Phase 2 streaming entry point: hand it a `webkitdirectory`-selected BDMV

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -21,9 +21,11 @@ Firefox.
 npm i @bdinfo-rs/wasm
 ```
 
-The published payload is **~360 KB of WebAssembly + ~5 KB of JS glue**, fetched
-lazily by the scan Worker — the main-thread entry is a few KB, and nothing else
-loads until you call `analyze` or `listPlaylists`.
+The published payload is **~360 KB of WebAssembly + ~22 KB of JS**. Only the
+main-thread entry you import (~4 KB) loads up front; the scan Worker (~2 KB) and
+the wasm-bindgen glue (~17 KB) that hosts the `.wasm` are fetched lazily inside
+the Worker, and nothing past the entry loads at all until you call `analyze` or
+`listPlaylists`.
 
 ## Usage
 
@@ -85,8 +87,14 @@ pattern. Any bundler that understands it works out of the box:
 - **Native ES modules** (no bundler — served straight from the package on a
   static host or via an import map) — works as published.
 
-If your bundler can't follow that pattern, host `dist/worker.js` and
-`pkg/bdinfo_rs_wasm_bg.wasm` yourself and pass the worker URL explicitly:
+If your bundler can't follow that pattern, host the Worker yourself and pass its
+URL explicitly. The package's `exports` map deliberately keeps the internals
+private (`dist/worker.js` and `pkg/` are not importable subpaths), so copy
+`dist/worker.js` **together with the `pkg/` directory** out of `node_modules`
+into your own source, preserving their relative layout — `worker.js` loads the
+wasm-bindgen glue and `.wasm` via `import "../pkg/bdinfo_rs_wasm.js"`, so `pkg/`
+must stay one level below it. Then pass the URL your bundler produces for the
+copied worker:
 
 ```ts
 import workerUrl from "./worker.js?worker&url"; // however your bundler exposes it

--- a/crates/bdinfo-rs-wasm/web/src/analyze.ts
+++ b/crates/bdinfo-rs-wasm/web/src/analyze.ts
@@ -88,9 +88,17 @@ type WorkerMessage =
 
 /** Spawns the scan Worker (a module worker by the bundler-aware convention). */
 function spawnWorker(options?: AnalyzeOptions): Worker {
-  return new Worker(options?.workerUrl ?? new URL("./worker.js", import.meta.url), {
-    type: "module",
-  });
+  // The default path MUST stay a bare `new Worker(new URL("./worker.js",
+  // import.meta.url), …)` literal: that exact shape is what Vite and webpack 5
+  // statically detect to compile the Worker into a chunk and emit the `.wasm` it
+  // loads as an asset. Folding it into `options?.workerUrl ?? new URL(...)` makes
+  // the first argument an expression rather than a `new URL(...)` node, which
+  // defeats that detection (the bundler then ships a broken worker and no wasm),
+  // so the override is a separate branch that keeps the default literal intact.
+  if (options?.workerUrl) {
+    return new Worker(options.workerUrl, { type: "module" });
+  }
+  return new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
 }
 
 /** The `(relativePath, File)` lists the Worker takes, from `files`. */


### PR DESCRIPTION
Fixes issues surfaced by a real-world consumer test of the published `@bdinfo-rs/wasm` package (install → import → bundle → run in a browser).

## The bug (high impact)

`spawnWorker` spawned the scan Worker with:

```
new Worker(options?.workerUrl ?? new URL("./worker.js", import.meta.url), { type: "module" })
```

The `??` makes the first argument a logical expression rather than a bare `new URL(...)` node, so neither Vite nor webpack 5 fires its `new Worker(new URL(...))` worker compiler. A default build then *succeeds* but is broken at runtime:

- **Vite 8** inlines `worker.js` as a `data:` URL (whose `import "../pkg/..."` can't resolve against a `data:` base) and emits no `.wasm`.
- **webpack 5** copies `worker.js` verbatim with the same dangling import and emits no `.wasm`.

So the README's "Vite/webpack handled natively" did not hold; only the no-bundler native-ESM path worked.

## The fix

Branch the `workerUrl` override out so the default path stays a bare `new Worker(new URL("./worker.js", import.meta.url), { type: "module" })` literal that both bundlers statically detect.

Verified against a freshly-packed build of this branch:
- Vite build → emits `worker-*.js` + `bdinfo_rs_wasm_bg-*.wasm`, no `data:` URL.
- webpack 5 build → emits the worker chunk + the wasm.
- A Vite-bundled app renders the Big Buck Bunny report byte-for-byte against the golden in a real browser; console clean.
- Node and native-ESM paths unchanged (still byte-identical to the golden).

## Also in this PR

- Remove the leftover `console.log("bdinfo-rs-wasm: rendered N bytes")` from `scan_report` (and the now-unused web-sys `console` feature); all scan exports are silent again.
- README: correct the JS payload figure (~22 KB, not ~5 KB) and document that the explicit-`workerUrl` fallback needs `worker.js` and `pkg/` copied out together.

Local wasm gate (`scripts/wasm-compliance.ps1`, mirrors `wasm.yml`) is green end to end: clippy on both targets, native 100% Tier-A coverage, Tier-A mutants 0 missed, size ratchet, publint/attw, Node + Chrome browser parity.