### PR TITLE
ci: address the infrastructure and CI audit findings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -39,9 +39,10 @@ dn = "deny check"
 # actuals — any regression exits non-zero. Ratchet UP as coverage rises; never
 # relax to dodge a fix. This stable alias covers lines/regions/functions for
 # quick local runs; the GATE (scripts/compliance.ps1) runs the authoritative
-# check on the pinned nightly with the extra `--branch --fail-under-branches`
-# dimension (branch coverage is nightly-only, so an alias — which can't carry
-# `+toolchain` — can't express it).
+# check on the pinned nightly with the extra `--branch` dimension, exporting the
+# LLVM JSON and enforcing the branch floors itself (cargo-llvm-cov has NO
+# `--fail-under-branches` flag; branch coverage is also nightly-only, so an alias —
+# which can't carry `+toolchain` — can't express it).
 cov = "llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100"
 
 # --- Periodic / pre-release (installed by setup.ps1) -----------------------

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -104,31 +104,34 @@ exclude_re = [
     "mpeg2\\.rs:49:\\d+: replace > with >= in scan",
 
     # ── 2026-06-11 audit: PES/PAT/PMT window guards proven equivalent ─────────
-    # (all line-pinned like the entries above; re-pin on file drift)
+    # (all line-pinned; re-pin on file drift — last re-pinned 2026-06-29 after a
+    # ~73-line shift. These CANNOT be de-line-pinned to the bare fn name: each of
+    # parse_chunk/parse_pat/parse_pmt holds many other `>` guards that are NOT
+    # equivalent and must stay killable, so the line:col is the only disambiguator.)
 
     # `parse_chunk` branch A guard `state.packet_length > 0` vs `>=`: a bounded
     # transfer closes the instant packet_length reaches 0 (transfer_state goes
     # false), and a PES declaring zero length sets the variable flag, failing the
     # branch's `!packet_length_variable` conjunct — the disputed `== 0` case is
     # unreachable with the flag clear.
-    "m2ts\\.rs:705:\\d+: replace > with >= in TsStreamFile::parse_chunk",
+    "m2ts\\.rs:778:\\d+: replace > with >= in TsStreamFile::parse_chunk",
 
     # `parse_chunk` branch B guard `parser.packet_length > 0` (all comparison
     # mutants): the conjunct is redundant under the clamp two lines later
     # (`if parser.packet_length <= offset { offset = parser.packet_length }`) —
     # whenever B's reach condition holds, the C-then-clamp fallback computes the
     # identical offset, so taking or skipping branch B changes nothing.
-    "m2ts\\.rs:710:\\d+: replace > with (==|<|>=) in TsStreamFile::parse_chunk",
+    "m2ts\\.rs:783:\\d+: replace > with (==|<|>=) in TsStreamFile::parse_chunk",
 
     # `parse_pat` transfer window `>` vs `>=`: at `bl - i == section_length` both
     # branches assign the same offset.
-    "m2ts\\.rs:1006:\\d+: replace > with >= in TsStreamFile::parse_pat",
+    "m2ts\\.rs:1079:\\d+: replace > with >= in TsStreamFile::parse_pat",
 
     # `parse_pat` post-section guard `pat_section_parse > 0` vs `>=`: the countdown
     # is a u32 that the mutant only ever decrements from the wrapped u32::MAX, so
     # the acting arms (1, 0) are ~4 GiB of PID-0 bytes away, and the corrupted
     # pat_section_length is only read under those arms.
-    "m2ts\\.rs:1077:\\d+: replace > with >= in TsStreamFile::parse_pat",
+    "m2ts\\.rs:1150:\\d+: replace > with >= in TsStreamFile::parse_pat",
 
     # `parse_pmt` program-info guard `pmt_program_info_length > 0` vs `>=`: the dead
     # branch decrements pmt_section_length and the program-info countdown in
@@ -137,7 +140,7 @@ exclude_re = [
     # transfer is zero-length and the stale section re-walk is idempotent
     # (create_stream is keyed on contains_key). Traced and verified empirically
     # with a 357-padding-packet stream.
-    "m2ts\\.rs:1231:\\d+: replace > with >= in TsStreamFile::parse_pmt",
+    "m2ts\\.rs:1304:\\d+: replace > with >= in TsStreamFile::parse_pmt",
 
     # ── 2026-06-11 audit: environment/platform probes no test process can observe ──
 

--- a/.github/build-linux-packages.sh
+++ b/.github/build-linux-packages.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Build the Linux distro packages (.deb + .rpm, for x86_64 AND aarch64) from the
+# static musl binaries dist already built, and stage them under dist-extra/ for
+# dist's `extra-artifacts` (dist-workspace.toml) to attach to the GitHub Release.
+#
+# WHY THIS LIVES INSIDE THE RELEASE: the packages are now release assets attached
+# AT release creation, before the release is published — so the release is
+# compatible with GitHub "immutable releases" (which freeze a release's assets at
+# publication; an after-the-fact `gh release upload` would be rejected). The old
+# packages.yml built+uploaded the .deb/.rpm AFTER the release, which immutability
+# forbids; that build moved here. packages.yml now only DOWNLOADS these assets to
+# install-verify them on a native runner and push them to Cloudsmith.
+#
+# WHERE THIS RUNS: dist's build-global-artifacts job (ubuntu, x86_64). At that
+# point dist has downloaded the per-target release archives to target/distrib/ but
+# the raw compiled binaries are not on disk — so we extract each binary (plus the
+# man page + shell completions) from its archive, stage it exactly where
+# [package.metadata.deb]/[package.metadata.generate-rpm] expect, and repackage.
+# cargo-deb / cargo-generate-rpm are pure Rust (no dpkg / rpmbuild needed) and here
+# only REPACKAGE a prebuilt binary (--no-build), so cross-arch packaging on an
+# x86_64 host is fine — the package's internal arch label comes from --target, not
+# the host. The output filenames are stable (triple-based, matching dist's archive
+# names) so dist's `extra-artifacts.artifacts` can list literal paths and
+# packages.yml can download them by a fixed pattern.
+set -euo pipefail
+
+TRIPLES=(x86_64-unknown-linux-musl aarch64-unknown-linux-musl)
+OUT=dist-extra
+mkdir -p "$OUT"
+
+# The pure-Rust packagers, compiled from source. Unpinned (latest), matching the
+# old packages.yml posture; there is no prebuilt-binary URL/SHA to rot, so this is
+# zero-maintenance. It runs only on a release tag, so the one-time compile is fine.
+# Skip if a cached copy is already on PATH (re-runs / future dist caching).
+command -v cargo-deb >/dev/null 2>&1 && command -v cargo-generate-rpm >/dev/null 2>&1 \
+  || cargo install --locked cargo-deb cargo-generate-rpm
+
+for triple in "${TRIPLES[@]}"; do
+  archive="target/distrib/bdinfo-rs-${triple}.tar.gz"
+  test -f "$archive" || { echo "::error::missing release archive $archive"; exit 1; }
+  tar xzf "$archive" -C target/distrib
+  # dist wraps unix archives in a <pkg>-<triple>/ directory.
+  d="target/distrib/bdinfo-rs-${triple}"
+
+  # Stage exactly where the package metadata's `assets` expect: the binary at
+  # target/<triple>/release/ (cargo-deb / cargo-generate-rpm rewrite the
+  # target/release/ asset prefix under --target), and the man page + completions
+  # under release-assets/ — which cargo-deb resolves relative to the crate dir,
+  # hence the second copy into crates/bdinfo-rs/release-assets/.
+  mkdir -p "target/${triple}/release" release-assets crates/bdinfo-rs/release-assets
+  cp "$d/bdinfo-rs" "target/${triple}/release/bdinfo-rs"
+  for f in bdinfo-rs.1 bdinfo-rs.bash _bdinfo-rs bdinfo-rs.fish; do
+    cp "$d/$f" release-assets/
+    cp "$d/$f" crates/bdinfo-rs/release-assets/
+  done
+
+  cargo deb --no-build --no-strip --target "$triple" -p bdinfo-rs
+  cp target/"${triple}"/debian/*.deb "$OUT/bdinfo-rs-${triple}.deb"
+
+  cargo generate-rpm -p crates/bdinfo-rs --target "$triple"
+  cp target/"${triple}"/generate-rpm/*.rpm "$OUT/bdinfo-rs-${triple}.rpm"
+done
+
+echo "Staged Linux packages for the release:"
+ls -l "$OUT"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,3 +88,22 @@ updates:
     commit-message:
       prefix: build
       include: scope
+
+  # The fuzz harness (fuzz/) is ALSO an independent workspace (`exclude`d from the
+  # root, its own Cargo.lock), so the `/` cargo entry never sees libfuzzer-sys / arbitrary
+  # and their transitive tree. These never ship (dev-only adversarial amplifier) but
+  # still want advisory coverage + freshness like the wasm crate. `build(deps):`
+  # (no-bump) keeps the squash subject + commit conventional.
+  - package-ecosystem: cargo
+    directory: "/fuzz"
+    schedule:
+      interval: daily
+    groups:
+      fuzz-cargo-dependencies:
+        patterns: ["*"]
+    allow:
+      - dependency-type: "all"
+    labels: [dependencies, fuzz]
+    commit-message:
+      prefix: build
+      include: scope

--- a/.github/scripts/source-rules.ps1
+++ b/.github/scripts/source-rules.ps1
@@ -1,0 +1,78 @@
+#!/usr/bin/env pwsh
+# Source-rule guard for the bdinfo-rs-core LIBRARY — two house rules that no clippy
+# lint covers, enforced IDENTICALLY by the local gate (scripts/compliance.ps1) and
+# CI (the `lint` job in ci.yml). This script is the single source of truth for both,
+# exactly like .github/scripts/check-banned-words.ps1.
+#
+#   (1) Big-endian only. Disc structures are big-endian, so from_ne_bytes /
+#       from_le_bytes / to_ne_bytes silently misreads on a little-endian host (x86).
+#       The vfs::udf reader is little-endian BY SPEC (ECMA-167) and is the sole
+#       exemption to this rule (HashMap/HashSet still applies there).
+#   (2) No HashMap/HashSet in the deterministic output path. Rust's HashMap is
+#       per-instance seed-randomized, so it yields nondeterministic iteration order
+#       and therefore nondeterministic report bytes — use BTreeMap/BTreeSet or a
+#       sorted Vec.
+#
+# #[cfg(test)] modules are exempt (test code may use either freely). Exits 1 with a
+# list of offenders on any violation in non-test library code, 0 when clean.
+
+[CmdletBinding()]
+param(
+    # Default: crates/bdinfo-rs-core/src relative to this script (.github/scripts/).
+    [string] $SrcDir = [System.IO.Path]::Combine($PSScriptRoot, '..', '..', 'crates', 'bdinfo-rs-core', 'src')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$srcPath = (Resolve-Path -LiteralPath $SrcDir).Path
+$rules = @(
+    @{ Rx = 'from_ne_bytes|from_le_bytes|to_ne_bytes'; Why = 'host/little-endian byte op (disc bytes are big-endian; use from_be_bytes)'; Exempt = '[\\/]udf([\\/]|\.rs$)' }
+    @{ Rx = '\bHashMap\b|\bHashSet\b'; Why = 'nondeterministic collection in an output path (use BTreeMap/BTreeSet or a sorted Vec)' }
+)
+
+$hits = @()
+foreach ($file in @(Get-ChildItem -LiteralPath $srcPath -Recurse -File -Filter *.rs)) {
+    # Track brace depth so a #[cfg(test)] mod can be skipped wholesale. $testAt is the
+    # depth at which the active test module opened, or -1 when not inside one.
+    $depth = 0; $testAt = -1; $pending = $false; $lineNo = 0
+    foreach ($raw in [System.IO.File]::ReadAllLines($file.FullName)) {
+        $lineNo++
+        # Drop line/doc comments so prose ("never HashMap") and braces in comments
+        # can't trip the scan.
+        $code = $raw -replace '//.*$', ''
+        if ($testAt -lt 0) {
+            if ($pending) {
+                # We saw #[cfg(test)] and are deciding what it attaches to. Skip blank
+                # lines and STACKED attributes (#[allow(...)] between cfg(test) and the
+                # item); the first real token decides: a `mod ... {` is a test module
+                # (exempt), anything else (a test fn/use/const) is NOT a module — clear
+                # pending so a LATER production `mod` is never mis-exempted (the G-06
+                # latent false-negative the old single-flag walk allowed).
+                if (-not $code.Trim()) { }
+                elseif ($code -match '^\s*#!?\[') { }
+                elseif ($code -match '\bmod\b.*\{') { $testAt = $depth; $pending = $false }
+                else { $pending = $false }
+            }
+            elseif ($code -match '#\[cfg\(test\)\]') {
+                $pending = $true
+            }
+            else {
+                foreach ($r in $rules) {
+                    if ($r.ContainsKey('Exempt') -and $file.FullName -match $r.Exempt) { continue }
+                    if ($code -match $r.Rx) { $hits += "    $($file.Name):$lineNo  $($r.Why)" }
+                }
+            }
+        }
+        $depth += ([regex]::Matches($code, '\{')).Count - ([regex]::Matches($code, '\}')).Count
+        if ($testAt -ge 0 -and $depth -le $testAt) { $testAt = -1 }
+    }
+}
+
+if ($hits.Count) {
+    Write-Host 'FAILED: source rules — forbidden constructs in non-test library code:' -ForegroundColor Red
+    $hits | ForEach-Object { Write-Host $_ -ForegroundColor DarkGray }
+    exit 1
+}
+Write-Host 'source rules: ok (big-endian only; no HashMap/HashSet outside tests)' -ForegroundColor Green
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI
 # Build and test on every supported OS. The pinned stable toolchain installs
 # itself from rust-toolchain.toml on first cargo use; `unsafe` is forbidden at
 # compile time, so a green build is also the memory-safety guarantee. Every
-# cargo call is --locked for reproducible builds.
+# dependency-resolving cargo call is --locked for reproducible builds (the one
+# exception is cargo-semver-checks, which builds its own baseline + current
+# checkouts and takes no --locked flag).
 
 on:
   push:
@@ -199,8 +201,13 @@ jobs:
   # bound functions with `#[cfg_attr(coverage_nightly, coverage(off))]`, and that
   # cfg is only set by cargo-llvm-cov on a nightly toolchain. On stable those
   # exclusions are inert, so the off-Windows platform arms count as uncovered and
-  # the floor can't be met on Linux. The branch floors (also nightly-only) stay
-  # in the local gate.
+  # the floor can't be met on Linux. The 97%/91% branch floors stay in the LOCAL
+  # gate (scripts/compliance.ps1) — NOT because they need nightly (this job is
+  # already on nightly) but because branch coverage is platform-VARIANT: the
+  # library carries #[cfg(windows)] arms (e.g. vfs/fs.rs) whose branch count
+  # differs by OS, so one CI floor calibrated on a single platform would misfire
+  # on another. CI gates the platform-INVARIANT 100% line/region/function floor;
+  # the contributor's local gate enforces the branch floors on their own platform.
   coverage:
     name: coverage (100% lines/regions/functions)
     runs-on: ubuntu-latest
@@ -228,6 +235,14 @@ jobs:
   # (cargo mutants --in-diff) is fast. It reads the tracked .cargo/mutants.toml
   # policy and the `mutants` nextest profile (.config/nextest.toml) — both now
   # published, so CI mutates exactly as the local gate does.
+  #
+  # ADVISORY, by design: this job is intentionally NOT in branch protection's
+  # required status checks. cargo-mutants --in-diff can false-TIMEOUT on the
+  # 4-core hosted runners (a hang-prone loop-guard mutant runs in ceil(n/cores)
+  # nextest-terminate waves), so gating merges on it would let an environment
+  # artifact block an unrelated PR. The AUTHORITATIVE "0 missed mutants" gate is
+  # the local full sweep run before each release (per CLAUDE.md); this surfaces
+  # regressions early but does not block. Keep it out of the required set.
   mutants:
     name: mutation testing (PR diff)
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,14 @@ jobs:
         with:
           tool: cargo-machete,cargo-shear,cargo-semver-checks,typos
 
+      # House rules with no clippy equivalent (big-endian-only + no HashMap/HashSet
+      # in the deterministic output path), mirrored from the local gate via the
+      # shared script so local and CI enforce the SAME rule. pwsh ships on the
+      # ubuntu runner.
+      - name: Source rules (big-endian + determinism)
+        shell: pwsh
+        run: ./.github/scripts/source-rules.ps1
+
       - name: Format (nightly rustfmt)
         run: cargo +${{ env.NIGHTLY }} fmt --all --check
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,4 +22,14 @@ jobs:
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: low
+          # License policy: block a PR introducing a strong-copyleft dependency
+          # that would force us to relicense the whole static binary (incompatible
+          # with our LGPL-2.1-or-later distribution). deny.toml's [licenses] allow
+          # list remains the AUTHORITATIVE full policy (enforced by the required
+          # `cargo deny check`); this denylist is a low-false-positive PR-time
+          # backstop targeting only the genuinely incompatible families.
+          deny-licenses: >-
+            GPL-2.0-only, GPL-2.0-or-later,
+            GPL-3.0-only, GPL-3.0-or-later,
+            AGPL-3.0-only, AGPL-3.0-or-later
           comment-summary-in-pr: on-failure

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,8 +18,9 @@ name: deploy-pages
 #        npx wrangler pages deploy site --project-name=bdinfo-rs
 #      Set the project's production branch to `master` so this workflow's
 #      `--branch=master` deploy is the production one.
-#   2. Add repo secrets CLOUDFLARE_API_TOKEN (a token scoped to Pages:Edit) and
-#      CLOUDFLARE_ACCOUNT_ID.
+#   2. Add CLOUDFLARE_API_TOKEN (a token scoped to Pages:Edit) and CLOUDFLARE_ACCOUNT_ID
+#      as ENVIRONMENT secrets on the `pages` environment (gated to the master branch),
+#      NOT repo secrets — so only a master deploy can read the Pages deploy token.
 
 on:
   workflow_dispatch:
@@ -42,6 +43,12 @@ jobs:
   deploy:
     name: build + deploy the demo to Cloudflare Pages
     runs-on: ubuntu-latest
+    # CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID are ENVIRONMENT secrets on `pages`
+    # (not repo secrets), so only a deploy from master can read them. The push trigger
+    # is master-only (github.ref = master), matched by the environment's `master` branch
+    # rule; a workflow_dispatch from any other branch is intentionally locked out of the
+    # production Pages token. No tag rule — there is no tag trigger here.
+    environment: pages
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -77,12 +77,18 @@ jobs:
         with:
           tool: cargo-fuzz
 
+      - name: Verify the committed fuzz lockfile is in sync
+        # cargo-fuzz's `run` has no --locked flag (it forwards everything after
+        # `--` to libFuzzer), so enforce the committed fuzz/Cargo.lock with a real
+        # cargo command up front; this also pre-fetches the deps for the build.
+        run: cargo +"$NIGHTLY" fetch --locked --manifest-path fuzz/Cargo.toml
+
       - name: Replay the committed corpus through every target
         run: |
           fail=0
           for t in $TARGETS; do
             echo "::group::replay $t"
-            cargo +"$NIGHTLY" fuzz run "$t" --target "$FUZZ_TARGET" --locked -- -runs=0 $GUARDS || fail=1
+            cargo +"$NIGHTLY" fuzz run "$t" --target "$FUZZ_TARGET" -- -runs=0 $GUARDS || fail=1
             echo "::endgroup::"
           done
           exit $fail
@@ -118,12 +124,18 @@ jobs:
         with:
           tool: cargo-fuzz
 
+      - name: Verify the committed fuzz lockfile is in sync
+        # cargo-fuzz's `run` has no --locked flag (it forwards everything after
+        # `--` to libFuzzer), so enforce the committed fuzz/Cargo.lock with a real
+        # cargo command up front; this also pre-fetches the deps for the build.
+        run: cargo +"$NIGHTLY" fetch --locked --manifest-path fuzz/Cargo.toml
+
       - name: Fresh-fuzz every target (120s each)
         run: |
           fail=0
           for t in $TARGETS; do
             echo "::group::fuzz $t"
-            cargo +"$NIGHTLY" fuzz run "$t" --target "$FUZZ_TARGET" --locked -- -max_total_time=120 $GUARDS -print_final_stats=1 || fail=1
+            cargo +"$NIGHTLY" fuzz run "$t" --target "$FUZZ_TARGET" -- -max_total_time=120 $GUARDS -print_final_stats=1 || fail=1
             echo "::endgroup::"
           done
           exit $fail

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,9 +6,14 @@ name: fuzz
 # scripts/fuzz-docker.{ps1,sh} (Windows via Docker) — the guards here match it.
 #
 #   pull_request / push to master -> replay the committed seed corpus (-runs=0),
-#                                     a fast deterministic regression gate.
-#   push of a v* tag              -> a longer fresh-fuzz pass per target as a
-#                                     release gate.
+#                                     a fast deterministic regression gate (the
+#                                     required `corpus replay` check).
+#   push of a v* tag              -> a longer fresh-fuzz pass per target. This runs
+#                                     ALONGSIDE the publish workflows the same tag
+#                                     triggers (release/publish-crates/publish-npm)
+#                                     and does NOT block them — a crash surfaces a
+#                                     regression to fix in a follow-up patch, it is
+#                                     a post-tag adversarial sweep, not a gate.
 
 on:
   pull_request:
@@ -77,13 +82,16 @@ jobs:
           fail=0
           for t in $TARGETS; do
             echo "::group::replay $t"
-            cargo +"$NIGHTLY" fuzz run "$t" --target "$FUZZ_TARGET" -- -runs=0 $GUARDS || fail=1
+            cargo +"$NIGHTLY" fuzz run "$t" --target "$FUZZ_TARGET" --locked -- -runs=0 $GUARDS || fail=1
             echo "::endgroup::"
           done
           exit $fail
 
-  # Release tag: a longer fresh-fuzz budget per target. New corpus growth and
-  # any crash artifacts are uploaded for inspection; a crash fails the release.
+  # Release tag: a longer fresh-fuzz budget per target. New corpus growth and any
+  # crash artifacts are uploaded for inspection. A crash fails THIS fuzz run and
+  # surfaces the regression; the publish workflows triggered by the same tag run
+  # independently (this job does not `needs:`-gate them), so treat a crash as a
+  # fast-follow patch trigger, not a release blocker.
   extended:
     name: extended fuzz (release tag)
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -115,7 +123,7 @@ jobs:
           fail=0
           for t in $TARGETS; do
             echo "::group::fuzz $t"
-            cargo +"$NIGHTLY" fuzz run "$t" --target "$FUZZ_TARGET" -- -max_total_time=120 $GUARDS -print_final_stats=1 || fail=1
+            cargo +"$NIGHTLY" fuzz run "$t" --target "$FUZZ_TARGET" --locked -- -max_total_time=120 $GUARDS -print_final_stats=1 || fail=1
             echo "::endgroup::"
           done
           exit $fail

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -32,6 +32,13 @@ jobs:
   homebrew:
     name: publish the Homebrew formula (with man page + completions)
     runs-on: ubuntu-latest
+    # HOMEBREW_TAP_TOKEN is an ENVIRONMENT secret on `release` (not a repo secret), so
+    # only a release run can read it. release.yml is tag-triggered, so this reusable
+    # job's github.ref is the `vX.Y.Z` tag → the environment's `v*` tag deployment rule
+    # admits it. The caller already passes `secrets: inherit`; with `environment:` set
+    # here at the job level, the env secret resolves — the documented reusable-workflow
+    # path (an env secret can't be passed via on.workflow_call, only resolved this way).
+    environment: release
     env:
       # GITHUB_TOKEN downloads the formula from THIS repo's release; the push to
       # the tap uses HOMEBREW_TAP_TOKEN (the checkout credentials), not this.

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -1,0 +1,117 @@
+name: linux-packages
+
+# PR-time smoke test for the .deb / .rpm packaging. The packages are now built
+# INSIDE the release (dist `extra-artifacts` -> .github/build-linux-packages.sh),
+# and a build failure there ABORTS the whole release (dist fail-fast) — so a broken
+# package metadata change must be caught BEFORE a tag, not at release time. This job
+# does exactly that: it builds the musl binary, runs the SAME cargo-deb /
+# cargo-generate-rpm invocations the release uses (reading the same
+# [package.metadata.{deb,generate-rpm}] config), installs the resulting packages and
+# asserts the binary + man page + completions (+ DEP-5 copyright) land. It does not
+# go through the archive-extraction in build-linux-packages.sh (there are no dist
+# archives on a PR) — that glue is exercised at release time — but it covers the real
+# risk surface: the packaging metadata and the tools producing installable packages.
+#
+# Scoped by `paths` to packaging-relevant files to stay frugal on CI minutes. Not a
+# required status check (yet) — it is a fast pre-tag warning, complementing the
+# post-release native-arch verification in packages.yml.
+
+on:
+  pull_request:
+    paths:
+      - .github/build-linux-packages.sh
+      - .github/workflows/linux-packages.yml
+      - dist-workspace.toml
+      - crates/bdinfo-rs/Cargo.toml
+      - crates/bdinfo-rs/debian/copyright
+      - Cargo.lock
+  push:
+    branches: [master]
+    paths:
+      - .github/build-linux-packages.sh
+      - .github/workflows/linux-packages.yml
+      - dist-workspace.toml
+      - crates/bdinfo-rs/Cargo.toml
+      - crates/bdinfo-rs/debian/copyright
+      - Cargo.lock
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: build + install .deb/.rpm (x86_64)
+    runs-on: ubuntu-latest
+    # Build the HOST gnu triple, not musl: this job verifies the PACKAGING (metadata,
+    # the cargo-deb/cargo-generate-rpm `--target` path rewrite, install + contents),
+    # for which the binary's libc is irrelevant — and gnu is the runner's native
+    # target, so there is no musl-linker friction to make the smoke test flaky. The
+    # static musl binaries themselves are e2e-tested on musl elsewhere (ci.yml).
+    env:
+      TRIPLE: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # build.rs writes the shell completions + man page into OUT_DIR during the build;
+      # passing the host triple explicitly nests output under target/<triple>/ so the
+      # `--target` path rewrite in cargo-deb/cargo-generate-rpm is exercised too.
+      # --locked keeps the smoke build honest against the committed lockfile.
+      - name: Build the binary (generates completions + man page)
+        run: cargo build --release --locked --target "$TRIPLE" -p bdinfo-rs
+
+      - name: Install cargo-deb + cargo-generate-rpm
+        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        with:
+          tool: cargo-deb,cargo-generate-rpm
+
+      # Stage exactly where [package.metadata.deb]/[generate-rpm] expect (the same
+      # layout build-linux-packages.sh produces): the binary under
+      # target/<triple>/release/ and the man page + completions under release-assets/
+      # (cargo-deb resolves those relative to the crate dir, hence the second copy).
+      - name: Stage the binary + completion/man assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          assets="$(dirname "$(ls target/"$TRIPLE"/release/build/bdinfo-rs-*/out/assets/bdinfo-rs.1 | head -n1)")"
+          mkdir -p release-assets crates/bdinfo-rs/release-assets
+          for f in bdinfo-rs.1 bdinfo-rs.bash _bdinfo-rs bdinfo-rs.fish; do
+            cp "$assets/$f" release-assets/
+            cp "$assets/$f" crates/bdinfo-rs/release-assets/
+          done
+
+      - name: Build + install + verify the .deb
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo deb --no-build --no-strip --target "$TRIPLE" -p bdinfo-rs
+          deb=$(ls target/"$TRIPLE"/debian/*.deb)
+          echo "== $deb =="; dpkg-deb --contents "$deb"
+          sudo dpkg -i "$deb"
+          bdinfo-rs --version
+          ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
+          for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+            test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
+          done
+          grep -q '^License: LGPL-2.1-or-later' /usr/share/doc/bdinfo-rs/copyright || { echo "NOT INSTALLED: DEP-5 copyright License field"; exit 1; }
+          sudo dpkg -r bdinfo-rs
+          echo ".deb OK"
+
+      - name: Build + install + verify the .rpm
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq && sudo apt-get install -y -qq rpm
+          sudo rpm --initdb 2>/dev/null || true
+          cargo generate-rpm -p crates/bdinfo-rs --target "$TRIPLE"
+          rpmf=$(ls target/"$TRIPLE"/generate-rpm/*.rpm)
+          echo "== $rpmf =="; rpm -qpl "$rpmf"
+          sudo rpm -i --nodeps --ignorearch --force "$rpmf"
+          bdinfo-rs --version
+          ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
+          for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+            test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
+          done
+          echo ".rpm OK"

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -28,8 +28,16 @@ name: packages
 #   - Scoop     -> the agentjp/scoop-bucket repo (Excavator auto-update bot)
 #
 # Secrets required (configure before the first release, or the jobs fail):
-#   WINGET_TOKEN - classic PAT (public_repo) on the bot account that forked winget-pkgs
-#   AUR_SSH_KEY  - private SSH key whose public half is on the aur.archlinux.org account
+#   WINGET_TOKEN       - classic PAT (public_repo) on the bot account that forked winget-pkgs
+#   AUR_SSH_KEY        - private SSH key whose public half is on the aur.archlinux.org account
+#   CLOUDSMITH_API_KEY - Cloudsmith API key (used by the active deb/rpm jobs)
+#
+# These three publish secrets live on the `release` ENVIRONMENT (not as repo secrets), so
+# only a release run can read them — a workflow on any other branch is structurally locked
+# out. GOTCHA: this workflow fires on `workflow_run` (after Release), where github.ref is
+# the DEFAULT BRANCH (master), NOT the release tag. So the `release` environment must allow
+# deployments from the `master` branch for the jobs below to read the secrets. (The tag
+# `v*` rule on that same environment is what admits the tag-triggered homebrew.yml instead.)
 #
 # NOTE: the deb/rpm CONTENTS (assets, metadata, the cargo-deb / cargo-generate-rpm
 # invocation) live in build-linux-packages.sh + [package.metadata.{deb,generate-rpm}]
@@ -83,6 +91,7 @@ jobs:
   winget:
     name: WinGet
     runs-on: ubuntu-latest
+    environment: release # WINGET_TOKEN is an env secret on `release` (see header)
     # GATED OFF (2026-06-23): winget-releaser UPDATES an existing package — it bases
     # the new manifest on the package's prior version already in microsoft/winget-pkgs.
     # The first submission (agentjp.bdinfo-rs 1.0.0) is still an open New-Package PR
@@ -112,6 +121,7 @@ jobs:
   aur:
     name: AUR (bdinfo-rs-bin)
     runs-on: ubuntu-latest
+    environment: release # AUR_SSH_KEY is an env secret on `release` (see header)
     # ON HOLD (2026-06-19): aur.archlinux.org account registration is currently
     # disabled, so there is no AUR account/package to push to yet. Re-enable by
     # setting the repo variable AUR_ENABLED=true (after registering the account and
@@ -149,6 +159,7 @@ jobs:
   deb:
     name: .deb (${{ matrix.triple }})
     runs-on: ${{ matrix.os }}
+    environment: release # CLOUDSMITH_API_KEY is an env secret on `release` (see header)
     needs: gate
     if: needs.gate.outputs.stable == 'true'
     # contents: read (inherited) is enough — the .deb is already a release asset; this
@@ -208,6 +219,7 @@ jobs:
   rpm:
     name: .rpm (${{ matrix.triple }})
     runs-on: ${{ matrix.os }}
+    environment: release # CLOUDSMITH_API_KEY is an env secret on `release` (see header)
     needs: gate
     if: needs.gate.outputs.stable == 'true'
     # contents: read (inherited) is enough — see the .deb job; this uploads nothing back.

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,13 +1,23 @@
 name: packages
 
 # Fan-out package publishing, run AFTER release.yml ("Release") has built and
-# uploaded the GitHub Release archives. release.yml (cargo-dist) creates that
-# release with the default GITHUB_TOKEN, and GitHub suppresses the
-# `release: released` event for token-created releases — so a `release`-triggered
-# workflow never fires (this is why v1.0.0's .deb/.rpm had to be uploaded by hand).
-# Instead we chain off release.yml's completion via `workflow_run` (which DOES
-# fire), and expose a manual `workflow_dispatch` for re-runs / backfills. Every job
-# runs on a Linux runner; every action is SHA-pinned.
+# uploaded the GitHub Release. release.yml (cargo-dist) creates that release with
+# the default GITHUB_TOKEN, and GitHub suppresses the `release: released` event for
+# token-created releases — so a `release`-triggered workflow never fires. Instead
+# we chain off release.yml's completion via `workflow_run` (which DOES fire), and
+# expose a manual `workflow_dispatch` for re-runs / backfills. Every job runs on a
+# Linux runner; every action is SHA-pinned.
+#
+# The .deb/.rpm packages are now BUILT INSIDE the release (dist `extra-artifacts`
+# -> .github/build-linux-packages.sh), so they are attached to the Release at
+# creation, before it is published. This workflow therefore only DOWNLOADS those
+# already-attached packages to install-verify them on a native-arch runner and push
+# them to Cloudsmith — it no longer builds them, and (crucially) no longer uploads
+# anything back to the Release. That post-publication `gh release upload` was the
+# one thing incompatible with GitHub "immutable releases" (a release's assets freeze
+# at publication); with it gone, immutability can be enabled. As a bonus the deb/rpm
+# jobs now need only `contents: read`, resolving the two job-level `contents: write`
+# Token-Permissions residuals (alerts #78/#79).
 #
 # Stable-only: the `gate` job skips prerelease tags (anything but a bare vX.Y.Z),
 # matching the old `released`-event semantics and Homebrew's default.
@@ -21,8 +31,9 @@ name: packages
 #   WINGET_TOKEN - classic PAT (public_repo) on the bot account that forked winget-pkgs
 #   AUR_SSH_KEY  - private SSH key whose public half is on the aur.archlinux.org account
 #
-# NOTE: the deb/rpm jobs repackage the prebuilt musl binaries; tweak the cargo-deb
-# / cargo-generate-rpm invocation here (not the binary) if a path needs adjusting.
+# NOTE: the deb/rpm CONTENTS (assets, metadata, the cargo-deb / cargo-generate-rpm
+# invocation) live in build-linux-packages.sh + [package.metadata.{deb,generate-rpm}]
+# in crates/bdinfo-rs/Cargo.toml; tweak packaging there, not here.
 
 on:  # zizmor: ignore[dangerous-triggers] repackages published release assets; checks out master at the tag, never PR code
   workflow_run:
@@ -140,8 +151,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: gate
     if: needs.gate.outputs.stable == 'true'
-    permissions:
-      contents: write # gh release upload
+    # contents: read (inherited) is enough — the .deb is already a release asset; this
+    # job downloads + verifies + pushes to Cloudsmith and uploads nothing back. (The
+    # old job needed contents: write for `gh release upload`; dropping it resolves the
+    # #78/#79 Token-Permissions residuals.)
     env:
       VERSION: ${{ needs.gate.outputs.version }}
     strategy:
@@ -153,38 +166,19 @@ jobs:
           - {triple: x86_64-unknown-linux-musl, os: ubuntu-latest}
           - {triple: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install cargo-deb
-        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
-        with:
-          tool: cargo-deb
-
-      - name: Stage the prebuilt binary + completion/man assets
+      # The package was built + attached to the release by dist `extra-artifacts`
+      # (.github/build-linux-packages.sh); just pull it back to verify + republish.
+      - name: Download the .deb attached to the release
         shell: bash
-        run: |
-          gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" -p "bdinfo-rs-${{ matrix.triple }}.tar.gz" -D dl
-          tar xzf "dl/bdinfo-rs-${{ matrix.triple }}.tar.gz" -C dl
-          d="dl/bdinfo-rs-${{ matrix.triple }}"
-          mkdir -p "target/${{ matrix.triple }}/release" release-assets crates/bdinfo-rs/release-assets
-          cp "$d/bdinfo-rs" "target/${{ matrix.triple }}/release/bdinfo-rs"
-          for f in bdinfo-rs.1 bdinfo-rs.bash _bdinfo-rs bdinfo-rs.fish; do
-            cp "$d/$f" release-assets/
-            cp "$d/$f" crates/bdinfo-rs/release-assets/
-          done
+        run: gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" -p "bdinfo-rs-${{ matrix.triple }}.deb" -D dl
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build the .deb
-        run: cargo deb --no-build --no-strip --target ${{ matrix.triple }} -p bdinfo-rs
 
       - name: Verify the .deb (install + run + man/completions on the native arch)
         shell: bash
         run: |
           set -euo pipefail
-          deb=$(ls target/${{ matrix.triple }}/debian/*.deb)
+          deb="dl/bdinfo-rs-${{ matrix.triple }}.deb"
           echo "== $deb =="; dpkg-deb --contents "$deb"
           sudo dpkg -i "$deb"
           bdinfo-rs --version
@@ -199,21 +193,16 @@ jobs:
           grep -q '^License: LGPL-2.1-or-later' /usr/share/doc/bdinfo-rs/copyright || { echo "NOT INSTALLED: DEP-5 copyright License field"; exit 1; }
           echo "${{ matrix.triple }} .deb: installs, runs, and ships man + completions + DEP-5 copyright"
 
-      - name: Upload the .deb to the release
-        shell: bash
-        run: gh release upload "$VERSION" target/${{ matrix.triple }}/debian/*.deb --repo "$GITHUB_REPOSITORY" --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Publish to the Cloudsmith apt repo so users can `apt install bdinfo-rs` by
-      # name (one `any-distro/any-version` upload serves every Debian-family distro).
+      # Publish the SAME bytes to the Cloudsmith apt repo so users can `apt install
+      # bdinfo-rs` by name (one `any-distro/any-version` upload serves every
+      # Debian-family distro).
       - name: Publish the .deb to Cloudsmith
         shell: bash
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
           pipx install cloudsmith-cli==1.19.0
-          cloudsmith push deb bdinfo-rs/bdinfo-rs/any-distro/any-version target/${{ matrix.triple }}/debian/*.deb
+          cloudsmith push deb bdinfo-rs/bdinfo-rs/any-distro/any-version dl/bdinfo-rs-${{ matrix.triple }}.deb
 
   # ── Fedora/RHEL: .rpm attached to the release (x64 + arm64) ────────────────
   rpm:
@@ -221,8 +210,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: gate
     if: needs.gate.outputs.stable == 'true'
-    permissions:
-      contents: write # gh release upload
+    # contents: read (inherited) is enough — see the .deb job; this uploads nothing back.
     env:
       VERSION: ${{ needs.gate.outputs.version }}
     strategy:
@@ -234,32 +222,13 @@ jobs:
           - {triple: x86_64-unknown-linux-musl, os: ubuntu-latest}
           - {triple: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install cargo-generate-rpm
-        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
-        with:
-          tool: cargo-generate-rpm
-
-      - name: Stage the prebuilt binary + completion/man assets
+      # The package was built + attached to the release by dist `extra-artifacts`
+      # (.github/build-linux-packages.sh); just pull it back to verify + republish.
+      - name: Download the .rpm attached to the release
         shell: bash
-        run: |
-          gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" -p "bdinfo-rs-${{ matrix.triple }}.tar.gz" -D dl
-          tar xzf "dl/bdinfo-rs-${{ matrix.triple }}.tar.gz" -C dl
-          d="dl/bdinfo-rs-${{ matrix.triple }}"
-          mkdir -p "target/${{ matrix.triple }}/release" release-assets crates/bdinfo-rs/release-assets
-          cp "$d/bdinfo-rs" "target/${{ matrix.triple }}/release/bdinfo-rs"
-          for f in bdinfo-rs.1 bdinfo-rs.bash _bdinfo-rs bdinfo-rs.fish; do
-            cp "$d/$f" release-assets/
-            cp "$d/$f" crates/bdinfo-rs/release-assets/
-          done
+        run: gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" -p "bdinfo-rs-${{ matrix.triple }}.rpm" -D dl
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build the .rpm
-        run: cargo generate-rpm -p crates/bdinfo-rs --target ${{ matrix.triple }}
 
       - name: Verify the .rpm (install + run + man/completions on the native arch)
         shell: bash
@@ -267,7 +236,7 @@ jobs:
           set -euo pipefail
           sudo apt-get update -qq && sudo apt-get install -y -qq rpm
           sudo rpm --initdb 2>/dev/null || true
-          rpmf=$(ls target/${{ matrix.triple }}/generate-rpm/*.rpm)
+          rpmf="dl/bdinfo-rs-${{ matrix.triple }}.rpm"
           echo "== $rpmf =="; rpm -qpl "$rpmf"
           # rpm tool on Ubuntu lays the package's files onto the filesystem; --nodeps
           # (the binary is static, no deps) and --ignorearch (rpm's host-arch string
@@ -281,21 +250,16 @@ jobs:
           done
           echo "${{ matrix.triple }} .rpm: installs (rpm -i), runs, and ships man + completions"
 
-      - name: Upload the .rpm to the release
-        shell: bash
-        run: gh release upload "$VERSION" target/${{ matrix.triple }}/generate-rpm/*.rpm --repo "$GITHUB_REPOSITORY" --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Publish to the Cloudsmith yum repo so users can `dnf install bdinfo-rs` by
-      # name (one `any-distro/any-version` upload serves every RPM-family distro).
+      # Publish the SAME bytes to the Cloudsmith yum repo so users can `dnf install
+      # bdinfo-rs` by name (one `any-distro/any-version` upload serves every
+      # RPM-family distro).
       - name: Publish the .rpm to Cloudsmith
         shell: bash
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
           pipx install cloudsmith-cli==1.19.0
-          cloudsmith push rpm bdinfo-rs/bdinfo-rs/any-distro/any-version target/${{ matrix.triple }}/generate-rpm/*.rpm
+          cloudsmith push rpm bdinfo-rs/bdinfo-rs/any-distro/any-version dl/bdinfo-rs-${{ matrix.triple }}.rpm
 
   # ── Verify the PUBLISHED Cloudsmith repo: install bdinfo-rs BY NAME and confirm
   # ── the binary + man + completions all land — on both arches, native runners, no

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -23,8 +23,24 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Refuse to publish a tag that is not on master — the same ancestry gate
+  # release.yml and publish-npm.yml use, via the same reusable workflow. A vX.Y.Z
+  # tag pushed onto a side branch (so it never passed CI on master) cannot ship to
+  # crates.io: the publish job `needs:` this one. crates.io publishing is LIVE and
+  # IRREVERSIBLE (a version can be yanked but never re-uploaded), so the off-master
+  # guard matters most here — the tag==version check alone is satisfiable by any
+  # crafted Cargo.toml on any branch.
+  guard-ancestor:
+    uses: ./.github/workflows/guard-ancestor.yml
+    # No `secrets: inherit` — guard-ancestor takes no secrets (checkout + a
+    # `git merge-base` ancestry check), so inheriting them is needless privilege
+    # (and zizmor's secrets-inherit audit flags it).
+    permissions:
+      contents: read
+
   publish:
     name: cargo publish --workspace (crates.io)
+    needs: guard-ancestor
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -83,7 +83,7 @@ jobs:
           node-version: "26.4.0"
 
       # Staged publishing (`npm stage publish`) needs npm >= 11.15.0. Node 26.4.0
-      # already bundles 11.17.0 (>= the floor), so this is not strictly required
+      # already bundles an npm >= the floor, so this is not strictly required
       # today — but pin npm explicitly anyway, so the publish runs on a
       # deterministic, version-freshness-watched npm independent of which npm a
       # given Node 26.x patch happens to bundle (the repo's pin-everything posture).
@@ -92,7 +92,7 @@ jobs:
       # runtime install; pinning npm (from the official registry) carries a scoped
       # inline ignore. Keep this pin in lockstep with version-freshness.yml.
       - name: Pin npm to a staged-publishing-capable version
-        run: npm install -g npm@11.17.0 # zizmor: ignore[adhoc-packages]
+        run: npm install -g npm@11.18.0 # zizmor: ignore[adhoc-packages]
 
       - name: Verify Node >= 26 and npm >= 11.15.0
         shell: pwsh

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -25,10 +25,12 @@ name: version-freshness
 #     — the staged-publishing floor), and wrangler (`npx wrangler@X` in
 #     deploy-pages.yml) — the last two are npx/setup-node inputs, NOT package.json
 #     deps, so Dependabot's npm scan cannot see them,
-#   - the Homebrew/actions/setup-homebrew SHA (install-smoke-test.yml) — the ONE
-#     action SHA watched here: it pins a TAGLESS repo's `master`, so Dependabot
-#     (which bumps toward releases) can't move it, and zizmor's ref-version-mismatch
-#     is inline-ignored for it; without this nag nothing would tell us it drifted.
+#   - two action SHAs whose comment tags MOVE (so Dependabot can't bump them and
+#     zizmor's ref-version-mismatch would red-X a PR once they drift): the
+#     Homebrew/actions/setup-homebrew SHA (install-smoke-test.yml) pins a TAGLESS
+#     repo's `master`, and vedantmgoyal9/winget-releaser (packages.yml) pins a SHA
+#     with a moving-major `# v2` comment (no patch tag at that commit). Both are
+#     nagged here when they drift past the pinned SHA, so re-pinning stays deliberate.
 # (Cargo deps/dev-deps, the web npm devDependencies — typescript / biome /
 # binaryen / playwright-core — and GitHub Action SHAs are already auto-bumped by
 # Dependabot — cargo + npm + github-actions ecosystems — so they are deliberately
@@ -352,7 +354,26 @@ jobs:
           $brewPinShort = if ($brewPin) { $brewPin.Substring(0, 12) } else { '?' }
           $brewHeadShort = if ($brewHead) { $brewHead.Substring(0, 12) } else { '?' }
 
-          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  ryl: $rylPin (latest $rylLatest)  taplo: $taploPin (latest $taploLatest)  convco: $convcoPin (latest $convcoLatest)  wasm-bindgen-cli: $wbGate (latest $wbLatest)  binaryen: $binPin (latest $binLatest)  biome-schema: $biomeSchema (dep $biomeLock)  node: $nodePin (latest-on-major $nodeLatestOnMajor, newest-even $nodeNewestEven)  npm: $npmPin (latest $npmLatest)  wrangler: $wranglerPin (latest $wranglerLatest)  brew: $brewPinShort (head $brewHeadShort)"
+          # --- vedantmgoyal9/winget-releaser: packages.yml SHA vs the v2 tag HEAD ---
+          # SHA-pinned with a MOVING-major `# v2` comment (no patch tag exists at that
+          # commit, so it can't be pinned more precisely). When upstream re-points the
+          # v2 tag to a new commit, our SHA stays put and the `# v2` comment then
+          # mismatches the resolved tag — zizmor's ref-version-mismatch would red-X
+          # every PR. Watch it like setup-homebrew: nag (don't fail) when v2 drifts so
+          # re-pinning stays deliberate. (The winget publish step is GATED OFF today,
+          # but its `uses:` line is still scanned on every PR.)
+          $wingetPin = Read-Pin '.github/workflows/packages.yml' 'winget-releaser@([0-9a-f]{40})'
+          if (-not $wingetPin) { throw 'No winget-releaser SHA pin in packages.yml' }
+          $wingetHead = gh api repos/vedantmgoyal9/winget-releaser/commits/v2 --jq '.sha' 2>$null
+          if ($LASTEXITCODE -ne 0 -or -not $wingetHead) {
+            $problems += '- could not query winget-releaser v2 tag HEAD (GitHub API)'
+          } elseif ($wingetPin -ne $wingetHead) {
+            $problems += "- winget-releaser pin ``$($wingetPin.Substring(0, 12))`` (packages.yml) no longer matches the v2 tag HEAD ``$($wingetHead.Substring(0, 12))`` — the moving major drifted; re-pin the SHA (keep the # v2 comment) deliberately"
+          }
+          $wingetPinShort = if ($wingetPin) { $wingetPin.Substring(0, 12) } else { '?' }
+          $wingetHeadShort = if ($wingetHead) { $wingetHead.Substring(0, 12) } else { '?' }
+
+          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  ryl: $rylPin (latest $rylLatest)  taplo: $taploPin (latest $taploLatest)  convco: $convcoPin (latest $convcoLatest)  wasm-bindgen-cli: $wbGate (latest $wbLatest)  binaryen: $binPin (latest $binLatest)  biome-schema: $biomeSchema (dep $biomeLock)  node: $nodePin (latest-on-major $nodeLatestOnMajor, newest-even $nodeNewestEven)  npm: $npmPin (latest $npmLatest)  wrangler: $wranglerPin (latest $wranglerLatest)  brew: $brewPinShort (head $brewHeadShort)  winget: $wingetPinShort (head $wingetHeadShort)"
           if ($problems.Count -eq 0) { Write-Host 'All pinned versions are fresh and consistent.'; exit 0 }
 
           $title = 'Pinned versions are stale'

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -2,7 +2,9 @@ name: version-freshness
 
 # Several versions in this repo are pinned for reproducibility but rot SILENTLY —
 # nothing else watches them:
-#   - the Rust toolchains (rust-toolchain.toml stable + the NIGHTLY env in ci.yml),
+#   - the Rust toolchains (rust-toolchain.toml stable + the NIGHTLY pin, which is
+#     hardcoded in ci.yml + fuzz.yml + wasm.yml + publish-npm.yml and cross-checked
+#     for agreement here so a bump to one can't silently drift the rest),
 #   - cargo-dist (dist-workspace.toml `cargo-dist-version` AND the `cargo-dist@X`
 #     install in ci.yml — the two must stay equal),
 #   - cargo-vet (the `--version` pin in audit.yml),
@@ -12,7 +14,8 @@ name: version-freshness
 #   - convco (the `tool: convco@X` pin in conventional.yml — pinned because its
 #     output drives a reproducible changelog/version format, like taplo/rustfmt),
 #   - wasm-bindgen-cli (the `wasm-bindgen-cli@X` pin in wasm.yml + publish-npm.yml
-#     — must equal the wasm-bindgen crate it generates glue for; wasm-pack is not
+#     + deploy-pages.yml — all three must equal the wasm-bindgen crate they
+#     generate glue for; wasm-pack is not
 #     used), and binaryen (the `"binaryen"` pin in web/package.json — wasm-opt's
 #     version is coupled to the committed wasm size budget),
 #   - the Node version (the `NODE_VERSION`/`node-version` pins in wasm.yml +
@@ -139,6 +142,20 @@ jobs:
           if ($nightlyAgeDays -gt 30) {
             $problems += "- nightly pin ``nightly-$nightlyPin`` (ci.yml NIGHTLY + scripts/_common.ps1) is $nightlyAgeDays days old"
           }
+          # The nightly is hardcoded in FOUR places (ci.yml/fuzz.yml/wasm.yml NIGHTLY
+          # env + publish-npm.yml's rustup install) that Dependabot can't see, so a
+          # bump to one silently drifts the rest. Cross-check they AGREE (like the
+          # cargo-dist / wasm-bindgen-cli / Node pin agreements); _common.ps1 is the
+          # cockpit twin kept in lockstep by hand.
+          $nightlyFuzz = Read-Pin '.github/workflows/fuzz.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
+          $nightlyWasm = Read-Pin '.github/workflows/wasm.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
+          $nightlyNpm  = Read-Pin '.github/workflows/publish-npm.yml' 'install nightly-(\d{4}-\d{2}-\d{2})'
+          if (-not $nightlyFuzz) { throw 'No NIGHTLY pin in fuzz.yml' }
+          if (-not $nightlyWasm) { throw 'No NIGHTLY pin in wasm.yml' }
+          if (-not $nightlyNpm)  { throw 'No nightly install pin in publish-npm.yml' }
+          if (($nightlyPin -ne $nightlyFuzz) -or ($nightlyPin -ne $nightlyWasm) -or ($nightlyPin -ne $nightlyNpm)) {
+            $problems += "- nightly pin mismatch: ci.yml ``$nightlyPin`` / fuzz.yml ``$nightlyFuzz`` / wasm.yml ``$nightlyWasm`` / publish-npm.yml ``$nightlyNpm`` — all must be identical (and match scripts/_common.ps1)"
+          }
 
           # --- cargo-dist: two pins must agree, both vs axodotdev/cargo-dist ----
           $distCfg = Read-Pin 'dist-workspace.toml' '^\s*cargo-dist-version\s*=\s*"([0-9.]+)"'
@@ -206,12 +223,14 @@ jobs:
           # equal the wasm-bindgen crate it generates glue for, so it is pinned and
           # nothing else watches it. (wasm-pack is NOT used — the build is plain
           # cargo + the CLI + wasm-opt.) The two workflow pins must also agree.
-          $wbGate = Read-Pin '.github/workflows/wasm.yml' 'wasm-bindgen-cli@([0-9.]+)'
-          $wbPub  = Read-Pin '.github/workflows/publish-npm.yml' 'wasm-bindgen-cli@([0-9.]+)'
-          if (-not $wbGate) { throw 'No wasm-bindgen-cli pin in wasm.yml' }
-          if (-not $wbPub)  { throw 'No wasm-bindgen-cli pin in publish-npm.yml' }
-          if ($wbGate -ne $wbPub) {
-            $problems += "- wasm-bindgen-cli pin mismatch: wasm.yml has ``$wbGate`` but publish-npm.yml has ``$wbPub`` — they must be identical"
+          $wbGate   = Read-Pin '.github/workflows/wasm.yml' 'wasm-bindgen-cli@([0-9.]+)'
+          $wbPub    = Read-Pin '.github/workflows/publish-npm.yml' 'wasm-bindgen-cli@([0-9.]+)'
+          $wbDeploy = Read-Pin '.github/workflows/deploy-pages.yml' 'wasm-bindgen-cli@([0-9.]+)'
+          if (-not $wbGate)   { throw 'No wasm-bindgen-cli pin in wasm.yml' }
+          if (-not $wbPub)    { throw 'No wasm-bindgen-cli pin in publish-npm.yml' }
+          if (-not $wbDeploy) { throw 'No wasm-bindgen-cli pin in deploy-pages.yml' }
+          if (($wbGate -ne $wbPub) -or ($wbGate -ne $wbDeploy)) {
+            $problems += "- wasm-bindgen-cli pin mismatch: wasm.yml has ``$wbGate`` / publish-npm.yml has ``$wbPub`` / deploy-pages.yml has ``$wbDeploy`` — all three must be identical"
           }
           $wbLatest = Latest-CratesIo 'wasm-bindgen-cli'
           if (-not $wbLatest) {

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -76,6 +76,12 @@ jobs:
         run: |
           $problems = @()
 
+          # Record one finding: $tag is a short package->version summary for the issue
+          # TITLE, $line the full markdown bullet for the body.
+          function Add-Problem($tag, $line) {
+            $script:problems += [pscustomobject]@{ tag = $tag; line = $line }
+          }
+
           # First pin matched by $regex (group 1) in $path, or $null.
           function Read-Pin($path, $regex) {
             foreach ($line in (Get-Content $path)) {
@@ -132,9 +138,9 @@ jobs:
           if (-not $stablePin) { throw 'No pinned stable channel in rust-toolchain.toml' }
           $stableLatest = Latest-Semver 'rust-lang/rust'
           if (-not $stableLatest) {
-            $problems += '- could not query the latest Rust stable release (rust-lang/rust)'
+            Add-Problem 'Rust stable (query failed)' '- could not query the latest Rust stable release (rust-lang/rust)'
           } elseif ([version]$stableLatest -gt [version]$stablePin) {
-            $problems += "- stable Rust pin ``$stablePin`` (rust-toolchain.toml) is behind the latest release ``$stableLatest``"
+            Add-Problem "Rust stable $stablePin->$stableLatest" "- stable Rust pin ``$stablePin`` (rust-toolchain.toml) is behind the latest release ``$stableLatest``"
           }
 
           # --- Rust nightly: age of the ci.yml NIGHTLY pin ---------------------
@@ -142,13 +148,12 @@ jobs:
           if (-not $nightlyPin) { throw 'No NIGHTLY pin in ci.yml' }
           $nightlyAgeDays = [int]((Get-Date) - [datetime]::ParseExact($nightlyPin, 'yyyy-MM-dd', $null)).TotalDays
           if ($nightlyAgeDays -gt 30) {
-            $problems += "- nightly pin ``nightly-$nightlyPin`` (ci.yml NIGHTLY + scripts/_common.ps1) is $nightlyAgeDays days old"
+            Add-Problem "nightly-$nightlyPin ($nightlyAgeDays d old)" "- nightly pin ``nightly-$nightlyPin`` (ci.yml NIGHTLY) is $nightlyAgeDays days old"
           }
           # The nightly is hardcoded in FOUR places (ci.yml/fuzz.yml/wasm.yml NIGHTLY
           # env + publish-npm.yml's rustup install) that Dependabot can't see, so a
           # bump to one silently drifts the rest. Cross-check they AGREE (like the
-          # cargo-dist / wasm-bindgen-cli / Node pin agreements); _common.ps1 is the
-          # cockpit twin kept in lockstep by hand.
+          # cargo-dist / wasm-bindgen-cli / Node pin agreements).
           $nightlyFuzz = Read-Pin '.github/workflows/fuzz.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
           $nightlyWasm = Read-Pin '.github/workflows/wasm.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
           $nightlyNpm  = Read-Pin '.github/workflows/publish-npm.yml' 'install nightly-(\d{4}-\d{2}-\d{2})'
@@ -156,7 +161,7 @@ jobs:
           if (-not $nightlyWasm) { throw 'No NIGHTLY pin in wasm.yml' }
           if (-not $nightlyNpm)  { throw 'No nightly install pin in publish-npm.yml' }
           if (($nightlyPin -ne $nightlyFuzz) -or ($nightlyPin -ne $nightlyWasm) -or ($nightlyPin -ne $nightlyNpm)) {
-            $problems += "- nightly pin mismatch: ci.yml ``$nightlyPin`` / fuzz.yml ``$nightlyFuzz`` / wasm.yml ``$nightlyWasm`` / publish-npm.yml ``$nightlyNpm`` — all must be identical (and match scripts/_common.ps1)"
+            Add-Problem 'nightly pins disagree' "- nightly pin mismatch: ci.yml ``$nightlyPin`` / fuzz.yml ``$nightlyFuzz`` / wasm.yml ``$nightlyWasm`` / publish-npm.yml ``$nightlyNpm`` — all must be identical"
           }
 
           # --- cargo-dist: two pins must agree, both vs axodotdev/cargo-dist ----
@@ -165,13 +170,13 @@ jobs:
           if (-not $distCfg) { throw 'No cargo-dist-version in dist-workspace.toml' }
           if (-not $distCi)  { throw 'No cargo-dist@<version> install in ci.yml' }
           if ($distCfg -ne $distCi) {
-            $problems += "- cargo-dist pin mismatch: dist-workspace.toml has ``$distCfg`` but ci.yml installs ``$distCi`` — they must be identical"
+            Add-Problem 'cargo-dist pins disagree' "- cargo-dist pin mismatch: dist-workspace.toml has ``$distCfg`` but ci.yml installs ``$distCi`` — they must be identical"
           }
           $distLatest = Latest-Semver 'axodotdev/cargo-dist'
           if (-not $distLatest) {
-            $problems += '- could not query the latest cargo-dist release (axodotdev/cargo-dist)'
+            Add-Problem 'cargo-dist (query failed)' '- could not query the latest cargo-dist release (axodotdev/cargo-dist)'
           } elseif ([version]$distLatest -gt [version]$distCfg) {
-            $problems += "- cargo-dist pin ``$distCfg`` (dist-workspace.toml + ci.yml) is behind the latest release ``$distLatest`` — bump both pins, then re-run ``dist generate``"
+            Add-Problem "cargo-dist $distCfg->$distLatest" "- cargo-dist pin ``$distCfg`` (dist-workspace.toml + ci.yml) is behind the latest release ``$distLatest`` — bump both pins, then re-run ``dist generate``"
           }
 
           # --- cargo-vet: audit.yml vs mozilla/cargo-vet -----------------------
@@ -179,9 +184,9 @@ jobs:
           if (-not $vetPin) { throw 'No cargo-vet --version pin in audit.yml' }
           $vetLatest = Latest-Semver 'mozilla/cargo-vet'
           if (-not $vetLatest) {
-            $problems += '- could not query the latest cargo-vet release (mozilla/cargo-vet)'
+            Add-Problem 'cargo-vet (query failed)' '- could not query the latest cargo-vet release (mozilla/cargo-vet)'
           } elseif ([version]$vetLatest -gt [version]$vetPin) {
-            $problems += "- cargo-vet pin ``$vetPin`` (audit.yml) is behind the latest release ``$vetLatest``"
+            Add-Problem "cargo-vet $vetPin->$vetLatest" "- cargo-vet pin ``$vetPin`` (audit.yml) is behind the latest release ``$vetLatest``"
           }
 
           # --- ryl: ci.yml YAML-lint pin vs crates.io --------------------------
@@ -191,9 +196,9 @@ jobs:
           if (-not $rylPin) { throw 'No `cargo install ryl --version` pin in ci.yml' }
           $rylLatest = Latest-CratesIo 'ryl'
           if (-not $rylLatest) {
-            $problems += '- could not query the latest ryl release (crates.io)'
+            Add-Problem 'ryl (query failed)' '- could not query the latest ryl release (crates.io)'
           } elseif ([version]$rylLatest -gt [version]$rylPin) {
-            $problems += "- ryl pin ``$rylPin`` (ci.yml) is behind the latest release ``$rylLatest``"
+            Add-Problem "ryl $rylPin->$rylLatest" "- ryl pin ``$rylPin`` (ci.yml) is behind the latest release ``$rylLatest``"
           }
 
           # --- taplo: toml.yml `tool: taplo-cli@X` pin vs crates.io -------------
@@ -203,9 +208,9 @@ jobs:
           if (-not $taploPin) { throw 'No `tool: taplo-cli@<version>` pin in toml.yml' }
           $taploLatest = Latest-CratesIo 'taplo-cli'
           if (-not $taploLatest) {
-            $problems += '- could not query the latest taplo release (crates.io taplo-cli)'
+            Add-Problem 'taplo (query failed)' '- could not query the latest taplo release (crates.io taplo-cli)'
           } elseif ([version]$taploLatest -gt [version]$taploPin) {
-            $problems += "- taplo pin ``$taploPin`` (toml.yml) is behind the latest release ``$taploLatest``"
+            Add-Problem "taplo $taploPin->$taploLatest" "- taplo pin ``$taploPin`` (toml.yml) is behind the latest release ``$taploLatest``"
           }
 
           # --- convco: conventional.yml `tool: convco@X` pin vs crates.io -------
@@ -215,9 +220,9 @@ jobs:
           if (-not $convcoPin) { throw 'No `tool: convco@<version>` pin in conventional.yml' }
           $convcoLatest = Latest-CratesIo 'convco'
           if (-not $convcoLatest) {
-            $problems += '- could not query the latest convco release (crates.io)'
+            Add-Problem 'convco (query failed)' '- could not query the latest convco release (crates.io)'
           } elseif ([version]$convcoLatest -gt [version]$convcoPin) {
-            $problems += "- convco pin ``$convcoPin`` (conventional.yml) is behind the latest release ``$convcoLatest``"
+            Add-Problem "convco $convcoPin->$convcoLatest" "- convco pin ``$convcoPin`` (conventional.yml) is behind the latest release ``$convcoLatest``"
           }
 
           # --- wasm-bindgen-cli: wasm.yml + publish-npm.yml pins vs crates.io ---
@@ -232,13 +237,13 @@ jobs:
           if (-not $wbPub)    { throw 'No wasm-bindgen-cli pin in publish-npm.yml' }
           if (-not $wbDeploy) { throw 'No wasm-bindgen-cli pin in deploy-pages.yml' }
           if (($wbGate -ne $wbPub) -or ($wbGate -ne $wbDeploy)) {
-            $problems += "- wasm-bindgen-cli pin mismatch: wasm.yml has ``$wbGate`` / publish-npm.yml has ``$wbPub`` / deploy-pages.yml has ``$wbDeploy`` — all three must be identical"
+            Add-Problem 'wasm-bindgen-cli pins disagree' "- wasm-bindgen-cli pin mismatch: wasm.yml has ``$wbGate`` / publish-npm.yml has ``$wbPub`` / deploy-pages.yml has ``$wbDeploy`` — all three must be identical"
           }
           $wbLatest = Latest-CratesIo 'wasm-bindgen-cli'
           if (-not $wbLatest) {
-            $problems += '- could not query the latest wasm-bindgen-cli release (crates.io)'
+            Add-Problem 'wasm-bindgen-cli (query failed)' '- could not query the latest wasm-bindgen-cli release (crates.io)'
           } elseif ([version]$wbLatest -gt [version]$wbGate) {
-            $problems += "- wasm-bindgen-cli pin ``$wbGate`` (wasm.yml + publish-npm.yml) is behind the latest release ``$wbLatest`` — bump both pins AND the wasm-bindgen crate dep together"
+            Add-Problem "wasm-bindgen-cli $wbGate->$wbLatest" "- wasm-bindgen-cli pin ``$wbGate`` (wasm.yml + publish-npm.yml) is behind the latest release ``$wbLatest`` — bump both pins AND the wasm-bindgen crate dep together"
           }
 
           # --- binaryen (wasm-opt): web/package.json pin vs npm ----------------
@@ -250,9 +255,9 @@ jobs:
           if (-not $binPin) { throw 'No binaryen pin in crates/bdinfo-rs-wasm/web/package.json' }
           $binLatest = Latest-Npm 'binaryen'
           if (-not $binLatest) {
-            $problems += '- could not query the latest binaryen release (npm)'
+            Add-Problem 'binaryen (query failed)' '- could not query the latest binaryen release (npm)'
           } elseif ([version]$binLatest -gt [version]$binPin) {
-            $problems += "- binaryen pin ``$binPin`` (web/package.json) is behind the latest release ``$binLatest`` — bump it, rebuild, and re-check the wasm size budget"
+            Add-Problem "binaryen $binPin->$binLatest" "- binaryen pin ``$binPin`` (web/package.json) is behind the latest release ``$binLatest`` — bump it, rebuild, and re-check the wasm size budget"
           }
 
           # --- biome: biome.json $schema must match the installed @biomejs/biome -
@@ -271,9 +276,9 @@ jobs:
                 ConvertFrom-Json -AsHashtable).packages.'node_modules/@biomejs/biome'.version
           } catch { }
           if (-not $biomeLock) {
-            $problems += '- could not read the @biomejs/biome version from web/package-lock.json'
+            Add-Problem 'biome (version unreadable)' '- could not read the @biomejs/biome version from web/package-lock.json'
           } elseif ($biomeSchema -ne $biomeLock) {
-            $problems += "- biome.json schema URL is pinned to ``$biomeSchema`` but the lockfile installs @biomejs/biome ``$biomeLock`` — bump the schema URL in biome.json to match"
+            Add-Problem "biome schema $biomeSchema vs $biomeLock" "- biome.json schema URL is pinned to ``$biomeSchema`` but the lockfile installs @biomejs/biome ``$biomeLock`` — bump the schema URL in biome.json to match"
           }
 
           # --- Node: the 3 workflow pins must AGREE, vs nodejs.org/dist ----------
@@ -290,14 +295,14 @@ jobs:
           if (-not $nodeDeploy) { throw 'No node-version pin in deploy-pages.yml' }
           if (-not $nodePub) { throw 'No node-version pin in publish-npm.yml' }
           if (($nodeWasm -ne $nodeDeploy) -or ($nodeWasm -ne $nodePub)) {
-            $problems += "- Node pin mismatch: wasm.yml ``$nodeWasm`` / deploy-pages.yml ``$nodeDeploy`` / publish-npm.yml ``$nodePub`` — they must be identical"
+            Add-Problem 'Node pins disagree' "- Node pin mismatch: wasm.yml ``$nodeWasm`` / deploy-pages.yml ``$nodeDeploy`` / publish-npm.yml ``$nodePub`` — they must be identical"
           }
           $nodePin = $nodeWasm
           $nodePinMajor = [int]($nodePin.Split('.')[0])
           $nodeLatestOnMajor = $null; $nodeNewestEven = $null
           $nodeRel = Get-NodeReleases
           if (-not $nodeRel) {
-            $problems += '- could not query the Node release list (nodejs.org/dist/index.json)'
+            Add-Problem 'Node (query failed)' '- could not query the Node release list (nodejs.org/dist/index.json)'
           } else {
             $nodeParsed = @($nodeRel | ForEach-Object {
                 if ($_.version -match '^v(\d+)\.(\d+)\.(\d+)$') {
@@ -306,11 +311,11 @@ jobs:
               })
             $nodeLatestOnMajor = (@($nodeParsed | Where-Object { $_.major -eq $nodePinMajor }) | Sort-Object ver -Descending | Select-Object -First 1).ver
             if ($nodeLatestOnMajor -and [version]$nodePin -lt $nodeLatestOnMajor) {
-              $problems += "- Node pin ``$nodePin`` (wasm.yml + deploy-pages.yml + publish-npm.yml) is behind the latest $nodePinMajor.x release ``$nodeLatestOnMajor`` — bump all three pins together"
+              Add-Problem "Node $nodePin->$nodeLatestOnMajor" "- Node pin ``$nodePin`` (wasm.yml + deploy-pages.yml + publish-npm.yml) is behind the latest $nodePinMajor.x release ``$nodeLatestOnMajor`` — bump all three pins together"
             }
             $nodeNewestEven = (@($nodeParsed | Where-Object { $_.major % 2 -eq 0 }) | Sort-Object major -Descending | Select-Object -First 1).major
             if ($nodeNewestEven -and $nodeNewestEven -gt $nodePinMajor) {
-              $problems += "- a newer even (LTS-bound) Node line ``$nodeNewestEven.x`` has shipped; the pins are on ``$nodePinMajor.x`` — plan the move (update all three pins together)"
+              Add-Problem "Node $nodeNewestEven.x available" "- a newer even (LTS-bound) Node line ``$nodeNewestEven.x`` has shipped; the pins are on ``$nodePinMajor.x`` — plan the move (update all three pins together)"
             }
           }
 
@@ -322,9 +327,9 @@ jobs:
           if (-not $npmPin) { throw 'No `npm install -g npm@<version>` pin in publish-npm.yml' }
           $npmLatest = Latest-Npm 'npm'
           if (-not $npmLatest) {
-            $problems += '- could not query the latest npm release (npm registry)'
+            Add-Problem 'npm (query failed)' '- could not query the latest npm release (npm registry)'
           } elseif ([version]$npmLatest -gt [version]$npmPin) {
-            $problems += "- npm pin ``$npmPin`` (publish-npm.yml) is behind the latest release ``$npmLatest``"
+            Add-Problem "npm $npmPin->$npmLatest" "- npm pin ``$npmPin`` (publish-npm.yml) is behind the latest release ``$npmLatest``"
           }
 
           # --- wrangler: deploy-pages.yml `npx wrangler@X` vs the npm registry ----
@@ -333,9 +338,9 @@ jobs:
           if (-not $wranglerPin) { throw 'No `wrangler@<version>` pin in deploy-pages.yml' }
           $wranglerLatest = Latest-Npm 'wrangler'
           if (-not $wranglerLatest) {
-            $problems += '- could not query the latest wrangler release (npm)'
+            Add-Problem 'wrangler (query failed)' '- could not query the latest wrangler release (npm)'
           } elseif ([version]$wranglerLatest -gt [version]$wranglerPin) {
-            $problems += "- wrangler pin ``$wranglerPin`` (deploy-pages.yml) is behind the latest release ``$wranglerLatest``"
+            Add-Problem "wrangler $wranglerPin->$wranglerLatest" "- wrangler pin ``$wranglerPin`` (deploy-pages.yml) is behind the latest release ``$wranglerLatest``"
           }
 
           # --- Homebrew/actions/setup-homebrew: install-smoke-test.yml vs master HEAD ---
@@ -347,9 +352,9 @@ jobs:
           if (-not $brewPin) { throw 'No Homebrew/actions/setup-homebrew SHA pin in install-smoke-test.yml' }
           $brewHead = gh api repos/Homebrew/actions/branches/master --jq '.commit.sha' 2>$null
           if ($LASTEXITCODE -ne 0 -or -not $brewHead) {
-            $problems += '- could not query Homebrew/actions master HEAD (GitHub API)'
+            Add-Problem 'Homebrew/actions (query failed)' '- could not query Homebrew/actions master HEAD (GitHub API)'
           } elseif ($brewPin -ne $brewHead) {
-            $problems += "- Homebrew/actions/setup-homebrew pin ``$($brewPin.Substring(0, 12))`` (install-smoke-test.yml) is behind master HEAD ``$($brewHead.Substring(0, 12))`` — re-pin deliberately (the repo ships no tags, so the SHA is frozen on purpose)"
+            Add-Problem 'setup-homebrew SHA drifted' "- Homebrew/actions/setup-homebrew pin ``$($brewPin.Substring(0, 12))`` (install-smoke-test.yml) is behind master HEAD ``$($brewHead.Substring(0, 12))`` — re-pin deliberately (the repo ships no tags, so the SHA is frozen on purpose)"
           }
           $brewPinShort = if ($brewPin) { $brewPin.Substring(0, 12) } else { '?' }
           $brewHeadShort = if ($brewHead) { $brewHead.Substring(0, 12) } else { '?' }
@@ -366,9 +371,9 @@ jobs:
           if (-not $wingetPin) { throw 'No winget-releaser SHA pin in packages.yml' }
           $wingetHead = gh api repos/vedantmgoyal9/winget-releaser/commits/v2 --jq '.sha' 2>$null
           if ($LASTEXITCODE -ne 0 -or -not $wingetHead) {
-            $problems += '- could not query winget-releaser v2 tag HEAD (GitHub API)'
+            Add-Problem 'winget-releaser (query failed)' '- could not query winget-releaser v2 tag HEAD (GitHub API)'
           } elseif ($wingetPin -ne $wingetHead) {
-            $problems += "- winget-releaser pin ``$($wingetPin.Substring(0, 12))`` (packages.yml) no longer matches the v2 tag HEAD ``$($wingetHead.Substring(0, 12))`` — the moving major drifted; re-pin the SHA (keep the # v2 comment) deliberately"
+            Add-Problem 'winget-releaser SHA drifted' "- winget-releaser pin ``$($wingetPin.Substring(0, 12))`` (packages.yml) no longer matches the v2 tag HEAD ``$($wingetHead.Substring(0, 12))`` — the moving major drifted; re-pin the SHA (keep the # v2 comment) deliberately"
           }
           $wingetPinShort = if ($wingetPin) { $wingetPin.Substring(0, 12) } else { '?' }
           $wingetHeadShort = if ($wingetHead) { $wingetHead.Substring(0, 12) } else { '?' }
@@ -376,20 +381,41 @@ jobs:
           Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  ryl: $rylPin (latest $rylLatest)  taplo: $taploPin (latest $taploLatest)  convco: $convcoPin (latest $convcoLatest)  wasm-bindgen-cli: $wbGate (latest $wbLatest)  binaryen: $binPin (latest $binLatest)  biome-schema: $biomeSchema (dep $biomeLock)  node: $nodePin (latest-on-major $nodeLatestOnMajor, newest-even $nodeNewestEven)  npm: $npmPin (latest $npmLatest)  wrangler: $wranglerPin (latest $wranglerLatest)  brew: $brewPinShort (head $brewHeadShort)  winget: $wingetPinShort (head $wingetHeadShort)"
           if ($problems.Count -eq 0) { Write-Host 'All pinned versions are fresh and consistent.'; exit 0 }
 
-          $title = 'Pinned versions are stale'
+          $bodyLines = @($problems | ForEach-Object { $_.line })
+          $tags = @($problems | ForEach-Object { $_.tag })
+
+          # Descriptive title: name the stale package(s) and the version move so the
+          # subject says WHAT is stale, not a fixed string. Cap the list so the title
+          # stays readable when several pins rot at once.
+          $maxShown = 3
+          if ($tags.Count -le $maxShown) {
+            $summary = $tags -join ', '
+          }
+          else {
+            $summary = (@($tags | Select-Object -First $maxShown) -join ', ') + " (+$($tags.Count - $maxShown) more)"
+          }
+          $title = if ($tags.Count -eq 1) { "Stale pin: $summary" } else { "Stale pins: $summary" }
+
           $body = @(
             'The daily version-freshness check found:'
             ''
-            $problems
+            $bodyLines
             ''
-            'Bump deliberately: update the pin(s), run the full local gate (`pwsh scripts/compliance.ps1 -Full`), keep ci.yml''s NIGHTLY in lockstep with scripts/_common.ps1, and re-run `dist generate` after any cargo-dist bump.'
+            'Bump deliberately: update the pin(s) in the file(s) named above, keep the four NIGHTLY pins (ci.yml / fuzz.yml / wasm.yml / publish-npm.yml) identical, and re-run `dist generate` after any cargo-dist bump. CI re-validates on the next push.'
           ) -join "`n"
 
-          $existing = gh issue list --state open --search 'Pinned versions are stale in:title' --json number --jq '.[0].number'
+          # One rolling issue, tracked by a stable label (the title now varies, so it
+          # can no longer be matched on the title). Adopt a pre-existing issue from the
+          # old fixed-title scheme on the first run after this change.
+          gh label create version-freshness --color ededed --description 'Stale or inconsistent pinned tool/toolchain versions' --force | Out-Null
+          $existing = gh issue list --state open --label version-freshness --json number --jq '.[0].number'
+          if (-not $existing) {
+            $existing = gh issue list --state open --search 'Pinned versions are stale in:title' --json number --jq '.[0].number'
+          }
           if ($existing) {
-            gh issue edit $existing --body $body
+            gh issue edit $existing --title $title --body $body --add-label version-freshness | Out-Null
             Write-Host "Updated existing issue #$existing"
           }
           else {
-            gh issue create --title $title --body $body
+            gh issue create --title $title --body $body --label version-freshness | Out-Null
           }

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@
 # `dist build`.
 /release-assets/
 
+# dist extra-artifacts staging: build-linux-packages.sh writes the .deb/.rpm here
+# for dist to attach to the release; a CI-only dir that may appear after a local
+# `dist build`.
+/dist-extra/
+
 # Local development plumbing (kept on disk, not published).
 # NOTE: deny.toml, supply-chain/, clippy.toml, typos.toml, .config/nextest.toml,
 # .cargo/mutants.toml, and fuzz/ ARE tracked — CI reads them (cargo deny + vet +

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -7,10 +7,14 @@
 # fails on every release or version-bump PR. We exclude only our own tag and
 # compare URLs, so those PRs stay green with no per-PR step while lychee still
 # verifies every other link, including the badges, /releases, and installer URLs.
-https://github\.com/agentjp/bdinfo-rs/releases/tag/v
-https://github\.com/agentjp/bdinfo-rs/compare/v
+# The optional `ai\.` matches the ai.github.com SSH-config host alias too: if a
+# convco-generated link ever escapes the release-prep host-rewrite, lychee would
+# fail to resolve ai.github.com AND the github.com-only exclude would miss it.
+https://(ai\.)?github\.com/agentjp/bdinfo-rs/releases/tag/v
+https://(ai\.)?github\.com/agentjp/bdinfo-rs/compare/v
 
-# The npm package @bdinfo-rs/wasm is published only on a v* tag (publish-npm.yml),
-# so its npmjs.com page 404s until the first release lands -- exclude it like our
-# own release-tag URLs above so the Check links gate stays green meanwhile.
+# The npm package @bdinfo-rs/wasm IS published now (registry 200), but its
+# npmjs.com PAGE returns 403 to automated clients (npm's anti-bot), so lychee
+# cannot verify it regardless of publication -- a permanent exclusion, like other
+# bot-walled hosts, NOT the earlier "404 until first release" reason.
 https://www\.npmjs\.com/package/@bdinfo-rs/wasm

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ shell, no libc, nothing to patch, about 1 MB. The tags match the repo's versions
 (`1.0.0`, plus rolling `1.0` and `1`):
 
 ```sh
-docker pull ghcr.io/agentjp/bdinfo-rs:latest      # or pin a release: :1.0.0
+docker pull ghcr.io/agentjp/bdinfo-rs:latest      # or pin a release: :1.0.1
 ```
 
 Mount the disc and pass its in-container path. `-it` gives the interactive playlist
@@ -416,7 +416,7 @@ each layer:
   [libbluray](https://code.videolan.org/videolan/libbluray) and [FFmpeg](https://ffmpeg.org/)
   to fix bugs in the original (see [Differences from BDInfo](#-differences-from-bdinfo)).
 - **UDF reader** — validated against [libudfread](https://code.videolan.org/videolan/libudfread)
-  and the OSTA UDF 2.60 specification.
+  and the OSTA UDF 2.50 specification.
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,6 @@ The quickest route if you already have one — a single command, kept up to date
 # macOS / Linux — Homebrew
 brew install agentjp/tap/bdinfo-rs
 
-# Windows — WinGet
-winget install agentjp.bdinfo-rs
-
 # Windows — Scoop
 scoop bucket add agentjp https://github.com/agentjp/scoop-bucket
 scoop install bdinfo-rs
@@ -122,6 +119,10 @@ cargo binstall bdinfo-rs
 # …or build it from crates.io
 cargo install bdinfo-rs
 ```
+
+A WinGet package (`agentjp.bdinfo-rs`) and an Arch Linux AUR package (`bdinfo-rs-bin`) are on the
+way but not available just yet — for now, Windows users have Scoop (above) and Arch users can
+`cargo install` or grab a prebuilt binary.
 
 On Debian/Ubuntu and Fedora/RHEL/openSUSE, install **by name with updates** from the hosted
 package repository — add it once (like any third-party repo), then use your package manager
@@ -240,7 +241,7 @@ into a `WARNING` block and the rest is scanned (exit code 3).
 Every release archive ships ready-to-install shell completion scripts — for **bash**,
 **zsh**, **fish**, and **PowerShell** — and a **`bdinfo-rs.1`** man page, all generated
 from the CLI itself so they always match the binary's flags and help text. Package
-managers that ship them (Homebrew, the `.deb`/`.rpm` packages, and the AUR package) drop
+managers that ship them (Homebrew and the `.deb`/`.rpm` packages) drop
 them into the standard locations automatically; to install one by hand from an extracted
 archive:
 

--- a/crates/bdinfo-rs-wasm/deny.toml
+++ b/crates/bdinfo-rs-wasm/deny.toml
@@ -5,6 +5,15 @@
 # deny.toml (advisories / permissive-license allowlist / crates.io-only / no-C
 # static-binary guard); the only deltas from root are spelled out and justified
 # below. Run: cargo deny --manifest-path crates/bdinfo-rs-wasm/Cargo.toml check
+#
+# DELIBERATELY deny-only, NOT cargo-vet'd: the root workspace carries a cargo-vet
+# audit store (supply-chain/), but this excluded crate does not. Standing up a
+# second vet store would duplicate the imports + per-crate exemptions for the
+# standard, widely-used wasm-bindgen / js-sys / web-sys tree, for marginal added
+# assurance — and this artifact never ships in the CLI/library distribution (it is
+# a separate wasm32 npm package). deny (here) + Dependabot freshness (the
+# `/crates/bdinfo-rs-wasm` cargo entry) cover this tree; cargo-vet's audit trail is
+# reserved for the shipped root workspace.
 
 [graph]
 all-features = true

--- a/crates/bdinfo-rs-wasm/web/_headers
+++ b/crates/bdinfo-rs-wasm/web/_headers
@@ -10,3 +10,18 @@
 /*.wasm
   Content-Type: application/wasm
   Cache-Control: public, max-age=0, must-revalidate
+
+# Security headers for every response (so the document AND the same-origin module
+# Worker — /* also covers worker.js, whose CSP is delivered by its own response —
+# both get the policy). The scan needs WebAssembly compilation, which requires
+# 'wasm-unsafe-eval' in script-src (the project's documented CSP posture).
+# Everything else is same-origin: external module scripts ('self'), the scan
+# Worker ('self', a `new Worker(new URL("./worker.js", import.meta.url))` literal),
+# index.html's one inline <style> ('unsafe-inline' for STYLES only — never
+# scripts), data: images, and blob: for the in-page report download
+# (URL.createObjectURL). No COOP/COEP (single-threaded FileReaderSync, no
+# SharedArrayBuffer) — see the note above.
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: no-referrer

--- a/crates/bdinfo-rs/README.md
+++ b/crates/bdinfo-rs/README.md
@@ -14,8 +14,9 @@ single statically-linked binary — no runtime, no DLLs, no install.
 cargo install bdinfo-rs
 ```
 
-OS package managers (winget / Homebrew / apt / pacman) are planned once tagged
-releases ship prebuilt binaries.
+Also available via Homebrew, Scoop, `cargo binstall`, and `.deb`/`.rpm` repositories — see the
+[project README](https://github.com/agentjp/bdinfo-rs) for every install route. A WinGet package
+and an Arch Linux AUR package are on the way.
 
 ## Usage
 

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,10 @@ all-features = true
 version = 2
 # Add advisory IDs here ONLY with a comment explaining why the risk is accepted.
 ignore = []
+# A yanked crate version defaults to a WARN in advisories v2 (so it would pass
+# `cargo deny check` silently). A yanked dep is one the publisher pulled — treat it
+# as a hard error so it cannot slip through the audit the gate claims to cover.
+yanked = "deny"
 
 [licenses]
 version = 2

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -119,6 +119,26 @@ publish-jobs = ["./homebrew"]
 # survives `dist generate --check`.
 plan-jobs = ["./guard-ancestor"]
 
+# Build the Linux distro packages (.deb + .rpm, x86_64 + aarch64) as PART of the
+# release so they are attached to the GitHub Release AT CREATION — before it is
+# published. That keeps the release compatible with GitHub "immutable releases"
+# (a release's assets freeze at publication, so an after-the-fact `gh release
+# upload` is rejected); the old packages.yml built+uploaded them AFTER the
+# release, which immutability forbids. The build runs in dist's global-artifacts
+# job, repackaging the musl binaries dist already built — see
+# .github/build-linux-packages.sh. extra-artifacts takes no globs, so the four
+# stable (triple-based) output paths are listed literally. packages.yml now only
+# DOWNLOADS these same assets to install-verify them on a native runner and push
+# them to Cloudsmith; it no longer builds or uploads them.
+[[dist.extra-artifacts]]
+build = ["bash", ".github/build-linux-packages.sh"]
+artifacts = [
+    "dist-extra/bdinfo-rs-x86_64-unknown-linux-musl.deb",
+    "dist-extra/bdinfo-rs-aarch64-unknown-linux-musl.deb",
+    "dist-extra/bdinfo-rs-x86_64-unknown-linux-musl.rpm",
+    "dist-extra/bdinfo-rs-aarch64-unknown-linux-musl.rpm",
+]
+
 [dist.github-custom-job-permissions.guard-ancestor]
 contents = "read"
 


### PR DESCRIPTION
Infrastructure and CI audit pass: tighten gates, supply-chain coverage, and correctness so that what the workflows *claim* to enforce is actually enforced. No change to the shipped library or CLI behaviour.

## Gate / CI enforcement
- **Big-endian + determinism rules now run in CI**, not just the local gate — extracted into the tracked `.github/scripts/source-rules.ps1` and wired into the required lint job, so a PR adding `from_le_bytes` to disc parsing or a `HashMap` to the output path can no longer pass every required check. Hardened the `#[cfg(test)]` walk so a stray `cfg(test)` can't mis-exempt a later production module.
- **crates.io publish guarded against off-master tags** — `publish-crates.yml` gained the `guard-ancestor` job (mirroring `release.yml` / `publish-npm.yml`), so a tag cut on an unmerged branch can no longer publish un-reviewed code irreversibly to crates.io.

## Supply chain
- **dependency-review** now enforces a strong-copyleft (GPL/AGPL) license denylist — the "blocks an incompatible license" claim was previously untrue.
- **cargo-deny** now sets `yanked = "deny"` (the v2 default is `warn`), so a yanked dependency hard-fails instead of passing silently.
- **fuzz workspace** deps (`libfuzzer-sys` / `arbitrary` + transitive tree) are now watched by Dependabot — the independent excluded workspace was covered by neither Dependabot nor the audits.

## Freshness / pin drift
- version-freshness now watches the **third wasm-bindgen-cli pin** (`deploy-pages.yml`) and cross-checks that all **four hardcoded nightly copies agree**, not just the age of one.
- Watches the **winget-releaser moving-major pin** for the same `ref-version-mismatch` drift `setup-homebrew` is already watched for.
- The freshness issue title now names the actually-stale package(s) and stops pointing at the gitignored cockpit.
- Bump the `publish-npm.yml` npm pin 11.17.0 → 11.18.0 flagged by the daily freshness run.

## Fixes
- `fix(gate)`: re-pin the five drifted m2ts equivalent-mutant `exclude_re` entries (had drifted ~73 lines) so the next full sweep doesn't false-MISS and block release-prep.
- `fix(wasm)`: add a Content-Security-Policy to the deployed demo (`web/_headers`).
- `ci(fuzz)`: pass `--locked` to the corpus replay; correct the over-stated "release gate" docs.

## Docs
- Correct three coverage/mutants/`--locked` rationale comments, the `cov`-alias branch-coverage comment, the README UDF spec version (2.60 → 2.50) and Docker tag, the link-check excludes, and document the wasm crate's deliberate deny-only (no cargo-vet) posture.

Closes #44
