### PR TITLE
chore(release): prepare the 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      heading shape used below, which cargo-dist parses for the GitHub Release notes. See
      CONTRIBUTING.md § "Cutting a release". -->
 
-## [Unreleased]
+## [v1.1.0](https://github.com/agentjp/bdinfo-rs/compare/v1.0.1...v1.1.0) (2026-06-29)
 
 ### Features
 
 * **wasm:** publish an in-browser build of the analyzer as the npm package
   `@bdinfo-rs/wasm`. It runs the FULL measured scan (M2TS demux + per-stream /
   per-chapter statistics) entirely in the browser — off the main thread in a Web
-  Worker, reading a `webkitdirectory`-picked `BDMV` folder synchronously at byte
-  offsets via `FileReaderSync`, so a multi-GB stream never has to fit in memory.
-  The rendered report is byte-for-byte the classic disc report, pinned to its own
-  golden rendered from the same Big Buck Bunny fixture the native end-to-end test
-  scans (held byte-identical across native, Node, and headless Chrome and Firefox).
-  No bytes leave the page.
+  Worker, reading a `webkitdirectory`-picked `BDMV` folder, or a single `.iso`
+  image, synchronously at byte offsets via `FileReaderSync`, so a multi-GB stream
+  never has to fit in memory. The rendered report is byte-for-byte the classic disc
+  report, pinned to its own golden rendered from the same Big Buck Bunny fixture the
+  native end-to-end test scans (held byte-identical across native, Node, and
+  headless Chrome and Firefox). No bytes leave the page. (#41)
+
+### Bug Fixes
+
+* **wasm:** spawn the scan Web Worker through a statically analyzable
+  `new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })`, so
+  bundlers (Vite, webpack) detect and emit the worker chunk instead of breaking at
+  runtime. (#45)
+* **packaging:** ship a complete machine-readable DEP-5 `copyright` in the `.deb`
+  (every bundled license enumerated), satisfying Debian policy. (#31)
 
 ### Changed
 
@@ -32,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   LGPL 2.1 version only), matching the upstream BDInfo per-file source headers
   ("either version 2.1 of the License, or (at your option) any later version"). This
   is a documentation/metadata correction: no code changes, and downstream terms are
-  unchanged except that the "or later" option is now explicitly granted.
+  unchanged except that the "or later" option is now explicitly granted. (#40)
 
 ### Added
 
@@ -40,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bdinfo-rs is a Rust port of, and derivative work based on, BDInfo (© 2010 Cinema
   Squid, LGPL-2.1-or-later) — with the report/analysis baseline ported from
   [UniqProject/BDInfo](https://github.com/UniqProject/BDInfo) and the console flow
-  following [tetrahydroc/BDInfoCLI](https://github.com/tetrahydroc/BDInfoCLI).
+  following [tetrahydroc/BDInfoCLI](https://github.com/tetrahydroc/BDInfoCLI). (#40)
 
 ## [v1.0.1](https://github.com/agentjp/bdinfo-rs/compare/v1.0.0...218dab463b7973086ae318e8d38da945787dd458) (2026-06-22)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bdinfo-rs-core",
  "clap",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "proptest",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["crates/bdinfo-rs-core", "crates/bdinfo-rs"]
 exclude = ["fuzz", "crates/bdinfo-rs-wasm"]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.96"
 # LGPL (unlike GPL) permits use from other applications.
@@ -120,7 +120,7 @@ private_intra_doc_links = "allow"
 
 [workspace.dependencies]
 # Internal (version + path so bdinfo-rs is publishable to crates.io).
-bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "1.0.1" }
+bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "1.1.0" }
 # External (pinned to latest stable minor; deny.toml forbids wildcards).
 clap = { version = "4.6", features = ["derive"] }
 proptest = "1.11"

--- a/crates/bdinfo-rs-wasm/Cargo.lock
+++ b/crates/bdinfo-rs-wasm/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "roxmltree",
  "thiserror",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-wasm"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bdinfo-rs-core",
  "js-sys",

--- a/crates/bdinfo-rs-wasm/Cargo.toml
+++ b/crates/bdinfo-rs-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdinfo-rs-wasm"
-version = "1.0.1"
+version = "1.1.0"
 publish = false
 edition = "2024"
 rust-version = "1.96"

--- a/crates/bdinfo-rs-wasm/web/package-lock.json
+++ b/crates/bdinfo-rs-wasm/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bdinfo-rs/wasm",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bdinfo-rs/wasm",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "LGPL-2.1-or-later",
       "devDependencies": {
         "@biomejs/biome": "^2",

--- a/crates/bdinfo-rs-wasm/web/package.json
+++ b/crates/bdinfo-rs-wasm/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bdinfo-rs/wasm",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "sideEffects": [
     "./dist/worker.js",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "roxmltree",
  "thiserror",


### PR DESCRIPTION
Cuts the **v1.1.0** release.

## Version alignment (all → 1.1.0)
- `Cargo.toml` `[workspace.package] version` + the internal `bdinfo-rs-core` pin
- `crates/bdinfo-rs-wasm/Cargo.toml` `[package] version` (excluded crate, literal — not reached by a workspace bump)
- `crates/bdinfo-rs-wasm/web/package.json` (the `@bdinfo-rs/wasm` npm package)
- All four lockfiles refreshed: root `Cargo.lock`, `crates/bdinfo-rs-wasm/Cargo.lock`, `fuzz/Cargo.lock`, `web/package-lock.json`

All three version sites must match the tag or `publish-npm` / `publish-crates` fail their tag==version guards; the lockfile refreshes keep the `--locked` builds (release, publish-crates, fuzz corpus replay) green.

## CHANGELOG
Cut the `[v1.1.0]` section from the merged PRs since v1.0.1. Folded in the two fixes `convco changelog v1.0.1..HEAD` surfaced that the curated draft was missing — `#31` (complete DEP-5 copyright in the `.deb`) and `#45` (statically analyzable Worker spawn for Vite/webpack) — and added per-PR refs for traceability.

Headline: `#41` ships `@bdinfo-rs/wasm`, the in-browser WebAssembly analyzer (BDMV folder or `.iso`), plus the LGPL-2.1-or-later relicense and upstream attribution.