### PR TITLE
ci(ci): annotate the branch-protection scorecard residual

### DIFF
--- a/scorecard.yml
+++ b/scorecard.yml
@@ -17,6 +17,16 @@
 # official source over enforced TLS, and the version is drift-guarded against
 # dist-workspace.toml. The necessary danger is remediated, not removable.
 #
+# The Branch-Protection check caps the score at 3/10 because `master` does not
+# require pull-request approvers or CODEOWNERS review. That tier is unreachable
+# for a single-maintainer project: GitHub forbids approving your own PR, and with
+# enforce-admins on there is no bypass, so requiring a reviewer would make every
+# merge impossible. Every other protection the check rewards is already on —
+# force-push and deletion blocked, required signatures, linear history,
+# enforce-admins, strict required status checks, and required conversation
+# resolution — so the only unmet requirement is the unattainable second reviewer.
+# We decline that one recommendation, not branch protection itself.
+#
 # Each `reason` records that the finding is accepted; the scorecard-action emits
 # it as a SARIF suppression, so code scanning stops raising the alert on future
 # runs.
@@ -29,3 +39,7 @@ annotations:
       - pinned-dependencies
     reasons:
       - reason: remediated
+  - checks:
+      - branch-protection
+    reasons:
+      - reason: not-supported


### PR DESCRIPTION
## What

Adds a `branch-protection` maintainer annotation (reason `not-supported`) to the root `scorecard.yml`, alongside the existing `binary-artifacts` and `pinned-dependencies` entries.

## Why

OpenSSF Scorecard's Branch-Protection check (code-scanning alert #1, severity High) caps `master` at **3/10** with:

> Warn: branch 'master' does not require approvers
> Warn: codeowners review is not required on branch 'master'

That tier (Tier 2+) is structurally unreachable for a single-maintainer project: GitHub forbids approving your own PR, and with enforce-admins on there is no bypass — so requiring a reviewer would make every merge impossible. Every other protection the check rewards is already on (force-push and deletion blocked, required signatures, linear history, enforce-admins, strict required status checks, required conversation resolution). The only unmet requirement is the unattainable second reviewer, so we decline that one recommendation, not branch protection itself.

The annotation makes the scorecard-action emit a SARIF suppression so the daily scan stops re-raising the alert. The currently-open alert #1 is dismissed separately in code scanning as "won't fix".