### PR TITLE
ci(packages): enable winget publishing on stable releases

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -92,15 +92,15 @@ jobs:
     name: WinGet
     runs-on: ubuntu-latest
     environment: release # WINGET_TOKEN is an env secret on `release` (see header)
-    # GATED OFF (2026-06-23): winget-releaser UPDATES an existing package — it bases
-    # the new manifest on the package's prior version already in microsoft/winget-pkgs.
-    # The first submission (agentjp.bdinfo-rs 1.0.0) is still an open New-Package PR
-    # awaiting manual moderator review, so an auto-update now would fail (no base
-    # manifest) and could jump ahead of that pending PR. Re-enable by setting the repo
-    # variable WINGET_ENABLED=true once 1.0.0 has merged into winget-pkgs master — no
-    # code change needed; the WINGET_TOKEN secret is already set.
+    # LIVE since 2026-07-07: agentjp.bdinfo-rs 1.0.0 merged into microsoft/winget-pkgs
+    # (PR #390663), so a base manifest now exists. winget-releaser UPDATES an existing
+    # package — it bases each new manifest on the prior version already in winget-pkgs —
+    # so from here on every stable release auto-submits a new-version PR. (1.1.0 was
+    # backfilled by hand with komac right after 1.0.0 merged; the first CI auto-submit is
+    # the next tag.) Now unconditional on a stable tag, like the deb/rpm jobs; only `aur`
+    # stays gated (AUR registration still pending).
     needs: gate
-    if: ${{ needs.gate.outputs.stable == 'true' && vars.WINGET_ENABLED == 'true' }}
+    if: needs.gate.outputs.stable == 'true'
     env:
       VERSION: ${{ needs.gate.outputs.version }}
     steps:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The quickest route if you already have one — a single command, kept up to date
 # macOS / Linux — Homebrew
 brew install agentjp/tap/bdinfo-rs
 
+# Windows — WinGet
+winget install agentjp.bdinfo-rs
+
 # Windows — Scoop
 scoop bucket add agentjp https://github.com/agentjp/scoop-bucket
 scoop install bdinfo-rs
@@ -120,9 +123,8 @@ cargo binstall bdinfo-rs
 cargo install bdinfo-rs
 ```
 
-A WinGet package (`agentjp.bdinfo-rs`) and an Arch Linux AUR package (`bdinfo-rs-bin`) are on the
-way but not available just yet — for now, Windows users have Scoop (above) and Arch users can
-`cargo install` or grab a prebuilt binary.
+An Arch Linux AUR package (`bdinfo-rs-bin`) is on the way but not available just yet — for now,
+Arch users can `cargo install` or grab a prebuilt binary.
 
 On Debian/Ubuntu and Fedora/RHEL/openSUSE, install **by name with updates** from the hosted
 package repository — add it once (like any third-party repo), then use your package manager

--- a/crates/bdinfo-rs/README.md
+++ b/crates/bdinfo-rs/README.md
@@ -14,9 +14,9 @@ single statically-linked binary — no runtime, no DLLs, no install.
 cargo install bdinfo-rs
 ```
 
-Also available via Homebrew, Scoop, `cargo binstall`, and `.deb`/`.rpm` repositories — see the
-[project README](https://github.com/agentjp/bdinfo-rs) for every install route. A WinGet package
-and an Arch Linux AUR package are on the way.
+Also available via WinGet (`winget install agentjp.bdinfo-rs`), Homebrew, Scoop, `cargo binstall`,
+and `.deb`/`.rpm` repositories — see the [project README](https://github.com/agentjp/bdinfo-rs)
+for every install route. An Arch Linux AUR package is on the way.
 
 ## Usage
 


### PR DESCRIPTION
Now that `agentjp.bdinfo-rs` 1.0.0 is merged into microsoft/winget-pkgs, the WinGet
publish job in `packages.yml` no longer needs the `WINGET_ENABLED` latch — that latch
existed only while the first New-Package submission was pending review. Drop it so the
job publishes on every stable release, consistent with the deb/rpm jobs; only `aur`
stays gated (AUR registration still pending).

Also promote WinGet from "on the way" to a live install route in both READMEs
(`winget install agentjp.bdinfo-rs`).

1.1.0 is being backfilled to winget-pkgs by hand (komac); the first CI auto-submit is
the next release tag.