### PR TITLE
ci: refresh stale pinned toolchain and tool versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   CARGO_TERM_COLOR: always
   # The nightly that backs the `fmt` step (rustfmt.toml has nightly-only options).
   # Keep in lockstep with $script:Nightly in scripts/_common.ps1.
-  NIGHTLY: nightly-2026-06-05
+  NIGHTLY: nightly-2026-07-06
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -99,4 +99,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx --yes wrangler@4.105.0 pages deploy site --project-name=bdinfo-rs --branch=master
+        run: npx --yes wrangler@4.108.0 pages deploy site --project-name=bdinfo-rs --branch=master

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   # cargo-fuzz needs nightly. Keep in lockstep with ci.yml NIGHTLY and
   # $script:Nightly in scripts/_common.ps1.
-  NIGHTLY: nightly-2026-06-05
+  NIGHTLY: nightly-2026-07-06
   # The 10 libFuzzer targets (fuzz/Cargo.toml). Keep in lockstep with it and
   # with scripts/fuzz-docker.sh.
   TARGETS: read_be discovery bitstream clpi mpls m2ts codec udf source parse_report

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -46,7 +46,7 @@ jobs:
       # nags (files an issue) when Homebrew master moves past this SHA, and the bump
       # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
       # releases, and this repo has none).
-      - uses: Homebrew/actions/setup-homebrew@841d750a0ed9262d3c3ca31f2173974696bc261a # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@097625b28a26ba4b7437926ab03b4d3bd2e6c3d1 # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pinned nightly rustfmt
-        run: rustup toolchain install nightly-2026-06-05 --profile minimal --component rustfmt
+        run: rustup toolchain install nightly-2026-07-06 --profile minimal --component rustfmt
 
       - name: Add the wasm32 target
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  NIGHTLY: nightly-2026-06-05 # keep in lockstep with scripts/_common.ps1 + ci.yml
+  NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + ci.yml
   NODE_VERSION: "26.4.0"      # the active Node line (26 -> LTS Oct 2026); watched by version-freshness.yml
 
 jobs:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 # compiler — reproducible gate across machines and CI. rustup reads this and
 # installs the version + components on demand. Bump deliberately.
 [toolchain]
-channel = "1.96.0" # latest stable (2026-05-25)
+channel = "1.96.1" # latest stable (2026-06-26)
 # clippy + rustfmt for the lint/format gate; llvm-tools-preview ships the
 # profdata/profcov binaries cargo-llvm-cov shells out to (the `cov` alias
 # fails on a fresh machine without it).

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,7 @@
 #
 # Formatting is checked/applied with the PINNED NIGHTLY rustfmt (see
 # `scripts/_common.ps1` $Nightly) so the unstable options below take effect; the
-# rest of the gate stays on stable 1.96.0. Apply: `pwsh scripts/fmt.ps1`.
+# rest of the gate stays on stable 1.96.1. Apply: `pwsh scripts/fmt.ps1`.
 # The gate checks with `cargo +<nightly> fmt --check`.
 
 # --- stable ---


### PR DESCRIPTION
Resolves the version-freshness nag (#49) — four stale pins bumped to current:

- **Rust stable** 1.96.0 -> 1.96.1 (`rust-toolchain.toml`; `rustfmt.toml` note)
- **pinned nightly** 2026-06-05 -> 2026-07-06 (`ci.yml`, `fuzz.yml`, `wasm.yml`, `publish-npm.yml`)
- **wrangler** 4.105.0 -> 4.108.0 (`deploy-pages.yml`)
- **Homebrew/actions/setup-homebrew** SHA -> `097625b2` (`install-smoke-test.yml`)

The local core gate passes on the new toolchains — fmt and clippy clean, branch coverage 97.84% (>= 97% floor).

Closes #49.