### PR TITLE
build(deps): sync biome.json schema URL to 2.5.3

### DIFF
--- a/crates/bdinfo-rs-wasm/web/biome.json
+++ b/crates/bdinfo-rs-wasm/web/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
The daily version-freshness check flagged that `crates/bdinfo-rs-wasm/web/biome.json` pins its `$schema` URL to `2.5.1` while the lockfile now installs `@biomejs/biome` `2.5.3` (bumped in #61). Dependabot moves the dependency but cannot touch the versioned schema URL, so the two drifted.

Bump the schema URL to `2.5.3` to match the installed biome.

Closes #60.