### PR TITLE
ci: bump stale tool pins (convco, node, npm, homebrew)

### DIFF
--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install convco (prebuilt, no from-source compile)
         uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2.83.0
         with:
-          tool: convco@0.6.4
+          tool: convco@0.7.0
 
       # Prove the banned-word regex still rejects attribution and passes innocent
       # prose, so the policy script can never silently rot.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           # Keep in lockstep with wasm.yml + publish-npm.yml (version-freshness.yml
           # cross-checks the three agree). The active Node line: 26 -> LTS Oct 2026.
-          node-version: "26.4.0"
+          node-version: "26.5.0"
 
       - name: Install the web toolchain (binaryen / typescript / biome)
         working-directory: crates/bdinfo-rs-wasm/web

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -46,7 +46,7 @@ jobs:
       # nags (files an issue) when Homebrew master moves past this SHA, and the bump
       # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
       # releases, and this repo has none).
-      - uses: Homebrew/actions/setup-homebrew@097625b28a26ba4b7437926ab03b4d3bd2e6c3d1 # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@24728b77430f9659b8d89068e4afe7f5fd0f973c # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -80,9 +80,9 @@ jobs:
         with:
           # The active Node line (26 -> LTS Oct 2026); kept in lockstep with
           # wasm.yml + deploy-pages.yml (version-freshness.yml cross-checks the three).
-          node-version: "26.4.0"
+          node-version: "26.5.0"
 
-      # Staged publishing (`npm stage publish`) needs npm >= 11.15.0. Node 26.4.0
+      # Staged publishing (`npm stage publish`) needs npm >= 11.15.0. Node 26.5.0
       # already bundles an npm >= the floor, so this is not strictly required
       # today — but pin npm explicitly anyway, so the publish runs on a
       # deterministic, version-freshness-watched npm independent of which npm a
@@ -92,7 +92,7 @@ jobs:
       # runtime install; pinning npm (from the official registry) carries a scoped
       # inline ignore. Keep this pin in lockstep with version-freshness.yml.
       - name: Pin npm to a staged-publishing-capable version
-        run: npm install -g npm@11.18.0 # zizmor: ignore[adhoc-packages]
+        run: npm install -g npm@12.0.0 # zizmor: ignore[adhoc-packages]
 
       - name: Verify Node >= 26 and npm >= 11.15.0
         shell: pwsh

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -28,7 +28,7 @@ concurrency:
 
 env:
   NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + ci.yml
-  NODE_VERSION: "26.4.0"      # the active Node line (26 -> LTS Oct 2026); watched by version-freshness.yml
+  NODE_VERSION: "26.5.0"      # the active Node line (26 -> LTS Oct 2026); watched by version-freshness.yml
 
 jobs:
   gate:


### PR DESCRIPTION
Bumps the stale tool pins flagged by version-freshness (#67):

- `convco` 0.6.4 → 0.7.0 (conventional.yml)
- Node 26.4.0 → 26.5.0 — wasm.yml `NODE_VERSION` + deploy-pages.yml + publish-npm.yml, all three kept in lockstep
- npm 11.18.0 → 12.0.0 (publish-npm.yml; only exercised at release time)
- `Homebrew/actions/setup-homebrew` SHA `097625b2` → `24728b77` (install-smoke-test.yml — deliberate freeze bump to current master HEAD; tagless, so it keeps the zizmor ref-version-mismatch ignore and no version comment)

Closes #67.