### PR TITLE
ci: bump stale tool pins (Rust 1.97.0, wrangler 4.110.0, setup-homebrew)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -99,4 +99,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx --yes wrangler@4.108.0 pages deploy site --project-name=bdinfo-rs --branch=master
+        run: npx --yes wrangler@4.110.0 pages deploy site --project-name=bdinfo-rs --branch=master

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -46,7 +46,7 @@ jobs:
       # nags (files an issue) when Homebrew master moves past this SHA, and the bump
       # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
       # releases, and this repo has none).
-      - uses: Homebrew/actions/setup-homebrew@24728b77430f9659b8d89068e4afe7f5fd0f973c # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@d74d1431a0ee36e645aa62ebebeec16da878e7e0 # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its

--- a/crates/bdinfo-rs-core/src/bytes.rs
+++ b/crates/bdinfo-rs-core/src/bytes.rs
@@ -210,13 +210,13 @@ mod tests {
 
     #[test]
     fn read_ascii_zero_count_is_empty() {
-        let buf = [b'A', b'B'];
+        let buf = *b"AB";
         assert_eq!(read_ascii(&buf, 0, 0).as_deref(), Some(""));
     }
 
     #[test]
     fn read_ascii_out_of_bounds_is_none() {
-        let buf = [b'A', b'B'];
+        let buf = *b"AB";
         assert_eq!(read_ascii(&buf, 0, 3), None);
         assert_eq!(read_ascii(&buf, usize::MAX, 1), None);
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 # compiler — reproducible gate across machines and CI. rustup reads this and
 # installs the version + components on demand. Bump deliberately.
 [toolchain]
-channel = "1.96.1" # latest stable (2026-06-26)
+channel = "1.97.0" # latest stable
 # clippy + rustfmt for the lint/format gate; llvm-tools-preview ships the
 # profdata/profcov binaries cargo-llvm-cov shells out to (the `cov` alias
 # fails on a fresh machine without it).


### PR DESCRIPTION
Bumps the stale pins flagged by version-freshness (#74):

- Rust stable `1.96.1` -> `1.97.0` (rust-toolchain.toml)
- wrangler `4.108.0` -> `4.110.0` (deploy-pages.yml)
- Homebrew/actions/setup-homebrew SHA `24728b77430f` -> `d74d1431a0ee` (install-smoke-test.yml, deliberate freeze re-pin to current master HEAD)

The four NIGHTLY pins are untouched. wrangler is only exercised at deploy time, not by PR CI.

Closes #74.