### PR TITLE
chore(release): prepare the 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      heading shape used below, which cargo-dist parses for the GitHub Release notes. See
      CONTRIBUTING.md § "Cutting a release". -->
 
+## [v1.2.0](https://github.com/agentjp/bdinfo-rs/compare/v1.1.0...v1.2.0) (2026-07-11)
+
+### Fixes
+
+* **cli:** recover the real disc label when scanning a Windows drive root
+(#77)
+([1f6ee48](https://github.com/agentjp/bdinfo-rs/commit/1f6ee485a43a4a105fb063e6355530e1ef3e82a2)),
+closes [#77](https://github.com/agentjp/bdinfo-rs/issues/77)
+[#76](https://github.com/agentjp/bdinfo-rs/issues/76)
+
+## [v1.1.0](https://github.com/agentjp/bdinfo-rs/compare/v1.0.1...v1.1.0) (2026-06-29)
+
+### Features
+
+* **wasm:** add the @bdinfo-rs/wasm in-browser WebAssembly package (#41)
+([38f2da7](https://github.com/agentjp/bdinfo-rs/commit/38f2da723172c8c4a1588a7f462ffed852f6d97d)),
+closes [#41](https://github.com/agentjp/bdinfo-rs/issues/41)
+
+### Fixes
+
+* **wasm:** make the scan Worker spawn detectable by Vite and webpack (#45)
+([f78fbcb](https://github.com/agentjp/bdinfo-rs/commit/f78fbcb5ab8bf46ada8c113269c176ea38a1095e)),
+closes [#45](https://github.com/agentjp/bdinfo-rs/issues/45)
+* **packaging:** ship a complete DEP-5 copyright in the .deb (#31)
+([3b97a48](https://github.com/agentjp/bdinfo-rs/commit/3b97a48c4f5ba064918ea4edd78f69bad08c0206)),
+closes [#31](https://github.com/agentjp/bdinfo-rs/issues/31)
+
 ## [v1.1.0](https://github.com/agentjp/bdinfo-rs/compare/v1.0.1...v1.1.0) (2026-06-29)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bdinfo-rs-core",
  "clap",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "proptest",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["crates/bdinfo-rs-core", "crates/bdinfo-rs"]
 exclude = ["fuzz", "crates/bdinfo-rs-wasm"]
 
 [workspace.package]
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.96"
 # LGPL (unlike GPL) permits use from other applications.
@@ -120,7 +120,7 @@ private_intra_doc_links = "allow"
 
 [workspace.dependencies]
 # Internal (version + path so bdinfo-rs is publishable to crates.io).
-bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "1.1.0" }
+bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "1.2.0" }
 # External (pinned to latest stable minor; deny.toml forbids wildcards).
 clap = { version = "4.6", features = ["derive"] }
 proptest = "1.11"

--- a/crates/bdinfo-rs-wasm/Cargo.lock
+++ b/crates/bdinfo-rs-wasm/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "roxmltree",
  "thiserror",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-wasm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bdinfo-rs-core",
  "js-sys",

--- a/crates/bdinfo-rs-wasm/Cargo.toml
+++ b/crates/bdinfo-rs-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdinfo-rs-wasm"
-version = "1.1.0"
+version = "1.2.0"
 publish = false
 edition = "2024"
 rust-version = "1.96"

--- a/crates/bdinfo-rs-wasm/web/package-lock.json
+++ b/crates/bdinfo-rs-wasm/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bdinfo-rs/wasm",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bdinfo-rs/wasm",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "LGPL-2.1-or-later",
       "devDependencies": {
         "@biomejs/biome": "^2",

--- a/crates/bdinfo-rs-wasm/web/package.json
+++ b/crates/bdinfo-rs-wasm/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bdinfo-rs/wasm",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "sideEffects": [
     "./dist/worker.js",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "roxmltree",
  "thiserror",


### PR DESCRIPTION
Release **1.2.0**.

A **minor** bump: the 1.1.1 bugfix (#77, drive-root disc-label recovery) also added the public `UdfSource::read_label` to the `bdinfo-rs-core` library, so strict SemVer makes this a minor release (cargo-semver-checks confirms no breaking change).

Prepared with the convco-driven `release-prep.ps1`:
- lock-stepped `[workspace.package] version` → 1.2.0 (both crates), internal `bdinfo-rs-core` pin, wasm crate + `web/package.json`, and all four lockfiles (root, wasm, fuzz, npm)
- generated `## [v1.2.0]` CHANGELOG section spliced above v1.1.0

Merging this does **not** release anything — pushing the `v1.2.0` tag afterwards drives the full publish fan-out (6 static binaries + installers + Sigstore, crates.io, Homebrew, WinGet, deb/rpm + Cloudsmith, GHCR image, npm).
