### PR TITLE
ci: fix winget (direct komac) and npm (provenance) release publishing

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -103,19 +103,40 @@ jobs:
     if: needs.gate.outputs.stable == 'true'
     env:
       VERSION: ${{ needs.gate.outputs.version }}
+      # Komac release to pin — the tool the manual backfills use, and what
+      # winget-releaser wrapped internally. A submission tool (not output-coupled),
+      # so it is a static pin bumped by hand; the winget-pkgs manifest schema is
+      # stable, so an occasional lag is harmless.
+      KOMAC_VERSION: 2.16.0
     steps:
+      # Submit with komac DIRECTLY — the same tool winget-releaser wraps, but
+      # without its `cargo-bins/cargo-binstall@main` bootstrap, which this repo's
+      # `sha_pinning_required` + allowlist policy (correctly) rejects. komac has no
+      # taiki-e/install-action entry, so fetch its pinned release binary over curl
+      # (a `run:` step, so no action-allowlist involvement at all).
+      - name: Install komac
+        run: |
+          url="https://github.com/russellbanks/Komac/releases/download/v${KOMAC_VERSION}/komac-${KOMAC_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fsSL "$url" -o komac.tar.gz
+          tar -xzf komac.tar.gz komac
+          install -m755 komac /usr/local/bin/komac
+          komac --version
       - name: Submit the new version to winget-pkgs
-        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
-        with:
-          identifier: agentjp.bdinfo-rs
-          # Pass the tag explicitly: the action's default (github.ref_name) is the
-          # default branch under workflow_run, not the release tag.
-          release-tag: ${{ env.VERSION }}
-          # Both windows-msvc .zip archives (x64 + arm64); excludes the .sha256 sidecars.
-          installers-regex: '-pc-windows-msvc\.zip$'
-          # The bot account that holds the fork of microsoft/winget-pkgs.
-          fork-user: agentjp-bot
-          token: ${{ secrets.WINGET_TOKEN }}
+        # WINGET_TOKEN is the agentjp-bot PAT; komac reads it from GITHUB_TOKEN and
+        # forks microsoft/winget-pkgs under that account (no fork-user flag needed).
+        env:
+          GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          ver="${VERSION#v}"
+          base="https://github.com/agentjp/bdinfo-rs/releases/download/v${ver}"
+          # Both windows-msvc .zip archives (x64 + arm64); komac reads the arch from
+          # each. --submit opens the version-bump PR against microsoft/winget-pkgs.
+          komac update agentjp.bdinfo-rs \
+            --version "$ver" \
+            --submit \
+            --urls \
+              "${base}/bdinfo-rs-x86_64-pc-windows-msvc.zip" \
+              "${base}/bdinfo-rs-aarch64-pc-windows-msvc.zip"
 
   # ── Arch Linux: AUR (-bin, repackages the prebuilt musl binary) ────────────
   aur:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -24,6 +24,16 @@ name: publish-npm
 on:
   push:
     tags: ["v*"]
+  # Manual re-publish (e.g. after a CI-only fix) WITHOUT re-tagging — re-pushing a
+  # tag would re-fire Release + crates.io, which error on an already-published
+  # version. Dispatch on master (guard-ancestor rejects any other ref); the tag
+  # defaults to `v<web/package.json version>`.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Version tag to (re)publish, e.g. v1.2.0 (default: web/package.json version)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -59,6 +69,29 @@ jobs:
         with:
           persist-credentials: false
 
+      # The release tag drives the version guard + npm dist-tag. On a tag push it
+      # is the ref; on a manual dispatch it is the input, or `v<package.json
+      # version>`. GitHub context is routed through env (never inlined into the
+      # run block) so zizmor's template-injection audit stays clean.
+      - name: Resolve the release tag (tag push or manual dispatch)
+        id: resolve
+        shell: pwsh
+        env:
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if ($env:EVENT -eq 'push') {
+            $tag = $env:REF_NAME
+          } elseif ($env:INPUT_TAG) {
+            $tag = $env:INPUT_TAG
+          } else {
+            $pkg = (Get-Content crates/bdinfo-rs-wasm/web/package.json -Raw | ConvertFrom-Json).version
+            $tag = "v$pkg"
+          }
+          "tag=$tag" | Add-Content -Path $env:GITHUB_OUTPUT
+          Write-Host "resolved release tag: $tag"
+
       - name: Install pinned nightly rustfmt
         run: rustup toolchain install nightly-2026-07-06 --profile minimal --component rustfmt
 
@@ -82,17 +115,20 @@ jobs:
           # wasm.yml + deploy-pages.yml (version-freshness.yml cross-checks the three).
           node-version: "26.5.0"
 
-      # Staged publishing (`npm stage publish`) needs npm >= 11.15.0. Node 26.5.0
-      # already bundles an npm >= the floor, so this is not strictly required
-      # today — but pin npm explicitly anyway, so the publish runs on a
-      # deterministic, version-freshness-watched npm independent of which npm a
-      # given Node 26.x patch happens to bundle (the repo's pin-everything posture).
-      # The published wasm bytes are fixed by the pinned rustc / wasm-bindgen /
-      # binaryen, independent of npm. zizmor's adhoc-packages audit flags any
-      # runtime install; pinning npm (from the official registry) carries a scoped
-      # inline ignore. Keep this pin in lockstep with version-freshness.yml.
+      # Staged publishing (`npm stage publish`) needs npm >= 11.15.0, and
+      # `--provenance` needs a working bundled `sigstore`. npm 12.0.x ships BROKEN
+      # here: `npm publish --provenance` dies with `Cannot find module 'sigstore'`
+      # (npm/cli#9722), so pin the latest 11.x — which has BOTH staged publishing
+      # and a working provenance path — until a fixed 12.x lands. Pinning also keeps
+      # the publish deterministic regardless of which npm a given Node 26.x bundles
+      # (the repo's pin-everything posture); the published wasm bytes are fixed by
+      # the pinned rustc / wasm-bindgen / binaryen, independent of npm. zizmor's
+      # adhoc-packages audit flags any runtime install; pinning npm (from the
+      # official registry) carries a scoped inline ignore. Keep this pin in lockstep
+      # with version-freshness.yml (which, until 12.x is fixed, flags it as "behind"
+      # the 12.x `latest` — that nag is the intended reminder to re-evaluate).
       - name: Pin npm to a staged-publishing-capable version
-        run: npm install -g npm@12.0.0 # zizmor: ignore[adhoc-packages]
+        run: npm install -g npm@11.18.0 # zizmor: ignore[adhoc-packages]
 
       - name: Verify Node >= 26 and npm >= 11.15.0
         shell: pwsh
@@ -108,8 +144,10 @@ jobs:
       # (mirrors the guard in publish-crates.yml).
       - name: Verify the tag matches the workspace + package versions
         shell: pwsh
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: |
-          $tag = $env:GITHUB_REF_NAME
+          $tag = $env:TAG
           if ($tag -notmatch '^v(?<base>\d+\.\d+\.\d+)(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$') {
             throw "Tag '$tag' is not vMAJOR.MINOR.PATCH[-prerelease]"
           }
@@ -164,12 +202,14 @@ jobs:
       - name: Stage publish @bdinfo-rs/wasm (provenance; prerelease -> dist-tag next)
         working-directory: crates/bdinfo-rs-wasm/web
         shell: pwsh
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           # A prerelease tag (vX.Y.Z-rc.1 — carries a `-` suffix) must NOT take the
           # `latest` dist-tag that a bare `npm install @bdinfo-rs/wasm` resolves;
           # ship it under `next` instead. Stable vX.Y.Z tags stage under `latest`.
           # The dist-tag is immutable on a staged package (reject + re-stage to change).
-          $tag = $env:GITHUB_REF_NAME
+          $tag = $env:TAG
           $distTag = if ($tag -match '-') { 'next' } else { 'latest' }
           Write-Host "staging $tag to npm dist-tag '$distTag'"
           npm stage publish --provenance --access public --tag $distTag
@@ -179,8 +219,10 @@ jobs:
       # Surface the exact commands in the run's job summary + log.
       - name: Remind to approve the staged release
         shell: pwsh
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: |
-          $tag = $env:GITHUB_REF_NAME
+          $tag = $env:TAG
           Write-Host "Staged $tag with provenance. It is NOT live until approved (2FA):"
           Write-Host "  npm stage view @bdinfo-rs/wasm"
           Write-Host "  npm stage download @bdinfo-rs/wasm"


### PR DESCRIPTION
Two secondary release channels failed on the **1.2.0** tag — both **pre-existing infra bugs**, unrelated to the release contents (everything else — binaries, crates.io, Homebrew, Docker, deb/rpm, Cloudsmith — shipped fine).

## WinGet
`vedantmgoyal9/winget-releaser` (only ever `v2`, no newer release) bootstraps komac via `cargo-bins/cargo-binstall@main`. The repo enforces `sha_pinning_required: true` + a fixed action allowlist, so that unpinned, non-allowlisted nested action is rejected and the job never starts.

**Fix:** drop the wrapper and run **komac directly** from its pinned release binary via a `run:` step (curl + tar — no `uses:`, so zero action-allowlist involvement). This is the same tool the wrapper used internally, and the same one the 1.0.0/1.1.0 manual backfills used — CI now does by hand what worked by hand.

## npm
The pinned `npm@12.0.0` is broken for `npm publish --provenance`: `Cannot find module 'sigstore'` ([npm/cli#9722](https://github.com/npm/cli/issues/9722)).

**Fix:** pin the latest **npm 11.x** (11.18.0) — has staged publishing (≥11.15.0) *and* a working provenance path — until a fixed 12.x lands. Also added a **`workflow_dispatch`** trigger so a missed publish can be re-run for the current `web/package.json` version **without re-tagging** (re-pushing a tag would re-fire Release + crates.io, which error on an already-published version). `guard-ancestor` still gates it to master.

## After merge (recovers 1.2.0)
- npm: dispatch `publish-npm` on master → stages 1.2.0 (then a maintainer `npm stage approve` with 2FA).
- WinGet: re-run the `packages` workflow (workflow_run uses master's fixed file) → komac opens the winget-pkgs PR. *(Or the 1.2.0 WinGet submission can be done by hand with komac in the meantime.)*

Fixes both channels for 1.2.0 **and every future release**.
