### PR TITLE
docs: remove the duplicate v1.1.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,23 +26,6 @@ closes [#77](https://github.com/agentjp/bdinfo-rs/issues/77)
 
 ### Features
 
-* **wasm:** add the @bdinfo-rs/wasm in-browser WebAssembly package (#41)
-([38f2da7](https://github.com/agentjp/bdinfo-rs/commit/38f2da723172c8c4a1588a7f462ffed852f6d97d)),
-closes [#41](https://github.com/agentjp/bdinfo-rs/issues/41)
-
-### Fixes
-
-* **wasm:** make the scan Worker spawn detectable by Vite and webpack (#45)
-([f78fbcb](https://github.com/agentjp/bdinfo-rs/commit/f78fbcb5ab8bf46ada8c113269c176ea38a1095e)),
-closes [#45](https://github.com/agentjp/bdinfo-rs/issues/45)
-* **packaging:** ship a complete DEP-5 copyright in the .deb (#31)
-([3b97a48](https://github.com/agentjp/bdinfo-rs/commit/3b97a48c4f5ba064918ea4edd78f69bad08c0206)),
-closes [#31](https://github.com/agentjp/bdinfo-rs/issues/31)
-
-## [v1.1.0](https://github.com/agentjp/bdinfo-rs/compare/v1.0.1...v1.1.0) (2026-06-29)
-
-### Features
-
 * **wasm:** publish an in-browser build of the analyzer as the npm package
   `@bdinfo-rs/wasm`. It runs the FULL measured scan (M2TS demux + per-stream /
   per-chapter statistics) entirely in the browser — off the main thread in a Web


### PR DESCRIPTION
The 1.2.0 release-prep spliced a **second `## [v1.1.0]` heading** (convco's terse auto-summary) above the curated one, so `CHANGELOG.md` had two 1.1.0 sections (introduced by #78, commit `33e6ba6`).

`parse-changelog` — which cargo-dist uses to build the GitHub Release notes — errors on that duplicate (`multiple release notes for '1.1.0'`), so the **v1.2.0 release shipped with empty notes**, and every future release would too.

This drops the duplicate terse section, keeping the canonical curated 1.1.0 entry. Verified: `parse-changelog CHANGELOG.md 1.2.0` now exits 0 with the correct section. The v1.2.0 GitHub Release notes have already been backfilled by hand.