### PR TITLE
ci: make every publish channel idempotent on re-run

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -24,6 +24,17 @@ on:
         description: The dist release plan (JSON), passed by dist.
         required: true
         type: string
+  # Manual re-push of just the tap formula (e.g. if only this job failed while the
+  # rest of the release is fine) WITHOUT re-running the whole release — which can't
+  # be re-run cleanly (gh release create errors once the Release exists). Dispatch
+  # from master; a synthesize step below rebuilds the minimal plan from the release's
+  # attached .rb so the publish loop stays identical to the dist-called path.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag whose Homebrew formula to (re)push, e.g. v1.2.0
+        required: true
+        type: string
 
 permissions:
   contents: read # read the release to download dist's generated formula
@@ -44,6 +55,9 @@ jobs:
       # the tap uses HOMEBREW_TAP_TOKEN (the checkout credentials), not this.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PLAN: ${{ inputs.plan }}
+      # The release tag: the caller's tag ref on the dist workflow_call path, or the
+      # dispatch input on a manual re-push (inputs.tag is empty off the dispatch path).
+      REF_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       # Check out the TAP repo (not this one) with a token that can push to it.
       # persist-credentials stays true so the formula commit below can push.
@@ -52,6 +66,23 @@ jobs:
           repository: agentjp/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           persist-credentials: true # zizmor: ignore[artipacked] the token MUST persist to push the formula commit
+
+      # On a manual dispatch there is no dist plan; rebuild a minimal one from the
+      # release's attached .rb (we ship exactly one) so the publish loop below is
+      # identical to the dist-called path. Overwrites the job-level PLAN env for the
+      # steps that follow. No-op on the workflow_call (dist) path.
+      - name: Synthesize the plan on manual dispatch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          filename=$(gh release view "$DISPATCH_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '[.assets[].name | select(endswith(".rb"))][0]')
+          if [ -z "$filename" ] || [ "$filename" = "null" ]; then
+            echo "::error::no .rb asset on release $DISPATCH_TAG"; exit 1
+          fi
+          plan=$(jq -cn --arg fn "$filename" --arg v "${DISPATCH_TAG#v}" '{releases: [{artifacts: [$fn], app_version: $v}]}')
+          echo "PLAN=$plan" >> "$GITHUB_ENV"
 
       - name: Add the man page + shell completions to dist's formula, then push
         shell: bash
@@ -70,7 +101,7 @@ jobs:
             version=$(echo "$release" | jq --raw-output '.app_version')
 
             # Pull dist's just-generated formula from the release into the tap.
-            gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --pattern "$filename" --dir Formula --clobber
+            gh release download "$REF_TAG" --repo "$GITHUB_REPOSITORY" --pattern "$filename" --dir Formula --clobber
             f="Formula/${filename}"
 
             # dist installs only the binary; add the man page + the bash/zsh/fish
@@ -94,7 +125,15 @@ jobs:
             brew update
             brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "$f" || true
 
+            # Guard the commit: a re-push of a byte-identical formula (same release,
+            # same bytes) has nothing staged, and `git commit` would fail "nothing to
+            # commit" under `set -e` and abort the job. Skip the commit when unchanged;
+            # the push below is then a clean no-op.
             git add "$f"
-            git commit -m "${name} ${version}"
+            if git diff --cached --quiet; then
+              echo "formula ${name} ${version} is unchanged — nothing to commit"
+            else
+              git commit -m "${name} ${version}"
+            fi
           done
           git push

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -127,16 +127,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
+          set -euo pipefail
           ver="${VERSION#v}"
           base="https://github.com/agentjp/bdinfo-rs/releases/download/v${ver}"
-          # Both windows-msvc .zip archives (x64 + arm64); komac reads the arch from
-          # each. --submit opens the version-bump PR against microsoft/winget-pkgs.
-          komac update agentjp.bdinfo-rs \
-            --version "$ver" \
-            --submit \
-            --urls \
-              "${base}/bdinfo-rs-x86_64-pc-windows-msvc.zip" \
-              "${base}/bdinfo-rs-aarch64-pc-windows-msvc.zip"
+          # Preflight: skip if this version already exists in winget-pkgs. komac has no
+          # "already submitted?" guard, so a re-run/backfill of `--submit` would open a
+          # DUPLICATE PR against microsoft/winget-pkgs that a moderator must close.
+          # `list-versions` reads the public manifests; strip whitespace and match the
+          # exact version. Biased toward submitting when the check is inconclusive (a
+          # stray duplicate PR is recoverable; a wrongly-skipped submit means the winget
+          # version never lands).
+          if komac list-versions agentjp.bdinfo-rs 2>/dev/null | sed 's/[[:space:]]//g' | grep -qxF "$ver"; then
+            echo "agentjp.bdinfo-rs ${ver} already in winget-pkgs — skipping submit"
+          else
+            # Both windows-msvc .zip archives (x64 + arm64); komac reads the arch from
+            # each. --submit opens the version-bump PR against microsoft/winget-pkgs.
+            komac update agentjp.bdinfo-rs \
+              --version "$ver" \
+              --submit \
+              --urls \
+                "${base}/bdinfo-rs-x86_64-pc-windows-msvc.zip" \
+                "${base}/bdinfo-rs-aarch64-pc-windows-msvc.zip"
+          fi
 
   # ── Arch Linux: AUR (-bin, repackages the prebuilt musl binary) ────────────
   aur:
@@ -229,21 +241,39 @@ jobs:
       # bdinfo-rs` by name (one `any-distro/any-version` upload serves every
       # Debian-family distro).
       #
-      # `--republish` makes this IDEMPOTENT so a workflow_dispatch re-run / backfill
-      # (the header advertises those) is safe: without it, re-pushing an already-
-      # published version uploads then FAILS mid-sync ("...already exists...Replace
-      # Package w/ Same Version was not enabled...This package should be deleted"),
-      # leaving a broken entry that must be hand-deleted in the Cloudsmith UI. The
-      # flag replaces the same-version package (identical release bytes) and does NOT
-      # need the repo-level "Replace Packages By Default" setting; on a first push
-      # there is nothing to replace, so it behaves like a normal push.
+      # IDEMPOTENT by preflight (best practice, replacing the old unconditional
+      # `--republish`): a workflow_dispatch re-run / backfill must not re-upload a
+      # version that is already there. A plain re-push of an existing version uploads
+      # then FAILS mid-sync ("...already exists...This package should be deleted"),
+      # leaving a broken entry; `--republish` avoids that but needlessly re-uploads and
+      # is discouraged by Cloudsmith. So query the List API by version + filename and
+      # SKIP if present; push cleanly (no `--republish`) only when absent. `--republish`
+      # is kept solely as the safe fallback for the two cases where a plain push would
+      # otherwise strand a broken entry: the preflight could not determine state, or the
+      # push races another run and hits "already exists".
       - name: Publish the .deb to Cloudsmith
         shell: bash
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
-          pipx install cloudsmith-cli==1.19.0
-          cloudsmith push deb --republish bdinfo-rs/bdinfo-rs/any-distro/any-version dl/bdinfo-rs-${{ matrix.triple }}.deb
+          set -euo pipefail
+          pipx install cloudsmith-cli==1.19.0 >/dev/null
+          ver="${VERSION#v}"
+          repo=bdinfo-rs/bdinfo-rs
+          file="dl/bdinfo-rs-${{ matrix.triple }}.deb"
+          count=""
+          if json=$(cloudsmith list packages "$repo" -q "filename:bdinfo-rs-${{ matrix.triple }}.deb version:${ver}" -F json 2>/dev/null); then
+            count=$(printf '%s' "$json" | jq -r '.data | length' 2>/dev/null || true)
+          fi
+          if [ -n "$count" ] && [ "$count" != "0" ]; then
+            echo "bdinfo-rs-${{ matrix.triple }}.deb ${ver} already in Cloudsmith (${count}) — skipping"
+          elif [ "$count" = "0" ]; then
+            cloudsmith push deb "$repo/any-distro/any-version" "$file" \
+              || { echo "plain push failed — retrying idempotently with --republish"; cloudsmith push deb --republish "$repo/any-distro/any-version" "$file"; }
+          else
+            echo "could not query Cloudsmith state — pushing with --republish (safe)"
+            cloudsmith push deb --republish "$repo/any-distro/any-version" "$file"
+          fi
 
   # ── Fedora/RHEL: .rpm attached to the release (x64 + arm64) ────────────────
   rpm:
@@ -294,14 +324,31 @@ jobs:
 
       # Publish the SAME bytes to the Cloudsmith yum repo so users can `dnf install
       # bdinfo-rs` by name (one `any-distro/any-version` upload serves every
-      # RPM-family distro). `--republish` for re-run idempotency — see the .deb job.
+      # RPM-family distro). Preflight-skip-if-present, `--republish` only as the safe
+      # fallback — see the .deb job for the full rationale.
       - name: Publish the .rpm to Cloudsmith
         shell: bash
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
-          pipx install cloudsmith-cli==1.19.0
-          cloudsmith push rpm --republish bdinfo-rs/bdinfo-rs/any-distro/any-version dl/bdinfo-rs-${{ matrix.triple }}.rpm
+          set -euo pipefail
+          pipx install cloudsmith-cli==1.19.0 >/dev/null
+          ver="${VERSION#v}"
+          repo=bdinfo-rs/bdinfo-rs
+          file="dl/bdinfo-rs-${{ matrix.triple }}.rpm"
+          count=""
+          if json=$(cloudsmith list packages "$repo" -q "filename:bdinfo-rs-${{ matrix.triple }}.rpm version:${ver}" -F json 2>/dev/null); then
+            count=$(printf '%s' "$json" | jq -r '.data | length' 2>/dev/null || true)
+          fi
+          if [ -n "$count" ] && [ "$count" != "0" ]; then
+            echo "bdinfo-rs-${{ matrix.triple }}.rpm ${ver} already in Cloudsmith (${count}) — skipping"
+          elif [ "$count" = "0" ]; then
+            cloudsmith push rpm "$repo/any-distro/any-version" "$file" \
+              || { echo "plain push failed — retrying idempotently with --republish"; cloudsmith push rpm --republish "$repo/any-distro/any-version" "$file"; }
+          else
+            echo "could not query Cloudsmith state — pushing with --republish (safe)"
+            cloudsmith push rpm --republish "$repo/any-distro/any-version" "$file"
+          fi
 
   # ── Verify the PUBLISHED Cloudsmith repo: install bdinfo-rs BY NAME and confirm
   # ── the binary + man + completions all land — on both arches, native runners, no

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -3,8 +3,10 @@ name: publish-crates
 # Publish bdinfo-rs-core then bdinfo-rs to crates.io on a vX.Y.Z tag, using
 # crates.io Trusted Publishing (OIDC): a short-lived, repo/workflow-scoped token is
 # minted at run time and revoked afterwards, so NO long-lived CARGO_REGISTRY_TOKEN
-# is stored. `cargo publish --workspace` (stable since Rust 1.90; the pinned
-# toolchain is 1.96) resolves the dependency order, publishing the library first.
+# is stored. Publishes the two crates individually in dependency order (library
+# first), checking crates.io and skipping any version already published so a re-run
+# after a partial failure finishes the release instead of erroring — see the publish
+# step for why `cargo publish --workspace` (one command for both) can't do this.
 #
 # Bootstrap: Trusted Publishing requires the crate to already exist, so the FIRST
 # publish of each crate is done by hand; this workflow takes over for every tag
@@ -77,7 +79,59 @@ jobs:
         id: auth
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
-      - name: Publish both crates (core first)
-        run: cargo publish --workspace --locked
+      # Idempotent publish. crates.io versions are immutable, so re-running an
+      # already-published version hard-errors ("crate version X.Y.Z is already
+      # uploaded"), and `cargo publish --workspace` publishes core then the CLI in ONE
+      # command — so if core published but the CLI did not on a first run (a mid-way CI
+      # failure), a naive re-run dies on core's "already uploaded" and NEVER reaches
+      # the CLI, stranding a half-published release. Instead check each crate against
+      # crates.io first and publish only what is missing, core before the CLI so the
+      # CLI's registry dep on core resolves (`cargo publish` blocks until the crate it
+      # just published is live in the index, so by the CLI's turn core is resolvable).
+      # Belt-and-braces: also tolerate an "already uploaded/exists" race as success, so
+      # an index-lag TOCTOU between the check and the publish cannot red-X the job.
+      - name: Publish core then the CLI, skipping any already on crates.io
+        shell: pwsh
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          # The published version is the [workspace.package] version (both crates
+          # inherit it via version.workspace = true) — the same value the tag guard
+          # above verified. Read it authoritatively from Cargo.toml.
+          $inWp = $false; $version = $null
+          foreach ($line in (Get-Content Cargo.toml)) {
+            if ($line -match '^\[workspace\.package\]') { $inWp = $true; continue }
+            if ($line -match '^\[') { $inWp = $false; continue }
+            if ($inWp -and $line -match '^version\s*=\s*"([^"]+)"') { $version = $Matches[1]; break }
+          }
+          if (-not $version) { throw 'No [workspace.package] version found in Cargo.toml' }
+
+          # $true if <crate>@<version> already exists on crates.io, $false on a 404.
+          # A real network/API error rethrows (never mistaken for "not published").
+          function Test-Published($crate, $version) {
+            try {
+              Invoke-RestMethod -Uri "https://crates.io/api/v1/crates/$crate/$version" `
+                -Headers @{ 'User-Agent' = 'bdinfo-rs-release (github actions)' } -ErrorAction Stop | Out-Null
+              return $true
+            } catch {
+              if ($_.Exception.Response.StatusCode.value__ -eq 404) { return $false }
+              throw
+            }
+          }
+
+          foreach ($crate in @('bdinfo-rs-core', 'bdinfo-rs')) {
+            if (Test-Published $crate $version) {
+              Write-Host "$crate@$version already on crates.io — skipping"
+              continue
+            }
+            Write-Host "publishing $crate@$version"
+            $out = cargo publish -p $crate --locked 2>&1 | Out-String
+            Write-Host $out
+            if ($LASTEXITCODE -ne 0) {
+              if ($out -match 'already (uploaded|exists)') {
+                Write-Host "$crate@$version already published (raced) — treating as success"
+              } else {
+                throw "cargo publish -p $crate failed (exit $LASTEXITCODE)"
+              }
+            }
+          }

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -205,15 +205,33 @@ jobs:
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
+          $tag = $env:TAG
+          $version = $tag -replace '^v', ''
+          # Preflight: if this version is already LIVE on npm, staging it is rejected
+          # (npm versions are immutable) — skip cleanly so a re-run/backfill no-ops.
+          $live = & npm view "@bdinfo-rs/wasm@$version" version 2>$null
+          if ($LASTEXITCODE -eq 0 -and $live) {
+            Write-Host "@bdinfo-rs/wasm@$version is already live on npm — skipping stage"
+            exit 0
+          }
           # A prerelease tag (vX.Y.Z-rc.1 — carries a `-` suffix) must NOT take the
           # `latest` dist-tag that a bare `npm install @bdinfo-rs/wasm` resolves;
           # ship it under `next` instead. Stable vX.Y.Z tags stage under `latest`.
           # The dist-tag is immutable on a staged package (reject + re-stage to change).
-          $tag = $env:TAG
           $distTag = if ($tag -match '-') { 'next' } else { 'latest' }
           Write-Host "staging $tag to npm dist-tag '$distTag'"
-          npm stage publish --provenance --access public --tag $distTag
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $out = & npm stage publish --provenance --access public --tag $distTag 2>&1 | Out-String
+          Write-Host $out
+          if ($LASTEXITCODE -ne 0) {
+            # Tolerate an "already staged / already exists" race (a re-run before the
+            # maintainer has approved or rejected the prior stage) as success; fail on
+            # anything else.
+            if ($out -match 'already (staged|exists|published)') {
+              Write-Host "@bdinfo-rs/wasm@$version is already staged — treating as success"
+              exit 0
+            }
+            exit $LASTEXITCODE
+          }
 
       # The staged version is NOT live yet — the maintainer must approve it (2FA).
       # Surface the exact commands in the run's job summary + log.

--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -1,0 +1,83 @@
+name: release-status
+
+# Read-only recovery dashboard. Given a version tag, report which distribution
+# channels already have it published — the "what is already out there for vX.Y.Z?"
+# matrix. Run this (Actions -> release-status -> Run workflow) when recovering a
+# partial release: it tells you exactly which channels still need publishing before
+# you re-run a channel's own workflow_dispatch, so a re-run never double-pushes.
+#
+# Queries PUBLIC endpoints only — no secrets, no writes. The immutable-registry
+# channels (crates.io, npm live, GitHub Release, GHCR, WinGet) are authoritative;
+# Cloudsmith is best-effort over its public API and npm's staged (not-yet-approved)
+# queue is not visible here (it needs auth), so "absent" on npm means "not live".
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Version tag to check, e.g. v1.2.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  status:
+    name: release status for the version
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ inputs.tag }}
+    steps:
+      - name: Query every distribution channel
+        shell: bash
+        run: |
+          # NOT `-e`: every check is best-effort so one failure never hides the rest.
+          set -uo pipefail
+          tag="$TAG"
+          ver="${tag#v}"
+          rows=()
+          add() { rows+=("$1|$2"); }
+
+          # GitHub Release
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            add "GitHub Release" "PRESENT"; else add "GitHub Release" "absent"; fi
+
+          # crates.io — both crates (200 = published, else absent)
+          for crate in bdinfo-rs-core bdinfo-rs; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' -A "bdinfo-rs-release-status" \
+              "https://crates.io/api/v1/crates/$crate/$ver" 2>/dev/null || echo "000")
+            if [ "$code" = "200" ]; then add "crates.io/$crate" "PRESENT"; else add "crates.io/$crate" "absent ($code)"; fi
+          done
+
+          # npm — live only (the staged queue needs auth and is not visible here)
+          if npm view "@bdinfo-rs/wasm@$ver" version >/dev/null 2>&1; then
+            add "npm @bdinfo-rs/wasm" "PRESENT (live)"; else add "npm @bdinfo-rs/wasm" "absent (or staged)"; fi
+
+          # GHCR image (anonymous inspect of the public multi-arch tag)
+          if docker buildx imagetools inspect "ghcr.io/$GITHUB_REPOSITORY:$ver" >/dev/null 2>&1; then
+            add "GHCR image" "PRESENT"; else add "GHCR image" "absent"; fi
+
+          # Homebrew tap formula (does the committed formula carry this version?)
+          rb=$(gh api "repos/agentjp/homebrew-tap/contents/Formula/bdinfo-rs.rb" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+          if printf '%s' "$rb" | grep -qF "$ver"; then add "Homebrew tap" "PRESENT ($ver)"; else add "Homebrew tap" "absent/other version"; fi
+
+          # WinGet — the version manifest directory in microsoft/winget-pkgs
+          if gh api "repos/microsoft/winget-pkgs/contents/manifests/a/agentjp/bdinfo-rs/$ver" >/dev/null 2>&1; then
+            add "WinGet" "PRESENT"; else add "WinGet" "absent"; fi
+
+          # Cloudsmith deb/rpm — best-effort anonymous query of the public repo
+          cs=$(curl -sS "https://api.cloudsmith.io/v1/packages/bdinfo-rs/bdinfo-rs/?query=version:$ver" 2>/dev/null | jq 'length' 2>/dev/null || echo "?")
+          if [ "$cs" = "?" ] || [ -z "$cs" ]; then add "Cloudsmith deb/rpm" "unknown (auth?)"
+          elif [ "$cs" -gt 0 ] 2>/dev/null; then add "Cloudsmith deb/rpm" "PRESENT ($cs)"
+          else add "Cloudsmith deb/rpm" "absent"; fi
+
+          # Render to the log and the job summary.
+          printf '\n=== release status for %s ===\n' "$tag"
+          { echo "### Release status for \`$tag\`"; echo ""; echo "| Channel | Status |"; echo "|---|---|"; } >> "$GITHUB_STEP_SUMMARY"
+          for r in "${rows[@]}"; do
+            chan="${r%%|*}"; stat="${r#*|}"
+            printf '  %-22s %s\n' "$chan" "$stat"
+            echo "| $chan | $stat |" >> "$GITHUB_STEP_SUMMARY"
+          done


### PR DESCRIPTION
Makes every publish channel safe to re-run after a partial release — the "half-broken release, re-run the workflow" scenario that previously double-pushed to Cloudsmith. Each channel now either skips what is already published or safely redoes it, never error-aborts or duplicates. From a review of every channel's duplicate-version semantics against how mature pipelines (release-plz, changesets, cargo-dist, goreleaser) handle idempotent multi-registry publishing.

## Per-channel guards

- **crates.io** (`publish-crates.yml`): publish core then the CLI individually, checking crates.io and skipping any version already there; tolerate an already-uploaded race. Fixes the sharpest trap — `cargo publish --workspace` published both crates in one command, so a re-run after core succeeded but the CLI failed died on core and never reached the CLI.
- **Cloudsmith deb/rpm** (`packages.yml`): drop the unconditional `--republish`; preflight the List API and skip if the version is already present. `--republish` is kept only as a safe fallback for the two cases where a plain push would strand a broken half-synced entry (preflight inconclusive, or a push race). This is the best-practice replacement for the reactive `--republish` added in #80.
- **WinGet** (`packages.yml`): `komac list-versions` preflight so a re-run does not open a duplicate PR against microsoft/winget-pkgs.
- **Homebrew** (`homebrew.yml`): guard the commit so a byte-identical re-push no longer aborts on "nothing to commit"; add a `workflow_dispatch` (rebuilding the plan from the release's `.rb`) so the formula can be re-pushed standalone. The dist `workflow_call` path is unchanged.
- **npm** (`publish-npm.yml`): skip staging if the version is already live; tolerate an already-staged race on re-run.

## Recovery dashboard

`release-status.yml` — a read-only `workflow_dispatch` that, given a tag, prints a present/absent matrix across every channel (GitHub Release, both crates, npm, GHCR, Homebrew tap, WinGet, Cloudsmith). Run it before re-running a channel to see exactly what still needs publishing.

## Notes

- Docker/GHCR needs no change (mutable tag, same digest is a benign no-op).
- The registry commands run only at release/dispatch time, so they are verified here by syntax + zizmor + `action-validator`/`ryl`; the `komac list-versions` and Cloudsmith List-API output shapes should be confirmed on the next real release.
- Immutable releases (asset freezing) is a separate repo-Settings toggle, handled outside this PR.