### PR TITLE
ci: exercise build-linux-packages.sh and aarch64 packaging in PR CI

### DIFF
--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -1,20 +1,31 @@
 name: linux-packages
 
-# PR-time smoke test for the .deb / .rpm packaging. The packages are now built
-# INSIDE the release (dist `extra-artifacts` -> .github/build-linux-packages.sh),
-# and a build failure there ABORTS the whole release (dist fail-fast) — so a broken
-# package metadata change must be caught BEFORE a tag, not at release time. This job
-# does exactly that: it builds the musl binary, runs the SAME cargo-deb /
-# cargo-generate-rpm invocations the release uses (reading the same
-# [package.metadata.{deb,generate-rpm}] config), installs the resulting packages and
-# asserts the binary + man page + completions (+ DEP-5 copyright) land. It does not
-# go through the archive-extraction in build-linux-packages.sh (there are no dist
-# archives on a PR) — that glue is exercised at release time — but it covers the real
-# risk surface: the packaging metadata and the tools producing installable packages.
+# PR-time smoke test for the .deb / .rpm packaging. The packages are built INSIDE
+# the release (dist `extra-artifacts` -> .github/build-linux-packages.sh), and a
+# failure there ABORTS the whole release (dist fail-fast) — so a broken packaging
+# change must be caught BEFORE a tag, not at release time.
+#
+# This job runs the REAL build-linux-packages.sh end to end, exercising the two paths
+# that otherwise first execute only at a tag: the archive-EXTRACTION glue (it unpacks
+# each dist `bdinfo-rs-<triple>.tar.gz` and stages the binary + man + completions) and
+# the AARCH64 packaging (cross-arch `cargo deb/generate-rpm --target aarch64-...` on an
+# x86_64 host). We can't produce real dist archives on a PR (no `dist build`), so we
+# synthesize them in dist's exact `<pkg>-<triple>/` layout from a host build — using a
+# host binary as a stand-in, which is fine because packaging is arch/libc-agnostic (the
+# package's arch label comes from --target, not the binary; the static musl binaries
+# themselves are e2e-tested elsewhere in ci.yml). cargo-deb / cargo-generate-rpm are
+# installed prebuilt at the SAME versions build-linux-packages.sh pins, so the script's
+# "already on PATH" check skips its source compile and the test uses the release tools.
+#
+# Residual it does NOT catch: dist itself CHANGING its archive layout out from under the
+# script (that needs a real tag) — but it does catch us breaking the script, the real
+# risk. The x86_64 package (native arch, runnable stand-in binary) is install-verified;
+# the aarch64 package is contents-verified (its binary is an x86_64 stand-in, unrunnable
+# here — but the packaging, metadata, and file layout are what this asserts).
 #
 # Scoped by `paths` to packaging-relevant files to stay frugal on CI minutes. Not a
-# required status check (yet) — it is a fast pre-tag warning, complementing the
-# post-release native-arch verification in packages.yml.
+# required status check (yet) — a fast pre-tag warning, complementing the post-release
+# native-arch verification in packages.yml.
 
 on:
   pull_request:
@@ -41,72 +52,75 @@ permissions:
 
 jobs:
   smoke:
-    name: build + install .deb/.rpm (x86_64)
+    name: build + install .deb/.rpm (x64 + arm64)
     runs-on: ubuntu-latest
-    # Build the HOST gnu triple, not musl: this job verifies the PACKAGING (metadata,
-    # the cargo-deb/cargo-generate-rpm `--target` path rewrite, install + contents),
-    # for which the binary's libc is irrelevant — and gnu is the runner's native
-    # target, so there is no musl-linker friction to make the smoke test flaky. The
-    # static musl binaries themselves are e2e-tested on musl elsewhere (ci.yml).
+    # Build the HOST gnu triple: this verifies the PACKAGING (extraction, metadata, the
+    # --target path rewrite, install + contents), for which the binary's libc/arch is
+    # irrelevant. gnu is the runner's native target, so there is no musl-linker friction.
     env:
-      TRIPLE: x86_64-unknown-linux-gnu
+      HOST: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       # build.rs writes the shell completions + man page into OUT_DIR during the build;
-      # passing the host triple explicitly nests output under target/<triple>/ so the
-      # `--target` path rewrite in cargo-deb/cargo-generate-rpm is exercised too.
-      # --locked keeps the smoke build honest against the committed lockfile.
+      # the host triple nests output under target/<triple>/ (mirroring what the release
+      # archives carry). --locked keeps the smoke build honest against the lockfile.
       - name: Build the binary (generates completions + man page)
-        run: cargo build --release --locked --target "$TRIPLE" -p bdinfo-rs
+        run: cargo build --release --locked --target "$HOST" -p bdinfo-rs
 
-      - name: Install cargo-deb + cargo-generate-rpm
+      # Prebuilt, at the SAME versions build-linux-packages.sh pins — so the script's
+      # `command -v cargo-deb` guard finds them and skips its (slower) source compile,
+      # and the smoke test packages with the exact release tools.
+      - name: Install cargo-deb + cargo-generate-rpm (release pins)
         uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2.83.0
         with:
-          tool: cargo-deb,cargo-generate-rpm
+          tool: cargo-deb@3.7.0,cargo-generate-rpm@0.21.0
 
-      # Stage exactly where [package.metadata.deb]/[generate-rpm] expect (the same
-      # layout build-linux-packages.sh produces): the binary under
-      # target/<triple>/release/ and the man page + completions under release-assets/
-      # (cargo-deb resolves those relative to the crate dir, hence the second copy).
-      - name: Stage the binary + completion/man assets
+      # Synthesize the two dist archives the script consumes, in dist's exact
+      # `<pkg>-<triple>/` layout, from the host build (binary stand-in + real assets).
+      - name: Synthesize the dist release archives (both musl arches)
         shell: bash
         run: |
           set -euo pipefail
-          assets="$(dirname "$(ls target/"$TRIPLE"/release/build/bdinfo-rs-*/out/assets/bdinfo-rs.1 | head -n1)")"
-          mkdir -p release-assets crates/bdinfo-rs/release-assets
-          for f in bdinfo-rs.1 bdinfo-rs.bash _bdinfo-rs bdinfo-rs.fish; do
-            cp "$assets/$f" release-assets/
-            cp "$assets/$f" crates/bdinfo-rs/release-assets/
+          bin="target/$HOST/release/bdinfo-rs"
+          assets="$(dirname "$(ls target/"$HOST"/release/build/bdinfo-rs-*/out/assets/bdinfo-rs.1 | head -n1)")"
+          mkdir -p target/distrib
+          for triple in x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
+            d="target/distrib/bdinfo-rs-${triple}"
+            mkdir -p "$d"
+            cp "$bin" "$d/bdinfo-rs"
+            for f in bdinfo-rs.1 bdinfo-rs.bash _bdinfo-rs bdinfo-rs.fish; do cp "$assets/$f" "$d/"; done
+            tar czf "target/distrib/bdinfo-rs-${triple}.tar.gz" -C target/distrib "bdinfo-rs-${triple}"
+            rm -rf "$d" # the script re-extracts from the tarball, so this truly tests extraction
           done
+          ls -l target/distrib
 
-      - name: Build + install + verify the .deb
+      - name: Run build-linux-packages.sh (the real release packaging path)
+        shell: bash
+        run: bash .github/build-linux-packages.sh
+
+      - name: Verify the x86_64 .deb + .rpm (install + run + man/completions/copyright)
         shell: bash
         run: |
           set -euo pipefail
-          cargo deb --no-build --no-strip --target "$TRIPLE" -p bdinfo-rs
-          deb=$(ls target/"$TRIPLE"/debian/*.deb)
+          deb="dist-extra/bdinfo-rs-x86_64-unknown-linux-musl.deb"
           echo "== $deb =="; dpkg-deb --contents "$deb"
           sudo dpkg -i "$deb"
           bdinfo-rs --version
+          # cargo-deb gzips the man page (.1.gz); cargo-generate-rpm keeps it (.1) — accept either.
           ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
           for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
             test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
           done
           grep -q '^License: LGPL-2.1-or-later' /usr/share/doc/bdinfo-rs/copyright || { echo "NOT INSTALLED: DEP-5 copyright License field"; exit 1; }
           sudo dpkg -r bdinfo-rs
-          echo ".deb OK"
+          echo "x86_64 .deb OK"
 
-      - name: Build + install + verify the .rpm
-        shell: bash
-        run: |
-          set -euo pipefail
           sudo apt-get update -qq && sudo apt-get install -y -qq rpm
           sudo rpm --initdb 2>/dev/null || true
-          cargo generate-rpm -p crates/bdinfo-rs --target "$TRIPLE"
-          rpmf=$(ls target/"$TRIPLE"/generate-rpm/*.rpm)
+          rpmf="dist-extra/bdinfo-rs-x86_64-unknown-linux-musl.rpm"
           echo "== $rpmf =="; rpm -qpl "$rpmf"
           sudo rpm -i --nodeps --ignorearch --force "$rpmf"
           bdinfo-rs --version
@@ -114,4 +128,37 @@ jobs:
           for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
             test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
           done
-          echo ".rpm OK"
+          echo "x86_64 .rpm OK"
+
+      - name: Verify the aarch64 .deb + .rpm (packaging + contents)
+        shell: bash
+        run: |
+          set -euo pipefail
+          deb="dist-extra/bdinfo-rs-aarch64-unknown-linux-musl.deb"
+          rpmf="dist-extra/bdinfo-rs-aarch64-unknown-linux-musl.rpm"
+          test -f "$deb" || { echo "MISSING: $deb"; exit 1; }
+          test -f "$rpmf" || { echo "MISSING: $rpmf"; exit 1; }
+          # The arm64 binary here is an x86_64 stand-in, so don't run it — assert the
+          # packaging produced the right arch label and shipped the binary + man +
+          # completions (the metadata/layout that a broken aarch64 package would drop).
+          echo "== $deb =="
+          arch=$(dpkg-deb -f "$deb" Architecture)
+          [ "$arch" = "arm64" ] || { echo "wrong deb arch label: $arch (expected arm64)"; exit 1; }
+          debc=$(dpkg-deb --contents "$deb")
+          echo "$debc"
+          for p in ./usr/bin/bdinfo-rs ./usr/share/bash-completion/completions/bdinfo-rs ./usr/share/zsh/site-functions/_bdinfo-rs ./usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+            echo "$debc" | grep -q " $p\$" || { echo "MISSING in .deb: $p"; exit 1; }
+          done
+          echo "$debc" | grep -qE ' \./usr/share/man/man1/bdinfo-rs\.1' || { echo "MISSING in .deb: man page"; exit 1; }
+          echo "aarch64 .deb OK"
+
+          echo "== $rpmf =="
+          rarch=$(rpm -qp --qf '%{ARCH}' "$rpmf")
+          case "$rarch" in aarch64|arm64) ;; *) echo "wrong rpm arch label: $rarch (expected aarch64)"; exit 1;; esac
+          rpmc=$(rpm -qpl "$rpmf")
+          echo "$rpmc"
+          for p in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+            echo "$rpmc" | grep -qx "$p" || { echo "MISSING in .rpm: $p"; exit 1; }
+          done
+          echo "$rpmc" | grep -qE '/usr/share/man/man1/bdinfo-rs\.1' || { echo "MISSING in .rpm: man page"; exit 1; }
+          echo "aarch64 .rpm OK"


### PR DESCRIPTION
Closes the last release-time packaging gap from the CI audit. The `.deb`/`.rpm` are built inside dist's `fail-fast` release by `build-linux-packages.sh`, so a break there aborts the whole release — but two of its paths never ran before a tag: the archive-**extraction** glue (unpacking each `bdinfo-rs-<triple>.tar.gz` and staging the binary + man + completions) and **aarch64** packaging (cross-arch `cargo deb/generate-rpm --target aarch64-...` on an x86_64 host).

The PR smoke test now runs the **real** `build-linux-packages.sh` against synthesized dist-layout archives for **both** musl arches:

- Builds the host binary once, synthesizes `target/distrib/bdinfo-rs-<triple>.tar.gz` in dist's exact `<pkg>-<triple>/` layout (a host binary stands in — packaging is arch/libc-agnostic, the arch label comes from `--target`; the musl binaries themselves are e2e-tested in ci.yml).
- Installs `cargo-deb@3.7.0` / `cargo-generate-rpm@0.21.0` prebuilt (the versions the script pins), so the script's `command -v` guard skips its source compile and the test packages with the release tools.
- Runs the script, then **install-verifies** the x86_64 `.deb`/`.rpm` (run + man + completions + DEP-5 copyright) and **contents-verifies** the aarch64 `.deb`/`.rpm` (arch label + binary + man + completions).

Because this PR edits `linux-packages.yml` (in that workflow's `paths` filter), the new smoke test runs on this PR itself.

Residual, stated plainly: this catches *us* breaking the script; it does **not** catch dist changing its own archive layout out from under the script — that still surfaces only at a real tag.