### PR TITLE
ci: match Cloudsmith's revisioned version so re-runs and the dashboard are exact

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -246,8 +246,9 @@ jobs:
       # version that is already there. A plain re-push of an existing version uploads
       # then FAILS mid-sync ("...already exists...This package should be deleted"),
       # leaving a broken entry; `--republish` avoids that but needlessly re-uploads and
-      # is discouraged by Cloudsmith. So query the List API by version + filename and
-      # SKIP if present; push cleanly (no `--republish`) only when absent. `--republish`
+      # is discouraged by Cloudsmith. So query the public API by filename (matching the
+      # version base — Cloudsmith stores it revisioned, e.g. 1.2.0-1) and SKIP if present;
+      # push cleanly (no `--republish`) only when absent. `--republish`
       # is kept solely as the safe fallback for the two cases where a plain push would
       # otherwise strand a broken entry: the preflight could not determine state, or the
       # push races another run and hits "already exists".
@@ -261,9 +262,13 @@ jobs:
           ver="${VERSION#v}"
           repo=bdinfo-rs/bdinfo-rs
           file="dl/bdinfo-rs-${{ matrix.triple }}.deb"
+          # Cloudsmith stores the packaging-revisioned version (e.g. 1.2.0-1), so a bare
+          # `version:${ver}` matches NOTHING. Query the anonymous public API by the exact
+          # filename and match the version BASE (strip the trailing -<revision>) — exact
+          # and revision-agnostic. count stays empty on any query error → --republish fallback.
           count=""
-          if json=$(cloudsmith list packages "$repo" -q "filename:bdinfo-rs-${{ matrix.triple }}.deb version:${ver}" -F json 2>/dev/null); then
-            count=$(printf '%s' "$json" | jq -r '.data | length' 2>/dev/null || true)
+          if json=$(curl -sSf -G "https://api.cloudsmith.io/v1/packages/$repo/" --data-urlencode "query=filename:bdinfo-rs-${{ matrix.triple }}.deb" --data-urlencode "page_size=100" 2>/dev/null); then
+            count=$(printf '%s' "$json" | jq --arg v "$ver" '[.[] | select((.version | sub("-[0-9]+$"; "")) == $v)] | length' 2>/dev/null || true)
           fi
           if [ -n "$count" ] && [ "$count" != "0" ]; then
             echo "bdinfo-rs-${{ matrix.triple }}.deb ${ver} already in Cloudsmith (${count}) — skipping"
@@ -336,9 +341,11 @@ jobs:
           ver="${VERSION#v}"
           repo=bdinfo-rs/bdinfo-rs
           file="dl/bdinfo-rs-${{ matrix.triple }}.rpm"
+          # Match the version BASE via the anonymous public API — see the .deb job for why
+          # a bare `version:${ver}` misses Cloudsmith's revisioned version (e.g. 1.2.0-1).
           count=""
-          if json=$(cloudsmith list packages "$repo" -q "filename:bdinfo-rs-${{ matrix.triple }}.rpm version:${ver}" -F json 2>/dev/null); then
-            count=$(printf '%s' "$json" | jq -r '.data | length' 2>/dev/null || true)
+          if json=$(curl -sSf -G "https://api.cloudsmith.io/v1/packages/$repo/" --data-urlencode "query=filename:bdinfo-rs-${{ matrix.triple }}.rpm" --data-urlencode "page_size=100" 2>/dev/null); then
+            count=$(printf '%s' "$json" | jq --arg v "$ver" '[.[] | select((.version | sub("-[0-9]+$"; "")) == $v)] | length' 2>/dev/null || true)
           fi
           if [ -n "$count" ] && [ "$count" != "0" ]; then
             echo "bdinfo-rs-${{ matrix.triple }}.rpm ${ver} already in Cloudsmith (${count}) — skipping"

--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -59,18 +59,24 @@ jobs:
           if docker buildx imagetools inspect "ghcr.io/$GITHUB_REPOSITORY:$ver" >/dev/null 2>&1; then
             add "GHCR image" "PRESENT"; else add "GHCR image" "absent"; fi
 
-          # Homebrew tap formula (does the committed formula carry this version?)
-          rb=$(gh api "repos/agentjp/homebrew-tap/contents/Formula/bdinfo-rs.rb" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
-          if printf '%s' "$rb" | grep -qF "$ver"; then add "Homebrew tap" "PRESENT ($ver)"; else add "Homebrew tap" "absent/other version"; fi
+          # Homebrew tap — a ROLLING formula holding ONLY the current version (not an
+          # archive), so this reports whether the tap is CURRENTLY at the target, not
+          # whether the version ever existed. Extract the formula's `version "X"` field and
+          # compare exactly. (Scoop is the same rolling shape; not queried here.)
+          hbver=$(gh api "repos/agentjp/homebrew-tap/contents/Formula/bdinfo-rs.rb" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | grep -oE 'version "[^"]+"' | head -1 | sed -E 's/version "([^"]+)"/\1/')
+          if [ "$hbver" = "$ver" ]; then add "Homebrew tap" "PRESENT (tap at $hbver)"; else add "Homebrew tap" "absent (tap at ${hbver:-none})"; fi
 
-          # WinGet — the version manifest directory in microsoft/winget-pkgs
+          # WinGet — the version manifest directory in microsoft/winget-pkgs (an archive)
           if gh api "repos/microsoft/winget-pkgs/contents/manifests/a/agentjp/bdinfo-rs/$ver" >/dev/null 2>&1; then
             add "WinGet" "PRESENT"; else add "WinGet" "absent"; fi
 
-          # Cloudsmith deb/rpm — best-effort anonymous query of the public repo
-          cs=$(curl -sS "https://api.cloudsmith.io/v1/packages/bdinfo-rs/bdinfo-rs/?query=version:$ver" 2>/dev/null | jq 'length' 2>/dev/null || echo "?")
-          if [ "$cs" = "?" ] || [ -z "$cs" ]; then add "Cloudsmith deb/rpm" "unknown (auth?)"
-          elif [ "$cs" -gt 0 ] 2>/dev/null; then add "Cloudsmith deb/rpm" "PRESENT ($cs)"
+          # Cloudsmith deb/rpm — anonymous public API. Cloudsmith stores the packaging-
+          # revisioned version (e.g. 1.2.0-1), so match the version BASE (strip -<revision>),
+          # NOT a bare version: query. Expect 4 (deb+rpm x2 arch).
+          cs=$(curl -sS -G "https://api.cloudsmith.io/v1/packages/bdinfo-rs/bdinfo-rs/" --data-urlencode "query=version:$ver*" --data-urlencode "page_size=100" 2>/dev/null \
+            | jq --arg v "$ver" '[.[] | select((.version | sub("-[0-9]+$"; "")) == $v)] | length' 2>/dev/null || echo "?")
+          if [ "$cs" = "?" ] || [ -z "$cs" ]; then add "Cloudsmith deb/rpm" "unknown (query failed)"
+          elif [ "$cs" -gt 0 ] 2>/dev/null; then add "Cloudsmith deb/rpm" "PRESENT ($cs/4)"
           else add "Cloudsmith deb/rpm" "absent"; fi
 
           # Render to the log and the job summary.


### PR DESCRIPTION
Fixes a version-matching bug in the Cloudsmith idempotency checks, found by running the `release-status` dashboard against v1.2.0 (it reported Cloudsmith absent while the 1.2.0 packages were clearly published).

**Root cause:** Cloudsmith stores the packaging-revisioned version — `1.2.0-1` (the `-1` that cargo-deb / cargo-generate-rpm append) — but the queries asked for `version:1.2.0`, which exact-matches nothing. Anonymous API access was fine; the query was wrong.

**Impact was more than cosmetic.** The same bug is in `packages.yml`'s real idempotency preflight: it would never detect an existing package on a re-run and would fall through to `--republish` every time (the fallback prevents a broken entry, but it re-uploads instead of cleanly skipping).

**Fix:** query the anonymous public API by exact filename (preflight) or `version:<ver>*` (dashboard) and match the version **base** — strip the trailing `-<revision>` in jq — so it is exact *and* revision-agnostic.

**Also** (`release-status.yml`): made the Homebrew check exact by extracting the formula's `version "X"` field, and labelled it as the tap's **current** version. A Homebrew tap is a rolling single-version formula, not a per-version archive like crates.io / npm / GHCR / WinGet / Cloudsmith — so "is the tap at this version" is the only meaningful check there. Every archive channel now verifies the exact target version.

**Verified in a Linux container** (the actual runner tooling, `curl` + `jq`, not a local approximation) against the live Cloudsmith API: `1.2.0` → 4 packages, a nonexistent version → 0, per-arch/format preflight → 1. Homebrew extraction verified against the live tap formula.