### PR TITLE
ci: fail closed on a winget list-versions error instead of submitting a duplicate PR

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -133,11 +133,29 @@ jobs:
           # Preflight: skip if this version already exists in winget-pkgs. komac has no
           # "already submitted?" guard, so a re-run/backfill of `--submit` would open a
           # DUPLICATE PR against microsoft/winget-pkgs that a moderator must close.
-          # `list-versions` reads the public manifests; strip whitespace and match the
-          # exact version. Biased toward submitting when the check is inconclusive (a
-          # stray duplicate PR is recoverable; a wrongly-skipped submit means the winget
-          # version never lands).
-          if komac list-versions agentjp.bdinfo-rs 2>/dev/null | sed 's/[[:space:]]//g' | grep -qxF "$ver"; then
+          #
+          # FAIL CLOSED, never open. `komac list-versions` exits non-zero on ANY error
+          # (verified: a clean success is exit 0 with the versions on stdout; an
+          # invalid/EXPIRED WINGET_TOKEN is exit 1 with empty stdout — "GitHub token is
+          # invalid"). The old `... 2>/dev/null | grep` swallowed that error, saw no match,
+          # and FELL THROUGH TO --submit — so an expired token would spam a duplicate PR.
+          # Instead capture the exit code: retry a transient failure, and if it still can't
+          # be determined, FAIL the job (a blocked winget submit is safe + recoverable; a
+          # duplicate PR to Microsoft is not). Only a CLEAN "version not present" submits.
+          # (agentjp.bdinfo-rs has existed in winget-pkgs since the 1.0.0 hand-bootstrap, so
+          # a real success always lists >=1 version — the "package does not exist" error,
+          # which is also exit 1, cannot legitimately occur here.)
+          versions=""; ok=0
+          for attempt in 1 2 3; do
+            if versions=$(komac list-versions agentjp.bdinfo-rs 2>/dev/null); then ok=1; break; fi
+            echo "komac list-versions failed (attempt $attempt/3) — retrying..." >&2
+            sleep 5
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::komac list-versions could not determine existing winget-pkgs versions (invalid WINGET_TOKEN or GitHub API error) — refusing to --submit, which could open a duplicate PR. Re-run once resolved, or submit by hand with komac." >&2
+            exit 1
+          fi
+          if printf '%s\n' "$versions" | sed 's/[[:space:]]//g' | grep -qxF "$ver"; then
             echo "agentjp.bdinfo-rs ${ver} already in winget-pkgs — skipping submit"
           else
             # Both windows-msvc .zip archives (x64 + arm64); komac reads the arch from


### PR DESCRIPTION
Answers a hard question — "what could create a duplicate WinGet PR that we are not thinking about?" — with a real, proven fix.

**The hole:** the winget preflight ran `komac list-versions ... 2>/dev/null | grep`, which swallowed komac's exit code. Probing komac in a container showed it exits **1 with empty stdout** on ANY error — including an **invalid or expired `WINGET_TOKEN`** ("GitHub token is invalid"). The old pipeline turned that empty output into "no match" and **fell through to `--submit`** — so an expired token (PATs expire) would open a **duplicate PR against microsoft/winget-pkgs** that a moderator has to close. The earlier verification only used a working token, so it proved the happy path, not this one.

**The fix:** fail **closed**. Capture the exit code, retry a transient failure, and if the existing versions still can't be determined, **fail the job** instead of submitting. A blocked winget submit is safe and recoverable (re-run, or hand-submit with komac); a duplicate upstream PR is not.

**Verified in an `ubuntu` container against real komac 2.16.0:**
- valid token + `1.2.0` (published) → **SKIP**
- valid token + `9.9.9` (new) → **would SUBMIT** (real releases still work)
- **expired/bogus token + `1.2.0` → retries, then FAIL-CLOSED, does NOT submit**

`bash -n` + action-validator + ryl + zizmor all clean.