### PR TITLE
ci: bump the npm publish pin to 12.0.1 now that provenance is fixed

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -157,19 +157,19 @@ jobs:
           node-version: "26.5.0"
 
       # Staged publishing (`npm stage publish`) needs npm >= 11.15.0, and
-      # `--provenance` needs a working bundled `sigstore`. npm 12.0.x ships BROKEN
-      # here: `npm publish --provenance` dies with `Cannot find module 'sigstore'`
-      # (npm/cli#9722), so pin the latest 11.x — which has BOTH staged publishing
-      # and a working provenance path — until a fixed 12.x lands. Pinning also keeps
-      # the publish deterministic regardless of which npm a given Node 26.x bundles
-      # (the repo's pin-everything posture); the published wasm bytes are fixed by
-      # the pinned rustc / wasm-bindgen / binaryen, independent of npm. zizmor's
-      # adhoc-packages audit flags any runtime install; pinning npm (from the
-      # official registry) carries a scoped inline ignore. Keep this pin in lockstep
-      # with version-freshness.yml (which, until 12.x is fixed, flags it as "behind"
-      # the 12.x `latest` — that nag is the intended reminder to re-evaluate).
+      # `--provenance` needs a working bundled `sigstore`. npm 12.0.0 shipped
+      # BROKEN here (`npm publish --provenance` died with `Cannot find module
+      # 'sigstore'`, npm/cli#9722 — the reason this pin sat on 11.18.0); 12.0.1
+      # ships the fix (npm/cli#9740), so the pin follows `latest` again. Pinning
+      # keeps the publish deterministic regardless of which npm a given Node 26.x
+      # bundles (the repo's pin-everything posture); the published wasm bytes are
+      # fixed by the pinned rustc / wasm-bindgen / binaryen, independent of npm.
+      # zizmor's adhoc-packages audit flags any runtime install; pinning npm (from
+      # the official registry) carries a scoped inline ignore. Keep this pin in
+      # lockstep with version-freshness.yml (its "behind latest" nag is the
+      # reminder to bump).
       - name: Pin npm to a staged-publishing-capable version
-        run: npm install -g npm@11.18.0 # zizmor: ignore[adhoc-packages]
+        run: npm install -g npm@12.0.1 # zizmor: ignore[adhoc-packages]
 
       - name: Verify Node >= 26 and npm >= 11.15.0
         shell: pwsh


### PR DESCRIPTION
Bumps the npm pin in publish-npm.yml from 11.18.0 to 12.0.1, resolving the stale-pin flag in #90. The pin sat on 11.x deliberately: npm 12.0.0 shipped a packaging bug that broke `npm publish --provenance` (`Cannot find module 'sigstore'`, npm/cli#9722). 12.0.1 ships the fix (npm/cli#9740), so the pin follows latest again.

The other pin flagged in #90 (Homebrew/actions/setup-homebrew) was already re-pinned to master HEAD by #94.

Note: this pin is only exercised on a release tag; if a future publish still trips, re-pin 11.x and re-run via workflow_dispatch.

Closes #90.