### PR TITLE
build(packaging): enable the aur release channel

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -97,8 +97,7 @@ jobs:
     # package — it bases each new manifest on the prior version already in winget-pkgs —
     # so from here on every stable release auto-submits a new-version PR. (1.1.0 was
     # backfilled by hand with komac right after 1.0.0 merged; the first CI auto-submit is
-    # the next tag.) Now unconditional on a stable tag, like the deb/rpm jobs; only `aur`
-    # stays gated (AUR registration still pending).
+    # the next tag.) Unconditional on a stable tag, like the deb/rpm and aur jobs.
     needs: gate
     if: needs.gate.outputs.stable == 'true'
     env:
@@ -173,10 +172,10 @@ jobs:
     name: AUR (bdinfo-rs-bin)
     runs-on: ubuntu-latest
     environment: release # AUR_SSH_KEY is an env secret on `release` (see header)
-    # ON HOLD (2026-06-19): aur.archlinux.org account registration is currently
-    # disabled, so there is no AUR account/package to push to yet. Re-enable by
-    # setting the repo variable AUR_ENABLED=true (after registering the account and
-    # the AUR_SSH_KEY public key) — no code change needed; the secret is already set.
+    # LIVE since 2026-07-14: the aur.archlinux.org account exists and its SSH key is
+    # registered; AUR_SSH_KEY (release environment) holds the private half. The repo
+    # variable AUR_ENABLED=true arms this job — unset it to pause AUR publishing
+    # without a code change.
     needs: gate
     if: ${{ needs.gate.outputs.stable == 'true' && vars.AUR_ENABLED == 'true' }}
     env:

--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -84,6 +84,20 @@ jobs:
           # WinGet — the version manifest directory in microsoft/winget-pkgs (an archive)
           if try3 gh api "repos/microsoft/winget-pkgs/contents/manifests/a/agentjp/bdinfo-rs/$ver"; then add "WinGet" "PRESENT"; else add "WinGet" "ABSENT"; fi
 
+          # AUR — rolling like the Homebrew tap (one current version per package base).
+          # The public RPC reports the pkgver-pkgrel of bdinfo-rs-bin; compare the
+          # version BASE (strip the -<pkgrel>). resultcount 0 = package base absent.
+          aurv="?"; i=0
+          while [ "$i" -lt 3 ]; do
+            aurv=$(curl -sS -A "bdinfo-rs-release-status" "https://aur.archlinux.org/rpc/v5/info?arg[]=bdinfo-rs-bin" 2>/dev/null \
+              | jq -r 'if .resultcount == 0 then "none" else .results[0].Version end' 2>/dev/null || echo "?")
+            { [ "$aurv" != "?" ] && [ -n "$aurv" ]; } && break
+            i=$((i+1)); sleep 2
+          done
+          if [ "$aurv" = "?" ] || [ -z "$aurv" ]; then add "AUR bdinfo-rs-bin" "UNKNOWN (query failed)"
+          elif [ "${aurv%-*}" = "$ver" ]; then add "AUR bdinfo-rs-bin" "PRESENT (at $aurv)"
+          else add "AUR bdinfo-rs-bin" "ABSENT (at $aurv)"; fi
+
           # Cloudsmith deb/rpm — anonymous public API. Cloudsmith stores the packaging-
           # revisioned version (e.g. 1.2.0-1), so match the version BASE (strip -<revision>),
           # NOT a bare version: query. Expect 4 (deb+rpm x2 arch). Retry a transient failure.

--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ winget install agentjp.bdinfo-rs
 scoop bucket add agentjp https://github.com/agentjp/scoop-bucket
 scoop install bdinfo-rs
 
+# Arch Linux — AUR (bdinfo-rs-bin, with your AUR helper of choice)
+yay -S bdinfo-rs-bin
+
 # Rust — fetch the prebuilt binary (no compile)…
 cargo binstall bdinfo-rs
 # …or build it from crates.io
 cargo install bdinfo-rs
 ```
-
-An Arch Linux AUR package (`bdinfo-rs-bin`) is on the way but not available just yet — for now,
-Arch users can `cargo install` or grab a prebuilt binary.
 
 On Debian/Ubuntu and Fedora/RHEL/openSUSE, install **by name with updates** from the hosted
 package repository — add it once (like any third-party repo), then use your package manager

--- a/crates/bdinfo-rs/README.md
+++ b/crates/bdinfo-rs/README.md
@@ -14,9 +14,9 @@ single statically-linked binary — no runtime, no DLLs, no install.
 cargo install bdinfo-rs
 ```
 
-Also available via WinGet (`winget install agentjp.bdinfo-rs`), Homebrew, Scoop, `cargo binstall`,
-and `.deb`/`.rpm` repositories — see the [project README](https://github.com/agentjp/bdinfo-rs)
-for every install route. An Arch Linux AUR package is on the way.
+Also available via WinGet (`winget install agentjp.bdinfo-rs`), Homebrew, Scoop, the AUR
+(`bdinfo-rs-bin`), `cargo binstall`, and `.deb`/`.rpm` repositories — see the
+[project README](https://github.com/agentjp/bdinfo-rs) for every install route.
 
 ## Usage
 

--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -14,6 +14,10 @@ url='https://github.com/agentjp/bdinfo-rs'
 license=('LGPL-2.1-or-later')
 provides=('bdinfo-rs')
 conflicts=('bdinfo-rs')
+# The release binary is prebuilt, static, and already stripped (cargo profile
+# strip=true) — don't re-strip it, and don't emit an (empty) -debug package on
+# hosts whose makepkg.conf enables the `debug` option.
+options=('!strip' '!debug')
 source_x86_64=("${_pkgname}-${pkgver}-x86_64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}-x86_64-unknown-linux-musl.tar.gz")
 source_aarch64=("${_pkgname}-${pkgver}-aarch64.tar.gz::${url}/releases/download/v${pkgver}/${_pkgname}-aarch64-unknown-linux-musl.tar.gz")
 sha256sums_x86_64=('SKIP')


### PR DESCRIPTION
The aur.archlinux.org account exists and its SSH key round-trips, so the `bdinfo-rs-bin` channel goes live: `AUR_ENABLED=true` is set on the repo.

- `options=('!strip' '!debug')` in the PKGBUILD template — the release binary is prebuilt, static, and already stripped; without this, hosts with `debug` in makepkg.conf emit an empty `-debug` split package and re-strip a shipped binary.
- READMEs: the AUR install command replaces the "on the way" note.
- `packages.yml`: the on-hold comments on the `aur` job reflect the live state.

Verified in an `archlinux:latest` container against the rendered 1.2.0 PKGBUILD: `updpkgsums` + `makepkg` + `pacman -U`, binary/man/completions/license all land, and the fixture disc scan (folder + .iso) is byte-identical to the goldens. The first publish will be exercised via `packages.yml` `workflow_dispatch` with tag v1.2.0 after this merges.
