### PR TITLE
ci(packaging): keep makepkg artifacts out of the aur repo when pushing assets

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -201,7 +201,13 @@ jobs:
           # The AUR submission guidelines want the packaging scripts themselves
           # licensed (0BSD): ship packaging/aur/LICENSE into the AUR repo root.
           # (This licenses the PKGBUILD; the packaged binary stays LGPL.)
-          assets: packaging/aur/LICENSE
+          # GOTCHA: with assets set the action commits via `git add --all`, which
+          # sweeps in updpkgsums' downloaded tarballs + the test-built package —
+          # the AUR push hook rejects those (max blob 488 KiB). The .gitignore
+          # asset keeps them out; never drop it while assets are in use.
+          assets: |
+            packaging/aur/LICENSE
+            packaging/aur/.gitignore
           updpkgsums: true # download the release tarballs and write real sha256sums
           test: true # build the package in an Arch container before pushing
           commit_username: bdinfo-rs CI

--- a/packaging/aur/.gitignore
+++ b/packaging/aur/.gitignore
@@ -1,0 +1,9 @@
+# Shipped into the AUR repo (packages.yml `assets:`). The deploy action uses
+# `git add --all` when assets are set, which would otherwise commit makepkg's
+# working artifacts — the downloaded release tarballs and the test-built
+# package. The AUR forbids those (max blob 488 KiB; scripts only), so keep
+# them invisible to git.
+*.tar.gz
+*.pkg.tar.zst
+src/
+pkg/


### PR DESCRIPTION
The v1.2.0 metadata re-push was rejected by the AUR's max-blob hook (488 KiB): with \ssets:\ set, the deploy action commits via \git add --all\, which swept in updpkgsums' downloaded release tarballs and the test-built package alongside the intended LICENSE. The AUR forbids build artifacts in package repos, so the push failed cleanly and the AUR still holds the previous clean state.

Fix per the wiki's own tip: ship a targeted \.gitignore\ (tarballs, built packages, src/, pkg/) into the AUR repo as a second asset, so \git add --all\ can only ever stage scripts.

Verified in an \rchlinux:latest\ container against a clone of the real AUR repo, replaying the action's exact flow (overlay, updpkgsums, test build, .SRCINFO regen, \git add --all\): staged set is exactly PKGBUILD + LICENSE + .gitignore, largest blob 2.2 KiB.