### PR TITLE
ci: bump stale tool pins (wrangler 4.111.0, setup-homebrew sha)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -99,4 +99,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx --yes wrangler@4.110.0 pages deploy site --project-name=bdinfo-rs --branch=master
+        run: npx --yes wrangler@4.111.0 pages deploy site --project-name=bdinfo-rs --branch=master

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -46,7 +46,7 @@ jobs:
       # nags (files an issue) when Homebrew master moves past this SHA, and the bump
       # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
       # releases, and this repo has none).
-      - uses: Homebrew/actions/setup-homebrew@18fcb8e3e06b4247c676c506750dc95ea7226479 # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@100978dc923ea73ee9ed454d1d5c4fcf3ee14a9e # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its


### PR DESCRIPTION
Bumps the stale pins flagged by version-freshness (#100): wrangler 4.110.0 -> 4.111.0 in deploy-pages.yml, and the frozen Homebrew/actions/setup-homebrew SHA to current master HEAD in install-smoke-test.yml.

Closes #100.