### PR TITLE
ci: bump the biome schema url to match the installed 2.5.4

### DIFF
--- a/crates/bdinfo-rs-wasm/web/biome.json
+++ b/crates/bdinfo-rs-wasm/web/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
Bumps the stale biome.json schema pin flagged by version-freshness (#106); the binaryen 131.0.0 bump it also flagged already landed via #107.

Closes #106.