### PR TITLE
ci: bump the stale stable rust pin to 1.97.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 # compiler — reproducible gate across machines and CI. rustup reads this and
 # installs the version + components on demand. Bump deliberately.
 [toolchain]
-channel = "1.97.0" # latest stable
+channel = "1.97.1" # latest stable
 # clippy + rustfmt for the lint/format gate; llvm-tools-preview ships the
 # profdata/profcov binaries cargo-llvm-cov shells out to (the `cov` alias
 # fails on a fresh machine without it).


### PR DESCRIPTION
Bumps the stale pin flagged by version-freshness (#111): stable Rust 1.97.0 -> 1.97.1 in rust-toolchain.toml.

Closes #111.