### PR TITLE
chore(gate): repoint the taplo config comment at the orchestrator job

### DIFF
--- a/taplo.toml
+++ b/taplo.toml
@@ -1,5 +1,6 @@
-# taplo configuration — TOML formatter + linter, enforced by the `toml` CI job and
-# the local gate (scripts/compliance.ps1 `tp` step). The formatting options below
+# taplo configuration — TOML formatter + linter, enforced by the orchestrator's
+# `taplo` job (ci.yml, `toml` area) and the local gate (scripts/compliance.ps1 `tp`
+# step). The formatting options below
 # are tuned to match the repo's existing hand-formatting, so the one-time baseline
 # reformat normalizes only spacing/commas and never re-flows the author's chosen
 # array line breaks.


### PR DESCRIPTION
taplo.toml's header still referenced the retired standalone toml workflow; the check now runs as the orchestrator's taplo job under the toml area.