### PR TITLE
ci: refresh stale comments in the orchestrator and gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1141,8 +1141,7 @@ jobs:
   # leave the required check "Expected" forever. This thin job keeps the exact
   # old string reporting: success when the gate passed OR the wasm area was
   # skipped (the same semantics an `if:`-skipped required job has), failure
-  # when the gate failed. Delete it in session 3, when branch protection swaps
-  # to ci-ok.
+  # when the gate failed. Delete it when branch protection swaps to ci-ok.
   wasm-required:
     name: wasm gate (build + size + parity)
     needs: [wasm]
@@ -1156,8 +1155,8 @@ jobs:
           echo "wasm gate result: $RESULT"
           [ "$RESULT" = "success" ] || [ "$RESULT" = "skipped" ]
 
-  # The fan-in: the ONE result branch protection will require (session 3 of the
-  # CI overhaul swaps the 28 name-matched contexts for this job + the three
+  # The fan-in: the ONE result branch protection will require (the protection
+  # cutover swaps the 28 name-matched contexts for this job + the three
   # standalone checks). Green = every gate job either succeeded or was skipped
   # by the plan; red = anything failed, was cancelled, or never ran because a
   # `needs` upstream failed.

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -53,7 +53,8 @@ env:
 
 jobs:
   # Build + the full test suite on every shipped arch — where per-platform bugs
-  # actually live. The snapshot ties run as a separate advisory step (above).
+  # actually live. The snapshot ties run as their own BLOCKING per-arch step
+  # below (excluded from the plain test step so their verdict reports alone).
   test:
     name: gui build + test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -124,8 +125,8 @@ jobs:
       # the shipped level over the full suite (every cfg(debug_assertions)
       # site lives in the Tier-B bin, but overflow-checks and codegen differ
       # crate-wide in release). Once is the signal — per-arch bugs are the
-      # debug matrix's job. Snapshots stay excluded: the advisory/hard split
-      # is decided on the debug matrix, not here.
+      # debug matrix's job. Snapshots stay excluded: the per-OS-family ties
+      # are the debug matrix's verdict, not this leg's.
       - name: Test (release mode)
         if: matrix.os == 'ubuntu-latest'
         working-directory: crates/bdinfo-rs-gui

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -22,7 +22,7 @@ name: sweep
 # it exists (`gui-v*` currently fires nothing, by tag-namespace design).
 #
 # The full sweeps are guarded by a TREE-HASH CACHE MARKER (the mechanism the
-# gui gate used as a session-1 stopgap, now owning the schedule): the sweep
+# gui gate used as a PR-era stopgap, now owning the schedule): the sweep
 # verifies the crate's SUITE against the crate's SOURCE, and both are captured
 # exactly by the crate dir's git tree hash (lockfile and .cargo/mutants.toml
 # included) plus rust-toolchain.toml — so a marker hit means this

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -22,8 +22,8 @@ name: wasm
 # 0-missed checkpoints); the PR path gets the advisory in-diff mutants job in
 # ci.yml (`wasm mutation testing (PR diff)`) instead (D1). The live
 # branch-protection context `wasm gate (build + size + parity)` keeps
-# reporting via a transitional alias job in ci.yml until session 3 swaps
-# protection to `ci-ok` (inside the reusable this job renders as
+# reporting via a transitional alias job in ci.yml until branch protection
+# swaps to `ci-ok` (inside the reusable this job renders as
 # `wasm / wasm gate (build + size + parity)` — a different string).
 
 on:


### PR DESCRIPTION
Comment-only: reword the alias-job and fan-in comments around the pending branch-protection swap, drop a stopgap-era phrasing in sweep.yml, and correct gui.yml's snapshot-step comments (the ties are a blocking step, not advisory).