### PR TITLE
chore: update the gitignore note for the corpus-replay move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@
 # Local development plumbing (kept on disk, not published).
 # NOTE: deny.toml, supply-chain/, clippy.toml, typos.toml, .config/nextest.toml,
 # .cargo/mutants.toml, and fuzz/ ARE tracked — CI reads them (cargo deny + vet +
-# clippy + typos + nextest, plus the incremental-mutants job in ci.yml and the
-# corpus-replay / extended-fuzz jobs in fuzz.yml).
+# clippy + typos + nextest, plus the incremental-mutants and corpus-replay jobs
+# in ci.yml and the tag-time extended fuzz in fuzz.yml).
 /scripts/
 /CLAUDE.md
 /.claude/


### PR DESCRIPTION
The tracked-config note still placed the corpus replay in fuzz.yml; it runs in ci.yml now, fuzz.yml keeps the tag-time extended fuzzing.