### PR TITLE
ci: bump the wrangler pin to 4.112.0

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -101,4 +101,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx --yes wrangler@4.111.0 pages deploy site --project-name=bdinfo-rs --branch=master
+        run: npx --yes wrangler@4.112.0 pages deploy site --project-name=bdinfo-rs --branch=master


### PR DESCRIPTION
Bumps the Cloudflare Pages deploy pin in `deploy-pages.yml` from 4.111.0 to 4.112.0.

Closes #122