### PR TITLE
ci: harden the mac gui legs, sweep core mutants in ci, and cross-check pins

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@
 # runs them in sequence (cargo aliases can't shell-chain, so the script does).
 #
 # Core gate (fast, run every edit):  ck nt lt ft dc mc dn cov
-# Periodic (slow, pre-release):       mt (mutants), sh (shear), vt (vet) + geiger
+# Periodic (slow, on demand):         mt (mutants), sh (shear), vt (vet) + geiger
 # (geiger has no alias — it needs a per-crate absolute --manifest-path that an
 #  alias can't carry; scripts/compliance.ps1 -Full runs it as an advisory step.)
 #
@@ -45,9 +45,10 @@ dn = "deny check"
 # which can't carry `+toolchain` — can't express it).
 cov = "llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100"
 
-# --- Periodic / pre-release (installed by setup.ps1) -----------------------
+# --- Periodic / on demand (installed by setup.ps1) -------------------------
 # Mutation testing — validates the SUITE, not the code. Strict+speed policy in
-# .cargo/mutants.toml. Slow: run pre-release or with --in-diff for a PR.
+# .cargo/mutants.toml. Slow: use --in-diff for a change slice; the
+# authoritative full sweep runs in CI (sweep.yml, daily + release tags).
 mt = "mutants"
 # Unused-dependency sweep, AST-based (complementary to machete).
 sh = "shear --locked --deny-warnings --check-test-targets"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,9 +364,9 @@ jobs:
   # typos.toml are tracked so clippy/typos behave identically. Format uses the
   # pinned nightly (rustfmt.toml has nightly-only options). Public repo = free
   # minutes, so the heavy quality checks run here too — incremental mutants run
-  # per-PR (the `mutants` job below) and the fuzz corpus replays per-PR (the
-  # `replay` job); only the full core mutants sweep + the Windows-via-Docker
-  # local fuzz stay local.
+  # per-PR (the `mutants` job below), the fuzz corpus replays per-PR (the
+  # `replay` job), and the full mutants sweeps for every crate live in
+  # sweep.yml; only the Windows-via-Docker fuzz runner stays local.
   lint:
     name: lint (clippy, fmt, typos, doc, deps, semver)
     needs: plan
@@ -465,8 +465,8 @@ jobs:
 
   # Incremental mutation testing on the PR diff: every line a pull request
   # changes must be killed by a test that FAILS when the line is mutated. The
-  # full-tree sweep (~hours) stays local/pre-release; this PR-scoped slice
-  # (cargo mutants --in-diff) is fast. It reads the tracked .cargo/mutants.toml
+  # full-tree sweep (~hours) lives in sweep.yml (sharded, daily + release
+  # tags); this PR-scoped slice (cargo mutants --in-diff) is fast. It reads the tracked .cargo/mutants.toml
   # policy and the `mutants` nextest profile (.config/nextest.toml) — both now
   # published, so CI mutates exactly as the local gate does.
   #
@@ -475,9 +475,10 @@ jobs:
   # can false-TIMEOUT on the 4-core hosted runners (a hang-prone loop-guard
   # mutant runs in ceil(n/cores) nextest-terminate waves), so gating merges on
   # it would let an environment artifact block an unrelated PR. The
-  # AUTHORITATIVE "0 missed mutants" gate is the local full sweep run before
-  # each release (per CLAUDE.md); this surfaces regressions early but does not
-  # block. Keep it out of the required set and out of ci-ok.
+  # AUTHORITATIVE "0 missed mutants" gate is sweep.yml's sharded full sweep
+  # (daily when the workspace changed + release tags); this surfaces
+  # regressions early but does not block. Keep it out of the required set and
+  # out of ci-ok.
   mutants:
     name: mutation testing (PR diff)
     needs: plan

--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -29,6 +29,13 @@ concurrency:
 jobs:
   conventional:
     name: conventional commits + banned words
+    # Open PRs only: the `edited` trigger also fires on title/body edits to
+    # CLOSED PRs (Dependabot edits merged-PR bodies routinely), and a closed —
+    # merged or not — PR has no squash subject left to lint, so re-running the
+    # gate there can only paint a spurious red X. Skipping is safe: a skipped
+    # run still reports a check-run, and required-context semantics only
+    # matter while the PR is open.
+    if: github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -293,32 +293,31 @@ jobs:
   # by the debug-only BDINFO_GUI_SMOKE_MS/BDINFO_GUI_OPEN env hooks over the
   # committed fixture disc. Proven recipes: xvfb + Mesa's lavapipe software
   # Vulkan on Linux, the in-box DX12 WARP software rasterizer on Windows
-  # (Bevy's CI runs real winit+wgpu windows with both). The arm legs entered
-  # SOFT ("promote to blocking after a green streak") and were promoted: the
-  # drive-experiment matrix (PR #128) ran lavapipe-arm64 and arm-native WARP
-  # windows green seven consecutive times on top of this smoke's own streak.
-  # The one remaining SOFT leg:
-  #   macos-15          the runner's paravirtual Metal is the one render path
-  #                     with no software fallback.
+  # (Bevy's CI runs real winit+wgpu windows with both). All five legs are
+  # HARD (the arm legs and finally macos-15 were each promoted after sustained
+  # green streaks, PR #128 and its follow-up): macOS is a crucial supported
+  # platform, and a gate that ignores its own signal is not a gate — a red
+  # macos-15 leg now means something actually broke. Its known failure mode:
+  # the runner's paravirtual Metal is the one render path with no software
+  # fallback. If a leg ever flakes for environment reasons, fix the harness
+  # or deliberately re-soften — never a silent retry loop.
   # macos-15-intel is deliberately ABSENT: its hosted VMs expose no Metal at
   # all, so there is no real window stack to smoke — that arch's compile/logic
   # coverage lives in `gui build + test (macos-15-intel)`. The per-OS
-  # install/launch steps below key on runner.os, so the arm legs reuse them
-  # unchanged.
+  # install/launch steps below key on runner.os.
   smoke:
     name: gui smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.soft }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - {os: ubuntu-latest, soft: false}
-          - {os: windows-2025, soft: false}
-          - {os: ubuntu-24.04-arm, soft: false}
-          - {os: windows-11-arm, soft: false}
-          - {os: macos-15, soft: true}
+        os:
+          - ubuntu-latest
+          - windows-2025
+          - ubuntu-24.04-arm
+          - windows-11-arm
+          - macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -356,7 +355,7 @@ jobs:
           WGPU_BACKEND: dx12
         run: cargo run --locked
 
-      - name: Launch smoke (paravirtual Metal — SOFT)
+      - name: Launch smoke (paravirtual Metal)
         if: runner.os == 'macOS'
         working-directory: crates/bdinfo-rs-gui
         env:
@@ -386,30 +385,36 @@ jobs:
   #             (calibrated to the 880-wide layout): a deliberate layout
   #             change must update it in the same PR, snapshot-test semantics.
   #
-  # Blocking on all four Linux/Windows legs — x86 AND arm, the same promoted
-  # split as the smoke above; macos-15 stays SOFT (paravirtual Metal plus the
-  # Sequoia screen-capture re-approval residual), and macos-15-intel is absent
-  # for the smoke's no-Metal reason. The x86 legs ride the proven display
-  # recipes (xvfb + lavapipe, DX12 WARP); every leg runs at a 1920x1080
-  # desktop with shots cropped to the 880x960 window, so the galleries are
-  # comparable across OSes. The old standalone workflow's nightly schedule is
-  # superseded by the daily sweep (which re-runs this whole workflow ungated
-  # and files the rolling issue on a scheduled red); a red leg here reddens
-  # the `gui` caller job and therefore ci-ok.
+  # Blocking on ALL FIVE legs — Linux/Windows x86 AND arm plus macos-15, hard
+  # like the smoke above: macOS is a crucial supported platform, its legs had
+  # been green throughout their soft period, and a gate that ignores its own
+  # signal is not a gate. Known macos-15 failure modes (residual risks, not
+  # reasons for softness): the paravirtual Metal path has no software
+  # fallback, and drive-inject carries the Sequoia screen-capture re-approval
+  # residual. If a leg ever flakes for environment reasons, fix the harness
+  # (the scripts already handle window polling and capture pre-authorization)
+  # or deliberately re-soften — never a silent retry loop. macos-15-intel is
+  # absent for the smoke's no-Metal reason. The x86 legs ride the proven
+  # display recipes (xvfb + lavapipe, DX12 WARP); every leg runs at a
+  # 1920x1080 desktop with shots cropped to the 880x960 window, so the
+  # galleries are comparable across OSes. The old standalone workflow's
+  # nightly schedule is superseded by the daily sweep (which re-runs this
+  # whole workflow ungated and files the rolling issue on a scheduled red —
+  # mac breakage included, previously invisible to the schedule); a red leg
+  # here reddens the `gui` caller job and therefore ci-ok.
   drive-assisted:
     name: gui drive assisted (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.soft }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - {os: ubuntu-latest, soft: false}
-          - {os: windows-2025, soft: false}
-          - {os: ubuntu-24.04-arm, soft: false}
-          - {os: windows-11-arm, soft: false}
-          - {os: macos-15, soft: true}
+        os:
+          - ubuntu-latest
+          - windows-2025
+          - ubuntu-24.04-arm
+          - windows-11-arm
+          - macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -465,7 +470,7 @@ jobs:
           -Disc crates/bdinfo-rs/tests/fixtures/BigBuckBunny
           -Gallery gallery
 
-      - name: Drive the walk (paravirtual Metal — SOFT)
+      - name: Drive the walk (paravirtual Metal)
         if: runner.os == 'macOS'
         run: >
           pwsh .github/scripts/gui-drive-assisted.ps1
@@ -485,17 +490,16 @@ jobs:
   drive-inject:
     name: gui drive inject (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.soft }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - {os: ubuntu-latest, soft: false}
-          - {os: windows-2025, soft: false}
-          - {os: ubuntu-24.04-arm, soft: false}
-          - {os: windows-11-arm, soft: false}
-          - {os: macos-15, soft: true}
+        os:
+          - ubuntu-latest
+          - windows-2025
+          - ubuntu-24.04-arm
+          - windows-11-arm
+          - macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -543,7 +547,7 @@ jobs:
           -Disc crates/bdinfo-rs/tests/fixtures/BigBuckBunny
           -Gallery gallery
 
-      - name: Inject the walk (cliclick — SOFT, records the Accessibility wall)
+      - name: Inject the walk (cliclick)
         if: runner.os == 'macOS'
         run: >
           pwsh .github/scripts/gui-drive-inject-macos.ps1

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -5,15 +5,17 @@ name: sweep
 # orchestrator with every area forced (a workflow_call with a non-PR/push
 # event makes the plan job fire all areas), plus the expensive tier the PR
 # path deliberately does not carry: the full-crate `cargo mutants --in-place`
-# sweeps for the gui and wasm sibling crates (D1). Untouched areas are thus
-# re-verified within 24 h, and environment drift (runner images, toolchain
-# point releases, a floating tool) cannot hide behind a skipped PR job. A
-# scheduled failure files/refreshes ONE rolling issue (closed again on the
-# next green sweep); workflow_dispatch exists so the sweep can be exercised on
-# demand.
+# sweeps for EVERY crate — the root workspace (core + CLI, sharded) and the
+# gui and wasm sibling crates (D1). These legs are the authoritative 0-missed
+# mutation bar for the whole repo; there is no local full-sweep ritual.
+# Untouched areas are thus re-verified within 24 h, and environment drift
+# (runner images, toolchain point releases, a floating tool) cannot hide
+# behind a skipped PR job. A scheduled failure files/refreshes ONE rolling
+# issue (closed again on the next green sweep); workflow_dispatch exists so
+# the sweep can be exercised on demand.
 #
 # Release tags (v*) run the full-mutants legs ONLY — the authoritative
-# 0-missed release checkpoint for the sibling crates, riding alongside the
+# 0-missed release checkpoint for every crate, riding alongside the
 # publish lanes exactly like fuzz.yml's extended pass (it surfaces a
 # regression, it does not block the release). The orchestrator call is
 # skipped on tags: every area was already green on the master commit the tag
@@ -57,6 +59,104 @@ jobs:
     name: orchestrator
     if: github.event_name != 'push'
     uses: ./.github/workflows/ci.yml
+
+  # Full mutation over the ROOT workspace (bdinfo-rs-core + the CLI), 0
+  # missed — the leg that retired the local pre-release `cargo mt` ritual;
+  # this sweep (daily + tags) is the authoritative core 0-missed bar. Policy
+  # comes from the tracked .cargo/mutants.toml: test_workspace = true (every
+  # mutant faces the whole suite, the CLI's end-to-end fixture flow included),
+  # which is what makes this expensive — ~3-4 h on a 24-core dev box, more on
+  # a 4-core hosted runner, against the 6 h job limit. So the run is SHARDED
+  # (cargo mutants --shard k/8): each shard builds its own baseline, then
+  # mutates a deterministic eighth of the mutant list, fitting comfortably
+  # (minutes are free on a public repo; concurrency is the only budget).
+  # --in-place skips the tree copy (each shard owns its runner's checkout);
+  # --no-shuffle keeps the shard partition deterministic.
+  #
+  # The marker key must capture EVERYTHING that can change a mutants verdict
+  # for the root workspace — wider than the gui/wasm single-crate keys (miss
+  # an input and a stale green marker lies): both crate trees, the workspace
+  # manifest (lints + the [profile.mutants] build profile), the lockfile, the
+  # mutants policy, the nextest profile (the `mutants` profile's timeouts),
+  # and the toolchain. Folded through sha256 to keep the key short. Every
+  # shard computes the identical key; the marker itself is saved only by
+  # core-mutants-ok below, after ALL shards ran green.
+  core-mutants:
+    name: core full mutants (shard ${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    outputs:
+      # Identical across legs (each computes it from the same HEAD), so the
+      # matrix-output last-writer-wins rule is harmless; core-mutants-ok
+      # reuses it instead of recomputing.
+      key: ${{ steps.key.outputs.key }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Compute the sweep marker key (root-workspace inputs hash)
+        id: key
+        run: |
+          inputs=$(git rev-parse HEAD:crates/bdinfo-rs-core HEAD:crates/bdinfo-rs HEAD:Cargo.toml HEAD:Cargo.lock HEAD:.cargo/mutants.toml HEAD:.config/nextest.toml HEAD:rust-toolchain.toml)
+          echo "$inputs"
+          echo "key=core-mutants-ok-$(echo "$inputs" | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the last-green marker
+        id: marker
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .mutants-ok
+          key: ${{ steps.key.outputs.key }}
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        if: steps.marker.outputs.cache-hit != 'true'
+        with:
+          # Same discipline as the sibling legs: tag legs build fresh, only
+          # master runs save.
+          lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Install mutation tools
+        if: steps.marker.outputs.cache-hit != 'true'
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
+        with:
+          tool: cargo-mutants,cargo-nextest
+
+      - name: Mutants (0 missed, this shard)
+        if: steps.marker.outputs.cache-hit != 'true'
+        run: cargo mutants --in-place --no-shuffle --shard ${{ matrix.shard }}/8
+
+  # The marker fan-in: runs only when every shard succeeded (default `needs`
+  # semantics), so the one saved marker attests the WHOLE root workspace
+  # passed. Probes first: on a marker hit the shards all short-circuited and
+  # the key already exists — saving it again would only warn.
+  core-mutants-ok:
+    name: core full mutants marker
+    needs: [core-mutants]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe for an existing marker
+        id: marker
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .mutants-ok
+          key: ${{ needs.core-mutants.outputs.key }}
+          lookup-only: true
+
+      - name: Write the marker
+        if: steps.marker.outputs.cache-hit != 'true'
+        run: echo ok > .mutants-ok
+
+      - name: Save the marker (all shards green)
+        if: steps.marker.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .mutants-ok
+          key: ${{ needs.core-mutants.outputs.key }}
 
   # Full Tier-A mutation over the GUI crate, 0 missed. --in-place because a
   # temp copy would not carry the ../bdinfo-rs-core path dep; reads the
@@ -174,7 +274,7 @@ jobs:
   # watching them.
   report:
     name: rolling failure issue
-    needs: [orchestrator, gui-mutants, wasm-mutants]
+    needs: [orchestrator, core-mutants, core-mutants-ok, gui-mutants, wasm-mutants]
     if: ${{ !cancelled() && github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -8,6 +8,12 @@ name: version-freshness
 #     rest),
 #   - cargo-dist (dist-workspace.toml `cargo-dist-version` AND the `cargo-dist@X`
 #     install in ci.yml — the two must stay equal),
+#   - the four action SHAs in dist-workspace.toml `[dist.github-action-commits]`
+#     (checkout, upload-/download-artifact, attest) — the SOURCE dist generates
+#     v-release.yml from, invisible to Dependabot (it bumps the GENERATED file,
+#     which then fails `dist generate --check`) — cross-checked against the
+#     hand-maintained workflows' pins for the same actions so the drift becomes
+#     a scheduled nag instead of a red X on an unrelated Dependabot PR,
 #   - cargo-vet (the `--version` pin in ci.yml's vet job),
 #   - ryl (the `cargo install ryl --version` pin in ci.yml's YAML-lint job),
 #   - taplo (the `tool: taplo-cli@X` pin in ci.yml's TOML job — a formatter, pinned like
@@ -36,9 +42,12 @@ name: version-freshness
 #   - cargo-deb + cargo-generate-rpm (the `cargo-deb@X` / `cargo-generate-rpm@X` pins
 #     in build-linux-packages.sh — the .deb/.rpm packagers are compiled from source
 #     INSIDE dist's fail-fast release, so they are version-pinned there so a broken
-#     upstream release can't abort the whole release; both checked vs crates.io), and
+#     upstream release can't abort the whole release; both checked vs crates.io, and
+#     both cross-checked against the second copy in ci.yml's pkg job, which must
+#     stay EQUAL so the PR smoke test packages with the exact release tools), and
 #     cloudsmith-cli (the `cloudsmith-cli==X` pipx pin in packages.yml — a pip pin
-#     invisible to Dependabot's cargo/npm/actions scans; checked vs PyPI),
+#     invisible to Dependabot's cargo/npm/actions scans; pinned once per push job,
+#     every occurrence checked to agree, then vs PyPI),
 # (Cargo deps/dev-deps, the web npm devDependencies — typescript / biome /
 # binaryen / playwright-core — and GitHub Action SHAs are already auto-bumped by
 # Dependabot — cargo + npm + github-actions ecosystems — so they are deliberately
@@ -94,6 +103,32 @@ jobs:
           function Read-Pin($path, $regex) {
             foreach ($line in (Get-Content $path)) {
               if ($line -match $regex) { return $Matches[1] }
+            }
+            return $null
+          }
+
+          # EVERY pin matched by $regex (group 1, one per line) in $path, in file
+          # order — for a pin that exists more than once in one file and must
+          # agree with itself (Read-Pin sees only the first occurrence).
+          function Read-AllPins($path, $regex) {
+            $found = @()
+            foreach ($line in (Get-Content $path)) {
+              if ($line -match $regex) { $found += $Matches[1] }
+            }
+            return , $found
+          }
+
+          # A SHA-pinned action reference (`<sha> # <tag>`), normalized, from a
+          # workflow (`uses: $action@<sha> # <tag>`) or from dist-workspace.toml's
+          # [dist.github-action-commits] (`"$action" = "<sha> # <tag>"`); $null if
+          # absent. Normalizing to one string compares SHA and tag comment
+          # together — Dependabot always moves both, so both must agree.
+          function Read-ActionPin($path, $action) {
+            $esc = [regex]::Escape($action)
+            foreach ($line in (Get-Content $path)) {
+              if ($line -match "$esc(@|`"\s*=\s*`")([0-9a-f]{40})\s*#\s*([^\s`"]+)") {
+                return "$($Matches[2]) # $($Matches[3])"
+              }
             }
             return $null
           }
@@ -200,6 +235,36 @@ jobs:
             Add-Problem "cargo-dist $distCfg->$distLatest" "- cargo-dist pin ``$distCfg`` (dist-workspace.toml + ci.yml) is behind the latest release ``$distLatest`` — bump both pins, then re-run ``dist generate``"
           }
 
+          # --- dist [dist.github-action-commits]: TOML pins vs the workflows -----
+          # The four action SHAs in dist-workspace.toml are the SOURCE dist
+          # generates v-release.yml from, and Dependabot cannot see the TOML: its
+          # bump of the same action in the workflows (generated v-release.yml
+          # included) leaves the TOML behind, caught today only as a red
+          # `dist generate --check` on that Dependabot PR. Cross-check each TOML
+          # pin against a hand-maintained workflow using the same action (one
+          # canonical file per action — checkout is everywhere so ci.yml is
+          # canonical; upload-/download-artifact live in gui.yml, attest in
+          # docker.yml; the github-actions Dependabot group bumps all
+          # hand-maintained workflows together, so any one file represents the
+          # fleet). A drift line here turns the red-X surprise into a scheduled
+          # nag; the fix is unchanged (scripts/dist-sync.ps1 / dist generate).
+          $distActionSources = [ordered]@{
+            'actions/checkout'          = '.github/workflows/ci.yml'
+            'actions/upload-artifact'   = '.github/workflows/gui.yml'
+            'actions/download-artifact' = '.github/workflows/gui.yml'
+            'actions/attest'            = '.github/workflows/docker.yml'
+          }
+          foreach ($action in $distActionSources.Keys) {
+            $wf = $distActionSources[$action]
+            $tomlPin = Read-ActionPin 'dist-workspace.toml' $action
+            $wfPin = Read-ActionPin $wf $action
+            if (-not $tomlPin) { throw "No $action pin in dist-workspace.toml [dist.github-action-commits]" }
+            if (-not $wfPin) { throw "No $action pin in $wf" }
+            if ($tomlPin -ne $wfPin) {
+              Add-Problem "$action dist pin drifted" "- dist-workspace.toml ``[dist.github-action-commits]`` pins ``$action`` at ``$tomlPin`` but $wf uses ``$wfPin`` — set the TOML pin to the workflow's value and re-run ``dist generate`` (scripts/dist-sync.ps1)"
+            }
+          }
+
           # --- cargo-vet: ci.yml vs mozilla/cargo-vet --------------------------
           $vetPin = Read-Pin '.github/workflows/ci.yml' 'cargo-vet --version ([0-9.]+)'
           if (-not $vetPin) { throw 'No cargo-vet --version pin in ci.yml' }
@@ -267,6 +332,23 @@ jobs:
             Add-Problem 'cargo-generate-rpm (query failed)' '- could not query the latest cargo-generate-rpm release (crates.io)'
           } elseif ([version]$cargoRpmLatest -gt [version]$cargoRpmPin) {
             Add-Problem "cargo-generate-rpm $cargoRpmPin->$cargoRpmLatest" "- cargo-generate-rpm pin ``$cargoRpmPin`` (build-linux-packages.sh) is behind the latest release ``$cargoRpmLatest``"
+          }
+          # Both pins exist a SECOND time in ci.yml's pkg job (`tool:
+          # cargo-deb@…,cargo-generate-rpm@…`) — deliberately equal so the PR
+          # smoke test packages with the exact release tools (the script's
+          # already-on-PATH guard then skips its source compile). A one-sided
+          # bump silently de-syncs the smoke test from the release path, so
+          # cross-check agreement like the NIGHTLY pins; freshness of the value
+          # itself is already covered above.
+          $cargoDebCi = Read-Pin '.github/workflows/ci.yml' 'cargo-deb@([0-9.]+)'
+          $cargoRpmCi = Read-Pin '.github/workflows/ci.yml' 'cargo-generate-rpm@([0-9.]+)'
+          if (-not $cargoDebCi) { throw 'No cargo-deb@<version> pin in ci.yml (pkg job)' }
+          if (-not $cargoRpmCi) { throw 'No cargo-generate-rpm@<version> pin in ci.yml (pkg job)' }
+          if ($cargoDebCi -ne $cargoDebPin) {
+            Add-Problem 'cargo-deb pins disagree' "- cargo-deb pin mismatch: build-linux-packages.sh has ``$cargoDebPin`` but ci.yml's pkg job installs ``$cargoDebCi`` — they must be identical (the smoke test must use the exact release tools)"
+          }
+          if ($cargoRpmCi -ne $cargoRpmPin) {
+            Add-Problem 'cargo-generate-rpm pins disagree' "- cargo-generate-rpm pin mismatch: build-linux-packages.sh has ``$cargoRpmPin`` but ci.yml's pkg job installs ``$cargoRpmCi`` — they must be identical (the smoke test must use the exact release tools)"
           }
 
           # --- wasm-bindgen-cli: wasm.yml + publish-npm.yml pins vs crates.io ---
@@ -423,9 +505,16 @@ jobs:
           # The deb/rpm jobs push to Cloudsmith with a pinned `cloudsmith-cli==X`
           # (pipx). A pip pin invisible to Dependabot's cargo/npm/actions scans, so a
           # server-side API change could break the frozen client silently; nag here
-          # like the other hand-bumped tools when a newer client ships.
-          $cloudsmithPin = Read-Pin '.github/workflows/packages.yml' 'cloudsmith-cli==([0-9.]+)'
-          if (-not $cloudsmithPin) { throw 'No `cloudsmith-cli==<version>` pin in packages.yml' }
+          # like the other hand-bumped tools when a newer client ships. The pin
+          # occurs once PER PUSH JOB (.deb and .rpm), so read every occurrence and
+          # assert they agree — the first-match-only read used to validate one job
+          # while the other could drift — then run freshness on the agreed value.
+          $cloudsmithPins = Read-AllPins '.github/workflows/packages.yml' 'cloudsmith-cli==([0-9.]+)'
+          if (-not $cloudsmithPins.Count) { throw 'No `cloudsmith-cli==<version>` pin in packages.yml' }
+          $cloudsmithPin = $cloudsmithPins[0]
+          if (@($cloudsmithPins | Sort-Object -Unique).Count -gt 1) {
+            Add-Problem 'cloudsmith-cli pins disagree' "- cloudsmith-cli pin mismatch inside packages.yml: ``$($cloudsmithPins -join '` / `')`` — the .deb and .rpm push jobs must pin the same version"
+          }
           $cloudsmithLatest = Latest-PyPI 'cloudsmith-cli'
           if (-not $cloudsmithLatest) {
             Add-Problem 'cloudsmith-cli (query failed)' '- could not query the latest cloudsmith-cli release (PyPI)'

--- a/README.md
+++ b/README.md
@@ -379,7 +379,8 @@ Every push and pull request runs the full gate in CI:
   no-C-dependencies ban) and `cargo vet` (every dependency covered by a trusted audit),
   plus CodeQL SAST and dependency review.
 - **Mutation testing — zero surviving mutants.** Every pull request mutation-tests its
-  diff (`cargo mutants --in-diff`), with a full sweep before each release; a mutant must
+  diff (`cargo mutants --in-diff`), with a daily full sweep in CI (re-run on every
+  release tag) as the authoritative bar; a mutant must
   either make a test *fail* or be documented as provably equivalent. Coverage that can't
   kill a mutant doesn't count.
 - **Fuzzing — no panics, no hangs.** Every untrusted-input parser (bitstream, M2TS, every


### PR DESCRIPTION
Pre-release CI tightening wave, four independent changes:

- **gui.yml**: the three `macos-15` legs (smoke, drive-assisted, drive-inject) lose the soft mechanism entirely — plain five-OS matrices, no `continue-on-error`, no SOFT step suffixes. A red mac leg now reddens the `gui` caller job and `ci-ok`, and a scheduled sweep red files the rolling issue. Comments keep the paravirtual-Metal and Sequoia screen-capture residuals as known failure modes rather than reasons for softness. `macos-15-intel` stays absent from the real-window jobs (no Metal on its hosted VMs).
- **sweep.yml**: new sharded core full-mutants leg — 8 shards over the root workspace under the tracked `.cargo/mutants.toml` policy (`test_workspace = true`), each shard a deterministic slice, with a marker key covering both crate trees, the workspace manifest, the lockfile, the mutants policy, the nextest profile, and the toolchain; a fan-in job saves the one marker only after all shards ran green. Runs daily and on `v*` tags with the same short-circuit as the gui/wasm legs; the rolling-issue job tracks the new jobs. The daily sweep + tag legs are now the authoritative 0-missed mutation bar for every crate; stale comments in ci.yml, .cargo/config.toml and README.md updated to match.
- **conventional.yml**: job-level `state == 'open'` guard — title/body edits to closed PRs no longer re-run the gate against a PR with no squash subject left to lint.
- **version-freshness.yml**: three coverage gaps closed, all of the one-pin-in-two-places species: the cargo-deb / cargo-generate-rpm pins in build-linux-packages.sh are now cross-checked against the second copy in ci.yml's `pkg` job; the `cloudsmith-cli==X` pin is read at every occurrence in packages.yml and asserted to agree before the PyPI freshness compare; and the four `[dist.github-action-commits]` SHAs in dist-workspace.toml are cross-checked against the hand-maintained workflows' pins for the same actions, turning generated-file drift into a scheduled nag instead of a red `dist generate --check` on an unrelated PR. Verified locally against the repo files: the agree case reports nothing, and each synthetic break produces its issue line.