### PR TITLE
ci: shard the gui mutants sweep, dedupe rust caches, and adjudicate two mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -163,6 +163,19 @@ exclude_re = [
     # terminal (piped stderr never styles).
     "main\\.rs:\\d+:\\d+: replace write_stderr with \\(\\)",
 
+    # CLI `terminal_columns` (every replacement value): samples the live console
+    # via `terminal::size()` — its ONLY caller is ProgressDisplay::observe's
+    # `styled` branch, gated on `stderr_styles()` (always false in a captured-
+    # stdio test process, excluded above), and the value flows only into
+    # `write_stderr` (also excluded — a test cannot read its own live stderr),
+    # so no test can observe the return. Asserting on a direct call instead
+    # would pin the live probe against unknown consoles (TIOCGWINSZ can
+    # genuinely report 0 columns). The width-driven rendering it feeds
+    # (compose_styled_progress / redraw_sequence) is tested with explicit
+    # columns; only the live sample is opaque. Surfaced by the first sharded CI
+    # sweep, 2026-07-18.
+    "main\\.rs:\\d+:\\d+: replace terminal_columns -> usize with \\d+",
+
     # CLI `ctrl_c_pressed` (the `-> false` replacement and every internal mutant):
     # the poll drains a live console's pending key events — in a test process there
     # is no console delivering a Ctrl+C press, so the real function and the `-> false`

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -20,11 +20,12 @@ name: gui
 # the iced_test Simulator interaction suite, the tiny-skia snapshot hashes, the
 # headless launch smoke, and the real-window drive walks below.
 #
-# The Tier-A mutation bar is NOT enforced here: the full-crate sweep (~50 min)
-# was rescheduled off the PR path (D1) into sweep.yml, which runs it daily —
-# only when the crate tree changed since the last green sweep — and on release
-# tags, the authoritative 0-missed checkpoints. The PR path gets the advisory
-# in-diff mutants job in ci.yml (`gui mutation testing (PR diff)`) instead.
+# The Tier-A mutation bar is NOT enforced here: the full-crate sweep was
+# rescheduled off the PR path (D1) into sweep.yml (now sharded), which runs it
+# daily — only when the crate tree changed since the last green sweep — and on
+# release tags, the authoritative 0-missed checkpoints. The PR path gets the
+# advisory in-diff mutants job in ci.yml (`gui mutation testing (PR diff)`)
+# instead.
 #
 # Job shape — the repo's standing pattern (same reasoning as the core/CLI in
 # ci.yml): arch bugs live in build + test, which runs on all six shipped
@@ -326,6 +327,12 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: crates/bdinfo-rs-gui
+          # smoke + drive-assisted + drive-inject run the IDENTICAL plain
+          # debug build per OS, so the three share ONE cache lineage instead
+          # of rust-cache's default per-job keys — three byte-duplicate
+          # multi-hundred-MB caches per OS family otherwise crowd the repo's
+          # 10 GB Actions-cache budget and LRU-evict the sweep markers.
+          shared-key: gui-drive
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install the virtual display + software Vulkan (Linux)
@@ -423,6 +430,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: crates/bdinfo-rs-gui
+          # One lineage with smoke/drive-inject — see the smoke job's note.
+          shared-key: gui-drive
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install the virtual display + software Vulkan + capture (Linux)
@@ -508,6 +517,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: crates/bdinfo-rs-gui
+          # One lineage with smoke/drive-assisted — see the smoke job's note.
+          shared-key: gui-drive
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install the virtual display + software Vulkan + xdotool + capture (Linux)

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -28,8 +28,8 @@ name: sweep
 # verifies the crate's SUITE against the crate's SOURCE, and both are captured
 # exactly by the crate dir's git tree hash (lockfile and .cargo/mutants.toml
 # included) plus rust-toolchain.toml — so a marker hit means this
-# byte-identical tree already passed a full sweep, and re-running (~50–90 min)
-# would re-verify unchanged inputs. The marker is saved only after a green
+# byte-identical tree already passed a full sweep, and re-running (tens of
+# minutes of sharded fleet time) would re-verify unchanged inputs. The marker is saved only after a green
 # sweep (implicit success() on the save step's `if:`), and only sweep runs
 # save it — schedule runs execute on master, so the marker is master-scoped
 # and restorable by the tag legs; a quiet day skips in seconds. Accepted
@@ -115,6 +115,13 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: steps.marker.outputs.cache-hit != 'true'
         with:
+          # shared-key: every shard builds the IDENTICAL baseline, so all
+          # shards share ONE cache lineage instead of rust-cache's default
+          # per-matrix-leg keys — without it each shard saves its own
+          # multi-GB target cache and the repo's 10 GB Actions-cache budget
+          # churns, evicting the sweep markers and the master-seeded PR
+          # caches. First finisher saves; the rest skip gracefully.
+          shared-key: core-mutants
           # Same discipline as the sibling legs: tag legs build fresh, only
           # master runs save.
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -158,14 +165,31 @@ jobs:
           path: .mutants-ok
           key: ${{ needs.core-mutants.outputs.key }}
 
-  # Full Tier-A mutation over the GUI crate, 0 missed. --in-place because a
-  # temp copy would not carry the ../bdinfo-rs-core path dep; reads the
-  # crate-local .cargo/mutants.toml Tier-B exclusions. The snapshot ties
-  # participate via the deterministic software renderer, keeping their mutant
-  # kill power (a palette or view-model mutation shifts the rendered hash).
+  # Full Tier-A mutation over the GUI crate, 0 missed — SHARDED like the core
+  # leg (the one-job run took ~1.7 h for 608 mutants; the shards divide that
+  # mutation phase, each still paying the setup + iced/wgpu baseline, so the
+  # floor is the baseline, not zero). Shard count is deliberately modest: the sweep's tail
+  # is 8 core shards + these, and the account-wide concurrent-job budget
+  # (~20) is the scarce resource, not minutes. --in-place because a temp copy
+  # would not carry the ../bdinfo-rs-core path dep; --no-shuffle keeps the
+  # shard partition deterministic; reads the crate-local .cargo/mutants.toml
+  # Tier-B exclusions. The snapshot ties participate via the deterministic
+  # software renderer, keeping their mutant kill power (a palette or
+  # view-model mutation shifts the rendered hash). The marker key is
+  # byte-identical to the pre-shard one — ci.yml's advisory PR-diff job
+  # computes the same string for its short-circuit. (wasm below stays
+  # unsharded on purpose: a ~3-minute job would only get SLOWER paying N
+  # baselines.)
   gui-mutants:
-    name: gui full mutants (Tier A 0 missed)
+    name: gui full mutants (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
+    outputs:
+      # Identical across legs; gui-mutants-ok reuses it (see core-mutants).
+      key: ${{ steps.key.outputs.key }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5]
     env:
       ICED_TEST_BACKEND: tiny-skia
     steps:
@@ -188,6 +212,9 @@ jobs:
         if: steps.marker.outputs.cache-hit != 'true'
         with:
           workspaces: crates/bdinfo-rs-gui
+          # One shared lineage for all shards (identical baselines) — see the
+          # core shards' shared-key note.
+          shared-key: gui-mutants
           # Tag legs build fresh: a cache poisoned elsewhere must not taint a
           # release-adjacent run (the fuzz.yml precedent). Schedule runs are on
           # master, so their saves seed every PR.
@@ -200,21 +227,35 @@ jobs:
         with:
           tool: cargo-mutants,cargo-nextest
 
-      - name: Mutants (Tier A 0 missed)
+      - name: Mutants (Tier A 0 missed, this shard)
         if: steps.marker.outputs.cache-hit != 'true'
         working-directory: crates/bdinfo-rs-gui
-        run: cargo mutants --in-place
+        run: cargo mutants --in-place --no-shuffle --shard ${{ matrix.shard }}/6
+
+  # The gui marker fan-in — same shape and reasoning as core-mutants-ok.
+  gui-mutants-ok:
+    name: gui full mutants marker
+    needs: [gui-mutants]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe for an existing marker
+        id: marker
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .mutants-ok
+          key: ${{ needs.gui-mutants.outputs.key }}
+          lookup-only: true
 
       - name: Write the marker
         if: steps.marker.outputs.cache-hit != 'true'
         run: echo ok > .mutants-ok
 
-      - name: Save the marker (green sweep only)
+      - name: Save the marker (all shards green)
         if: steps.marker.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .mutants-ok
-          key: ${{ steps.key.outputs.key }}
+          key: ${{ needs.gui-mutants.outputs.key }}
 
   # Full Tier-A mutation over the wasm crate, 0 missed — same marker pattern.
   # --in-place for the same path-dep reason; the crate-local .cargo/mutants.toml
@@ -274,7 +315,7 @@ jobs:
   # watching them.
   report:
     name: rolling failure issue
-    needs: [orchestrator, core-mutants, core-mutants-ok, gui-mutants, wasm-mutants]
+    needs: [orchestrator, core-mutants, core-mutants-ok, gui-mutants, gui-mutants-ok, wasm-mutants]
     if: ${{ !cancelled() && github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Follow-up to #129, informed by the first live sharded sweep (run 29664388016):

- **sweep.yml**: the gui full-mutants leg is now sharded like core — 6 shards (`--shard k/6`, `--in-place --no-shuffle`) plus a `gui-mutants-ok` marker fan-in; the marker key is byte-identical to the pre-shard one so ci.yml's advisory PR-diff short-circuit keeps matching. The one-job leg measured 103.9 min for 608 mutants with a 105s+6s baseline, so six shards land ~20-25 min each. wasm stays unsharded on purpose (3m12s single job — N baselines would only slow it).
- **Cache dedup (`shared-key`)**: the 8 core shards and 6 gui shards each share one rust-cache lineage (`core-mutants` / `gui-mutants`) instead of per-matrix-leg keys, and the smoke / drive-assisted / drive-inject jobs share `gui-drive` per OS — they run the identical plain debug build, and their three byte-duplicate caches per OS family (474 MB x 3 on Linux-x64 alone) were crowding the repo's 10 GB Actions-cache budget at 9+ GB, putting the sweep markers in LRU-eviction range.
- **.cargo/mutants.toml**: the two mutants the first sharded core sweep surfaced (`terminal_columns -> 0 / 1`, main.rs) are adjudicated environment-bound with a written proof: the only caller is `ProgressDisplay::observe`'s styled branch, gated on the already-excluded `stderr_styles()` live-tty probe, and the value flows only into the already-excluded `write_stderr`; a direct-call assertion would pin `terminal::size()` against consoles that can genuinely report 0 columns. The width-driven rendering it feeds is tested with explicit columns. Verified via `cargo mutants --list`: the two mutants no longer generate, the remaining 120 in main.rs are intact.

First-run shard data (core, 8 shards): 25-44 min walls, avg 37.5 / median 38.0; baselines 10-21s build + 1-3s test on the warm shared cache; 2,573 mutants fleet-wide. Shard 0 correctly failed on the two mutants above - the fail path of the new gate proven live alongside the pass path.