### PR TITLE
docs: correct the comment layer and rebalance the mutants sweep shards

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -90,8 +90,9 @@ exclude_re = [
     "dts_hd\\.rs:\\d+:\\d+: replace < with <= in scan",
 
     # `codec::mpeg2::scan` picture-counter guard: `picture_parse > 0` vs `>= 0`
-    # (line 49 — NOTE: line-pinned, re-pin when the file shifts; the 2026-06-11
-    # audit found the old `:52:` pin stale, which resurfaced this known mutant).
+    # (pinned by COLUMN 33 — the operator's own position, which an edit above it
+    # cannot move; the 2026-06-11 audit found the then-current `:52:` LINE pin
+    # stale, which resurfaced this known mutant).
     # `picture_parse` is only ever set to 2 (a picture start code) and
     # decremented; the only readers are this branch and the inner `if picture_parse
     # == 0`. At `picture_parse == 0` the `>= 0` mutant enters and decrements to -1
@@ -101,32 +102,38 @@ exclude_re = [
     # both. The two are behaviorally indistinguishable. The sibling
     # `sequence_header_parse > 0` (line 40) is NOT equivalent and is killed by
     # `a_picture_started_inside_a_sequence_header_decodes_after_init`.
-    "mpeg2\\.rs:49:\\d+: replace > with >= in scan",
+    "mpeg2\\.rs:\\d+:33: replace > with >= in scan",
 
     # ── 2026-06-11 audit: PES/PAT/PMT window guards proven equivalent ─────────
-    # (all line-pinned; re-pin on file drift — last re-pinned 2026-07-12 after the
-    # cancel-flag plumbing shifted m2ts.rs by ~53 lines. These CANNOT be
-    # de-line-pinned to the bare fn name: each of parse_chunk/parse_pat/parse_pmt
-    # holds many other `>` guards that are NOT equivalent and must stay killable,
-    # so the line:col is the only disambiguator.)
+    # (These CANNOT be de-pinned to the bare fn name: each of parse_chunk /
+    # parse_pat / parse_pmt holds many other `>` guards that are NOT equivalent and
+    # must stay killable, so the position is the only disambiguator. Four of the six
+    # position-pinned exclusions — 832, 837 and 1133 below, plus mpeg2.rs `scan`
+    # above — are pinned by COLUMN, which no edit above them can shift, so they never
+    # need re-pinning. Only 1204 and 1358 still drift with the file: their columns
+    # (48, 54) COLLIDE with the non-equivalent guards at 1183 and 1330, and a pin
+    # wide enough to cover those would exclude a real test gap SILENTLY — strictly
+    # worse than a stale pin, which fails loudly as a MISSED mutant. So those two
+    # stay line-pinned; re-pin them when m2ts.rs shifts (last re-pinned 2026-07-12,
+    # after the cancel-flag plumbing moved the file by ~53 lines).)
 
     # `parse_chunk` branch A guard `state.packet_length > 0` vs `>=`: a bounded
     # transfer closes the instant packet_length reaches 0 (transfer_state goes
     # false), and a PES declaring zero length sets the variable flag, failing the
     # branch's `!packet_length_variable` conjunct — the disputed `== 0` case is
     # unreachable with the flag clear.
-    "m2ts\\.rs:832:\\d+: replace > with >= in TsStreamFile::parse_chunk",
+    "m2ts\\.rs:\\d+:56: replace > with >= in TsStreamFile::parse_chunk",
 
     # `parse_chunk` branch B guard `parser.packet_length > 0` (all comparison
     # mutants): the conjunct is redundant under the clamp two lines later
     # (`if parser.packet_length <= offset { offset = parser.packet_length }`) —
     # whenever B's reach condition holds, the C-then-clamp fallback computes the
     # identical offset, so taking or skipping branch B changes nothing.
-    "m2ts\\.rs:837:\\d+: replace > with (==|<|>=) in TsStreamFile::parse_chunk",
+    "m2ts\\.rs:\\d+:57: replace > with (==|<|>=) in TsStreamFile::parse_chunk",
 
     # `parse_pat` transfer window `>` vs `>=`: at `bl - i == section_length` both
     # branches assign the same offset.
-    "m2ts\\.rs:1133:\\d+: replace > with >= in TsStreamFile::parse_pat",
+    "m2ts\\.rs:\\d+:38: replace > with >= in TsStreamFile::parse_pat",
 
     # `parse_pat` post-section guard `pat_section_parse > 0` vs `>=`: the countdown
     # is a u32 that the mutant only ever decrements from the wrapped u32::MAX, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
             if [ "$core" = "true" ]; then fuzz=true; fi
           fi
 
-          # The canary (D3, "most complete cheap option"): meta-only events —
+          # The canary: meta-only events —
           # CI plumbing changed but no code — still build + test on one leg
           # per OS/shell family, exercising the changed checkout / rust-cache /
           # install-action plumbing from both sides without the 6-arch fleet.
@@ -231,9 +231,9 @@ jobs:
           # save; PRs restore the master-seeded cache.
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
-      # Clippy on EVERY build+test leg (D6, "standardize up"): the ubuntu-only
-      # lint job never clips the #[cfg(windows)] arms (e.g. the vfs/fs.rs
-      # raw-volume reader), so per-arch lint bugs used to sail through CI.
+      # Clippy on EVERY build+test leg: the ubuntu-only lint job never clips
+      # the #[cfg(windows)] arms (e.g. the vfs/fs.rs raw-volume reader), so a
+      # per-arch lint bug reaches master unless every leg lints.
       # Cheap: shares this leg's dep build. The alias is the tracked `lt`
       # (clippy --workspace --all-targets --locked -- -D warnings).
       - name: Clippy (-D warnings, pedantic/nursery/restriction)
@@ -505,7 +505,7 @@ jobs:
           git diff "origin/${GITHUB_BASE_REF}...HEAD" > pr.diff
           cargo mutants --no-shuffle --in-diff pr.diff
 
-  # Advisory in-diff mutation over the GUI crate on the PR path (D1): mirrors
+  # Advisory in-diff mutation over the GUI crate on the PR path: mirrors
   # the local `gui-compliance.ps1 -InDiff` dev loop — the diff is taken
   # --relative from inside the crate so its paths match cargo-mutants' working
   # directory, and --in-place because a temp copy would not carry the
@@ -630,9 +630,9 @@ jobs:
   # One native runner per SHIPPED binary (x86_64 AND aarch64 × Linux/Windows/macOS),
   # so this exercises the actual RELEASE/static artifact (not the debug test binary)
   # on hardware we don't own — Linux builds the static musl target it ships.
-  # Deliberately NOT `needs:`-chained behind test/lint/coverage (D5): that chain
-  # was pure scheduling — ci-ok still requires e2e green, so running it in
-  # parallel changes nothing but the wall-clock. (Running the binary in TOTAL
+  # Deliberately NOT `needs:`-chained behind test/lint/coverage: such a chain is
+  # pure scheduling — ci-ok requires e2e green either way, so running it in
+  # parallel costs nothing but wall-clock. (Running the binary in TOTAL
   # isolation — FROM scratch, zero runtime deps — is the separate `isolation`
   # job below; docker.yml ships that same scratch image on release.)
   e2e:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: fuzz
-          # Lookup-only: this workflow now runs exclusively on release tags, and
+          # Lookup-only: this workflow runs exclusively on release tags, and
           # a cache poisoned elsewhere must not taint a release-adjacent run
           # (zizmor cache-poisoning); the per-PR replay leg in ci.yml is where
           # the fuzz build cache is used and (on master) saved.

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -20,10 +20,9 @@ name: gui
 # the iced_test Simulator interaction suite, the tiny-skia snapshot hashes, the
 # headless launch smoke, and the real-window drive walks below.
 #
-# The Tier-A mutation bar is NOT enforced here: the full-crate sweep was
-# rescheduled off the PR path (D1) into sweep.yml (now sharded), which runs it
-# daily — only when the crate tree changed since the last green sweep — and on
-# release tags, the authoritative 0-missed checkpoints. The PR path gets the
+# The full-crate mutation bar is NOT enforced here: it lives in sweep.yml,
+# sharded, running daily — only when the crate tree changed since the last
+# green sweep — and on release tags, the authoritative 0-missed checkpoints. The PR path gets the
 # advisory in-diff mutants job in ci.yml (`gui mutation testing (PR diff)`)
 # instead.
 #
@@ -371,11 +370,8 @@ jobs:
         run: cargo run --locked
 
   # The real-window DRIVE gates: the app driven end to end on a real desktop
-  # session, a screenshot per step uploaded as a gallery either way. Promoted
-  # from the standalone advisory experiment (PR #128) after seven consecutive
-  # all-ten-green matrices — the deliberate owner decision superseding the
-  # experiment's stay-advisory recommendation; the future gui release lane
-  # inherits these as part of its bar. Two complementary proofs:
+  # session, a screenshot per step uploaded as a gallery either way. The gui
+  # release lane inherits these as part of its bar. Two complementary proofs:
   #
   #   assisted  the debug-only BDINFO_GUI_DRIVE seam walks the app through the
   #             full click-everything sequence (sort → splitter → rows →
@@ -393,10 +389,9 @@ jobs:
   #             change must update it in the same PR, snapshot-test semantics.
   #
   # Blocking on ALL FIVE legs — Linux/Windows x86 AND arm plus macos-15, hard
-  # like the smoke above: macOS is a crucial supported platform, its legs had
-  # been green throughout their soft period, and a gate that ignores its own
-  # signal is not a gate. Known macos-15 failure modes (residual risks, not
-  # reasons for softness): the paravirtual Metal path has no software
+  # like the smoke above: macOS is a crucial supported platform, and a gate
+  # that ignores its own signal is not a gate. Known macos-15 failure modes
+  # (residual risks, not reasons to soften): the paravirtual Metal path has no software
   # fallback, and drive-inject carries the Sequoia screen-capture re-approval
   # residual. If a leg ever flakes for environment reasons, fix the harness
   # (the scripts already handle window polling and capture pre-authorization)
@@ -404,11 +399,10 @@ jobs:
   # absent for the smoke's no-Metal reason. The x86 legs ride the proven
   # display recipes (xvfb + lavapipe, DX12 WARP); every leg runs at a
   # 1920x1080 desktop with shots cropped to the 880x960 window, so the
-  # galleries are comparable across OSes. The old standalone workflow's
-  # nightly schedule is superseded by the daily sweep (which re-runs this
-  # whole workflow ungated and files the rolling issue on a scheduled red —
-  # mac breakage included, previously invisible to the schedule); a red leg
-  # here reddens the `gui` caller job and therefore ci-ok.
+  # galleries are comparable across OSes. Scheduled coverage comes from the
+  # daily sweep, which re-runs this whole workflow ungated and files the
+  # rolling issue on a scheduled red; a red leg here reddens the `gui` caller
+  # job and therefore ci-ok.
   drive-assisted:
     name: gui drive assisted (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -8,16 +8,15 @@ name: packages
 # expose a manual `workflow_dispatch` for re-runs / backfills. Every job runs on a
 # Linux runner; every action is SHA-pinned.
 #
-# The .deb/.rpm packages are now BUILT INSIDE the release (dist `extra-artifacts`
+# The .deb/.rpm packages are BUILT INSIDE the release (dist `extra-artifacts`
 # -> .github/build-linux-packages.sh), so they are attached to the Release at
 # creation, before it is published. This workflow therefore only DOWNLOADS those
 # already-attached packages to install-verify them on a native-arch runner and push
-# them to Cloudsmith — it no longer builds them, and (crucially) no longer uploads
-# anything back to the Release. That post-publication `gh release upload` was the
-# one thing incompatible with GitHub "immutable releases" (a release's assets freeze
-# at publication); with it gone, immutability can be enabled. As a bonus the deb/rpm
-# jobs now need only `contents: read`, resolving the two job-level `contents: write`
-# Token-Permissions residuals (alerts #78/#79).
+# them to Cloudsmith. It builds nothing and (crucially) uploads nothing back to the
+# Release: a post-publication `gh release upload` is incompatible with GitHub
+# "immutable releases", where a release's assets freeze at publication. Keeping the
+# upload out is what lets immutability stay enabled, and it holds the deb/rpm jobs
+# to `contents: read`.
 #
 # Stable-only: the `gate` job skips prerelease tags (anything but a bare vX.Y.Z),
 # matching the old `released`-event semantics and Homebrew's default.

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -1,12 +1,12 @@
 name: sweep
 
 # The completeness backstop that makes the orchestrator's area gating provably
-# non-weakening (D2/D3): once a day, run EVERYTHING — the whole ci.yml
+# non-weakening: once a day, run EVERYTHING — the whole ci.yml
 # orchestrator with every area forced (a workflow_call with a non-PR/push
 # event makes the plan job fire all areas), plus the expensive tier the PR
 # path deliberately does not carry: the full-crate `cargo mutants --in-place`
 # sweeps for EVERY crate — the root workspace (core + CLI, sharded) and the
-# gui and wasm sibling crates (D1). These legs are the authoritative 0-missed
+# gui and wasm sibling crates. These legs are the authoritative 0-missed
 # mutation bar for the whole repo; there is no local full-sweep ritual.
 # Untouched areas are thus re-verified within 24 h, and environment drift
 # (runner images, toolchain point releases, a floating tool) cannot hide

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -135,7 +135,7 @@ jobs:
 
       - name: Mutants (0 missed, this shard)
         if: steps.marker.outputs.cache-hit != 'true'
-        run: cargo mutants --in-place --no-shuffle --shard ${{ matrix.shard }}/8
+        run: cargo mutants --in-place --no-shuffle --shard ${{ matrix.shard }}/15
 
   # The marker fan-in: runs only when every shard succeeded (default `needs`
   # semantics), so the one saved marker attests the WHOLE root workspace
@@ -189,7 +189,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: [0, 1, 2, 3, 4]
     env:
       ICED_TEST_BACKEND: tiny-skia
     steps:
@@ -230,7 +230,7 @@ jobs:
       - name: Mutants (Tier A 0 missed, this shard)
         if: steps.marker.outputs.cache-hit != 'true'
         working-directory: crates/bdinfo-rs-gui
-        run: cargo mutants --in-place --no-shuffle --shard ${{ matrix.shard }}/6
+        run: cargo mutants --in-place --no-shuffle --shard ${{ matrix.shard }}/5
 
   # The gui marker fan-in — same shape and reasoning as core-mutants-ok.
   gui-mutants-ok:

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -507,8 +507,8 @@ jobs:
           # server-side API change could break the frozen client silently; nag here
           # like the other hand-bumped tools when a newer client ships. The pin
           # occurs once PER PUSH JOB (.deb and .rpm), so read every occurrence and
-          # assert they agree — the first-match-only read used to validate one job
-          # while the other could drift — then run freshness on the agreed value.
+          # assert they agree — a first-match-only read validates one job while the
+          # other drifts unseen — then run freshness on the agreed value.
           $cloudsmithPins = Read-AllPins '.github/workflows/packages.yml' 'cloudsmith-cli==([0-9.]+)'
           if (-not $cloudsmithPins.Count) { throw 'No `cloudsmith-cli==<version>` pin in packages.yml' }
           $cloudsmithPin = $cloudsmithPins[0]
@@ -548,9 +548,9 @@ jobs:
             'Bump deliberately: update the pin(s) in the file(s) named above, keep the five NIGHTLY pins (ci.yml / fuzz.yml / wasm.yml / gui.yml / publish-npm.yml) identical, and re-run `dist generate` after any cargo-dist bump. CI re-validates on the next push.'
           ) -join "`n"
 
-          # One rolling issue, tracked by a stable label (the title now varies, so it
-          # can no longer be matched on the title). Adopt a pre-existing issue from the
-          # old fixed-title scheme on the first run after this change.
+          # One rolling issue, tracked by a stable label — the title varies with the
+          # stale pins, so it is not matchable. The title search below adopts an issue
+          # left open by the earlier fixed-title scheme instead of opening a second one.
           gh label create version-freshness --color ededed --description 'Stale or inconsistent pinned tool/toolchain versions' --force | Out-Null
           $existing = gh issue list --state open --label version-freshness --json number --jq '.[0].number'
           if (-not $existing) {

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -17,10 +17,10 @@ name: wasm
 # caller's; the gate still deliberately NEVER runs on tags, so its build
 # caches are never a publishing-time cache-poisoning vector (the tag-driven
 # npm publish lives beside publish-crates.yml in publish-npm.yml). The
-# full-crate mutants sweep moved to sweep.yml (daily when the crate tree
+# full-crate mutants sweep lives in sweep.yml (daily when the crate tree
 # changed since the last green sweep, plus release tags — the authoritative
 # 0-missed checkpoints); the PR path gets the advisory in-diff mutants job in
-# ci.yml (`wasm mutation testing (PR diff)`) instead (D1). Inside the
+# ci.yml (`wasm mutation testing (PR diff)`) instead. Inside the
 # reusable this gate renders as `wasm / wasm gate (build + size + parity)`;
 # it gates merges through the caller job and ci-ok, not by its own name —
 # branch protection requires `ci-ok` alone among the CI jobs.

--- a/crates/bdinfo-rs-core/src/bdrom.rs
+++ b/crates/bdinfo-rs-core/src/bdrom.rs
@@ -65,8 +65,8 @@ mod tests {
     #[test]
     fn helpers_read_in_bounds_values() {
         let buf = [0x12_u8, 0x34, 0x56, 0x78, b'e', b'n', b'g'];
-        // `BdError` is no longer `PartialEq` (its `Io` variant wraps `io::Error`),
-        // so the result tests compare the `Ok`/`Err` shape via `.ok()`/`matches!`.
+        // `BdError` is not `PartialEq` (its `Io` wraps `io::Error`), so the result tests
+        // compare the `Ok`/`Err` shape via `.ok()`/`matches!`.
         assert_eq!(byte(&buf, 0).ok(), Some(0x12));
         assert_eq!(u16_be(&buf, 0).ok(), Some(0x1234));
         assert_eq!(u32_be(&buf, 0).ok(), Some(0x1234_5678));

--- a/crates/bdinfo-rs-core/src/bdrom/clpi.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/clpi.rs
@@ -371,8 +371,9 @@ mod tests {
     #[test]
     fn a_clip_with_zero_program_sequences_has_no_streams() {
         // num_prog == 0: nothing past the count is read — in particular the
-        // byte at the old fixed stream-count offset (8) is junk here, not a
-        // count, and the entry-shaped bytes after it must not parse.
+        // byte at offset 8, where a single-program clip carries its stream
+        // count, is junk here, and the entry-shaped bytes after it must not
+        // parse.
         let mut clip_data = vec![0_u8, 0]; // reserved + num_prog = 0
         clip_data.extend_from_slice(&[0_u8; 6]);
         clip_data.push(1); // junk where the single-program layout put the count
@@ -385,7 +386,7 @@ mod tests {
     #[test]
     fn scan_rejects_unknown_file_type() {
         let buf = build_clpi(*b"XXXX0100", &[]);
-        // `BdError` no longer derives `PartialEq` (its `Io` wraps `io::Error`), so the
+        // `BdError` is not `PartialEq` (its `Io` wraps `io::Error`), so the
         // error assertions check the failure's `Display` — region-clean and pinning
         // the message text the codec/report layers surface to the CLI.
         assert_eq!(

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -541,10 +541,9 @@ impl Sink<'_> {
     /// Like [`absorb`](Self::absorb), with a `BDMV/BACKUP` recovery attempt
     /// between a primary failure and recording it.
     ///
-    /// **Resilient mode only.** Strict `open` never reads BACKUP — it is the
-    /// honest fail-fast path, so a recovery facility belongs to the resilient
-    /// scan that `open_resilient` (the CLI default) runs. On a primary `Err` in
-    /// resilient mode `backup` is invoked; `Some(Ok(value))` is returned with
+    /// Recovery is resilient-mode only; `discover_backups` documents why, and
+    /// leaves the pools empty in strict mode so `backup` can only miss there. On
+    /// a primary `Err` `backup` is invoked; `Some(Ok(value))` is returned with
     /// the *primary* failure still recorded against `file`/`stage`, so the
     /// report's `WARNING` block surfaces the bad primary even though the
     /// recovered data is present. A missing or also-failing backup falls
@@ -744,7 +743,6 @@ impl BdRom {
         cancel: &AtomicBool,
         sink: &mut Sink<'_>,
     ) -> Result<Self, BdError> {
-        // --- locate directories ---------------------------------------------
         // Walk self+ancestors for a `BDMV` before trying the child lookup,
         // tolerating input that points at the BDMV directory itself or inside
         // it. When the walk finds a scannable BDMV ancestor, its parent becomes
@@ -1889,16 +1887,19 @@ fn clip_stem(name: &str) -> &str {
 
 /// The file handles of one `BDMV/BACKUP` metadata directory, keyed by
 /// upper-cased name — the recovery pool a damaged primary's replacement is
-/// drawn from. Empty when the disc has no such backup directory (or the scan is
-/// strict, which never recovers).
+/// drawn from. Empty when there is no such pool to draw from (see
+/// `discover_backups`).
 type BackupFiles = BTreeMap<String, Box<dyn BdFile>>;
 
 /// The `BDMV/BACKUP` recovery pools — `(index.bdmv, PLAYLIST, CLIPINF)` — built
 /// once per open and drawn from only when a primary read fails.
 ///
-/// **Resilient mode only.** Strict `open` never recovers from BACKUP, so it
-/// skips the probe entirely (three empty pools, no extra IO, no new failure
-/// points). A directory-listing failure anywhere in the probe is recorded once
+/// **Resilient mode only, and this is where that is decided.** Strict `open` is
+/// the honest fail-fast path, so a recovery facility belongs to the resilient
+/// scan that `open_resilient` (the CLI default) runs: a strict scan skips the
+/// probe entirely (three empty pools, no extra IO, no new failure points) and
+/// every downstream backup lookup therefore misses. A directory-listing failure
+/// anywhere in the probe is recorded once
 /// under `BACKUP` — surfaced, not silently swallowed — and leaves the pools
 /// empty; a disc with no `BDMV/BACKUP` yields empty pools with nothing
 /// recorded.

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -3695,7 +3695,7 @@ mod tests {
     #[test]
     fn open_rejects_a_folder_without_bdmv() {
         let disc = TempDisc::build(&["random"], &[]);
-        // `BdError` no longer derives `PartialEq` (its `Io` wraps `io::Error`); the
+        // `BdError` is not `PartialEq` (its `Io` wraps `io::Error`); the
         // error paths assert on the failure's `Display` instead.
         assert_eq!(disc.open().unwrap_err().to_string(), "unable to locate BD structure");
     }

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -60,7 +60,7 @@ pub struct PlaylistSummary {
     /// Number of chapter marks.
     pub chapter_count: usize,
     /// Number of presented streams, excluding SSIF-only rows
-    /// ([]) — the count the report presents.
+    /// ([`StreamSummary::ssif_only`]) — the count the report presents.
     pub stream_count: usize,
     /// The number of extra camera angles (0 for a single-angle playlist).
     pub angle_count: usize,
@@ -298,7 +298,9 @@ impl AngleTotals {
 pub struct StreamSummary {
     /// The packet identifier (PID), emitted zero-padded to five digits.
     pub pid: Pid,
-    /// The elementary-stream type (its  is the report's  type cell).
+    /// The elementary-stream type — the code that selects which report table
+    /// (`VIDEO`/`AUDIO`/`SUBTITLES`/`TEXT`) the row lands in. The type itself is
+    /// never printed.
     pub stream_type: TsStreamType,
     /// The short codec name, e.g. `AVC`, `DTS-HD MA`.
     pub codec_short_name: String,
@@ -348,7 +350,7 @@ pub struct StreamSummary {
     pub is_hidden: bool,
     /// Whether the stream is presented only through the interleaved (`*.ssif`)
     /// dependent-view scan — the 3D MVC video the clip information omits
-    /// ([] does not count these rows).
+    /// ([`PlaylistSummary::stream_count`] does not count these rows).
     pub ssif_only: bool,
 }
 
@@ -362,8 +364,9 @@ pub struct StreamSummary {
     reason = "the seven flags are independent disc properties (3D/50Hz/UHD/BD+/BD-Java/D-BOX/PSP), not a state machine"
 )]
 pub struct BdRom {
-    /// Disc volume label — here the disc-root directory name (see the
-    /// module-level note on folder input).
+    /// Disc volume label — the genuine UDF `LogicalVolumeIdentifier` for
+    /// `.iso` input, the disc-root directory name for folder input (see the
+    /// module-level input conventions).
     pub volume_label: String,
     /// Disc title from `META/bdmt_eng.xml`; `None` when absent or the
     /// placeholder `"blu-ray"`.

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -3366,7 +3366,7 @@ mod tests {
         let mut payload = vec![4_u8, 0x00, 0x00, 0x01, 0xE0]; // AF length 4 + fake start
         payload.extend(pes_pts(0xE0, 90_000, &[0xAB; 10]));
         let mut bytes = pat_pmt_video();
-        bytes.extend(packet_raw(0x1011, true, 0x3, &payload)); // AFC = 11
+        bytes.extend(packet_raw(0x1011, true, 0x3, &payload));
         let mut file = TsStreamFile::new("00000.m2ts");
         let mut pls = [empty_playlist()];
         let mut cur = Cursor::new(bytes);

--- a/crates/bdinfo-rs-core/src/bdrom/mpls.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/mpls.rs
@@ -884,7 +884,7 @@ mod tests {
         }
         let mut bad = comprehensive_mpls();
         bad.splice(0..8, *b"MPLSXXXX");
-        // `BdError` no longer derives `PartialEq` (its `Io` wraps `io::Error`); assert
+        // `BdError` is not `PartialEq` (its `Io` wraps `io::Error`); assert
         // on the failure's `Display` instead.
         assert_eq!(
             TsPlaylistFile::scan("p.mpls", &bad).unwrap_err().to_string(),

--- a/crates/bdinfo-rs-core/src/bitstream.rs
+++ b/crates/bdinfo-rs-core/src/bitstream.rs
@@ -61,8 +61,8 @@ pub struct TsStreamBuffer {
     /// Emulation-prevention bytes (`0x03`) skipped during the current read.
     /// Reset to zero at the start of each bit read.
     skipped_bytes: usize,
-    /// Total bytes ever passed to [`add`](Self::add) (pre-clamp).
-    /// Diagnostic only; reset by [`reset`](Self::reset).
+    /// The diagnostic counter behind [`transfer_length`](Self::transfer_length);
+    /// reset by [`reset`](Self::reset).
     transfer_length: usize,
 }
 
@@ -595,7 +595,6 @@ mod tests {
         b.add(&[0x00, 0x01, 0x02, 0x03, 0x04], 2, 2);
         assert_eq!(b.length(), 2);
         b.begin_read();
-        // The stored bytes are [0x02, 0x03]: their top bits are 0,0.
         assert!(!b.read_bool(false));
         assert!(!b.read_bool(false));
     }
@@ -644,7 +643,6 @@ mod tests {
         b.reset();
         assert_eq!(b.length(), 0);
         assert_eq!(b.transfer_length(), 0);
-        // The buffer is reusable after a reset.
         b.add(&[0x04], 0, 1);
         assert_eq!(b.length(), 1);
     }

--- a/crates/bdinfo-rs-core/src/bitstream.rs
+++ b/crates/bdinfo-rs-core/src/bitstream.rs
@@ -298,9 +298,11 @@ impl TsStreamBuffer {
     /// position, so the readable span is fixed at 16 bits regardless of the
     /// current bit offset. A read whose `skip_bits + bits` exceeds 16 returns the
     /// `16 - skip_bits` real bits then **zero**-filled tail bits — it never reads
-    /// further into the stream. Every in-tree call site is byte-aligned, so a
-    /// full-width `read_bits2(16, …)` always starts at offset 0 and this never
-    /// bites; a new codec scanner requesting full width at a non-zero bit offset
+    /// further into the stream. Every *full-width* in-tree call site is
+    /// byte-aligned, so a `read_bits2(16, …)` always starts at offset 0 and this
+    /// never bites; the unaligned callers that do exist are all sub-width and stay
+    /// inside the window (`hevc` reads a 6-bit `nal_unit_type` one bit into the NAL
+    /// header). A new codec scanner requesting full width at a non-zero bit offset
     /// would silently corrupt the tail. Pinned by
     /// `read_bits2_past_window_zero_extends`.
     #[must_use]
@@ -339,10 +341,13 @@ impl TsStreamBuffer {
     /// stream — and, unlike [`read_bits2`](Self::read_bits2) /
     /// [`read_bits8`](Self::read_bits8) (whose tails zero-fill), the past-window
     /// mask here wraps back into the window's high bits, so the tail repeats the
-    /// window top (effectively `window << skip_bits`). Latent: every in-tree call
-    /// site is byte-aligned (`read_bits4(32, …)` at offset 0); a new unaligned
-    /// full-width caller would get corrupt tail bits, not the true stream bits.
-    /// Pinned by `read_bits4_unaligned_full_width_wraps_not_zero_fills`.
+    /// window top (effectively `window << skip_bits`). Latent: every *full-width*
+    /// in-tree call site is byte-aligned (`read_bits4(32, …)` at offset 0), and the
+    /// unaligned callers are all sub-width — `ac3`'s EMDF sync search reads 16 bits
+    /// per iteration while advancing one bit at a time — so they stay inside the
+    /// window. A new unaligned full-width caller would get corrupt tail bits, not
+    /// the true stream bits. Pinned by
+    /// `read_bits4_unaligned_full_width_wraps_not_zero_fills`.
     #[must_use]
     pub fn read_bits4(&mut self, bits: usize, skip_h26x_emulation_byte: bool) -> u32 {
         let pos = self.position;
@@ -369,7 +374,7 @@ impl TsStreamBuffer {
     /// **byte** position; the readable span is fixed at 64 bits. A read whose
     /// `skip_bits + bits` exceeds 64 returns the real bits then **zero**-filled
     /// tail bits (the explicit `(0..64)` index guard below), never reading past
-    /// the window into the stream. Latent — every in-tree call site is
+    /// the window into the stream. Latent — every full-width in-tree call site is
     /// byte-aligned. Pinned by `read_bits8_past_window_contributes_zero`.
     #[must_use]
     pub fn read_bits8(&mut self, bits: usize, skip_h26x_emulation_byte: bool) -> u64 {
@@ -902,8 +907,9 @@ mod tests {
         // read_bits2 / read_bits8 — whose tails zero-fill — read_bits4's
         // negative-shift mask wraps back into the 32-bit window's high bits, so the
         // tail repeats the window top (effectively `window << skip_bits`). Every
-        // in-tree call site is byte-aligned, so this never bites; this pins the
-        // behavior so an unaligned full-width caller is a noticed change.
+        // full-width in-tree call site is byte-aligned, so this never bites (the
+        // unaligned callers are sub-width and stay inside the window); this pins
+        // the behavior so an unaligned full-width caller is a noticed change.
         let mut b = buf(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
         assert_eq!(b.read_bits4(3, false), 0b111);
         assert_eq!(b.read_bits4(32, false), 0xFFFF_FFFF); // wraps to all-ones, not 0xFFFF_FFF8

--- a/crates/bdinfo-rs-core/src/codec/ac3.rs
+++ b/crates/bdinfo-rs-core/src/codec/ac3.rs
@@ -9,12 +9,8 @@
 //! optional dependent-substream core via [`TsAudioStream::ts_clone`], and the EMD
 //! framework scan that detects Atmos).
 //!
-//! All fixed-width codec math uses `wrapping_*` so hostile field values cannot
-//! overflow; the `f64`→`i64` bit-rate conversion truncates toward zero. A buffer
-//! too short for a header read returns early and leaves the stream untouched.
-//! The two `dheadphonmod` bits are read purely for framing (nothing acts on
-//! them), and inside the first-payload block the EMDF payload id is always
-//! `1..=15`, so the `0x1F` escape handling lives only in the payload loop.
+//! The `f64`→`i64` bit-rate conversion truncates toward zero. A buffer too short
+//! for a header read returns early and leaves the stream untouched.
 
 use crate::bitstream::{SeekOrigin, TsStreamBuffer};
 use crate::stream::{TsAudioMode, TsAudioStream, TsStreamType};

--- a/crates/bdinfo-rs-core/src/codec/ac3.rs
+++ b/crates/bdinfo-rs-core/src/codec/ac3.rs
@@ -298,6 +298,9 @@ pub fn scan(stream: &mut TsAudioStream, buffer: &mut TsStreamBuffer, tag: &mut O
     if half_rate {
         // Reduced-rate E-AC-3 (`fscod2`): the decoded rate is half the table value
         // (24 / 22.05 / 16 kHz), which also feeds the derived bit-rate below.
+        // Classic BDInfo does not halve it — a deliberate divergence that cannot
+        // change a disc report, since Blu-ray E-AC-3 is always 48 kHz. See
+        // DIFFERENCES.md "Correctness fixes with no effect on a normal disc".
         stream.sample_rate = stream.sample_rate.wrapping_div(2);
     }
 
@@ -305,7 +308,10 @@ pub fn scan(stream: &mut TsAudioStream, buffer: &mut TsStreamBuffer, tag: &mut O
         // Legacy AC-3 `bsid` 9 / 10 are the half / quarter "low-sample-rate"
         // variants: `sr_shift = max(bsid, 8) - 8` right-shifts both the sample rate
         // and the table bit rate (ATSC A/52 / ETSI TS 102 366 §5.4.1; FFmpeg
-        // `ac3_parser.c`). Conforming Blu-ray AC-3 is always `bsid 8` (shift 0).
+        // `ac3_parser.c`). Conforming Blu-ray AC-3 is always `bsid 8` (shift 0), so
+        // this deliberate divergence from classic BDInfo — which applies no shift —
+        // cannot change a disc report. See DIFFERENCES.md "Correctness fixes with no
+        // effect on a normal disc".
         let sr_shift = bsid.max(8).wrapping_sub(8);
         stream.sample_rate = stream.sample_rate.wrapping_shr(sr_shift);
         // `frmsizecod >> 1` indexes the 19-entry bit-rate table; `.get()` is the

--- a/crates/bdinfo-rs-core/src/codec/ac3.rs
+++ b/crates/bdinfo-rs-core/src/codec/ac3.rs
@@ -30,7 +30,6 @@ const AC3_CHANNELS: [u8; 8] = [2, 1, 2, 3, 3, 4, 4, 5];
 #[must_use]
 pub fn ac3_chan_map(chan_map: u32) -> u8 {
     let mut channels: u8 = 0;
-    // Walk the 16-bit channel map MSB-first.
     for i in 0..16_u8 {
         let bit = 1_u32.wrapping_shl(15_u32.wrapping_sub(u32::from(i)));
         if (chan_map & bit) != 0 && matches!(i, 5 | 6 | 9 | 10 | 11) {
@@ -63,8 +62,8 @@ const fn to_i64_trunc(x: f64) -> i64 {
     reason = "one linear bit-stream-information parse; splitting it would obscure the header layout"
 )]
 pub fn scan(stream: &mut TsAudioStream, buffer: &mut TsStreamBuffer, tag: &mut Option<String>) {
-    // `tag` is part of the shared codec-scan signature; AC-3 never sets it (and a
-    // `pub fn` is exempt from `needless_pass_by_ref_mut`).
+    // The `let _` silences the unused parameter; a `pub fn` is exempt from
+    // `needless_pass_by_ref_mut`, so the `&mut` stays.
     let _ = tag;
     if stream.base.is_initialized {
         return;

--- a/crates/bdinfo-rs-core/src/codec/avc.rs
+++ b/crates/bdinfo-rs-core/src/codec/avc.rs
@@ -71,6 +71,9 @@ pub fn scan(stream: &mut TsVideoStream, buffer: &mut TsStreamBuffer, tag: &mut O
                         // 244 (High 4:4:4 Predictive, the live H.264 code) shares the
                         // legacy 144 (old High 4:4:4) spelling so it is caught with an
                         // existing report line instead of falling to "Unknown Profile".
+                        // Deliberate divergence from classic BDInfo, which maps only
+                        // 144 and drops 244 to "Unknown Profile" — see DIFFERENCES.md
+                        // "AVC High 4:4:4 (profile 244)".
                         // Codes BDInfo has no string for (44 CAVLC 4:4:4, and the
                         // Constrained-Baseline / High-Intra constraint-flag refinements)
                         // are deliberately left as their lineage outcome — emitting a

--- a/crates/bdinfo-rs-core/src/codec/dts.rs
+++ b/crates/bdinfo-rs-core/src/codec/dts.rs
@@ -11,8 +11,7 @@
 //! is used only for the "open" bit-rate marker. The DTS core never sets `tag`;
 //! the wrapping [`crate::codec::dts_hd`] scanner sets it.
 //!
-//! All fixed-width codec math uses `wrapping_*` so hostile field values cannot
-//! overflow. The 4-bit sample-rate and 5-bit bit-rate codes can never reach their
+//! The 4-bit sample-rate and 5-bit bit-rate codes can never reach their
 //! 16- and 32-entry table bounds, so those lookups carry no range guard; the
 //! 3-bit source-PCM-resolution code *can* reach the 7-entry bit-depth table's
 //! length (code 7), so that lookup is a bounds-checked `.get()` whose miss is an

--- a/crates/bdinfo-rs-core/src/codec/dts_hd.rs
+++ b/crates/bdinfo-rs-core/src/codec/dts_hd.rs
@@ -39,6 +39,10 @@ const DTS_X_PATTERN: u32 = 0x0200_0850;
 /// and `0xF14000D1` count as DTS:X IMAX — the two values that `>> 1` collapses to (per
 /// `libavcodec/dca_xll.c`). A DTS:X IMAX stream carries this word and not the legacy
 /// one, so without it the track loses its DTS:X label.
+///
+/// Deliberate divergence from classic `BDInfo` — see `DIFFERENCES.md`, "DTS:X IMAX
+/// detection". `BDInfo` knows only the legacy [`DTS_X_PATTERN`] and so renders these
+/// tracks as plain `DTS-HD Master Audio`; bdinfo-rs renders `DTS:X Master Audio`.
 const DTS_X_IMAX_PATTERN: u32 = 0xF140_00D0;
 
 /// The DTS:X IMAX pattern with its low bit set — the second value the LSB-ignored

--- a/crates/bdinfo-rs-core/src/codec/dts_hd.rs
+++ b/crates/bdinfo-rs-core/src/codec/dts_hd.rs
@@ -14,8 +14,7 @@
 //! `bitrate` is the demux-measured stream rate; Master Audio is always flagged VBR,
 //! while High-Res / Express initialize from that measured rate (plus the core's).
 //!
-//! All fixed-width codec math uses `wrapping_*` so hostile field values cannot
-//! overflow. The asset section is a single pass: only the first asset's
+//! The asset section is a single pass: only the first asset's
 //! descriptor feeds the stream fields, and any further assets go unparsed.
 //! Several descriptor arrays (the active-extension masks, mix-output masks, asset
 //! sizes, and info text) are read purely for framing — their values feed nothing.

--- a/crates/bdinfo-rs-core/src/codec/hevc.rs
+++ b/crates/bdinfo-rs-core/src/codec/hevc.rs
@@ -15,9 +15,7 @@
 //! 4:2:0 + signalled colour description with BT.2020 primaries (9) + PQ transfer
 //! (16) + BT.2020 matrix (9/10) + a present mastering display ⇒ the label is
 //! `Dolby Vision` when the stream `PID >= 4117`, else `HDR10+` when an ST 2094-40
-//! ITU-T T.35 message was seen (`is_hdr10_plus`), else `HDR10`. The
-//! mastering-display colour reading carries a known caveat — TODO: the colour
-//! reading is sometimes off.
+//! ITU-T T.35 message was seen (`is_hdr10_plus`), else `HDR10`.
 //!
 //! The HDR SEI messages (mastering display, content light level, ST 2094-40
 //! T.35) are *sparse* on some streams — they can recur only every few seconds

--- a/crates/bdinfo-rs-core/src/codec/hevc.rs
+++ b/crates/bdinfo-rs-core/src/codec/hevc.rs
@@ -79,11 +79,8 @@ const MASTERING_DISPLAY_COLOR_VOLUME_VALUES: [MasteringDisplayColorVolumeValue; 
 /// output-dead; see the module notes).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct VuiColour {
-    /// `video_signal_type_present_flag`.
     video_signal_type_present_flag: bool,
-    /// `colour_description_present_flag`.
     colour_description_present_flag: bool,
-    /// `video_full_range_flag`.
     video_full_range_flag: u8,
     /// `colour_primaries` (2 = unspecified, the default).
     colour_primaries: u8,
@@ -113,19 +110,13 @@ impl VuiColour {
 /// that feeds observable output.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct SeqParameterSet {
-    /// `general_profile_space`.
     profile_space: u32,
-    /// `general_tier_flag`.
     tier_flag: bool,
-    /// `general_profile_idc`.
     profile_idc: u16,
-    /// `general_level_idc`.
     level_idc: u16,
     /// `chroma_format_idc` (1 = 4:2:0, 2 = 4:2:2, 3 = 4:4:4).
     chroma_format_idc: u32,
-    /// `bit_depth_luma_minus8`.
     bit_depth_luma_minus8: u8,
-    /// `bit_depth_chroma_minus8`.
     bit_depth_chroma_minus8: u8,
     /// The VUI colour description.
     vui: VuiColour,
@@ -135,9 +126,7 @@ struct SeqParameterSet {
 /// the slice-segment header reads.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct PicParameterSet {
-    /// `num_extra_slice_header_bits`.
     num_extra_slice_header_bits: u8,
-    /// `dependent_slice_segments_enabled_flag`.
     dependent_slice_segments_enabled_flag: bool,
 }
 
@@ -145,13 +134,9 @@ struct PicParameterSet {
 /// `general_level_idc` — the profile-tier-level outputs the SPS records.
 #[derive(Debug, Clone, Copy, Default)]
 struct ProfileTierLevel {
-    /// `general_profile_space`.
     profile_space: u32,
-    /// `general_tier_flag`.
     tier_flag: bool,
-    /// `general_profile_idc`.
     profile_idc: u16,
-    /// `general_level_idc`.
     level_idc: u16,
 }
 
@@ -1942,7 +1927,7 @@ mod tests {
         assert!(s.encoding_profile.is_none());
         assert!(!s.base.is_initialized);
         assert_eq!(tag, None);
-        // is_vbr is set unconditionally at the end of the scan.
+        // Every scan sets `is_vbr` at the end, start codes or not.
         assert!(s.base.is_vbr);
     }
 

--- a/crates/bdinfo-rs-core/src/codec/hevc.rs
+++ b/crates/bdinfo-rs-core/src/codec/hevc.rs
@@ -617,6 +617,9 @@ impl Hevc<'_, '_> {
         // the CVS also conforms to profile i, so the first set flag names the
         // profile. Index 0 maps to profile 0 (a no-op recovery), so the scan can
         // start there without a guard — the first *meaningful* set flag still wins.
+        // Classic BDInfo keeps the coded 0 and prints an unknown profile; recovering
+        // it is a deliberate divergence confined to malformed headers. See
+        // DIFFERENCES.md "Correctness fixes with no effect on a normal disc".
         let compatibility_flags = self.buffer.read_bits4(32, true);
         let mut compat_idx: u16 = 0;
         while compat_idx < 32 {
@@ -1122,6 +1125,8 @@ fn build_extended_format_info(ext: &mut HevcExtendedData, sps: &SeqParameterSet,
     // the mastering SEI alone (as the BDInfo lineage does) drops the label on a
     // valid HDR10+ stream that carries dynamic metadata but no static mastering
     // display — so `is_hdr10_plus` alone is enough to claim the (HDR10+) label.
+    // Deliberate divergence from classic BDInfo — see DIFFERENCES.md "HDR10+
+    // without a mastering display".
     if u16::from(sps.bit_depth_luma_minus8).wrapping_add(8) == 10
         && sps.chroma_format_idc == 1
         && sps.vui.video_signal_type_present_flag
@@ -1163,6 +1168,10 @@ fn build_extended_format_info(ext: &mut HevcExtendedData, sps: &SeqParameterSet,
         info.push(format!("Mastering display luminance: {}", ext.mastering_display_luminance));
     }
     if ext.light_level_available && ext.maximum_content_light_level > 0 {
+        // `cd/m2`, not the lineage's `cd / m2`: classic BDInfo spaces the slash on
+        // this one line while every neighbouring luminance / light-level line uses
+        // `cd/m2` — one string literal out of step with the rest. Deliberate
+        // divergence from classic BDInfo — see DIFFERENCES.md "MaxCLL unit label".
         info.push(format!(
             "Maximum Content Light Level: {} cd/m2",
             ext.maximum_content_light_level

--- a/crates/bdinfo-rs-core/src/codec/hevc.rs
+++ b/crates/bdinfo-rs-core/src/codec/hevc.rs
@@ -541,8 +541,8 @@ impl Hevc<'_, '_> {
         self.short_term_ref_pic_sets(num_short_term_ref_pic_sets);
         if self.buffer.read_bool(true) {
             // long_term_ref_pics_present_flag
-            // `num_long_term_ref_pics_sps` is an unbounded `ue(v)`; clamp a
-            // malformed huge count to the spec ceiling.
+            // `num_long_term_ref_pics_sps` is an unbounded `ue(v)`; clamp it to
+            // `MAX_LONG_TERM_REF_PICS`.
             let num_long_term_ref_pics_sps = self.buffer.read_exp(true).min(MAX_LONG_TERM_REF_PICS);
             let mut i = 0;
             while i < num_long_term_ref_pics_sps {
@@ -670,13 +670,9 @@ impl Hevc<'_, '_> {
     ///
     /// `num_short_term_ref_pic_sets` arrives already clamped to
     /// [`MAX_SHORT_TERM_REF_PIC_SETS`]; the per-set `num_negative_pics` /
-    /// `num_positive_pics` are clamped to [`MAX_DELTA_POCS_PER_SET`] here. Those
-    /// are unbounded `ue(v)` codes a malformed SPS can decode astronomically large
-    /// — looping on the raw values would never terminate on hostile bytes (a hang
-    /// the fuzz tier caught); the clamps bound every loop by construction.
-    /// Output-neutral: a spec-conformant SPS never exceeds the ceilings, so the
-    /// clamps are no-ops and `num_pics` (at most twice [`MAX_DELTA_POCS_PER_SET`])
-    /// keeps the inter-pred loop bounded too.
+    /// `num_positive_pics` are clamped to [`MAX_DELTA_POCS_PER_SET`] here, for the
+    /// reason documented on [`MAX_SHORT_TERM_REF_PIC_SETS`]. `num_pics` is then at
+    /// most twice [`MAX_DELTA_POCS_PER_SET`], which bounds the inter-pred loop too.
     fn short_term_ref_pic_sets(&mut self, num_short_term_ref_pic_sets: u32) {
         let mut num_pics: u32 = 0;
         let mut st_rps_idx: u32 = 0;

--- a/crates/bdinfo-rs-core/src/codec/hevc.rs
+++ b/crates/bdinfo-rs-core/src/codec/hevc.rs
@@ -386,7 +386,7 @@ impl Hevc<'_, '_> {
     }
 
     /// The shared outer/inner loop guard — keep scanning while there are at least
-    /// three bytes left and the stream is not yet a finished, frame-typed unit.
+    /// four bytes left and the stream is not yet a finished, frame-typed unit.
     fn scan_should_continue(&self, frame_type_read: bool) -> bool {
         self.buffer.position() < self.buffer.length().saturating_sub(3)
             && (!self.is_initialized || !frame_type_read)
@@ -974,7 +974,7 @@ fn match_color_volume(primaries: &[u16; 8], green: usize, blue: usize, red: usiz
     None
 }
 
-/// Whether `primaries[channel*2 + j]` is within ±25 (≈±0.0005) of
+/// Whether `primaries[channel*2 + j]` is within `-25..=+24` (≈±0.0005) of
 /// `reference[ref_channel*2 + j]` — the primary-coordinate tolerance test.
 fn within(
     primaries: &[u16; 8],
@@ -990,7 +990,7 @@ fn within(
     actual >= expected.wrapping_sub(25) && actual < expected.wrapping_add(25)
 }
 
-/// Whether the white point `primaries[6 + j]` is within `-2..=+2` (≈±0.00005) of
+/// Whether the white point `primaries[6 + j]` is within `-2..=+2` (±0.00004) of
 /// the reference white point — the tighter white-point tolerance.
 fn within_white(primaries: &[u16; 8], j: usize, reference: &[u16; 8]) -> bool {
     let actual = i32::from(primaries.get(6_usize.wrapping_add(j)).copied().unwrap_or(0));

--- a/crates/bdinfo-rs-core/src/codec/pgs.rs
+++ b/crates/bdinfo-rs-core/src/codec/pgs.rs
@@ -24,7 +24,7 @@
 //! forced flag (and its caption / forced-caption tally). bdinfo-rs chooses spec
 //! correctness here: a multi-object uncropped PG stream is counted correctly,
 //! while single-object and fully-cropped compositions stay byte-identical to
-//! `BDInfo`.
+//! `BDInfo`. See `DIFFERENCES.md`, "PGS forced-caption counts".
 //!
 //! Like every codec scanner this is panic-free over arbitrary bytes (the bit reader
 //! bounds-checks; the caption counters use `wrapping_add` so a hostile caption flood

--- a/crates/bdinfo-rs-core/src/codec/truehd.rs
+++ b/crates/bdinfo-rs-core/src/codec/truehd.rs
@@ -10,8 +10,7 @@
 //! and the Atmos substream-extension (`has_extensions`) flag. The whole stream is
 //! initialized only once both the `TrueHD` header and its AC-3 core are.
 //!
-//! All fixed-width codec math uses `wrapping_*` so hostile field values cannot
-//! overflow; the peak bit rate `(peak_bitrate * sample_rate) >> 4` is
+//! The peak bit rate `(peak_bitrate * sample_rate) >> 4` is
 //! computed in `i64` then deliberately truncated to its low 32 bits, and the
 //! peak-bit-depth division is `f64` (a zero channel/sample-rate divisor yields a
 //! non-finite value that simply fails the `> 14` test).

--- a/crates/bdinfo-rs-core/src/codec/vc1.rs
+++ b/crates/bdinfo-rs-core/src/codec/vc1.rs
@@ -51,7 +51,12 @@ pub fn scan(stream: &mut TsVideoStream, buffer: &mut TsStreamBuffer, tag: &mut O
                     // fixed 3-bit FPTYPE at bits 29..=27 (SMPTE 421M §9.1.1.5), not a
                     // unary code. Collapse the pair to its representative type exactly
                     // as FFmpeg does (`fptype & 4` picks the B/BI half, `fptype & 2` the
-                    // pair's second member).
+                    // pair's second member). Classic BDInfo decodes the field header as
+                    // if it carried the unary code; correcting it is a deliberate
+                    // divergence with no visible effect, because the tag is only ever
+                    // counted as a frame-present marker and its string is never
+                    // rendered. See DIFFERENCES.md "Correctness fixes with no effect on
+                    // a normal disc".
                     let fptype = (p & 0x3800_0000).wrapping_shr(27);
                     *tag = Some(
                         match ((fptype & 0x4) == 0, (fptype & 0x2) == 0) {

--- a/crates/bdinfo-rs-core/src/vfs/udf/source.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/source.rs
@@ -4071,7 +4071,7 @@ mod tests {
     fn open_with_oversized_block_size_is_structure_not_found() {
         // The same volume one doubling past the cap is rejected by the cap
         // alone (the 32 KiB twin above proves it would otherwise open fine) —
-        // a hostile block size can no longer size every sector read.
+        // the cap is what stops a hostile block size from sizing every sector read.
         let err = UdfSource::open(MemIso::boxed(minimal_iso_with_block_size(64 << 10)))
             .expect_err("oversized block size");
         assert_eq!(err.to_string(), "unable to locate BD structure");

--- a/crates/bdinfo-rs-core/src/vfs/udf/source.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/source.rs
@@ -31,11 +31,9 @@
 //! to absolute byte runs), so the [`BdDir`]/[`BdFile`] accessors are infallible
 //! arena lookups — directory data is read at open, file data is read lazily through
 //! [`UdfFileReader`]. The walk is bounded ([`Limits::max_nodes`], a visited-ICB set,
-//! and [`Limits::max_depth`]) so malformed or cyclic input can never hang — and,
-//! because the depth cap bounds how deep the arena's directory chain can run, the
-//! recursive arena consumers (glob recursion here, `directory_size` in the BDROM
-//! scan) cannot overflow the thread stack either (the crate-wide contract: never
-//! panic/hang on disc bytes). `u64` byte offsets throughout (a Blu-ray `.iso` is
+//! and [`Limits::max_depth`]) so malformed or cyclic input can neither hang nor
+//! overflow the thread stack of the recursive arena consumers — `build_tree`
+//! documents that argument. `u64` byte offsets throughout (a Blu-ray `.iso` is
 //! tens of GB, its `.m2ts`/`.ssif` streams routinely >4 GB).
 //!
 //! All numeric *parsing* stays in the little-endian [`super`] core; this module
@@ -97,10 +95,8 @@ struct Limits {
     /// shattered metadata mapping can't amass an unbounded list.
     max_extents: usize,
     /// Upper bound on the arena's directory nesting depth (root = depth 0): a
-    /// subdirectory deeper than this is dropped, so the recursive arena consumers
-    /// ([`UdfDir::collect_from`] here, `directory_size` in the BDROM scan) recurse a
-    /// bounded number of frames and a hostile chain of ~1M nested directories cannot
-    /// overflow the thread stack.
+    /// subdirectory deeper than this is dropped. `build_tree` documents why that
+    /// bound is what keeps the recursive arena consumers off the thread stack.
     max_depth: usize,
     /// Upper bound on the File Set Descriptor extent blocks scanned for the FSD
     /// (a hostile `LongAd` length can't drive an unbounded search; an authored
@@ -1187,10 +1183,6 @@ fn load_metadata_extents(
     Some(extents)
 }
 
-// ---------------------------------------------------------------------------
-// Extent resolution → byte runs
-// ---------------------------------------------------------------------------
-
 /// The byte offset of `LengthOfAllocationDescriptors` in an Allocation Extent
 /// Descriptor (ECMA-167 §4/14.5): the 16-byte tag, then
 /// `PreviousAllocationExtentLocation` (4 bytes).
@@ -1434,10 +1426,6 @@ fn read_runs(reader: &mut dyn ReadSeek, runs: &[Run], cap: u64) -> Result<Vec<u8
     Ok(out)
 }
 
-// ---------------------------------------------------------------------------
-// Directory-tree walk → arena
-// ---------------------------------------------------------------------------
-
 /// Walks the whole directory tree from the root ICB into a flat [`Node`] arena
 /// (node 0 = root). Bounded by [`Limits::max_nodes`], a visited-ICB set, and
 /// [`Limits::max_depth`], so malformed or cyclic input cannot hang.
@@ -1477,11 +1465,8 @@ fn build_tree(
                 break;
             }
             let is_dir = matches!(child.kind, ChildKind::Dir);
-            // Drop a subdirectory past the depth cap: its node is the start of a
-            // chain the recursive consumers would descend, so truncating it here
-            // (the parent at `depth` is the deepest expanded level once
-            // `depth == max_depth`) keeps their recursion bounded. Files are leaves
-            // — always kept.
+            // Drop a subdirectory past the depth cap (see this function's doc);
+            // files are leaves and are always kept.
             if is_dir && depth >= limits.max_depth {
                 continue;
             }

--- a/crates/bdinfo-rs-gui/src/clipboard.rs
+++ b/crates/bdinfo-rs-gui/src/clipboard.rs
@@ -1,4 +1,4 @@
-//! Tier A — clipboard text sanitizing.
+//! Clipboard text sanitizing.
 //!
 //! The rendered report can carry literal NUL bytes: a degenerate disc with a
 //! zeroed 3-letter language code renders those bytes verbatim (the report is

--- a/crates/bdinfo-rs-gui/src/columns.rs
+++ b/crates/bdinfo-rs-gui/src/columns.rs
@@ -1,4 +1,4 @@
-//! Tier A — the resizable-column weight math.
+//! The resizable-column weight math.
 //!
 //! The three data panes render their columns as proportional weights (the
 //! `BDInfo` ratios), and the user re-weights them by dragging a header

--- a/crates/bdinfo-rs-gui/src/diagnostics.rs
+++ b/crates/bdinfo-rs-gui/src/diagnostics.rs
@@ -1,5 +1,5 @@
-//! Tier A — best-effort diagnostics: the per-launch log file, the panic
-//! hook, and the tolerated-error helper.
+//! Best-effort diagnostics: the per-launch log file, the panic hook, and
+//! the tolerated-error helper.
 //!
 //! The release binary hides the console on Windows (`windows_subsystem`), so
 //! stderr does not exist — without a file, a failed boot, a panic, or a

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -1,4 +1,4 @@
-//! Tier A — the app's flow state machine.
+//! The app's flow state machine.
 //!
 //! The window moves through real states: nothing picked ([`Stage::Idle`]) → a
 //! fast structural scan in flight ([`Stage::Listing`]) → the playlist table with

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -1097,7 +1097,7 @@ mod tests {
         assert!(flow.all_selected());
         flow.select_none();
         assert_eq!(flow.selected_count(), 0);
-        // Nothing checked no longer blocks scanning — it becomes a whole-disc scan.
+        // Nothing checked does not block scanning — it is a whole-disc scan.
         assert!(flow.can_scan());
     }
 

--- a/crates/bdinfo-rs-gui/src/lib.rs
+++ b/crates/bdinfo-rs-gui/src/lib.rs
@@ -1,6 +1,6 @@
 //! bdinfo-rs desktop GUI — the library half.
 //!
-//! Holds the Tier-A logic — the playlist view-model ([`model`]), the
+//! Holds the pure logic — the playlist view-model ([`model`]), the
 //! master-detail pane view-models ([`panes`]), the selection model (`selection`),
 //! the live-progress model ([`progress`]), the flow state machine ([`flow`]),
 //! the copy-path helpers ([`paths`]), the clipboard sanitizer ([`clipboard`]),
@@ -11,7 +11,7 @@
 //! ([`winres`], shared with `build.rs`), and the scan seam ([`scan`]) — so the
 //! golden-tie + unit
 //! tests link them directly, and the `bdinfo-rs-gui` binary is the thin iced
-//! (Tier-B) shell over this surface: it translates messages to calls here and
+//! shell over this surface: it translates messages to calls here and
 //! results to widgets, holding no business logic of its own. The one impure thing
 //! the shell does is spawn the measured-scan worker thread and forward its
 //! progress over a channel.
@@ -22,7 +22,7 @@
 #![forbid(unsafe_code)]
 // The nightly-only coverage attribute, active only under `cargo llvm-cov`
 // (which sets cfg(coverage_nightly)): lets the env-bound raw-device reads in
-// `volume` opt out of the 100% Tier-A floor, as in the CLI.
+// `volume` opt out of the 100% coverage floor, as in the CLI.
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub mod clipboard;

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -364,10 +364,8 @@ fn drive_window_ms() -> u64 {
     std::env::var("BDINFO_GUI_DRIVE_MS").ok().and_then(|v| v.parse().ok()).unwrap_or(1500)
 }
 
-/// How long a step's messages get to render before its marker is written.
 #[cfg(debug_assertions)]
 const DRIVE_SETTLE_MS: u64 = 500;
-/// The poll interval while a step waits for its precondition.
 #[cfg(debug_assertions)]
 const DRIVE_POLL_MS: u64 = 200;
 /// Poll attempts before the walk gives up on a step (450 × 200 ms = 90 s).
@@ -405,7 +403,6 @@ static DRIVE_STEPS: &[DriveStep] = &[
         ready: drive_listed,
         act: |app| app.update(Message::SortBy(SortColumn::Length)),
     },
-    // The same header again — the ascending order flips.
     DriveStep {
         name: "sort-length-flip",
         ready: drive_listed,
@@ -621,10 +618,9 @@ fn window_settings(persisted: &settings::Settings) -> iced::window::Settings {
             .log_err("window icon")
             .ok(),
         exit_on_close_request: false,
-        // Wayland ignores the RGBA icon above by protocol — the dock icon and
-        // window grouping key off this id, matched against the `.desktop`
-        // file ([`APP_ID`]). The field only exists on Linux; every other
-        // platform (the BSDs included) keeps its own platform defaults.
+        // Wayland ignores the RGBA icon above by protocol and keys off this
+        // id instead — see `APP_ID`. The field only exists on Linux; every
+        // other platform (the BSDs included) keeps its own platform defaults.
         #[cfg(target_os = "linux")]
         platform_specific: iced::window::settings::PlatformSpecific {
             application_id: APP_ID.to_owned(),
@@ -817,7 +813,6 @@ enum Command {
 }
 
 impl Command {
-    /// The label shown on this command's control.
     const fn label(self) -> &'static str {
         match self {
             Self::OpenFolder => "Open folder…",
@@ -829,7 +824,6 @@ impl Command {
         }
     }
 
-    /// The message this command dispatches.
     const fn message(self) -> Message {
         match self {
             Self::OpenFolder => Message::OpenFolder,
@@ -1039,7 +1033,6 @@ impl App {
         f32::from(percent) / 100.0
     }
 
-    /// The window title (an iced title function over the app state).
     fn title(&self) -> String {
         self.flow
             .label()
@@ -1682,9 +1675,7 @@ impl App {
         self.showing_report = false;
         self.notice = None;
         self.pane_selection = None;
-        // A fresh cancel flag per scan: the Cancel button sets it, the demux
-        // polls it per read chunk. Cancelling a superseded scan can never
-        // touch this one — it holds its own flag.
+        // A fresh flag per scan — see the `scan_cancel` field.
         let cancel = Arc::new(AtomicBool::new(false));
         self.scan_cancel = Some(Arc::clone(&cancel));
 
@@ -2533,8 +2524,8 @@ fn header_cell<'a>(
             .wrapping(text::Wrapping::None),
     )
     .width(width)
-    // Fill the header band and centre vertically, so every column's label sits on
-    // the same baseline whether or not it carries a resize grab.
+    // So every column's label sits on the same baseline whether or not it
+    // carries a resize grab.
     .height(Length::Fill)
     .align_x(align)
     .align_y(Vertical::Center)

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -1,11 +1,11 @@
 //! `bdinfo-rs-gui` — the native desktop window for the bdinfo-rs Blu-ray
 //! analyzer.
 //!
-//! The thin iced (Tier-B) shell over the [`bdinfo_rs_gui`] library: it drives the
+//! The thin iced shell over the [`bdinfo_rs_gui`] library: it drives the
 //! full two-phase flow — pick a disc FOLDER or `.iso`, fast structural scan →
 //! selectable playlist table → measured scan on a worker thread with a live
 //! progress bar → the rendered report, with Save / Copy. Every `update` arm calls
-//! a Tier-A transition ([`Flow`]) or seam ([`scan`]) and applies the result; the
+//! a library transition ([`Flow`]) or seam ([`scan`]) and applies the result; the
 //! `view` is a thin projection of [`Flow`] onto widgets dressed in the
 //! "Projection Booth" identity ([`theme`] + [`ui`]). The only impure thing the
 //! shell owns is the measured-scan worker thread and the channel that streams its
@@ -576,7 +576,7 @@ fn drive_marker(index: usize, name: &str, stage: Stage) {
 /// The per-platform config file location, resolved from the process
 /// environment — `None` when no base directory can be resolved (the app then
 /// runs without persistence). The one env-bound read in the config story; the
-/// per-platform path math it dispatches to is Tier A ([`settings`]).
+/// per-platform path math it dispatches to is pure ([`settings`]).
 fn config_path() -> Option<PathBuf> {
     #[cfg(target_os = "windows")]
     {
@@ -632,7 +632,7 @@ fn window_settings(persisted: &settings::Settings) -> iced::window::Settings {
     }
 }
 
-/// The app state — the Tier-A [`Flow`] the shell drives, plus the runtime-side
+/// The app state — the pure [`Flow`] the shell drives, plus the runtime-side
 /// bits: the visual preference + last-known OS mode, the scan generation counter
 /// (stamped on the worker's messages so a stale event is ignored), the scan start
 /// time (for the elapsed / remaining estimate), and a transient status line.
@@ -758,7 +758,7 @@ fn default_panes() -> pane_grid::State<Region> {
     })
 }
 
-/// A column weight as an `iced` `FillPortion` — the Tier-A scaling
+/// A column weight as an `iced` `FillPortion` — the pure scaling
 /// ([`columns::portion`]) wrapped in the layout type.
 fn fill(weight: f32) -> Length {
     Length::FillPortion(columns::portion(weight))
@@ -1065,7 +1065,7 @@ impl App {
         }
     }
 
-    /// The pure-ish message dispatch: each arm applies a Tier-A transition and
+    /// The pure-ish message dispatch: each arm applies a library transition and
     /// returns the side effect to run (a dialog, the scan worker, a clipboard
     /// write, an exit, or nothing).
     fn update(&mut self, message: Message) -> Task<Message> {
@@ -1609,7 +1609,7 @@ impl App {
 
     /// Opens `path` — a dropped item or the boot argument — through the same
     /// classify-and-list road the pickers take ([`Input::classify`], the one
-    /// Tier-A classifier both roads share). Ignored while a scan is in flight,
+    /// classifier both roads share). Ignored while a scan is in flight,
     /// the same rule that disables the Source buttons; a path that is neither a
     /// directory nor a `.iso` file lands in the same friendly failure state as
     /// a bad pick, with the loaded-disc chrome cleared like any new open.
@@ -1757,7 +1757,7 @@ impl App {
 
     /// Writes the rendered report into `dir` as `BDINFO.{label}.txt`, bytes
     /// verbatim (the locked CRLF / UTF-8 no-BOM contract — never re-encode).
-    /// The label is disc-controlled, so the filename goes through the Tier-A
+    /// The label is disc-controlled, so the filename goes through the
     /// sanitizer ([`paths::report_file_name`]) — the same name the CLI writes.
     fn save_report(&mut self, dir: &std::path::Path) {
         let (Some(report), Some(label)) = (self.flow.report(), self.flow.label()) else {
@@ -3387,10 +3387,10 @@ mod harness {
     }
 }
 
-/// Tier-B interaction tests: `iced_test`'s Simulator renders the real
+/// Interaction tests: `iced_test`'s Simulator renders the real
 /// `view()` offscreen, clicks it by visible text, and the produced messages
 /// run through the real `update` — so the widget wiring (what a click
-/// dispatches, what a state renders) is verified against the Tier-A state it
+/// dispatches, what a state renders) is verified against the library state it
 /// must land in. No window, no Tasks, no subscriptions: worker completions
 /// are injected as the messages they would arrive as.
 #[cfg(test)]
@@ -3766,7 +3766,7 @@ mod interaction {
     }
 }
 
-/// Tier-B pixel ties: key states rendered offscreen on the deterministic
+/// Pixel ties: key states rendered offscreen on the deterministic
 /// tiny-skia backend with the bundled fonts, pinned as committed SHA-256
 /// hashes per OS family (`snapshots/{windows,unix}/*.sha256` — see
 /// [`harness::assert_snapshot`] for the family evidence). Run them via the

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -10,8 +10,8 @@
 //! "Projection Booth" identity ([`theme`] + [`ui`]). The only impure thing the
 //! shell owns is the measured-scan worker thread and the channel that streams its
 //! progress back as messages, plus the OS-theme and file-drop subscriptions and
-//! the best-effort config store ([`settings`]): window geometry, the last opened
-//! source, and the theme preference persist across launches.
+//! the best-effort config store ([`settings`]): the window geometry, the last
+//! opened source, and every Settings-dialog preference persist across launches.
 //! A disc can arrive three ways — the pickers, a drag-and-drop onto the window,
 //! or a boot argument (`bdinfo-rs-gui <path>`) — all funnelling into the same
 //! open flow. The recalled last source is not a fourth: it only pre-fills the
@@ -50,7 +50,9 @@ use iced::{Element, Length, Task};
 /// The window's initial logical size — a **portrait-leaning** footprint (taller
 /// than wide), because the three master-detail panes are stacked vertically, so
 /// the vertical axis is where the value is. Roughly `BDInfo`'s width but much
-/// taller, sized to nearly fill a standard ~900-tall work area. The layout is
+/// taller — it fills the work area of a 1080-tall display and overflows a
+/// smaller one (see `debug_window_override`, which exists because the
+/// 960-tall default hangs off-screen on a 1024x768 CI runner). The layout is
 /// fully responsive (`Fill`/`FillPortion` + scrollable panes), so any size works;
 /// long codec descriptions clip at the pane edge exactly as they do in `BDInfo`.
 const WINDOW_SIZE: (f32, f32) = (880.0, 960.0);

--- a/crates/bdinfo-rs-gui/src/model.rs
+++ b/crates/bdinfo-rs-gui/src/model.rs
@@ -1,11 +1,10 @@
-//! Tier A — the pure playlist view-model.
+//! The pure playlist view-model.
 //!
 //! These constructors mirror the CLI's playlist table (and the wasm crate's
 //! `table_rows` / `table_length` / `estimated_bytes` / `playlist_rows`) over the
 //! public [`PlaylistSummary`] type — the GUI cannot import the CLI binary's
 //! private helpers, so it reimplements them the same way. No widgets, no IO:
-//! plain data in, plain data out, so `view()` is a thin projection and Phase 4
-//! can hold this layer to the core bar (100% coverage + 0 missed mutants).
+//! plain data in, plain data out, so `view()` is a thin projection.
 
 use std::cmp::Ordering;
 

--- a/crates/bdinfo-rs-gui/src/model.rs
+++ b/crates/bdinfo-rs-gui/src/model.rs
@@ -69,8 +69,7 @@ impl ViewSettings {
     }
 
     /// The core playlist filter these settings build — what the row
-    /// construction applies in place of the old hard-coded
-    /// `PlaylistFilter::default()`.
+    /// construction applies instead of `PlaylistFilter::default()`.
     #[must_use]
     pub fn filter(&self) -> PlaylistFilter {
         PlaylistFilter {
@@ -671,7 +670,7 @@ mod tests {
         assert_eq!(first.file, "00000.MPLS");
         assert_eq!(first.estimated_bytes, "1,000.00 B");
         assert_eq!(first.measured_bytes, "0");
-        // The defaults render exactly as before the settings existed.
+        // The defaults render the chapter suffix and grouped-byte sizes.
         let default_cells = display_rows(&rows, ViewSettings::default());
         let first = default_cells.first().expect("the feature row");
         assert_eq!(first.file, "00000.MPLS [12 Chapters]");

--- a/crates/bdinfo-rs-gui/src/panes.rs
+++ b/crates/bdinfo-rs-gui/src/panes.rs
@@ -1,4 +1,4 @@
-//! Tier A — the master-detail pane view-models.
+//! The master-detail pane view-models.
 //!
 //! When a playlist row is the active (highlighted) one, the lower two panes show
 //! its **stream files** and its **streams / codecs** — exactly the classic

--- a/crates/bdinfo-rs-gui/src/paths.rs
+++ b/crates/bdinfo-rs-gui/src/paths.rs
@@ -1,4 +1,4 @@
-//! Tier A — the copy-path helpers behind the Ctrl+C shortcut.
+//! The copy-path helpers behind the Ctrl+C shortcut.
 //!
 //! `BDInfo`'s `ProcessCmdKey` copies the highlighted playlist's or stream
 //! file's real OS path. For **folder** input the disc's `BDMV` directory is

--- a/crates/bdinfo-rs-gui/src/progress.rs
+++ b/crates/bdinfo-rs-gui/src/progress.rs
@@ -1,4 +1,4 @@
-//! Tier A — the pure live-progress model.
+//! The pure live-progress model.
 //!
 //! Ports the CLI's (`main.rs`) `progress_stats` + `hms` math: from a scan's
 //! `done` / `total` byte counts and the elapsed wall time it derives the

--- a/crates/bdinfo-rs-gui/src/selection.rs
+++ b/crates/bdinfo-rs-gui/src/selection.rs
@@ -1,4 +1,4 @@
-//! Tier A — the pure playlist selection model.
+//! The pure playlist selection model.
 //!
 //! The window lists the standard filtered playlist rows ([`crate::model`]); the
 //! user checks the ones to measure, and the measured scan is narrowed to exactly
@@ -10,8 +10,7 @@
 //! the wasm crate do (the GUI cannot import the CLI binary's private helpers).
 //!
 //! No widgets, no IO: plain data in, plain data out, so the iced shell is a thin
-//! projection and Phase 4 can hold this layer to the core bar (100% coverage + 0
-//! missed mutants).
+//! projection.
 
 use std::collections::BTreeSet;
 

--- a/crates/bdinfo-rs-gui/src/settings.rs
+++ b/crates/bdinfo-rs-gui/src/settings.rs
@@ -1,7 +1,10 @@
 //! The persistent GUI configuration.
 //!
 //! The app's small memory between launches: the window geometry, the last
-//! opened source path, and the theme preference, stored as a flat
+//! opened source path, and every Settings-dialog preference — theme, UI
+//! scale, the table filters and their threshold, the size and chapter-count
+//! formatting, autosave, and the two optional report sections (see
+//! [`Settings`] for the full set) — stored as a flat
 //! `key = value` text file (hand-rolled parser + writer, pure std — this
 //! project hand-rolled a UDF reader; a key-value file is squarely in its
 //! idiom). The store is a **convenience, never a dependency**: unknown keys
@@ -200,16 +203,16 @@ impl Default for Settings {
             window_maximized: false,
             last_path: None,
             theme: ThemeChoice::default(),
-            // Native scale — a fresh install renders exactly as before the
-            // setting existed.
+            // Native scale — a fresh install adds no scaling of its own on
+            // top of the OS DPI.
             ui_scale_percent: 100,
             // The filter defaults are core's (on at 20 s) — today's table.
             filter_short_playlists: true,
             short_playlist_seconds: 20,
             filter_looping_playlists: true,
             // Two deliberate divergences from BDInfo's own defaults, chosen so
-            // a fresh config renders this GUI's table exactly as before the
-            // Settings dialog existed: BDInfo defaults SizeFormatHR ON (we
+            // a fresh config renders this GUI's table the way its golden ties
+            // pin it: BDInfo defaults SizeFormatHR ON (we
             // ship grouped bytes) and DisplayChapterCount OFF (we show the
             // chapter suffix).
             human_readable_sizes: false,
@@ -225,8 +228,13 @@ impl Default for Settings {
 
 impl Settings {
     /// Parses the config file's text. Tolerant by design: unknown keys are
-    /// ignored (forward compatibility), malformed lines are skipped, and an
-    /// out-of-range or non-finite number is dropped — whatever the bytes,
+    /// ignored (forward compatibility) and malformed lines are skipped. A
+    /// non-numeric value is always dropped, leaving the default; an
+    /// out-of-range one depends on the key — a non-finite or implausibly
+    /// large geometry number is dropped (`parse_axis`), while the
+    /// short-playlist threshold and the UI-scale percent are clamped into
+    /// their bounds (`parse_seconds`, `parse_ui_scale`), so
+    /// `ui-scale-percent = 999` loads as 200, not 100. Whatever the bytes,
     /// this returns a usable value and never panics.
     #[must_use]
     pub fn parse(text: &str) -> Self {
@@ -235,8 +243,8 @@ impl Settings {
 
     /// [`parse`](Self::parse), also returning the unknown keys it ignored
     /// (first-seen order, deduplicated) — the loader warns about them so a
-    /// `theem = dark` typo is diagnosable, while the parse itself stays
-    /// exactly as tolerant as before: reporting, not validation.
+    /// `theem = dark` typo is diagnosable. The parse itself is unchanged by
+    /// the reporting: an unknown key is still ignored, not rejected.
     #[must_use]
     pub fn parse_reporting(text: &str) -> (Self, Vec<String>) {
         let mut settings = Self::default();
@@ -309,7 +317,8 @@ impl Settings {
     /// Renders the config file's text: one `key = value` line per stored
     /// fact, sorted by key (deterministic output), `\n` endings. Absent
     /// fields write no line, and a value that cannot live on one line (a
-    /// non-UTF-8 or control-character path) is simply not persisted.
+    /// non-UTF-8 path, or one containing a line break) is simply not
+    /// persisted.
     #[must_use]
     pub fn render(&self) -> String {
         let mut entries: Vec<(&str, String)> = vec![

--- a/crates/bdinfo-rs-gui/src/settings.rs
+++ b/crates/bdinfo-rs-gui/src/settings.rs
@@ -26,37 +26,22 @@
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
-/// The config file's key for the short-playlist filter switch.
+// The config file's keys.
 const KEY_FILTER_SHORT: &str = "filter-short-playlists";
-/// The config file's key for the short-playlist threshold (whole seconds).
 const KEY_SHORT_SECONDS: &str = "short-playlist-seconds";
-/// The config file's key for the looping-playlist filter switch.
 const KEY_FILTER_LOOPS: &str = "filter-looping-playlists";
-/// The config file's key for the human-readable size toggle.
 const KEY_HUMAN_SIZES: &str = "human-readable-sizes";
-/// The config file's key for the chapter-count display toggle.
 const KEY_CHAPTER_COUNT: &str = "display-chapter-count";
-/// The config file's key for the autosave-report switch.
 const KEY_AUTOSAVE: &str = "autosave-report";
-/// The config file's key for the report's stream-diagnostics sections.
 const KEY_REPORT_DIAGNOSTICS: &str = "report-stream-diagnostics";
-/// The config file's key for the report's quick-summary blocks.
 const KEY_REPORT_SUMMARY: &str = "report-quick-summary";
-/// The config file's key for the last opened source path.
 const KEY_LAST_PATH: &str = "last-path";
-/// The config file's key for the theme preference.
 const KEY_THEME: &str = "theme";
-/// The config file's key for the UI scale, in percent.
 const KEY_UI_SCALE: &str = "ui-scale-percent";
-/// The config file's keys for the window's logical size.
 const KEY_WINDOW_WIDTH: &str = "window-width";
-/// See [`KEY_WINDOW_WIDTH`].
 const KEY_WINDOW_HEIGHT: &str = "window-height";
-/// The config file's keys for the window's logical position.
 const KEY_WINDOW_X: &str = "window-x";
-/// See [`KEY_WINDOW_X`].
 const KEY_WINDOW_Y: &str = "window-y";
-/// The config file's key for the window's maximized state.
 const KEY_WINDOW_MAXIMIZED: &str = "window-maximized";
 
 /// The largest believable window axis, in logical pixels — a stored size or
@@ -252,7 +237,7 @@ impl Settings {
         let (mut width, mut height, mut x, mut y) = (None, None, None, None);
         for line in text.lines() {
             let Some((raw_key, raw_value)) = line.split_once('=') else {
-                continue; // not a `key = value` line — skipped
+                continue;
             };
             let key = raw_key.trim();
             // The writer puts exactly one space after `=`; strip exactly that
@@ -522,9 +507,7 @@ pub fn sanitize_seconds(text: &str) -> String {
 
 // ── where the file lives ─────────────────────────────────────────────────────
 
-/// The directory + file name under the platform's config base.
 const APP_DIR: &str = "bdinfo-rs";
-/// See [`APP_DIR`].
 const FILE_NAME: &str = "gui.conf";
 
 /// Windows: `%APPDATA%\bdinfo-rs\gui.conf`. `None` without a usable

--- a/crates/bdinfo-rs-gui/src/settings.rs
+++ b/crates/bdinfo-rs-gui/src/settings.rs
@@ -1,4 +1,4 @@
-//! Tier A — the persistent GUI configuration.
+//! The persistent GUI configuration.
 //!
 //! The app's small memory between launches: the window geometry, the last
 //! opened source path, and the theme preference, stored as a flat

--- a/crates/bdinfo-rs-gui/src/volume.rs
+++ b/crates/bdinfo-rs-gui/src/volume.rs
@@ -1,5 +1,5 @@
-//! Tier A — recovering the real disc label when a folder scan lands on a
-//! nameless Windows drive root.
+//! Recovering the real disc label when a folder scan lands on a nameless
+//! Windows drive root.
 //!
 //! A folder scan labels the disc after its root directory's name. That works
 //! everywhere a disc is mounted at a *named* path — an extracted folder, or the

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -316,9 +316,8 @@ fn js_message(value: &JsValue) -> String {
 /// read (an empty caller buffer, or a cursor at/after EOF).
 ///
 /// The panic-safety-critical arithmetic split out of the `FileReaderSync` I/O so
-/// the off-by-one and EOF-clamp edges are exercised on the native (Tier-A)
-/// build. `end` is clamped to `len`, so a window that would cross EOF is
-/// shortened rather than over-reading the caller's `buf`.
+/// the off-by-one and EOF-clamp edges are exercised on the native build. `end` is clamped to `len`,
+/// so a window that would cross EOF is shortened rather than over-reading the caller's `buf`.
 #[cfg(any(target_arch = "wasm32", test))]
 fn read_window(pos: u64, buf_len: usize, len: u64) -> Option<(u64, u64)> {
     if buf_len == 0 || pos >= len {
@@ -1287,7 +1286,7 @@ mod tests {
     fn tree_error_messages_describe_each_variant() {
         // `message` is consumed natively only here: its `From<TreeError> for
         // JsValue` caller is wasm32-only, so this is the test that keeps it both
-        // live and covered on the native (Tier-A) build.
+        // live and covered on the native build.
         assert!(TreeError::BareFile("loose.mpls".to_owned()).message().contains("loose.mpls"));
         assert!(
             TreeError::MixedRoots("A".to_owned(), "B".to_owned())
@@ -1614,8 +1613,8 @@ mod tests {
         assert_eq!(seek_target(SeekFrom::Current(i64::MAX), u64::MAX, 0).expect("sat"), u64::MAX);
     }
 
-    /// CLI-parity selection helpers (Tier A): the structural playlist listing
-    /// and the by-name measured scan, native-tested to the core bar.
+    /// CLI-parity selection helpers: the structural playlist listing and the
+    /// by-name measured scan, native-tested.
     mod selection {
         use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary};
 
@@ -1915,7 +1914,7 @@ mod tests {
 
     // The reader math is panic-safety-critical, so amplify the unit cases with
     // property tests. proptest's backend does not build for wasm32, so these run
-    // only on the native (Tier-A) build.
+    // only on the native build.
     #[cfg(not(target_arch = "wasm32"))]
     mod prop {
         use std::io::{self, SeekFrom};

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -4,8 +4,8 @@
 //! browser. Several entry points feed the very same render path:
 //!
 //! - [`scan_report`] — the in-memory export: BDMV bytes are framed into a synthetic disc tree (six
-//!   `u32`-BE sections), opened with [`BdRom::open_resilient`] (packet scan **on**), and rendered
-//!   to the classic report. Used by the native ⇄ in-browser byte-parity test.
+//!   `u32`-BE sections), opened with [`BdRom::open_resilient_with`] (packet scan **on**), and
+//!   rendered to the classic report. Used by the native ⇄ in-browser byte-parity test.
 //! - [`scan_files`] — the streaming export: a `webkitdirectory`-selected BDMV folder arrives as a
 //!   flat list of `(relativePath, File)` pairs. The files stay on disk; their bytes are read
 //!   **synchronously** at byte offsets through [`web_sys::FileReaderSync`] (no JSPI, no Asyncify),
@@ -97,9 +97,10 @@ impl<F> Node<F> {
     }
 }
 
-/// ASCII case-insensitive glob: `*` = any run, `?` = any one byte. Mirrors the
-/// core's [`fs::glob_ci`](bdinfo_rs_core) so file-backed input matches patterns
-/// exactly like folder input does.
+/// ASCII case-insensitive glob: `*` = any run, `?` = any one byte. Mirrors
+/// `glob_ci` in the core's `vfs::fs` (crate-private there, so it cannot be
+/// reused or linked) so file-backed input matches patterns exactly like
+/// folder input does — the two implementations must agree.
 fn glob_match(pattern: &[u8], name: &[u8]) -> bool {
     match pattern.split_first() {
         None => name.is_empty(),

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -3,15 +3,15 @@
 //! This crate exposes the library's whole **measured** scan pipeline to the
 //! browser. Several entry points feed the very same render path:
 //!
-//! - [`scan_report`] — the Phase 1 in-memory export: BDMV bytes are framed into a synthetic disc
-//!   tree (six `u32`-BE sections), opened with [`BdRom::open_resilient`] (packet scan **on**), and
-//!   rendered to the classic report. Used by the native ⇄ in-browser byte-parity test.
-//! - [`scan_files`] — the Phase 2 streaming export: a `webkitdirectory`-selected BDMV folder
-//!   arrives as a flat list of `(relativePath, File)` pairs. The files stay on disk; their bytes
-//!   are read **synchronously** at byte offsets through [`web_sys::FileReaderSync`] (no JSPI, no
-//!   Asyncify), so a multi-GB `*.m2ts` never has to fit in memory. The export runs inside a Web
-//!   Worker (the only scope where `FileReaderSync` exists). [`list_playlists`] is its structural
-//!   twin: the fast selection-table scan (`bdinfo-rs <disc> --list`) over the same pairs.
+//! - [`scan_report`] — the in-memory export: BDMV bytes are framed into a synthetic disc tree (six
+//!   `u32`-BE sections), opened with [`BdRom::open_resilient`] (packet scan **on**), and rendered
+//!   to the classic report. Used by the native ⇄ in-browser byte-parity test.
+//! - [`scan_files`] — the streaming export: a `webkitdirectory`-selected BDMV folder arrives as a
+//!   flat list of `(relativePath, File)` pairs. The files stay on disk; their bytes are read
+//!   **synchronously** at byte offsets through [`web_sys::FileReaderSync`] (no JSPI, no Asyncify),
+//!   so a multi-GB `*.m2ts` never has to fit in memory. The export runs inside a Web Worker (the
+//!   only scope where `FileReaderSync` exists). [`list_playlists`] is its structural twin: the fast
+//!   selection-table scan (`bdinfo-rs <disc> --list`) over the same pairs.
 //! - [`scan_iso`] / [`list_iso_playlists`] — the streaming `.iso` exports: a single OS-picked
 //!   `.iso` `File` is opened through the core read-only UDF 2.50 reader ([`UdfSource`]) over the
 //!   same windowed [`web_sys::FileReaderSync`] cursor ([`WebIso`] is the [`IsoReader`] factory), so
@@ -1030,7 +1030,7 @@ pub fn run_iso_report(reader: Box<dyn IsoReader>) -> String {
     render_disc(&source.root(), &mut |_| {}).unwrap_or_default()
 }
 
-/// The Phase 1 in-memory entry point: feed it BDMV bytes (the six `u32`-BE
+/// The in-memory entry point: feed it BDMV bytes (the six `u32`-BE
 /// framed sections — see the module-level docs), get back the classic report.
 ///
 /// Runs the **measured** scan (M2TS demux + per-stream/per-chapter statistics),
@@ -1041,7 +1041,7 @@ pub fn scan_report(data: &[u8]) -> String {
     run_report(data)
 }
 
-/// The Phase 2 streaming entry point: hand it a `webkitdirectory`-selected BDMV
+/// The streaming entry point: hand it a `webkitdirectory`-selected BDMV
 /// folder as parallel `(relativePath, File)` lists and get back the classic
 /// disc report.
 ///

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -1049,7 +1049,7 @@ pub fn scan_report(data: &[u8]) -> String {
 /// Runs the **full measured** scan — M2TS demux + per-stream/per-chapter
 /// statistics, `run_packet_scan = true` — reading every file's bytes
 /// synchronously at byte offsets through [`web_sys::FileReaderSync`]. This MUST
-/// run in a Web Worker (the only scope where `FileReaderSync` exists). When
+/// run in a Web Worker (see the module docs). When
 /// `on_progress` is supplied it is called as `(file, done, total)` after each
 /// demux read. A non-empty `selection` names the playlists to measure (CLI
 /// `--mpls` semantics — unfiltered, in order); an empty `selection` measures the
@@ -1091,8 +1091,8 @@ pub fn scan_files(
 /// [`web_sys::FileReaderSync`] ([`WebIso`] is the [`IsoReader`] factory), so a
 /// multi-GB `.iso` never has to fit in memory. It then runs the **full measured**
 /// scan and renders the same report `bdinfo-rs <disc>.iso` writes. Like
-/// [`scan_files`], this MUST run in a Web Worker (the only scope where
-/// `FileReaderSync` exists); `on_progress`, when supplied, is called as
+/// [`scan_files`], this MUST run in a Web Worker; `on_progress`, when
+/// supplied, is called as
 /// `(file, done, total)`; a non-empty `selection` measures only the named
 /// playlists (CLI `--mpls` semantics, unfiltered, in order), an empty one the
 /// standard `--whole` set.

--- a/crates/bdinfo-rs/build.rs
+++ b/crates/bdinfo-rs/build.rs
@@ -1,8 +1,10 @@
 //! Build script: generate the shell completions + man page for the `bdinfo-rs`
 //! CLI, derived from the same `clap::Command` the binary parses.
 //!
-//! WHERE THE ARTIFACTS LAND (the contract the release packaging — prompt 04 —
-//! relies on; do not change without updating it):
+//! WHERE THE ARTIFACTS LAND (the contract `.github/build-setup.yml` — the
+//! cargo-dist build-setup step wired in by `dist-workspace.toml`'s
+//! `github-build-setup` — and `.github/workflows/ci.yml`'s packaging step both
+//! rely on; do not change without updating them):
 //!
 //! Every generated file is written into a single `assets/` directory rooted at
 //! this build script's `OUT_DIR`:

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -1,4 +1,5 @@
-//! `bdinfo-rs` CLI — drives the `bdinfo-rs-core` library. No GUI, ever.
+//! `bdinfo-rs` CLI — drives the `bdinfo-rs-core` library. Terminal only: the
+//! desktop window is a separate binary (`bdinfo-rs-gui`).
 //!
 //! Usage: `bdinfo-rs <BD_PATH> [REPORT_DEST]`.
 //!


### PR DESCRIPTION
Corrects the comment layer across `bdinfo-rs-core`, the CLI, the GUI and wasm sibling
crates, and the workflow YAML. Comment-only in every `.rs` file; the two exceptions are
noted below.

## Comments

- **False and over-claimed statements corrected.** Nine comments contradicted the code
  beneath them; five were drifted summaries of something real, so each was rewritten to
  the true statement rather than deleted. Several others over-claimed a quantifier
  ("every call site" where the code covers only the full-width ones) and were narrowed to
  what the code actually guarantees.
- **BDInfo divergence markers added at their implementation sites.** Fourteen lines across
  six codec files now name the deliberate divergence and point at `DIFFERENCES.md`, which
  previously recorded them only centrally — the code that implements a divergence carried
  no sign of it.
- **Dead references removed.** Eight `(D1)`–`(D6)` decision codes in `ci.yml`, `gui.yml`,
  `wasm.yml` and `sweep.yml` cited a register that exists in no tracked file, so no reader
  of the repository could resolve them. The parenthetical is dropped and the surrounding
  sentence kept. Development-phase labels in the wasm and CLI docs are replaced with the
  tracked symbols they meant.
- **Gate taxonomy dropped from module docs.** Tier and coverage-bar classifications are
  properties of the CI configuration, not of the module, and are stated in the gate config
  already.
- **Duplicated facts collapsed.** Invariants stated three or more times within a crate are
  now stated once and referenced; the copies had already drifted into disagreement.
- **Restatements of the adjacent code deleted**, and change-relative phrasing ("used to",
  "no longer", "was rescheduled") replaced with present-tense statements of what the code
  and the workflows now do.

## Mutation exclusions

Four `exclude_re` entries in `.cargo/mutants.toml` move from line pins to column pins.
Line pins match the mutant's `file:LINE:COL` display string, so adding or removing a
comment line above one silently stops it matching and the excluded mutant returns as
MISSED in the daily sweep rather than in the pull request. Column pins are immune: a
comment edit never changes an operator's column on its own line.

Two entries stay line-pinned. `m2ts.rs` `parse_pat` and `parse_pmt` each hold a second
same-operator mutant at the same column, and those two must stay killable — widening the
pin to a column would exclude a real test gap silently, whereas a stale line pin fails
loudly as a MISSED mutant. A loud failure is not traded for a silent one.

## Sweep shards

`sweep.yml` rebalances the mutation shards to core 15 and gui 5, matching the measured
per-crate runtimes.

## Verification

- Every changed line in every `.rs` file is a comment line, checked across the whole
  branch by diffing against `master` and filtering for non-comment additions and
  deletions. The only two hits are trailing comments removed from otherwise-identical
  code lines.
- The mutation pins were verified to resolve identically before and after: `cargo mutants
  --list` fingerprints all 386 mutants in `m2ts.rs` and `mpeg2.rs` by `(file, column,
  description)`, omitting the line, so the fingerprint is stable across the line shifts
  the comment edits cause and moves only if a pin started or stopped matching. The set is
  unchanged at 386.
- Full local gate green, including 100% lines/regions/functions and 97.89% branch
  coverage over a 97% floor.
