### PR TITLE
fix(ci): compile the linux packagers from source on the gui release legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,14 @@ jobs:
               case "$f" in
                 crates/bdinfo-rs-core/*|crates/bdinfo-rs/*|Cargo.toml|rust-toolchain.toml|rustfmt.toml|clippy.toml|typos.toml|.config/*|.cargo/*) core_edge=true ;;
               esac
-              case "$f" in crates/bdinfo-rs-gui/*|.github/workflows/gui.yml|.github/workflows/gui-release.yml|.github/scripts/gui-*.ps1) gui=true ;; esac
+              # gui-release.yml is deliberately NOT here: the orchestrator
+              # never runs it (tag/dispatch-only), so a lane-only edit gets
+              # the meta checks (YAML schema/style/security) and its real
+              # verification from the next dispatch dry run — not a ~40-minute
+              # gui fleet re-run that exercises none of the changed lines.
+              # The gui-package-*.ps1 scripts DO re-fire the area: the
+              # packaging smoke runs them.
+              case "$f" in crates/bdinfo-rs-gui/*|.github/workflows/gui.yml|.github/scripts/gui-*.ps1) gui=true ;; esac
               case "$f" in crates/bdinfo-rs-wasm/*|.github/workflows/wasm.yml) wasm=true ;; esac
               case "$f" in fuzz/*) fuzz=true ;; esac
               case "$f" in Cargo.lock|Cargo.toml|*/Cargo.toml|deny.toml|supply-chain/*|crates/*/deny.toml) deps=true ;; esac

--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -132,6 +132,14 @@ jobs:
       # same posture as .github/build-linux-packages.sh inside the dist
       # release. The PR smoke keeps the fast pre-install (ubuntu-latest).
 
+      # The check script's validators (desktop-file-validate, appstream-util,
+      # rpm -qp) — none preinstalled on the runner image.
+      - name: Install the Linux packaging validators
+        if: matrix.kind == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends desktop-file-utils appstream-util rpm
+
       - name: Build (release profile, locked)
         working-directory: crates/bdinfo-rs-gui
         run: cargo build --release --locked -p bdinfo-rs-gui

--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -125,13 +125,12 @@ jobs:
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
-      # Release-pinned; the packaging script compiles the same versions from
-      # source if this pre-install were ever absent.
-      - name: Install the Linux packagers
-        if: matrix.kind == 'linux'
-        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
-        with:
-          tool: cargo-deb@3.7.0,cargo-generate-rpm@0.21.0
+      # No packager pre-install here, deliberately: install-action's prebuilt
+      # cargo-deb links glibc 2.39 and dies on these ubuntu-22.04 legs (glibc
+      # 2.35, the compatibility floor the app builds against). The packaging
+      # script compiles the release-pinned versions from source instead — the
+      # same posture as .github/build-linux-packages.sh inside the dist
+      # release. The PR smoke keeps the fast pre-install (ubuntu-latest).
 
       - name: Build (release profile, locked)
         working-directory: crates/bdinfo-rs-gui

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -45,7 +45,7 @@ name: version-freshness
 #     upstream release can't abort the whole release; both checked vs crates.io, and
 #     both cross-checked against every other copy — ci.yml's pkg job, the GUI
 #     packaging script (.github/scripts/gui-package-linux.ps1), and the taiki-e
-#     installs in gui.yml + gui-release.yml — which must all stay EQUAL so the PR
+#     install in gui.yml's packaging smoke — which must all stay EQUAL so the PR
 #     smoke tests package with the exact release tools),
 #   - appimagetool (the `$appimagetoolVersion` curl-download pin in
 #     .github/scripts/gui-package-linux.ps1 — the GUI lane's AppImage packer,
@@ -356,15 +356,15 @@ jobs:
           if ($cargoRpmCi -ne $cargoRpmPin) {
             Add-Problem 'cargo-generate-rpm pins disagree' "- cargo-generate-rpm pin mismatch: build-linux-packages.sh has ``$cargoRpmPin`` but ci.yml's pkg job installs ``$cargoRpmCi`` — they must be identical (the smoke test must use the exact release tools)"
           }
-          # The GUI lane carries three MORE copies of the same two pins: the
-          # packaging script's install fallback plus the taiki-e pre-installs
-          # in gui.yml's packaging smoke and gui-release.yml's Linux legs. All
+          # The GUI lane carries two MORE copies of the same two pins: the
+          # packaging script's source-compile pins (what the release legs run
+          # — their ubuntu-22.04 glibc floor rules out the prebuilt binaries)
+          # plus the taiki-e pre-install in gui.yml's packaging smoke. All
           # must equal build-linux-packages.sh's, for the same
           # smoke-packages-with-the-release-tools reason.
           $guiPackagerHomes = [ordered]@{
             '.github/scripts/gui-package-linux.ps1' = @("cargoDebVersion\s*=\s*'([0-9.]+)'", "cargoGenerateRpmVersion\s*=\s*'([0-9.]+)'")
             '.github/workflows/gui.yml'             = @('cargo-deb@([0-9.]+)', 'cargo-generate-rpm@([0-9.]+)')
-            '.github/workflows/gui-release.yml'     = @('cargo-deb@([0-9.]+)', 'cargo-generate-rpm@([0-9.]+)')
           }
           foreach ($file in $guiPackagerHomes.Keys) {
             $debHere = Read-Pin $file $guiPackagerHomes[$file][0]


### PR DESCRIPTION
The first dispatch dry run failed on the ubuntu-22.04 legs and a desk-check of the remaining dispatch-only surface found two more latent failures; all three fixes are batched here, everything else pre-verified locally.

- **Packager install (the dry-run failure):** install-action's prebuilt cargo-deb links glibc 2.39 and dies on the release legs' ubuntu-22.04 (glibc 2.35, the deliberate compatibility floor). Dropped the pre-install there; gui-package-linux.ps1 compiles the release-pinned versions from source, the same posture as build-linux-packages.sh inside the dist release. The PR packaging smoke keeps the fast pre-install on ubuntu-latest. version-freshness drops the removed pin home.
- **Missing validators (latent):** the release legs run gui-package-check.ps1, whose desktop-file-validate / appstream-util / rpm -qp validators only the smoke job installed. Added the same apt step to the Linux release legs.
- **Classifier (loop cost):** gui-release.yml leaves the gui area — the orchestrator never runs it (tag/dispatch-only), so a lane-only edit now gets the meta checks instead of a ~40-minute gui fleet re-run that exercises none of the changed lines. The packaging scripts stay in the gui area (the smoke runs them).

Pre-verified locally to avoid burning dispatches: the arm64 MSI path end to end on this box — candle -arch arm64 authoring, the Arm64;1033 platform summary, cross-arch msiexec /a administrative extract on an x64 host, and the full windows pair check, all green.