### PR TITLE
fix(ci): stage the gui release downloads outside the tracked assets dir

### DIFF
--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -278,15 +278,18 @@ jobs:
         with:
           persist-credentials: false
 
+      # Staged OUTSIDE the checkout's tracked paths: `assets/` exists in the
+      # repo (the README screenshot), and merging downloads into it put a 13th
+      # file under the exactly-12 completeness check.
       - name: Download every packaged artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: gui-release-*
-          path: assets
+          path: dist-gui-assets
           merge-multiple: true
 
       - name: Hard-fail on any missing artifact, then write SHA256SUMS
-        working-directory: assets
+        working-directory: dist-gui-assets
         run: |
           expected="
           bdinfo-rs-gui-x86_64-unknown-linux-gnu.AppImage
@@ -319,7 +322,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: assets/*
+          subject-path: dist-gui-assets/*
 
       - name: Create the GitHub release (immutable; never "latest")
         if: startsWith(github.ref, 'refs/tags/')
@@ -355,13 +358,13 @@ jobs:
             --latest=false \
             --title "bdinfo-rs GUI v$VERSION" \
             --notes-file "$RUNNER_TEMP/notes.md" \
-            assets/*
+            dist-gui-assets/*
 
       - name: Upload the dry-run bundle (dispatch only)
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gui-release-dry-run
-          path: assets/
+          path: dist-gui-assets/
           retention-days: 7
           if-no-files-found: error


### PR DESCRIPTION
The second dry run built and checked all 12 artifacts on all six targets; the only failure was the publish job's completeness check counting 13 files — the artifact downloads merged into `assets/`, which the checkout already populates with the README screenshot. Stage into `dist-gui-assets/` instead (download, checksum, attest, release, and dry-run-bundle paths all follow).