### PR TITLE
fix(ci): resolve appimagetool freshness against its highest semver tag

### DIFF
--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -49,8 +49,9 @@ name: version-freshness
 #     smoke tests package with the exact release tools),
 #   - appimagetool (the `$appimagetoolVersion` curl-download pin in
 #     .github/scripts/gui-package-linux.ps1 — the GUI lane's AppImage packer,
-#     fetched at a static version invisible to Dependabot; checked vs
-#     AppImage/appimagetool's latest release), and
+#     fetched at a static version invisible to Dependabot; checked vs the highest
+#     SEMVER tag AppImage/appimagetool has released, since its `releases/latest`
+#     is the rolling `continuous` nightly), and
 #     cloudsmith-cli (the `cloudsmith-cli==X` pipx pin in packages.yml — a pip pin
 #     invisible to Dependabot's cargo/npm/actions scans; pinned once per push job,
 #     every occurrence checked to agree, then vs PyPI),
@@ -146,6 +147,23 @@ jobs:
             if ($LASTEXITCODE -ne 0) { return $null }
             if ($tag -match '(\d+\.\d+\.\d+)') { return $Matches[1] }
             return $null
+          }
+
+          # The highest X.Y.Z among $repo's non-draft, non-prerelease release tags,
+          # or $null if the API call fails. For repos whose `releases/latest` points
+          # at a rolling non-semver tag — AppImage/appimagetool marks its nightly
+          # `continuous` release latest — where Latest-Semver finds no digits and
+          # returns $null, which reads here as a failed query.
+          function Latest-Semver-Listed($repo) {
+            $tags = gh api "repos/$repo/releases" --paginate `
+              --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' 2>$null
+            if ($LASTEXITCODE -ne 0) { return $null }
+            $versions = @()
+            foreach ($tag in $tags) {
+              if ($tag -match '(\d+\.\d+\.\d+)') { $versions += [version]$Matches[1] }
+            }
+            if ($versions.Count -eq 0) { return $null }
+            return ($versions | Sort-Object -Descending | Select-Object -First 1).ToString()
           }
 
           # The latest stable version of a crates.io crate (the source `cargo
@@ -384,7 +402,7 @@ jobs:
           # version — invisible to Dependabot, watched here like komac.
           $appimagetoolPin = Read-Pin '.github/scripts/gui-package-linux.ps1' "appimagetoolVersion\s*=\s*'([0-9.]+)'"
           if (-not $appimagetoolPin) { throw 'No appimagetoolVersion pin in gui-package-linux.ps1' }
-          $appimagetoolLatest = Latest-Semver 'AppImage/appimagetool'
+          $appimagetoolLatest = Latest-Semver-Listed 'AppImage/appimagetool'
           if (-not $appimagetoolLatest) {
             Add-Problem 'appimagetool (query failed)' '- could not query the latest appimagetool release (AppImage/appimagetool)'
           } elseif ([version]$appimagetoolLatest -gt [version]$appimagetoolPin) {

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -162,6 +162,31 @@ value is never rendered.
 
 ---
 
+## Desktop app vs. the BDInfo GUI
+
+The report is byte-identical; the window around it is not a pixel-for-pixel port. The three-pane
+Playlist / Stream File / Codec view, the playlist table, sorting, drag-and-drop, the settings
+dialog, and the report toggles all behave as in the original.
+
+Not carried over:
+
+- **Bitrate charts.** The original plots six chart types (`FormChart`) from per-second and
+  per-frame measurements; bdinfo-rs keeps only the aggregate statistics the report prints, so
+  there is nothing to plot. The chart-tied image-prefix setting is absent with them.
+- **Custom playlist builder.** Playlists are selected from the disc's own table, not assembled.
+- **Taskbar progress and live in-grid numbers.** Progress is shown in the window, not painted into
+  the taskbar button or streamed into the playlist grid mid-scan.
+- **The `KeepStreamOrder`, `EnableSSIF`, and `ExtendedStreamDiagnostics` toggles.**
+- **Selectable report text.** The text widgets in use cannot span-select; *Copy report* and
+  *Save report…* cover the same need.
+
+Deliberately different:
+
+- **Unreadable files do not prompt.** The original asks Yes/No per failing file; bdinfo-rs collects
+  them, scans the rest, and shows one warning banner — the same `WARNING` block the report carries.
+- **Saving is both manual and automatic.** A *Save report…* dialog exists alongside the
+  save-on-completion setting.
+
 ## See also
 
 - [`CHANGELOG.md`](CHANGELOG.md#differences-from-bdinfo) — the per-release record of these

--- a/README.md
+++ b/README.md
@@ -25,16 +25,21 @@
 bdinfo-rs scans `BDMV` folders and `.iso` images — playlists, clips, M2TS demux — and produces the
 classic BDInfo disc report: per-stream video and audio specs, codecs, measured bitrates, resolution,
 and HDR / Dolby Vision / HDR10+. One parser engine,
-[`bdinfo-rs-core`](https://crates.io/crates/bdinfo-rs-core), drives all three front-ends, so the
-report is byte-identical whichever you use.
+[`bdinfo-rs-core`](https://crates.io/crates/bdinfo-rs-core)
+([docs](https://docs.rs/bdinfo-rs-core)), is the whole analyzer behind a documented API — disc
+discovery, MPLS/CLPI/index parsing, M2TS demux, the codec scanners, the UDF 2.50 reader, the report
+renderer — and all three front-ends are thin shells over it, so the report is byte-identical
+whichever you use.
 
 - **The BDInfo report, byte-for-byte** — deterministic across every platform and front-end.
+- **Structure and metadata only** — no decryption, no circumvention, and feature content is never
+  copied. It works on already-decrypted discs; analyze the ones you own.
 - **Memory-safe** — `unsafe` is `forbid`-den; malformed input returns an error, never a crash.
 - **Zero C** — in-house M2TS demuxer, 13 codec scanners, and UDF 2.50 `.iso` reader. No libbluray, no FFI.
 - **Fast and small** — a pipelined demuxer that stays near NVMe read speed; the CLI is a ~1 MB binary with no runtime.
 - **Everywhere** — Windows, macOS, and Linux on x64 and arm64, plus WebAssembly.
 
-| | | |
+| Front-end | Best for | Get it |
 |---|---|---|
 | **Desktop app** | point and click | [Download ↓](#desktop-app) |
 | **Command line** | scriptable static binary | [Install ↓](#command-line) |
@@ -104,32 +109,17 @@ const report = await analyze(picked); // the classic disc report, as a string
 `listPlaylists` returns the selection table; `listPlaylistsIso` / `analyzeIso` do the same for a
 single `.iso`. Bundler, CSP, and browser-support notes: [`crates/bdinfo-rs-wasm`](crates/bdinfo-rs-wasm).
 
-## What it does not do
-
-- **No decryption, no circumvention.** It reads structure and metadata only, and never copies feature
-  content. It therefore works on already-decrypted discs — analyze the ones you own.
-- **No bitrate charts and no custom playlist builder** in the desktop app.
-- **A browser cannot write to a picked folder**, so the web version returns the report as text
-  instead of saving it next to the disc.
-
-Filing an [output difference](https://github.com/agentjp/bdinfo-rs/issues/new?template=output_difference.yml)?
-Paste the **text report** — codecs, bitrates, stream layout — never audio or video. A
-[blu-ray.com](https://www.blu-ray.com) link to the release helps identify the disc.
-
 ## Differences from BDInfo
 
 The report follows the classic format byte-for-byte, except where the original is provably wrong
 against the codec specification or FFmpeg — there, bdinfo-rs emits the correct value.
 
-**[DIFFERENCES.md](DIFFERENCES.md)** has the exact before/after for every divergence and flags which
-ones appear on a normal disc.
+**[DIFFERENCES.md](DIFFERENCES.md)** has the exact before/after for every divergence, flags which
+ones appear on a normal disc, and lists how the desktop app differs from the BDInfo GUI.
 
-## Library
-
-[`bdinfo-rs-core`](https://crates.io/crates/bdinfo-rs-core) is the whole analyzer behind a documented
-API: disc discovery, MPLS/CLPI/index parsing, M2TS demux, the codec scanners, the UDF 2.50 reader,
-and the report renderer. All three front-ends are thin shells over it.
-[Docs](https://docs.rs/bdinfo-rs-core).
+Filing an [output difference](https://github.com/agentjp/bdinfo-rs/issues/new?template=output_difference.yml)?
+Paste the **text report** — codecs, bitrates, stream layout — never audio or video. A
+[blu-ray.com](https://www.blu-ray.com) link to the release helps identify the disc.
 
 ## Quality & security
 


### PR DESCRIPTION
`Latest-Semver` resolves a pin against `repos/<repo>/releases/latest`. AppImage/appimagetool marks its rolling `continuous` nightly as the latest release, so the tag carries no digits, the semver extraction returns `$null`, and the appimagetool check reports a failed query. It files a stale-pin issue on every daily run regardless of the pin state.

Resolve that one pin against the highest non-draft, non-prerelease semver tag instead, via a sibling `Latest-Semver-Listed` helper. Other pins keep using `releases/latest`.

The pin is current: `gui-package-linux.ps1` has `1.9.1`, and `1.9.1` is the newest semver release (`1.9.1`, `continuous`, `1.9.0`).

Verified by running the helper as committed against the live API — resolves `1.9.1`, so neither the query-failed nor the behind-latest branch fires. `action-validator`, `ryl -s`, `typos` and `zizmor` pass on the changed workflow.

Closes #135