### PR TITLE
fix(ci): emit the gui-publish channel matrix as a flat JSON array

### DIFF
--- a/.github/scripts/publish-gui-verify.ps1
+++ b/.github/scripts/publish-gui-verify.ps1
@@ -120,5 +120,10 @@ if ($env:AUR_ENABLED -ne 'true' -and $selected -contains 'aur') {
 }
 
 Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "version=$version"
-Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "channels=$(ConvertTo-Json $selected -Compress -AsArray)"
+# Pipeline, not -InputObject: ConvertTo-Json treats a positional array as one
+# object and -AsArray then wraps it AGAIN ([["a","b"]]), which fromJson turns
+# into a single matrix job whose channel is the whole list. The pipeline
+# enumerates the elements, and -AsArray re-wraps a lone survivor so a
+# single-channel dispatch still yields a JSON array.
+Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "channels=$($selected | ConvertTo-Json -Compress -AsArray)"
 Write-Host "verified release $Tag (version $version): 12 packages + SHA256SUMS, checksums + attestations ok; channels: $($selected -join ', ')"


### PR DESCRIPTION
publish-gui-verify.ps1 passed the selected channel list to ConvertTo-Json positionally, where it lands in -InputObject and is serialized as a single object; -AsArray then wrapped it a second time, emitting a nested array. fromJson on that value produced a one-element prepare matrix whose channel was the entire list, so no per-channel step matched and the payload upload failed on an empty directory.

Switch to the pipeline form: the elements are enumerated individually and -AsArray re-wraps a lone element, so a single-channel dispatch still yields a JSON array.

Observed on the first prepare-only dispatch of gui-publish.yml (the rehearsal lane doing its job); verify and the per-channel logic were unaffected.