### PR TITLE
fix(ci): apply the -Sums shadowing fix to the homebrew and cloudsmith legs

### DIFF
--- a/.github/scripts/publish-gui-cloudsmith.ps1
+++ b/.github/scripts/publish-gui-cloudsmith.ps1
@@ -52,9 +52,11 @@ function Stop-Leg([string] $why) {
 
 if ($Mode -eq 'prepare') {
     if (-not $Sums) { Stop-Leg 'prepare needs -Sums' }
-    $sums = @{}
+    # Not `$sums`: PowerShell variable names are case-insensitive, so that
+    # would overwrite the $Sums path parameter before the loop reads it.
+    $shaByName = @{}
     foreach ($line in Get-Content -LiteralPath $Sums) {
-        if ($line -match '^([0-9a-f]{64})\s+\*?(.+)$') { $sums[$Matches[2].Trim()] = $Matches[1] }
+        if ($line -match '^([0-9a-f]{64})\s+\*?(.+)$') { $shaByName[$Matches[2].Trim()] = $Matches[1] }
     }
 
     New-Item -ItemType Directory -Force $Payload | Out-Null
@@ -63,7 +65,7 @@ if ($Mode -eq 'prepare') {
         if ($LASTEXITCODE -ne 0) { Stop-Leg "gh release download $name failed" }
         $path = Join-Path $Payload $name
         $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $path).Hash.ToLowerInvariant()
-        if ($hash -ne $sums[$name]) { Stop-Leg "checksum mismatch for $name (SHA256SUMS $($sums[$name]), downloaded $hash)" }
+        if ($hash -ne $shaByName[$name]) { Stop-Leg "checksum mismatch for $name (SHA256SUMS $($shaByName[$name]), downloaded $hash)" }
         Write-Host "    sha256 ok  $name"
     }
 

--- a/.github/scripts/publish-gui-homebrew.ps1
+++ b/.github/scripts/publish-gui-homebrew.ps1
@@ -43,12 +43,14 @@ $repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..' '..')).Path
 if ($Mode -eq 'prepare') {
     foreach ($p in @($Sums, $Payload)) { if (-not $p) { Stop-Leg 'prepare needs -Sums and -Payload' } }
 
-    $sums = @{}
+    # Not `$sums`: PowerShell variable names are case-insensitive, so that
+    # would overwrite the $Sums path parameter before the loop reads it.
+    $shaByName = @{}
     foreach ($line in Get-Content -LiteralPath $Sums) {
-        if ($line -match '^([0-9a-f]{64})\s+\*?(.+)$') { $sums[$Matches[2].Trim()] = $Matches[1] }
+        if ($line -match '^([0-9a-f]{64})\s+\*?(.+)$') { $shaByName[$Matches[2].Trim()] = $Matches[1] }
     }
-    $shaArm = $sums['bdinfo-rs-gui-aarch64-apple-darwin.dmg']
-    $shaIntel = $sums['bdinfo-rs-gui-x86_64-apple-darwin.dmg']
+    $shaArm = $shaByName['bdinfo-rs-gui-aarch64-apple-darwin.dmg']
+    $shaIntel = $shaByName['bdinfo-rs-gui-x86_64-apple-darwin.dmg']
     if (-not $shaArm -or -not $shaIntel) { Stop-Leg 'SHA256SUMS carries no entry for one of the two .dmg assets' }
 
     $template = Join-Path $repoRoot 'packaging/homebrew/bdinfo-rs-gui.rb.template'


### PR DESCRIPTION
The same defect #143 fixed in the aur leg: a local \\\ hashtable overwrites the case-insensitive \\\ path parameter before Get-Content reads it. An AST-based scan (regex missed these — the param declarations span lines) found the two remaining instances; the other \\ = Resolve-Path \\-style assignments it surfaced read the parameter before replacing it and are benign.

Verified locally against the gui-v2.0.0 release: the homebrew leg renders the cask with the correct per-arch hashes (the ruby syntax check is runner-side), and the cloudsmith leg downloads and checksum-verifies all four Linux packages before stopping at the runner-only apt tooling.