### PR TITLE
fix(ci): package the gui crate with cargo package instead of publish --dry-run

### DIFF
--- a/.github/scripts/publish-gui-crates.ps1
+++ b/.github/scripts/publish-gui-crates.ps1
@@ -4,13 +4,17 @@
 # bytes were built from that same commit, and the attested release is what
 # admitted the tag into this workflow).
 #
-#   -Mode prepare  guard tag == crate version, then `cargo publish --dry-run
-#                  --locked`: packages the crate and verify-builds it against
-#                  the registry, which is also where the sequencing rule
+#   -Mode prepare  guard tag == crate version, then `cargo package --locked`:
+#                  packages the crate and verify-builds it against the
+#                  registry, which is also where the sequencing rule
 #                  bites — bdinfo-rs-gui depends on bdinfo-rs-core at the
 #                  same version, so this fails cleanly until the CLI
 #                  release's publish-crates.yml run has put that core version
 #                  on crates.io. The built .crate lands in -Payload.
+#                  `package`, not `publish --dry-run`: the latter stages the
+#                  .crate under target/package/tmp-crate/ and only a real
+#                  publish promotes it (observed with cargo 1.96), while
+#                  `package` finalizes target/package/<name>-<ver>.crate.
 #   -Mode publish  the same guard, then `cargo publish --locked`, tolerating
 #                  "already uploaded" as success — crates.io versions are
 #                  immutable, so that error IS the idempotent re-dispatch
@@ -65,7 +69,7 @@ Push-Location -LiteralPath $crate
 $code = 1
 try {
     if ($Mode -eq 'prepare') {
-        cargo publish --dry-run --locked -p bdinfo-rs-gui
+        cargo package --locked -p bdinfo-rs-gui
         $code = $LASTEXITCODE
     }
     else {


### PR DESCRIPTION
The crates prepare leg harvested the .crate from target/package/ after \cargo publish --dry-run\, but cargo 1.96 stages the package under target/package/tmp-crate/ and only promotes it on a real publish — the dry run succeeded and the harvest found nothing.

Switch prepare to \cargo package --locked\, which runs the same verify build and finalizes target/package/<name>-<version>.crate. Publish mode is unchanged. Verified locally from a gui-v2.0.0 worktree: the leg completes and stages bdinfo-rs-gui-2.0.0.crate.

Fourth prepare-only dispatch otherwise green: winget (bootstrap-pending recorded), homebrew, aur, and cloudsmith all validated.