### PR TITLE
style(packaging): add the sorbet sigil and frozen-string headers to the gui cask

### DIFF
--- a/packaging/homebrew/bdinfo-rs-gui.rb.template
+++ b/packaging/homebrew/bdinfo-rs-gui.rb.template
@@ -1,3 +1,6 @@
+# typed: strict
+# frozen_string_literal: true
+
 # Cask for the agentjp/homebrew-tap third-party tap. The `gui-publish.yml`
 # homebrew leg replaces __PKGVER__ / __SHA256_ARM__ / __SHA256_INTEL__ from the
 # release's verified SHA256SUMS and commits the result to the tap as


### PR DESCRIPTION
`brew style` flags the rendered cask with Style/FrozenStringLiteralComment, Sorbet/TrueSigil, and Sorbet/StrictSigil — three error-level annotations on every gui-publish homebrew prepare leg, despite the advisory posture. Add the two standard header magic comments to the template; `typed: strict` satisfies both sigil cops.