### PR TITLE
fix(packaging): keep the aur deploy from committing the downloaded .deb sources

### DIFF
--- a/packaging/aur/.gitignore
+++ b/packaging/aur/.gitignore
@@ -1,9 +1,10 @@
-# Shipped into the AUR repo (packages.yml `assets:`). The deploy action uses
-# `git add --all` when assets are set, which would otherwise commit makepkg's
-# working artifacts — the downloaded release tarballs and the test-built
-# package. The AUR forbids those (max blob 488 KiB; scripts only), so keep
-# them invisible to git.
+# Shipped into the AUR repo (packages.yml and gui-publish.yml `assets:`). The
+# deploy action uses `git add --all` when assets are set, which would otherwise
+# commit makepkg's working artifacts — the downloaded release sources (the
+# CLI's tarballs, the GUI's .debs) and the test-built package. The AUR forbids
+# those (max blob 488 KiB; scripts only), so keep them invisible to git.
 *.tar.gz
+*.deb
 *.pkg.tar.zst
 src/
 pkg/


### PR DESCRIPTION
The aur deploy action commits with `git add --all`, filtered only by the shipped `packaging/aur/.gitignore` — written for the CLI's tarball sources. The GUI package's sources are .deb files, so updpkgsums' downloads rode into the commit and aur.archlinux.org rejected the push (max blob 488 KiB). Ignore `*.deb` too; the rejection was server-side, so the AUR repo is untouched and the next push is a clean first commit.