### PR TITLE
ci: bump biome schema and wrangler pins

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -101,4 +101,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx --yes wrangler@4.112.0 pages deploy site --project-name=bdinfo-rs --branch=master
+        run: npx --yes wrangler@4.113.0 pages deploy site --project-name=bdinfo-rs --branch=master

--- a/crates/bdinfo-rs-wasm/web/biome.json
+++ b/crates/bdinfo-rs-wasm/web/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
Bumps the two stale pins reported by the daily version-freshness check:

- `crates/bdinfo-rs-wasm/web/biome.json`: schema URL 2.5.4 -> 2.5.5, matching the `@biomejs/biome` version resolved in `package-lock.json`.
- `.github/workflows/deploy-pages.yml`: `wrangler@4.112.0` -> `wrangler@4.113.0`.

The wrangler pin runs only on the Pages deploy, so it is not exercised by PR CI.

Closes #156