### PR TITLE
fix(bdrom): cap metadata reads and cut peak scan memory

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -2,7 +2,7 @@
 
 ## Why BDInfo
 
-BDInfo is mostly dead code. Blu-ray is a finished format and the spec is very unlikely to change
+Blu-ray is a finished format and the spec is very unlikely to change
 again. That made it a near-perfect target: a real, non-trivial, widely used tool with a frozen
 specification and a fixed, verifiable output — you can tell exactly when a port is correct.
 
@@ -36,7 +36,7 @@ straight back into the loop. Issues get handled.
 |---|---|
 | [`bdinfo-rs-core`](https://crates.io/crates/bdinfo-rs-core) | The analyzer: discovery, MPLS/CLPI/index, M2TS demux, 13 codec scanners, UDF 2.50, report renderer |
 | [`bdinfo-rs`](https://crates.io/crates/bdinfo-rs) | The command-line front-end |
-| `bdinfo-rs-gui` | The native desktop app (iced) |
+| [`bdinfo-rs-gui`](https://crates.io/crates/bdinfo-rs-gui) | The native desktop app (iced) |
 | [`@bdinfo-rs/wasm`](https://www.npmjs.com/package/@bdinfo-rs/wasm) | The same analyzer compiled to WebAssembly |
 
 The three front-ends are thin shells. All of the parsing, and the report itself, lives in the core

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ These update automatically through a package manager and uninstall cleanly:
 
 | OS | Command line | Desktop app |
 |---|---|---|
-| Windows | `winget install agentjp.bdinfo-rs` | `winget install agentjp.bdinfo-rs-gui` |
+| Windows | `winget install agentjp.bdinfo-rs` | `winget install agentjp.bdinfo-rs-gui` *(pending: [winget-pkgs#405038](https://github.com/microsoft/winget-pkgs/pull/405038))* |
 | macOS | `brew install agentjp/tap/bdinfo-rs` | `brew install --cask agentjp/tap/bdinfo-rs-gui` |
 | Debian / Ubuntu | [apt repository](#apt--dnf-repository-linux) | same repository, `bdinfo-rs-gui` |
 | Fedora / RHEL / openSUSE | [dnf repository](#apt--dnf-repository-linux) | same repository, `bdinfo-rs-gui` |
@@ -264,6 +264,12 @@ Release artifacts, per platform:
 
 ## WinGet (Windows)
 
+> [!WARNING]
+> Not available yet — the desktop app's WinGet package is in the community-repository review
+> queue ([winget-pkgs#405038](https://github.com/microsoft/winget-pkgs/pull/405038)). Until it
+> merges, `winget install agentjp.bdinfo-rs-gui` fails with *No package found*; install via the
+> [MSI installer](#msi-installer-windows) or [portable zip](#portable-zip-windows) below for now.
+
 ```powershell
 winget install agentjp.bdinfo-rs-gui
 ```
@@ -271,8 +277,8 @@ winget install agentjp.bdinfo-rs-gui
 - **Where it goes** — WinGet runs the MSI below silently, so everything in the next section
   applies: `%LOCALAPPDATA%\Programs\bdinfo-rs GUI\`, per-user, no administrator rights. A silent
   install never shows the license page and does not add the install directory to `PATH`.
-- **Updates** — `winget upgrade agentjp.bdinfo-rs-gui`.
-- **Uninstall** — `winget uninstall agentjp.bdinfo-rs-gui` (or Apps & features).
+- **Updates** — `winget upgrade agentjp.bdinfo-rs-gui` (once the package is published).
+- **Uninstall** — `winget uninstall agentjp.bdinfo-rs-gui` (once it is published), or Apps & features.
 
 ## MSI installer (Windows)
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,16 @@ progress, then save or copy the report. Pure Rust and GPU-accelerated (wgpu, wit
 fallback) — no webview and no bundled runtime.
 
 ```sh
-winget install agentjp.bdinfo-rs-gui              # Windows
+winget install agentjp.bdinfo-rs-gui              # Windows (pending — see note)
 brew install --cask agentjp/tap/bdinfo-rs-gui     # macOS / Linux
 yay -S bdinfo-rs-gui-bin                          # Arch
 ```
+
+> [!WARNING]
+> The desktop app's WinGet package is still in review
+> ([winget-pkgs#405038](https://github.com/microsoft/winget-pkgs/pull/405038)); until it merges,
+> `winget install agentjp.bdinfo-rs-gui` fails with *No package found*. Use the `.msi`, the
+> Homebrew cask, or the AUR meanwhile.
 
 | Windows | macOS | Linux |
 |---|---|---|

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -1850,6 +1850,11 @@ fn scan_one_stream_file(
     let cancel = progress.cancel;
     let mut reader = CountingReader { inner, name: file.name().to_ascii_uppercase(), progress };
     stream_file.scan_cancellable(&mut reader, playlists, is_full_scan, cancel)?;
+    // The scan's public outputs are now captured; free the demux scratch (its
+    // per-PID PES buffers) before the file is parked in the result map, so a
+    // multi-clip disc holds only the in-flight clip's buffers, not every scanned
+    // clip's at once. Pure reclaim — see `TsStreamFile::release_scratch`.
+    stream_file.release_scratch();
     Ok(stream_file)
 }
 

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -1966,11 +1966,44 @@ fn recover_backup<T>(
     Some(read_file(&**file).and_then(|bytes| parse(file.name(), &bytes)))
 }
 
+/// The most bytes [`read_file`] buffers for one metadata file.
+///
+/// The largest `*.mpls`/`*.clpi` an authored disc carries is well under a
+/// megabyte, so this never bites real media. It exists because a file's
+/// *declared* size is attacker-controlled and need not be backed by stored
+/// bytes at all: a UDF File Entry can claim an arbitrary `InformationLength`
+/// over not-recorded extents, which `vfs::udf` serves as zeros without reading
+/// the image. Without a cap a few-hundred-KB `.iso` can drive an unbounded
+/// allocation. `vfs::udf`'s own `max_dir_bytes` bounds the directory side of
+/// exactly this hazard, and matches this value.
+const MAX_METADATA_BYTES: u64 = 64 << 20;
+
 /// Reads a VFS file fully into a byte vector, mapping IO errors to [`BdError::Io`].
+///
+/// Capped at [`MAX_METADATA_BYTES`]; see [`read_file_capped`].
 fn read_file(file: &dyn BdFile) -> Result<Vec<u8>, BdError> {
-    let mut reader = file.open_read()?;
+    read_file_capped(file, MAX_METADATA_BYTES)
+}
+
+/// Reads a VFS file fully into a byte vector, refusing to buffer more than
+/// `cap` bytes.
+///
+/// The cap is a parameter only so the boundary cases can be tested against a
+/// handful of bytes instead of materializing [`MAX_METADATA_BYTES`]; production
+/// always goes through [`read_file`].
+///
+/// Reads one byte past `cap`, because that overshoot is what separates a file
+/// sitting exactly on the cap from one running past it — [`std::io::Take::limit`]
+/// reaching zero means the latter. Truncating instead would hand a silently
+/// clipped buffer to a parser, which would then report a misleading
+/// [`BdError::UnexpectedEof`].
+fn read_file_capped(file: &dyn BdFile, cap: u64) -> Result<Vec<u8>, BdError> {
+    let mut reader = file.open_read()?.take(cap.saturating_add(1));
     let mut bytes = Vec::new();
     reader.read_to_end(&mut bytes)?;
+    if reader.limit() == 0 {
+        return Err(BdError::MetadataTooLarge { file: file.name().to_owned(), limit: cap });
+    }
     Ok(bytes)
 }
 
@@ -1985,12 +2018,13 @@ mod tests {
     use proptest::prelude::{prop_assert, prop_assert_eq, proptest};
 
     use super::{
-        BdError, BdRom, ClipMeta, ClipSummary, MVC_PID, PlaylistFilter, PlaylistSummary, Progress,
-        ScanMode, ScanProgress, ScanStage, Sink, TsPlaylistFile, TsStreamFile, backup_subdir_files,
-        build_chapter_summaries, build_clip_summaries, build_sorted_streams, clear_measurements,
-        clip_has_50hz_video, clip_stem, collect_backups, merge_stream, rate_over, read_disc_title,
-        read_file, resolve_playlist_streams, scan_stream_files, scan_total, select_reference,
-        stream_summary, walked_disc_root,
+        BdError, BdRom, ClipMeta, ClipSummary, MAX_METADATA_BYTES, MVC_PID, PlaylistFilter,
+        PlaylistSummary, Progress, ScanMode, ScanProgress, ScanStage, Sink, TsPlaylistFile,
+        TsStreamFile, backup_subdir_files, build_chapter_summaries, build_clip_summaries,
+        build_sorted_streams, clear_measurements, clip_has_50hz_video, clip_stem, collect_backups,
+        merge_stream, rate_over, read_disc_title, read_file, read_file_capped,
+        resolve_playlist_streams, scan_stream_files, scan_total, select_reference, stream_summary,
+        walked_disc_root,
     };
     use crate::bdrom::clpi::TsStreamClip;
     use crate::bdrom::interleaved::{MemBdFile, TsInterleavedFile};
@@ -4632,6 +4666,119 @@ mod tests {
         // Exercise the failing reader's seek.
         let mut reader = unreadable.open_read().expect("open");
         assert_eq!(reader.seek(SeekFrom::Start(0)).expect("seek"), 0);
+    }
+
+    /// A reader that never reaches EOF — the in-process analogue of a `.iso`
+    /// file entry whose not-recorded extents serve unlimited zeros without the
+    /// image storing them.
+    struct EndlessReader;
+
+    impl Read for EndlessReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            buf.fill(0);
+            Ok(buf.len())
+        }
+    }
+
+    impl Seek for EndlessReader {
+        fn seek(&mut self, _: SeekFrom) -> io::Result<u64> {
+            Ok(0)
+        }
+    }
+
+    /// A file that claims `len` bytes and yields them forever.
+    struct EndlessFile {
+        name: String,
+        extension: String,
+        len: u64,
+    }
+
+    impl BdFile for EndlessFile {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn full_name(&self) -> &str {
+            &self.name
+        }
+
+        fn extension(&self) -> &str {
+            &self.extension
+        }
+
+        fn length(&self) -> u64 {
+            self.len
+        }
+
+        fn is_dir(&self) -> bool {
+            false
+        }
+
+        fn open_read(&self) -> io::Result<Box<dyn ReadSeek>> {
+            Ok(Box::new(EndlessReader))
+        }
+
+        fn open_text(&self) -> io::Result<Box<dyn BufRead>> {
+            Ok(Box::new(BufReader::new(EndlessReader)))
+        }
+    }
+
+    #[test]
+    fn read_file_capped_accepts_a_file_sitting_exactly_on_the_cap() {
+        let file = MockFile {
+            name: "00000.MPLS".to_owned(),
+            extension: ".mpls".to_owned(),
+            bytes: vec![7; 8],
+            trip: Trip::new(usize::MAX),
+            fail_read: false,
+        };
+        // Exactly `cap` bytes is legal — only the byte *past* the cap is not.
+        assert_eq!(read_file_capped(&file, 8).expect("at the cap"), vec![7; 8]);
+    }
+
+    #[test]
+    fn read_file_capped_rejects_a_file_one_byte_over_the_cap() {
+        let file = MockFile {
+            name: "00000.MPLS".to_owned(),
+            extension: ".mpls".to_owned(),
+            bytes: vec![7; 9],
+            trip: Trip::new(usize::MAX),
+            fail_read: false,
+        };
+        let err = read_file_capped(&file, 8).expect_err("one byte over the cap");
+        assert!(matches!(
+            err,
+            BdError::MetadataTooLarge { ref file, limit: 8 } if file == "00000.MPLS"
+        ));
+    }
+
+    #[test]
+    fn read_file_caps_an_endless_reader_instead_of_buffering_it_forever() {
+        // A hostile `.iso` can declare any InformationLength over not-recorded
+        // extents, which the UDF reader serves as zeros without the image
+        // holding a byte of them; before the cap this read_to_end grew until
+        // the allocator gave up. The declared length is deliberately absurd to
+        // pin that the guard is the read cap, not a trusted size field.
+        let file = EndlessFile {
+            name: "00000.MPLS".to_owned(),
+            extension: ".mpls".to_owned(),
+            len: u64::MAX,
+        };
+        let err = read_file(&file).expect_err("an endless file is refused");
+        assert!(matches!(
+            err,
+            BdError::MetadataTooLarge { limit, .. } if limit == MAX_METADATA_BYTES
+        ));
+        // The mock's remaining trait surface, so the mock itself stays covered.
+        assert_eq!(file.name(), "00000.MPLS");
+        assert_eq!(file.full_name(), "00000.MPLS");
+        assert_eq!(file.extension(), ".mpls");
+        assert_eq!(file.length(), u64::MAX);
+        assert!(!file.is_dir());
+        let mut one = [0xAA_u8; 1];
+        file.open_text().expect("open_text").read_exact(&mut one).expect("read");
+        assert_eq!(one, [0]);
+        assert_eq!(file.open_read().expect("open_read").seek(SeekFrom::End(0)).expect("seek"), 0);
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -614,7 +614,7 @@ impl TsStreamFile {
             let mut read_result: Result<(), BdError> = Ok(());
             let this = &mut *self;
             let (full_tx, full_rx) = mpsc::sync_channel::<Vec<u8>>(1);
-            let (free_tx, free_rx) = mpsc::sync_channel::<Vec<u8>>(3);
+            let (free_tx, free_rx) = mpsc::sync_channel::<Vec<u8>>(2);
             thread::scope(|scope| {
                 let read_failed = &read_failed;
                 let finished_early = &finished_early;
@@ -642,10 +642,13 @@ impl TsStreamFile {
                     }
                     this.finish_scan(&mut relevant);
                 });
-                // Three fresh buffers prime the pipeline; afterwards each iteration
-                // blocks on a recycled one (a closed channel means the worker
-                // finished early — stop reading).
-                let mut fresh: u8 = 3;
+                // Two fresh buffers prime the pipeline — one in flight to the
+                // parser, one being filled — which double-buffers the read against
+                // the parse; afterwards each iteration blocks on a recycled one (a
+                // closed channel means the worker finished early — stop reading).
+                // The parse is the bottleneck (the reader outruns it on any disk),
+                // so a deeper read-ahead only holds more idle buffers, not speed.
+                let mut fresh: u8 = 2;
                 loop {
                     let mut buffer = if fresh > 0 {
                         fresh = fresh.wrapping_sub(1);

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -428,6 +428,22 @@ impl TsStreamFile {
         }
     }
 
+    /// Releases the per-PID demux scratch ([`stream_states`](Self::stream_states))
+    /// once a completed scan's public outputs (`streams`, `stream_order`,
+    /// `stream_diagnostics`, `size`, `length`) have been captured.
+    ///
+    /// Pure memory reclaim with no effect on any output: `stream_states` is
+    /// private scratch the demux fills while parsing — including the per-PID PES
+    /// reassembly buffers, which reach the 5 MiB PES clamp
+    /// ([`TsStreamBuffer`]'s `BUFFER_SIZE`) for video — and nothing reads it once
+    /// the scan returns. Each scanned clip is otherwise retained (in both
+    /// measurement passes) in the disc scan's result map with this scratch alive,
+    /// so a multi-clip disc holds every clip's buffers at once at peak. The demux
+    /// unit tests inspect `stream_states` after a scan and so must not call this.
+    pub(crate) fn release_scratch(&mut self) {
+        self.stream_states = BTreeMap::new();
+    }
+
     /// The name shown for this clip — the interleaved `*.ssif`
     /// [`name`](TsInterleavedFile::name) when present and SSIF reading is enabled,
     /// else the `*.m2ts` [`name`](Self::name).
@@ -2126,6 +2142,32 @@ mod tests {
         assert_eq!(st.transfer_count, 3);
         assert_eq!(st.peak_transfer_length, 100);
         assert_eq!(st.peak_transfer_rate, 0); // video: no audio peak rate
+    }
+
+    #[test]
+    fn release_scratch_frees_the_demux_state_and_keeps_the_public_outputs() {
+        // release_scratch drops the private per-PID scratch (its PES buffers)
+        // once the scan is done — the disc scan calls it before parking the
+        // clip in its result map. Its effect is invisible to the report, so it
+        // is pinned directly here: the scratch goes empty while the public
+        // outputs the disc scan reads afterwards (`streams`, `stream_order`,
+        // `stream_diagnostics`, `size`, `length`) are untouched.
+        let mut file = TsStreamFile::new("00000.m2ts");
+        file.stream_states.entry(0x1011).or_default();
+        file.stream_states.entry(0x1100).or_default();
+        file.stream_order.push(0x1011);
+        file.stream_diagnostics.insert(0x1011, Vec::new());
+        file.size = 4096;
+        file.length = 2.5;
+        assert!(!file.stream_states.is_empty(), "the scan populated the scratch");
+
+        file.release_scratch();
+
+        assert!(file.stream_states.is_empty(), "the scratch is freed");
+        assert_eq!(file.stream_order, vec![0x1011], "stream order retained");
+        assert!(file.stream_diagnostics.contains_key(&0x1011), "diagnostics retained");
+        assert_eq!(file.size, 4096, "size retained");
+        assert_eq!(file.length.to_bits(), 2.5_f64.to_bits(), "length retained");
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/error.rs
+++ b/crates/bdinfo-rs-core/src/error.rs
@@ -48,6 +48,20 @@ pub enum BdError {
     /// them.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+    /// A metadata file (`index.bdmv`, `*.mpls`, `*.clpi`, `bdmt_*.xml`) is larger
+    /// than the parsers are willing to buffer whole. Authored BDMV metadata is
+    /// kilobytes, so this only fires on malformed or hostile input — notably a
+    /// UDF File Entry may declare any `InformationLength` over *not-recorded*
+    /// extents, which the reader serves as zeros without the `.iso` storing a
+    /// single corresponding byte, so a file's declared size is no evidence that
+    /// its data exists. Carries the file's name and the cap it exceeded.
+    #[error("metadata file too large: {file} exceeds {limit} bytes")]
+    MetadataTooLarge {
+        /// The file, as named on the disc.
+        file: String,
+        /// The cap, in bytes.
+        limit: u64,
+    },
     /// The packet scan was cancelled through the caller's cooperative cancel
     /// flag (the `cancel` parameter of `BdRom::open_with` /
     /// `BdRom::open_resilient_with`) — the caller's abort, not a disc failure.
@@ -139,6 +153,11 @@ mod tests {
         );
         let io = BdError::Io(io::Error::new(io::ErrorKind::PermissionDenied, "denied"));
         assert_eq!(io.to_string(), "io error: denied");
+        assert_eq!(
+            BdError::MetadataTooLarge { file: "00000.MPLS".to_owned(), limit: 67_108_864 }
+                .to_string(),
+            "metadata file too large: 00000.MPLS exceeds 67108864 bytes"
+        );
         assert_eq!(BdError::ScanCancelled.to_string(), "scan cancelled");
     }
 
@@ -155,7 +174,7 @@ mod tests {
     fn only_the_io_variant_exposes_an_underlying_cause() {
         // The wrapped IO error is reachable as the error's `source` (the chain the
         // stringifying predecessor discarded); every other variant has no source.
-        // Exercising `source` on all five covers each arm thiserror generates.
+        // Exercising `source` on all six covers each arm thiserror generates.
         let io = BdError::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "short"));
         assert_eq!(io.source().expect("Io carries a source").to_string(), "short");
         for sourceless in [
@@ -163,6 +182,7 @@ mod tests {
             BdError::UnexpectedEof,
             BdError::StructureNotFound,
             BdError::MissingClipFile("00000.CLPI".to_owned()),
+            BdError::MetadataTooLarge { file: "00000.MPLS".to_owned(), limit: 1 },
             BdError::ScanCancelled,
         ] {
             assert!(sourceless.source().is_none());

--- a/crates/bdinfo-rs-core/src/vfs/udf/source.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/source.rs
@@ -2116,6 +2116,59 @@ mod tests {
         assert!(UdfSource::read_label(&*factory).is_err());
     }
 
+    /// The largest length a 30-bit `short_ad` extent can encode (~1 GiB).
+    const MAX_EXTENT: u32 = 0x3FFF_FFFF;
+
+    /// A tiny `.iso` whose `00000.MPLS` declares `extents` × [`MAX_EXTENT`]
+    /// bytes of *not-recorded* (zero-filled, no backing bytes) data.
+    fn sparse_overdeclared_iso(extents: u32) -> Vec<u8> {
+        let mut iso = Iso::new(300);
+        iso.write(256, &avdp(257, 2 * SS as u32));
+        iso.write(257, &pd(0, 260, 50));
+        iso.write(258, &lvd("HOSTILE", SS as u32, 1, 0, &phys_map(0), 1));
+        iso.write(261, &fsd(0, 2));
+        let root_fids = dir_data(&[fid(0x0A, "", 2, 0), fid(0x00, "00000.MPLS", 6, 0)]);
+        let root_len = root_fids.len() as u64;
+        iso.write(262, &fe(261, 4, 0, root_len, &sad(0, root_len as u32, 3)));
+        iso.write(263, &root_fids);
+        // The payload: N not-recorded extents, each the maximum 30-bit length,
+        // and an InformationLength covering them all. None of it is backed by a
+        // single byte of the image.
+        let mut ads = Vec::new();
+        for _ in 0..extents {
+            ads.extend_from_slice(&sad(1, MAX_EXTENT, 99));
+        }
+        let info_len = u64::from(MAX_EXTENT) * u64::from(extents);
+        iso.write(266, &fe(261, 5, 0, info_len, &ads));
+        iso.into_bytes()
+    }
+
+    #[test]
+    fn not_recorded_extents_serve_their_declared_length_without_backing_bytes() {
+        // The amplification primitive `bdrom::disc`'s metadata read cap exists to
+        // bound: a ~600 KB image hands out a 2 GiB file whose bytes are stored
+        // nowhere, so a declared size is no evidence the data exists. Only a
+        // short prefix is read here — materialising the whole declared length is
+        // exactly what the cap prevents.
+        let image = sparse_overdeclared_iso(2);
+        let image_len = u64::try_from(image.len()).expect("image size fits");
+        let src = UdfSource::open(MemIso::boxed(image)).expect("open");
+        let files = src.root().get_files().expect("get_files");
+        let target = files
+            .iter()
+            .find(|f| f.name().eq_ignore_ascii_case("00000.MPLS"))
+            .expect("the over-declared file is listed");
+        let declared = u64::from(MAX_EXTENT).saturating_mul(2);
+        assert_eq!(target.length(), declared);
+        assert!(
+            declared > image_len.saturating_mul(3000),
+            "amplification is unbounded by image size"
+        );
+        let mut prefix = vec![0xAA_u8; 4096];
+        target.open_read().expect("open_read").read_exact(&mut prefix).expect("read prefix");
+        assert!(prefix.iter().all(|&b| b == 0), "not-recorded extents read as zeros");
+    }
+
     #[test]
     fn read_label_propagates_an_open_failure() {
         // The factory itself fails to open → the IO error surfaces.


### PR DESCRIPTION
## Summary

Core scan-memory work, plus the docs that ship alongside it. Output is byte-identical throughout — the folder/BDMV goldens pass and a real UHD report is SHA256-unchanged before and after each code change.

- **fix(bdrom): cap metadata file reads at 64 MiB.** `read_file` buffered `index.bdmv`, `*.mpls`, `*.clpi`, and `bdmt_*.xml` with an uncapped `read_to_end`. A UDF File Entry can declare an arbitrary `InformationLength` over not-recorded extents, which the reader serves as zeros without the `.iso` storing a byte — so a few-hundred-KB image could drive an effectively unbounded allocation, an allocator abort that also escaped resilient-scan isolation. Reads now stop one byte past the cap and fail with `BdError::MetadataTooLarge`.
- **perf(bdrom): free per-clip demux scratch after each file scan.** Releases the per-PID PES buffers once a clip's public outputs are captured, so a multi-clip disc holds only the in-flight clip's scratch. Whole-disc peak RSS 57 → 43 MiB (−24%).
- **perf(m2ts): prime the read-ahead pipeline with two buffers, not three.** The parse is the bottleneck, so a third prime buffer only sat idle. Whole-disc peak RSS 43 → 38 MiB; single 51 GiB feature 41 → 36 MiB; wall time unchanged.
- **docs:** flag the GUI's pending WinGet package (microsoft/winget-pkgs#405038) across README/INSTALL, link `bdinfo-rs-gui` on the About page, and drop a stale line.

## Versioning

Ships as **2.0.1** (patch): the one `fix` bumps patch; the `perf`/`docs` commits do not. The new `BdError::MetadataTooLarge` variant is non-breaking — `BdError` is `#[non_exhaustive]`. `cargo semver-checks` vs `v2.0.0`: 223 pass, no update required.
