### PR TITLE
ci: re-pin setup-homebrew to current master head

### DIFF
--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -55,7 +55,7 @@ jobs:
       # nags (files an issue) when Homebrew master moves past this SHA, and the bump
       # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
       # releases, and this repo has none).
-      - uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@15d0b666bf0311bfe676c178e0824dc1b52074a7 # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its
@@ -118,7 +118,7 @@ jobs:
     steps:
       # A SHA-frozen Homebrew/actions pin — the full rationale sits on the
       # homebrew job's identical line above.
-      - uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@15d0b666bf0311bfe676c178e0824dc1b52074a7 # zizmor: ignore[ref-version-mismatch]
 
       # The same tap-trust story as the homebrew job above, for its reasons.
       - name: Trust the taps (ours + the runner's pre-tapped ones)


### PR DESCRIPTION
Bumps the two `Homebrew/actions/setup-homebrew` pins in install-smoke-test.yml from df4b0910 to 15d0b666 (Homebrew/actions master HEAD). The intervening commits touch only that repo's own workflows and other actions; nothing under setup-homebrew/ changed.

Closes #172