### PR TITLE
ci: refresh biome schema and wrangler pins

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -101,4 +101,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx --yes wrangler@4.114.0 pages deploy site --project-name=bdinfo-rs --branch=master
+        run: npx --yes wrangler@4.115.0 pages deploy site --project-name=bdinfo-rs --branch=master

--- a/crates/bdinfo-rs-wasm/web/biome.json
+++ b/crates/bdinfo-rs-wasm/web/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
Bumps the biome.json schema URL to 2.5.6 to match the installed @biomejs/biome, and the wrangler pin in deploy-pages.yml to 4.115.0.

Closes #187