### PR TITLE
docs(test): point the tsMuxeR attribution link at the upstream repository

### DIFF
--- a/crates/bdinfo-rs/tests/fixtures/README.md
+++ b/crates/bdinfo-rs/tests/fixtures/README.md
@@ -26,11 +26,11 @@ The audio/video content is **_Big Buck Bunny_ © 2008 Blender Foundation**
 A ~30-second clip (`00000.MPLS`, `00:00:30.113`) was re-encoded to a Blu-ray-compliant
 H.264 1080p video track and a 48 kHz/16-bit stereo **LPCM** audio track (the only freely
 redistributable Blu-ray audio — AC-3/DTS are patent-encumbered), then muxed into the
-BD-ROM structures above with [tsMuxeR](https://tsmuxer.com/). The visual content is
-irrelevant to the test; only the disc structure and stream metadata are exercised. The
-length is deliberate: it clears the default 20-second playlist filter, so the table-driven
-presentation path (`--list` / `--whole` / the picker) is exercised end-to-end, not just the
-`-m 00000` direct selection.
+BD-ROM structures above with [tsMuxeR](https://github.com/justdan96/tsMuxer). The visual
+content is irrelevant to the test; only the disc structure and stream metadata are
+exercised. The length is deliberate: it clears the default 20-second playlist filter, so
+the table-driven presentation path (`--list` / `--whole` / the picker) is exercised
+end-to-end, not just the `-m 00000` direct selection.
 
 ## Regenerating
 


### PR DESCRIPTION
tsmuxer.com stopped resolving to a live origin (Cloudflare 521 across all paths) between the 2026-07-27 and 2026-07-28 sweeps, turning the Check links gate red. The site is a third-party redistributor, not the project itself; the upstream repository is the accurate attribution target and stays reachable while archived.

Refs #184