### PR TITLE
ci(gate): classify the diff by causal reachability

### DIFF
--- a/.github/scripts/classify-diff.ps1
+++ b/.github/scripts/classify-diff.ps1
@@ -1,0 +1,546 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Map changed paths to the CI areas that gate the workflow's jobs.
+
+.DESCRIPTION
+    One rule governs every entry in $Rules below: a job runs if and only if the
+    diff could change that job's verdict. A rule therefore asks what KIND of
+    input a file is (Rust source, manifest, lockfile, YAML, TOML, disc bytes,
+    icon, prose) before it asks which directory holds it — classifying by
+    directory alone treats a README beside a source file as if it were source.
+
+    Every rule carries a Why: the mechanism by which the file reaches the jobs
+    its areas gate. A rule whose Why cannot be stated as a mechanism does not
+    belong here.
+
+    Areas and the jobs they gate:
+
+      core       build + test, lint, coverage, mutants, install + scan, musl scan
+      gui        the gui reusable workflow and its mutation job
+      wasm       the wasm reusable workflow and its mutation job
+      fuzz       corpus replay
+      deps       cargo deny, cargo vet
+      yaml       action-validator + ryl
+      workflows  zizmor
+      canary     build + test on one leg per shell family
+      dist       dist generate --check
+      pkg        .deb/.rpm build + install
+      toml       taplo
+      links      lychee
+      typos      typos
+
+    A rule with an empty Areas list is a deliberate declaration that no job on
+    the pull-request path reads the file. -SelfTest requires every tracked path
+    to match at least one Structural rule, so a file added without a rule fails
+    the gate rather than silently gating nothing.
+
+.PARAMETER Path
+    Paths to classify, relative to the repository root, forward-slash
+    separated. Read from standard input when omitted.
+
+.PARAMETER All
+    Emit every area. The caller's fail-safe for a diff it could not compute.
+
+.PARAMETER SelfTest
+    Assert the golden cases in $GoldenCases and that every tracked path matches
+    a Structural rule, then exit. Classifies nothing.
+
+.EXAMPLE
+    git diff --name-only HEAD^1 HEAD | ./.github/scripts/classify-diff.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromPipeline)]
+    [string[]] $Path,
+
+    [switch] $All,
+
+    [switch] $SelfTest
+)
+
+begin {
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    $script:Inputs = [System.Collections.Generic.List[string]]::new()
+
+    # Every area this script can emit. The workflow reads each as a job output,
+    # so adding one here without adding the matching `if:` gates nothing.
+    $script:AllAreas = @(
+        'core', 'gui', 'wasm', 'fuzz', 'deps', 'yaml', 'workflows',
+        'canary', 'dist', 'pkg', 'toml', 'links', 'typos'
+    )
+
+    # The four crates that link bdinfo-rs-core by path (bdinfo-rs, the two
+    # sibling workspaces, and the fuzz targets) rebuild when its sources change.
+    # bdinfo-rs itself is a leaf: nothing depends on the CLI crate, so its
+    # sources reach `core` alone.
+    $script:CoreDependents = @('core', 'gui', 'wasm', 'fuzz')
+
+    function Test-Match {
+        param([string] $File, [string[]] $Patterns)
+
+        foreach ($p in $Patterns) {
+            if ($File -like $p) { return $true }
+        }
+        return $false
+    }
+
+    # Prose carries no build input: no source file includes a Markdown file,
+    # rustdoc does not read one, and `cargo package` requires only that the
+    # readme named in a manifest exists. Prose under a crate directory is
+    # therefore prose, not that crate's source.
+    function Test-Prose {
+        param([string] $File)
+
+        return (Test-Match $File @('*.md', 'LICENSE', '*/LICENSE', 'NOTICE'))
+    }
+
+    # Opaque bytes: no URL for lychee to resolve and no word for typos to spell.
+    # Mirrors the `binary` attributes in .gitattributes.
+    function Test-Binary {
+        param([string] $File)
+
+        return (Test-Match $File @(
+                '*.iso', '*.m2ts', '*.clpi', '*.mpls', '*.bdmv',
+                '*.png', '*.ico', '*.icns', '*.jpg', '*.jpeg', '*.gif', '*.webp',
+                '*.exe', '*.pdb',
+                'fuzz/corpus/*'
+            ))
+    }
+
+    # ------------------------------------------------------------------ rules
+    # Ordered only for readability; every matching rule contributes its areas.
+    # Structural = $false marks the two whole-tree scanners, whose own configs
+    # decide what they read — they can match any file and so cannot serve as
+    # evidence that a path was deliberately classified.
+    $script:Rules = @(
+        @{
+            Name       = 'core and CLI sources'
+            Areas      = $script:CoreDependents
+            Structural = $true
+            Why        = 'bdinfo-rs-core is a path dependency of bdinfo-rs, both sibling workspaces and the fuzz targets, so its sources rebuild all four.'
+            Match      = { param($f) (Test-Match $f @('crates/bdinfo-rs-core/*')) -and -not (Test-Prose $f) }
+        },
+        @{
+            Name       = 'CLI sources and fixtures'
+            Areas      = @('core')
+            Structural = $true
+            Why        = 'The bdinfo-rs binary crate is a leaf. Its sources, the committed disc fixtures and the golden reports feed build + test, coverage and the install + scan jobs; no other crate links it.'
+            Match      = { param($f) (Test-Match $f @('crates/bdinfo-rs/*')) -and -not (Test-Prose $f) }
+        },
+        @{
+            Name       = 'debian packaging inputs'
+            Areas      = @('pkg')
+            Structural = $true
+            Why        = 'build-linux-packages.sh reads this tree to assemble the .deb.'
+            Match      = { param($f) Test-Match $f @('crates/bdinfo-rs/debian/*') }
+        },
+        @{
+            Name       = 'gui crate'
+            Areas      = @('gui')
+            Structural = $true
+            Why        = 'Sources, the generated icon set the packaging step consumes, and the crate manifest all feed the gui workflow.'
+            Match      = { param($f) (Test-Match $f @('crates/bdinfo-rs-gui/*')) -and -not (Test-Prose $f) }
+        },
+        @{
+            Name       = 'wasm crate'
+            Areas      = @('wasm')
+            Structural = $true
+            Why        = 'Sources, the web assets and the parity golden all feed the wasm workflow.'
+            Match      = { param($f) (Test-Match $f @('crates/bdinfo-rs-wasm/*')) -and -not (Test-Prose $f) }
+        },
+        @{
+            Name       = 'fuzz workspace'
+            Areas      = @('fuzz')
+            Structural = $true
+            Why        = 'Targets, the seed corpus and fuzz/Cargo.lock are exactly what the replay job builds and feeds.'
+            Match      = { param($f) (Test-Match $f @('fuzz/*')) -and -not (Test-Prose $f) }
+        },
+        @{
+            Name       = 'root workspace manifest'
+            Areas      = $script:CoreDependents + @('deps', 'dist', 'toml')
+            Structural = $true
+            Why        = 'bdinfo-rs-core inherits version, edition, rust-version, license and authors from [workspace.package], so the manifest reaches every crate that links it; dist derives the release workflow from it.'
+            Match      = { param($f) $f -eq 'Cargo.toml' }
+        },
+        @{
+            Name       = 'root lockfile'
+            Areas      = @('core', 'deps', 'pkg')
+            Structural = $true
+            Why        = 'Resolves the root workspace only: crates/bdinfo-rs-gui, crates/bdinfo-rs-wasm and fuzz each carry their own Cargo.lock and never read this one.'
+            Match      = { param($f) $f -eq 'Cargo.lock' }
+        },
+        @{
+            Name       = 'toolchain and formatting configuration'
+            Areas      = $script:CoreDependents + @('toml')
+            Structural = $true
+            Why        = 'rust-toolchain.toml pins the compiler for every workspace in the tree; rustfmt reads the nearest rustfmt.toml walking up from each file, so the root file governs the sibling crates too.'
+            Match      = { param($f) Test-Match $f @('rust-toolchain.toml', 'rustfmt.toml') }
+        },
+        @{
+            Name       = 'root clippy configuration'
+            Areas      = $script:CoreDependents + @('toml')
+            Structural = $true
+            Why        = 'crates/bdinfo-rs-gui carries its own clippy.toml but crates/bdinfo-rs-wasm does not; rather than depend on clippy resolving a configuration across workspace roots, this fires every lint that could read it.'
+            Match      = { param($f) $f -eq 'clippy.toml' }
+        },
+        @{
+            Name       = 'cargo configuration'
+            Areas      = $script:CoreDependents + @('toml')
+            Structural = $true
+            Why        = 'Cargo merges configuration from every ancestor directory of the invocation, so the root aliases and build settings apply inside the sibling workspaces as well.'
+            Match      = { param($f) $f -eq '.cargo/config.toml' }
+        },
+        @{
+            Name       = 'root mutation and test-runner configuration'
+            Areas      = @('core', 'toml')
+            Structural = $true
+            Why        = 'cargo-mutants and nextest each read the configuration under the workspace root they are invoked in; the sibling workspaces carry their own .cargo/mutants.toml and neither reads these.'
+            Match      = { param($f) Test-Match $f @('.cargo/mutants.toml', '.config/nextest.toml') }
+        },
+        @{
+            Name       = 'spell-check configuration'
+            Areas      = @('typos', 'toml')
+            Structural = $true
+            Why        = 'The allow-list and exclusions decide the typos verdict and nothing else.'
+            Match      = { param($f) $f -eq 'typos.toml' }
+        },
+        @{
+            Name       = 'dependency ban policy'
+            Areas      = @('deps', 'toml')
+            Structural = $true
+            Why        = 'The cargo-deny policy for bans, licences and sources.'
+            Match      = { param($f) Test-Match $f @('deny.toml', 'crates/*/deny.toml') }
+        },
+        @{
+            Name       = 'vet audit store'
+            Areas      = @('deps')
+            Structural = $true
+            Why        = 'The cargo-vet audits, imports and configuration. Written by cargo-vet and excluded from taplo, so a change here reaches no formatter.'
+            Match      = { param($f) Test-Match $f @('supply-chain/*') }
+        },
+        @{
+            Name       = 'release layout'
+            Areas      = @('dist', 'pkg', 'toml')
+            Structural = $true
+            Why        = 'dist generate --check regenerates the release workflow from dist-workspace.toml, and the Linux package build reads its target list.'
+            Match      = { param($f) $f -eq 'dist-workspace.toml' }
+        },
+        @{
+            Name       = 'orchestrator workflow'
+            Areas      = @('yaml', 'workflows', 'canary')
+            Structural = $true
+            Why        = 'Editing the file that defines the checkout, cache and tool-install steps must exercise them; one leg per shell family is enough to do that.'
+            Match      = { param($f) $f -eq '.github/workflows/ci.yml' }
+        },
+        @{
+            Name       = 'gui reusable workflow'
+            Areas      = @('yaml', 'workflows', 'gui')
+            Structural = $true
+            Why        = 'The file is the gui gate: an edit to it, including a pinned action digest, changes what those jobs do.'
+            Match      = { param($f) $f -eq '.github/workflows/gui.yml' }
+        },
+        @{
+            Name       = 'wasm reusable workflow'
+            Areas      = @('yaml', 'workflows', 'wasm')
+            Structural = $true
+            Why        = 'The file is the wasm gate; see the gui reusable workflow.'
+            Match      = { param($f) $f -eq '.github/workflows/wasm.yml' }
+        },
+        @{
+            Name       = 'generated release workflow'
+            Areas      = @('yaml', 'workflows', 'dist')
+            Structural = $true
+            Why        = 'cargo-dist generates this file; an edit that dist would not regenerate byte-for-byte fails dist generate --check.'
+            Match      = { param($f) $f -eq '.github/workflows/v-release.yml' }
+        },
+        @{
+            Name       = 'dist build setup'
+            Areas      = @('yaml', 'dist')
+            Structural = $true
+            Why        = 'cargo-dist splices this file into the generated release workflow.'
+            Match      = { param($f) $f -eq '.github/build-setup.yml' }
+        },
+        @{
+            Name       = 'remaining workflows'
+            Areas      = @('yaml', 'workflows')
+            Structural = $true
+            Why        = 'zizmor audits every file under .github/workflows and action-validator schema-checks it. Workflows the orchestrator never calls are verified by their own dispatch or tag run, not by re-running an unrelated gate.'
+            Match      = { param($f) Test-Match $f @('.github/workflows/*') }
+        },
+        @{
+            Name       = 'zizmor configuration'
+            Areas      = @('yaml', 'workflows')
+            Structural = $true
+            Why        = 'The suppression list decides the zizmor verdict.'
+            Match      = { param($f) $f -eq '.github/zizmor.yml' }
+        },
+        @{
+            Name       = 'source rule script'
+            Areas      = @('core')
+            Structural = $true
+            Why        = 'The lint job runs it over the root workspace sources.'
+            Match      = { param($f) $f -eq '.github/scripts/source-rules.ps1' }
+        },
+        @{
+            Name       = 'gui gate scripts'
+            Areas      = @('gui')
+            Structural = $true
+            Why        = 'The gui workflow runs these directly. The publishing helpers are named publish-gui-* so that this pattern cannot reach them.'
+            Match      = { param($f) (Test-Match $f @('.github/scripts/gui-*.ps1')) }
+        },
+        @{
+            Name       = 'linux package script'
+            Areas      = @('pkg')
+            Structural = $true
+            Why        = 'The .deb/.rpm job runs it.'
+            Match      = { param($f) $f -eq '.github/build-linux-packages.sh' }
+        },
+        @{
+            Name       = 'checkout byte fidelity'
+            Areas      = $script:CoreDependents
+            Structural = $true
+            Why        = 'The attributes decide the bytes every job checks out: eol=lf keeps rustfmt --check green, `binary` keeps the fuzz corpus and disc fixtures from line-ending rewriting, and -text preserves the CRLF the golden reports are compared against.'
+            Match      = { param($f) $f -eq '.gitattributes' }
+        },
+        @{
+            Name       = 'link-check exclusions'
+            Areas      = @('links')
+            Structural = $true
+            Why        = 'The ignore list decides the lychee verdict.'
+            Match      = { param($f) $f -eq '.lycheeignore' }
+        },
+        @{
+            Name       = 'remaining YAML'
+            Areas      = @('yaml')
+            Structural = $true
+            Why        = 'ryl lints every tracked YAML file in the repository, not only the workflows.'
+            Match      = { param($f) Test-Match $f @('*.yml', '*.yaml') }
+        },
+        @{
+            Name       = 'remaining TOML'
+            Areas      = @('toml')
+            Structural = $true
+            Why        = 'taplo formats and lints every *.toml outside the trees its own exclude list names.'
+            Match      = {
+                param($f)
+                if (-not (Test-Match $f @('*.toml'))) { return $false }
+                return -not (Test-Match $f @('supply-chain/*', 'target/*', 'scratch/*'))
+            }
+        },
+        @{
+            Name       = 'crate manifests'
+            Areas      = @('deps')
+            Structural = $true
+            Why        = 'cargo-deny resolves bans, licences and sources from the manifests.'
+            Match      = { param($f) Test-Match $f @('*/Cargo.toml') }
+        },
+        @{
+            Name       = 'prose'
+            Areas      = @()
+            Structural = $true
+            Why        = 'Reaches lychee and typos through the whole-tree rules below and no other job: nothing includes, compiles or parses it.'
+            Match      = { param($f) Test-Prose $f }
+        },
+        @{
+            Name       = 'publishing helpers'
+            Areas      = @()
+            Structural = $true
+            Why        = 'Run only by the tag and dispatch publishing lanes, which the orchestrator never calls; their dry runs verify them.'
+            Match      = { param($f) Test-Match $f @('.github/scripts/publish-*.ps1') }
+        },
+        @{
+            Name       = 'banned-word and classifier scripts'
+            Areas      = @()
+            Structural = $true
+            Why        = 'Both run unconditionally on every pull request — the banned-word check from a workflow this classifier does not gate, and this script from the job that calls it — so neither needs an area to be verified.'
+            Match      = { param($f) Test-Match $f @('.github/scripts/check-banned-words.ps1', '.github/scripts/classify-diff.ps1') }
+        },
+        @{
+            Name       = 'packaging templates'
+            Areas      = @()
+            Structural = $true
+            Why        = 'Rendered by the tag and dispatch publishing lanes only; no pull-request job reads them.'
+            Match      = { param($f) Test-Match $f @('packaging/*') }
+        },
+        @{
+            Name       = 'container build'
+            Areas      = @()
+            Structural = $true
+            Why        = 'The image workflow runs on workflow_run after a completed Release and on dispatch, never on a pull request.'
+            Match      = { param($f) Test-Match $f @('Dockerfile', '.dockerignore') }
+        },
+        @{
+            Name       = 'repository metadata'
+            Areas      = @()
+            Structural = $true
+            Why        = 'Read by git, editors, the citation widget and the commit-message linter — none of which is a job this classifier gates.'
+            Match      = { param($f) Test-Match $f @('.gitignore', '*/.gitignore', '.editorconfig', '.convco', 'CITATION.cff') }
+        },
+
+        # --- whole-tree scanners -------------------------------------------
+        # Both read the working tree rather than a declared file set, so their
+        # exclusions are mirrored from the tools' own configuration.
+        @{
+            Name       = 'link surface'
+            Areas      = @('links')
+            Structural = $false
+            Why        = 'lychee walks the whole tree, so any file it can read as text can carry a URL that changes its verdict.'
+            Match      = {
+                param($f)
+                if (Test-Binary $f) { return $false }
+                return -not (Test-Match $f @(
+                        'Cargo.lock',
+                        'fuzz/corpus/*',
+                        'crates/bdinfo-rs/tests/fixtures/golden/*',
+                        'crates/bdinfo-rs-wasm/tests/golden_report.txt'
+                    ))
+            }
+        },
+        @{
+            Name       = 'spell-check surface'
+            Areas      = @('typos')
+            Structural = $false
+            Why        = 'typos walks the whole tree; the exclusions mirror files.extend-exclude in typos.toml.'
+            Match      = {
+                param($f)
+                if (Test-Binary $f) { return $false }
+                return -not (Test-Match $f @(
+                        'target/*', 'fuzz/target/*', 'fuzz/corpus/*',
+                        'crates/bdinfo-rs/tests/fixtures/*',
+                        'crates/bdinfo-rs-wasm/tests/golden_report.txt',
+                        'crates/bdinfo-rs-core/src/language_codes.rs',
+                        'supply-chain/*', 'Cargo.lock', '*.exe'
+                    ))
+            }
+        }
+    )
+
+    function Get-PathAreas {
+        param([string] $File)
+
+        $areas = [System.Collections.Generic.SortedSet[string]]::new()
+        $structural = $false
+
+        foreach ($rule in $script:Rules) {
+            if (-not (& $rule.Match $File)) { continue }
+            if ($rule.Structural) { $structural = $true }
+            foreach ($a in $rule.Areas) { [void] $areas.Add($a) }
+        }
+
+        return [pscustomobject]@{
+            Areas      = @($areas)
+            Structural = $structural
+        }
+    }
+}
+
+process {
+    if ($Path) { $script:Inputs.AddRange([string[]] $Path) }
+}
+
+end {
+    # ------------------------------------------------------------- self-test
+    if ($SelfTest) {
+        # Each case pins one rule's outcome. A case is the assertion that the
+        # rule's Why holds, so a case that starts failing is a claim to re-check,
+        # not a number to update.
+        $GoldenCases = @(
+            @{ Path = 'crates/bdinfo-rs/tests/fixtures/README.md'; Areas = 'links' }
+            @{ Path = 'crates/bdinfo-rs-gui/README.md'; Areas = 'links typos' }
+            @{ Path = 'README.md'; Areas = 'links typos' }
+            @{ Path = 'crates/bdinfo-rs/tests/fixtures/BigBuckBunny/BDMV/index.bdmv'; Areas = 'core' }
+            @{ Path = 'crates/bdinfo-rs/tests/fixtures/golden/folder.txt'; Areas = 'core' }
+            @{ Path = 'crates/bdinfo-rs/src/main.rs'; Areas = 'core links typos' }
+            @{ Path = 'crates/bdinfo-rs-core/src/bdrom/m2ts.rs'; Areas = 'core fuzz gui links typos wasm' }
+            @{ Path = 'crates/bdinfo-rs-gui/packaging/icons/hicolor/32x32/apps/bdinfo-rs-gui.png'; Areas = 'gui' }
+            @{ Path = 'crates/bdinfo-rs-gui/src/main.rs'; Areas = 'gui links typos' }
+            @{ Path = '.cargo/config.toml'; Areas = 'core fuzz gui links toml typos wasm' }
+            @{ Path = '.cargo/mutants.toml'; Areas = 'core links toml typos' }
+            @{ Path = '.config/nextest.toml'; Areas = 'core links toml typos' }
+            @{ Path = 'Cargo.lock'; Areas = 'core deps pkg' }
+            @{ Path = 'Cargo.toml'; Areas = 'core deps dist fuzz gui links toml typos wasm' }
+            @{ Path = '.gitattributes'; Areas = 'core fuzz gui links typos wasm' }
+            @{ Path = '.lycheeignore'; Areas = 'links typos' }
+            @{ Path = 'scorecard.yml'; Areas = 'links typos yaml' }
+            @{ Path = '.github/dependabot.yml'; Areas = 'links typos yaml' }
+            @{ Path = '.github/workflows/ci.yml'; Areas = 'canary links typos workflows yaml' }
+            @{ Path = '.github/workflows/gui.yml'; Areas = 'gui links typos workflows yaml' }
+            @{ Path = '.github/workflows/docker.yml'; Areas = 'links typos workflows yaml' }
+            @{ Path = '.github/scripts/gui-package-windows.ps1'; Areas = 'gui links typos' }
+            @{ Path = '.github/scripts/publish-gui-aur.ps1'; Areas = 'links typos' }
+            @{ Path = 'packaging/aur/PKGBUILD.template'; Areas = 'links typos' }
+            @{ Path = 'Dockerfile'; Areas = 'links typos' }
+            @{ Path = 'fuzz/fuzz_targets/mpls.rs'; Areas = 'fuzz links typos' }
+            @{ Path = 'fuzz/corpus/mpls/seed'; Areas = 'fuzz' }
+            @{ Path = 'supply-chain/audits.toml'; Areas = 'deps links' }
+            @{ Path = 'deny.toml'; Areas = 'deps links toml typos' }
+        )
+
+        $failures = [System.Collections.Generic.List[string]]::new()
+
+        foreach ($case in $GoldenCases) {
+            $got = (Get-PathAreas $case.Path).Areas -join ' '
+            if ($got -ne $case.Areas) {
+                $failures.Add("  $($case.Path)`n      expected: $($case.Areas)`n      got:      $got")
+            }
+        }
+
+        # Exhaustiveness. A tracked path that matches no Structural rule gates
+        # nothing and would be verified only by a scheduled full run, so the
+        # gate refuses it until a rule either claims it or declares, with a
+        # Why, that no pull-request job reads it.
+        $tracked = @(git ls-files)
+        if ($LASTEXITCODE -ne 0) { throw 'git ls-files failed' }
+
+        $unclassified = @($tracked | Where-Object { -not (Get-PathAreas $_).Structural })
+        if ($unclassified) {
+            $failures.Add("  no rule claims these tracked paths:`n" +
+                (($unclassified | ForEach-Object { "      $_" }) -join "`n"))
+        }
+
+        if ($failures.Count -gt 0) {
+            Write-Host "classify-diff self-test FAILED`n"
+            $failures | ForEach-Object { Write-Host $_ }
+            exit 1
+        }
+
+        Write-Host "classify-diff self-test passed: $($GoldenCases.Count) cases, $($tracked.Count) tracked paths classified."
+        exit 0
+    }
+
+    # ------------------------------------------------------------- classify
+    $fired = [System.Collections.Generic.SortedSet[string]]::new()
+
+    if ($All) {
+        foreach ($a in $script:AllAreas) { [void] $fired.Add($a) }
+    }
+    else {
+        foreach ($f in $script:Inputs) {
+            $f = $f.Trim()
+            if (-not $f) { continue }
+            foreach ($a in (Get-PathAreas $f).Areas) { [void] $fired.Add($a) }
+        }
+    }
+
+    # build + test runs one leg per released target when the root workspace is
+    # in play, and one leg per shell family when only the orchestrator changed.
+    $testOs = '[]'
+    if ($fired.Contains('core')) {
+        $testOs = '["ubuntu-latest","ubuntu-24.04-arm","windows-2025","windows-11-arm","macos-15-intel","macos-15"]'
+    }
+    elseif ($fired.Contains('canary')) {
+        $testOs = '["ubuntu-latest","windows-2025"]'
+    }
+
+    foreach ($a in $script:AllAreas) {
+        "$a=$($fired.Contains($a).ToString().ToLowerInvariant())"
+    }
+    "test=$(($testOs -ne '[]').ToString().ToLowerInvariant())"
+    "test-os=$testOs"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,16 @@ name: CI
 # uv, cargo, zed and wgpu converged on independently): a ~10 s `plan` job
 # classifies the event's diff into AREAS, every gate job runs only when its
 # area fired, and a final `ci-ok` fan-in job is the single branch-protection
-# context. The gating loses nothing: sweep.yml re-runs this whole orchestrator
-# UNGATED on master daily (workflow_call, every area forced), so untouched
-# areas are re-verified within 24 h and environment drift (runner images,
-# toolchain point releases) cannot hide behind a skipped job.
+# context.
+#
+# A job fires if and only if the diff could change that job's verdict, so the
+# classifier asks what KIND of input a file is before it asks which directory
+# holds it — see .github/scripts/classify-diff.ps1, which owns the rules, the
+# mechanism behind each one, and a self-test that refuses any tracked path no
+# rule claims. Because that self-test makes an unclassified file a failure
+# rather than a silent skip, gating rests on the rules themselves; sweep.yml
+# re-runs this orchestrator UNGATED on master daily so that environment drift
+# (runner images, toolchain point releases, link rot) is caught as well.
 #
 # WHY plan + `if:`, never `on.paths:`, on anything required: a job skipped via
 # `if:` still reports a check-run with conclusion `skipped`, which satisfies a
@@ -54,19 +60,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Classify the event's changed files into areas. Areas are unions of
-  # pathspecs; one file can hit several. Cross-crate dependency edges are
-  # encoded HERE (core → gui/wasm/fuzz), never guessed at runtime; the one
-  # deliberate exception is a root Cargo.lock-only change, which does NOT
-  # propagate to gui/wasm — they are excluded workspaces with their own
-  # lockfiles, so the daily Dependabot root-lockfile chore cannot re-fire
-  # their gates.
-  #
-  # A gate's implementation files belong to its area, not just `meta`: the
-  # reusable workflow files and the .github/scripts helpers a gate executes
-  # (gui.yml + gui-*.ps1 → gui, wasm.yml → wasm, source-rules.ps1 → core)
-  # re-fire the gate they implement — editing a gate must re-run it, or the
-  # edit ships proven only by YAML lint.
+  # Classify the event's changed files into areas. The rules, the mechanism
+  # behind each one and the self-test that holds them honest all live in
+  # .github/scripts/classify-diff.ps1; this job only decides WHICH files to
+  # hand it.
   #
   # Fail-safes: if the diff cannot be computed (missing before-SHA,
   # force-push, git error) every area fires; so does the `ci-full` PR label.
@@ -81,11 +78,14 @@ jobs:
       wasm: ${{ steps.classify.outputs.wasm }}
       fuzz: ${{ steps.classify.outputs.fuzz }}
       deps: ${{ steps.classify.outputs.deps }}
-      meta: ${{ steps.classify.outputs.meta }}
+      yaml: ${{ steps.classify.outputs.yaml }}
+      workflows: ${{ steps.classify.outputs.workflows }}
+      canary: ${{ steps.classify.outputs.canary }}
       dist: ${{ steps.classify.outputs.dist }}
       pkg: ${{ steps.classify.outputs.pkg }}
       toml: ${{ steps.classify.outputs.toml }}
-      docs: ${{ steps.classify.outputs.docs }}
+      links: ${{ steps.classify.outputs.links }}
+      typos: ${{ steps.classify.outputs.typos }}
       test: ${{ steps.classify.outputs.test }}
       test-os: ${{ steps.classify.outputs.test-os }}
     steps:
@@ -99,120 +99,70 @@ jobs:
           filter: blob:none
           sparse-checkout: .github
 
+      # The classifier gates every job below, so prove it still holds its own
+      # rules before trusting it — the same order conventional.yml uses for
+      # check-banned-words.ps1. Also fails when a tracked path matches no rule,
+      # which is what keeps a newly added file from silently gating nothing.
+      - name: Self-test the classifier
+        shell: pwsh
+        run: ./.github/scripts/classify-diff.ps1 -SelfTest
+
       - name: Classify the changed files into areas
         id: classify
+        shell: pwsh
         env:
           EVENT: ${{ github.event_name }}
           BEFORE: ${{ github.event.before }}
           AFTER: ${{ github.event.after }}
           CI_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'ci-full') }}
         run: |
-          # ---- pick the file list (mode=all = the fail-safe: everything fires)
-          mode=diff
-          reason=""
-          changed=""
-          if [ "$CI_FULL" = "true" ]; then
-            mode=all; reason="ci-full label"
-          elif [ "$EVENT" = "pull_request" ]; then
+          $ErrorActionPreference = 'Stop'
+          $mode = 'diff'
+          $reason = ''
+          $changed = @()
+
+          if ($env:CI_FULL -eq 'true') {
+            $mode = 'all'; $reason = 'ci-full label'
+          }
+          elseif ($env:EVENT -eq 'pull_request') {
             # HEAD is the PR merge commit, so parent 1 is the up-to-date base
             # tip and this two-dot diff is exactly the PR's effective diff
             # against master.
-            changed=$(git diff --name-only HEAD^1 HEAD) || { mode=all; reason="git diff failed"; }
-          elif [ "$EVENT" = "push" ]; then
-            # event.before...after is exactly the squash-merge's diff. A zero
-            # or missing before (branch creation, history rewrite) fails safe.
-            case "$BEFORE" in
-              ""|0000000000000000000000000000000000000000) mode=all; reason="no usable before SHA" ;;
-              *) changed=$(git diff --name-only "$BEFORE" "$AFTER") || { mode=all; reason="git diff failed"; } ;;
-            esac
-          else
+            $changed = @(git diff --name-only 'HEAD^1' HEAD)
+            if ($LASTEXITCODE -ne 0) { $mode = 'all'; $reason = 'git diff failed' }
+          }
+          elseif ($env:EVENT -eq 'push') {
+            # before...after is exactly the squash-merge's diff. A zero or
+            # missing before (branch creation, history rewrite) fails safe.
+            if (-not $env:BEFORE -or $env:BEFORE -eq ('0' * 40)) {
+              $mode = 'all'; $reason = 'no usable before SHA'
+            }
+            else {
+              $changed = @(git diff --name-only $env:BEFORE $env:AFTER)
+              if ($LASTEXITCODE -ne 0) { $mode = 'all'; $reason = 'git diff failed' }
+            }
+          }
+          else {
             # workflow_call from sweep.yml (schedule / workflow_dispatch).
-            mode=all; reason="$EVENT event — the sweep runs everything"
-          fi
+            $mode = 'all'; $reason = "$($env:EVENT) event — the sweep runs everything"
+          }
 
-          core=false; gui=false; wasm=false; fuzz=false; deps=false
-          meta=false; dist=false; pkg=false; toml=false; docs=false
-          # core minus root Cargo.lock: what propagates over the core→gui/wasm
-          # dependency edges (see the job comment).
-          core_edge=false
+          $areas = if ($mode -eq 'all') {
+            ./.github/scripts/classify-diff.ps1 -All
+          }
+          else {
+            $changed | ./.github/scripts/classify-diff.ps1
+          }
 
-          if [ "$mode" = "all" ]; then
-            core=true; gui=true; wasm=true; fuzz=true; deps=true
-            meta=true; dist=true; pkg=true; toml=true; docs=true
-          else
-            # `case` patterns: `*` crosses `/`, so `crates/bdinfo-rs/*` matches
-            # the whole subtree.
-            while IFS= read -r f; do
-              [ -n "$f" ] || continue
-              case "$f" in
-                crates/bdinfo-rs-core/*|crates/bdinfo-rs/*|Cargo.toml|Cargo.lock|rust-toolchain.toml|rustfmt.toml|clippy.toml|typos.toml|.config/*|.cargo/*|.github/scripts/source-rules.ps1) core=true ;;
-              esac
-              # source-rules.ps1 is deliberately NOT in core_edge: it only
-              # implements the core lint step, so it re-fires the core gate
-              # without dragging the sibling crates along.
-              case "$f" in
-                crates/bdinfo-rs-core/*|crates/bdinfo-rs/*|Cargo.toml|rust-toolchain.toml|rustfmt.toml|clippy.toml|typos.toml|.config/*|.cargo/*) core_edge=true ;;
-              esac
-              # gui-release.yml is deliberately NOT here, and gui-publish.yml
-              # plus its .github/scripts/publish-gui-*.ps1 helpers follow the
-              # same rule: the orchestrator never runs either lane
-              # (tag/dispatch-only), so a lane-only edit gets the meta checks
-              # (YAML schema/style/security) and its real verification from
-              # the next dispatch (dry run / prepare-only) — not a ~40-minute
-              # gui fleet re-run that exercises none of the changed lines.
-              # The helpers are named publish-gui-*.ps1 precisely so the
-              # gui-*.ps1 pattern below cannot catch them. The
-              # gui-package-*.ps1 scripts DO re-fire the area: the packaging
-              # smoke runs them.
-              case "$f" in crates/bdinfo-rs-gui/*|.github/workflows/gui.yml|.github/scripts/gui-*.ps1) gui=true ;; esac
-              case "$f" in crates/bdinfo-rs-wasm/*|.github/workflows/wasm.yml) wasm=true ;; esac
-              case "$f" in fuzz/*) fuzz=true ;; esac
-              case "$f" in Cargo.lock|Cargo.toml|*/Cargo.toml|deny.toml|supply-chain/*|crates/*/deny.toml) deps=true ;; esac
-              case "$f" in .github/*|.yamllint.yml) meta=true ;; esac
-              case "$f" in .github/workflows/v-release.yml|dist-workspace.toml|.github/build-setup.yml|Cargo.toml) dist=true ;; esac
-              case "$f" in .github/build-linux-packages.sh|crates/bdinfo-rs/debian/*|dist-workspace.toml|Cargo.lock|crates/bdinfo-rs/Cargo.toml) pkg=true ;; esac
-              case "$f" in *.toml) toml=true ;; esac
-              case "$f" in *.md|*.rs) docs=true ;; esac
-            done <<< "$changed"
-            # Cross-crate dependency edges: the sibling crates path-dep
-            # bdinfo-rs-core, so core changes re-fire their gates — except the
-            # root-lockfile-only case (core_edge). The fuzz targets link the
-            # core parsers and DO resolve against the root lockfile via their
-            # path deps' source, so full core re-fires the replay.
-            if [ "$core_edge" = "true" ]; then gui=true; wasm=true; fi
-            if [ "$core" = "true" ]; then fuzz=true; fi
-          fi
+          $areas | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
-          # The canary: meta-only events —
-          # CI plumbing changed but no code — still build + test on one leg
-          # per OS/shell family, exercising the changed checkout / rust-cache /
-          # install-action plumbing from both sides without the 6-arch fleet.
-          # When the job is skipped it reports ONCE, unexpanded (a skipped
-          # matrix never materializes per-leg check runs — observed live), so
-          # the list's value only matters when the job actually runs.
-          test=false
-          test_os='["ubuntu-latest","ubuntu-24.04-arm","windows-2025","windows-11-arm","macos-15-intel","macos-15"]'
-          if [ "$core" = "true" ]; then
-            test=true
-          elif [ "$meta" = "true" ]; then
-            test=true
-            test_os='["ubuntu-latest","windows-2025"]'
-          fi
-
-          {
-            echo "core=$core"; echo "gui=$gui"; echo "wasm=$wasm"
-            echo "fuzz=$fuzz"; echo "deps=$deps"; echo "meta=$meta"
-            echo "dist=$dist"; echo "pkg=$pkg"; echo "toml=$toml"
-            echo "docs=$docs"; echo "test=$test"; echo "test-os=$test_os"
-          } >> "$GITHUB_OUTPUT"
-
-          echo "mode: $mode${reason:+ ($reason)}"
-          if [ "$mode" = "diff" ]; then
-            echo "changed files:"
-            printf '%s\n' "$changed" | sed 's/^/  /'
-          fi
-          echo "areas: core=$core gui=$gui wasm=$wasm fuzz=$fuzz deps=$deps meta=$meta dist=$dist pkg=$pkg toml=$toml docs=$docs"
-          echo "build+test: run=$test os=$test_os"
+          Write-Host "mode: $mode$(if ($reason) { " ($reason)" })"
+          if ($mode -eq 'diff') {
+            Write-Host 'changed files:'
+            $changed | ForEach-Object { Write-Host "  $_" }
+          }
+          Write-Host 'areas:'
+          $areas | ForEach-Object { Write-Host "  $_" }
 
   test:
     name: build + test (${{ matrix.os }})
@@ -224,8 +174,8 @@ jobs:
     # in tests/cli.rs) runs on every architecture we ship: no shipped arch goes
     # unscanned. arm64 Linux/Windows and Intel macOS are standard GitHub-hosted
     # runners, free for public repos. The OS list is plan output — the full six
-    # for `core`, the 2-leg canary for meta-only events; keep the plan job's
-    # list in lockstep with the six dist targets in dist-workspace.toml.
+    # for `core`, one leg per shell family for `canary`; keep the list in
+    # classify-diff.ps1 in lockstep with the six dist-workspace.toml targets.
     strategy:
       fail-fast: false
       matrix:
@@ -266,7 +216,7 @@ jobs:
   yaml:
     name: lint YAML (action-validator + ryl)
     needs: plan
-    if: needs.plan.outputs.meta == 'true'
+    if: needs.plan.outputs.yaml == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -379,7 +329,7 @@ jobs:
   # `replay` job), and the full mutants sweeps for every crate live in
   # sweep.yml; only the Windows-via-Docker fuzz runner stays local.
   lint:
-    name: lint (clippy, fmt, typos, doc, deps, semver)
+    name: lint (clippy, fmt, doc, deps, semver)
     needs: plan
     if: needs.plan.outputs.core == 'true'
     runs-on: ubuntu-latest
@@ -399,7 +349,7 @@ jobs:
       - name: Install gate tools
         uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
-          tool: cargo-machete,cargo-shear,cargo-semver-checks,typos
+          tool: cargo-machete,cargo-shear,cargo-semver-checks
 
       # House rules with no clippy equivalent (big-endian-only + no HashMap/HashSet
       # in the deterministic output path), mirrored from the local gate via the
@@ -414,9 +364,6 @@ jobs:
 
       - name: Clippy (-D warnings, pedantic/nursery/restriction)
         run: cargo lt
-
-      - name: Typos
-        run: typos
 
       - name: Unused deps (machete)
         run: cargo mc
@@ -809,7 +756,7 @@ jobs:
   zizmor:
     name: zizmor (workflow security)
     needs: plan
-    if: needs.plan.outputs.meta == 'true'
+    if: needs.plan.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -834,10 +781,32 @@ jobs:
   # push. This is the PR/push leg (`docs` = any .md or .rs, since doc-comments
   # carry links); the daily cron leg (links rot after merge without touching our
   # code) stays in link-check.yml.
+  # typos reads the whole working tree (minus files.extend-exclude in
+  # typos.toml), so prose changes reach it while changing no Rust source. It is
+  # its own job rather than a step of `lint` for that reason: the rest of that
+  # job compiles the workspace, which a Markdown edit cannot affect.
+  typos:
+    name: spell-check (typos)
+    needs: plan
+    if: needs.plan.outputs.typos == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install typos
+        uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
+        with:
+          tool: typos
+
+      - name: Typos
+        run: typos
+
   links:
     name: Check links
     needs: plan
-    if: needs.plan.outputs.docs == 'true'
+    if: needs.plan.outputs.links == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1177,7 +1146,7 @@ jobs:
   # a manually-cancelled run must not end green.
   ci-ok:
     name: ci-ok
-    needs: [plan, test, yaml, release-yaml, lint, coverage, e2e, isolation, taplo, zizmor, links, deny, vet, replay, pkg, gui, wasm]
+    needs: [plan, test, yaml, release-yaml, lint, coverage, e2e, isolation, taplo, zizmor, typos, links, deny, vet, replay, pkg, gui, wasm]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The plan job classified a diff by matching changed paths against directory
patterns. Since sh wildcards cross the path separator, those patterns claimed
whole subtrees, including files that no job reads. A five-line URL fix in
crates/bdinfo-rs/tests/fixtures/README.md fired 56 check runs and 94+
job-minutes; exactly one of those jobs, lychee, could observe the change.

## What changed

The rules move to .github/scripts/classify-diff.ps1, which asks what kind of
input a file is before it asks which directory holds it, and records for every
rule the mechanism by which the file reaches the jobs its areas gate. The plan
job runs its -SelfTest first, the order conventional.yml already uses for
check-banned-words.ps1.

The self-test pins one case per rule and requires every tracked path to match a
structural rule, so a path that no rule claims fails the gate instead of
silently gating nothing. 29 cases, 6523 tracked paths.

Where a job scans the working tree rather than a declared file set (lychee,
typos, taplo), the classifier mirrors that tool's own exclusions.

## Corrected over-firing

- .cargo/mutants.toml and .config/nextest.toml no longer cross to the sibling
  workspaces, which carry their own.
- crates/bdinfo-rs no longer crosses to the sibling crates or the fuzz targets:
  all three link bdinfo-rs-core, and nothing links the CLI.
- The root lockfile no longer crosses to fuzz, which has its own.
- Prose no longer sets a build area.
- The meta area splits into yaml, workflows and canary, so editing a publishing
  lane no longer runs a build canary that no changed file can affect.

## Corrected under-firing

Sixteen tracked paths matched no pattern at all. Among them .gitattributes,
whose eol and binary attributes decide the bytes that rustfmt --check, the
golden report comparisons and the fuzz corpus all depend on. Two earlier merges
fired no gate job and ci-ok went green.

typos becomes its own job, reached by prose anywhere rather than only prose
under a crate directory. The link check widens from Markdown and Rust to every
text file, matching what lychee already scans.

## Effect

Replayed over the 41 most recent merges: 3 change behaviour, 38 are identical.
The fixture README case goes from 56 check runs and 94+ job-minutes to 4 and
roughly 1.

A pinned-digest bump inside gui.yml still fires all 27 gui legs, since changing
a pinned action changes what those jobs do.
