### PR TITLE
docs(gui): drop the winget in-review warnings for the desktop package

### DIFF
--- a/.github/workflows/gui-publish.yml
+++ b/.github/workflows/gui-publish.yml
@@ -52,9 +52,10 @@ name: gui-publish
 #     core version on crates.io; until then the dry-run fails in prepare. The
 #     crate must also already exist on crates.io for Trusted Publishing, so
 #     the FIRST publish is manual (the publish-crates.yml bootstrap rule).
-#   - winget: agentjp.bdinfo-rs-gui is a new package id komac cannot create
-#     headlessly, so the FIRST submission is a manual interactive komac run;
-#     the leg auto-submits every version after that PR merges.
+#   - winget: komac cannot create a package id headlessly, so a package's
+#     FIRST submission is a manual interactive komac run — done for
+#     agentjp.bdinfo-rs-gui via winget-pkgs#405038; the leg auto-submits
+#     every later version and records bootstrap-pending if the id is absent.
 #
 # Secrets (all on the `release` ENVIRONMENT, like packages.yml — its
 # deployment rules admit `master`, which is what both a workflow_dispatch

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ These update automatically through a package manager and uninstall cleanly:
 
 | OS | Command line | Desktop app |
 |---|---|---|
-| Windows | `winget install agentjp.bdinfo-rs` | `winget install agentjp.bdinfo-rs-gui` *(pending: [winget-pkgs#405038](https://github.com/microsoft/winget-pkgs/pull/405038))* |
+| Windows | `winget install agentjp.bdinfo-rs` | `winget install agentjp.bdinfo-rs-gui` |
 | macOS | `brew install agentjp/tap/bdinfo-rs` | `brew install --cask agentjp/tap/bdinfo-rs-gui` |
 | Debian / Ubuntu | [apt repository](#apt--dnf-repository-linux) | same repository, `bdinfo-rs-gui` |
 | Fedora / RHEL / openSUSE | [dnf repository](#apt--dnf-repository-linux) | same repository, `bdinfo-rs-gui` |
@@ -264,12 +264,6 @@ Release artifacts, per platform:
 
 ## WinGet (Windows)
 
-> [!WARNING]
-> Not available yet — the desktop app's WinGet package is in the community-repository review
-> queue ([winget-pkgs#405038](https://github.com/microsoft/winget-pkgs/pull/405038)). Until it
-> merges, `winget install agentjp.bdinfo-rs-gui` fails with *No package found*; install via the
-> [MSI installer](#msi-installer-windows) or [portable zip](#portable-zip-windows) below for now.
-
 ```powershell
 winget install agentjp.bdinfo-rs-gui
 ```
@@ -277,8 +271,9 @@ winget install agentjp.bdinfo-rs-gui
 - **Where it goes** — WinGet runs the MSI below silently, so everything in the next section
   applies: `%LOCALAPPDATA%\Programs\bdinfo-rs GUI\`, per-user, no administrator rights. A silent
   install never shows the license page and does not add the install directory to `PATH`.
-- **Updates** — `winget upgrade agentjp.bdinfo-rs-gui` (once the package is published).
-- **Uninstall** — `winget uninstall agentjp.bdinfo-rs-gui` (once it is published), or Apps & features.
+- **Updates** — `winget upgrade agentjp.bdinfo-rs-gui` (or `winget upgrade --all`). New releases
+  are submitted to the WinGet community repository automatically.
+- **Uninstall** — `winget uninstall agentjp.bdinfo-rs-gui`, or Apps & features.
 
 ## MSI installer (Windows)
 

--- a/README.md
+++ b/README.md
@@ -53,16 +53,10 @@ progress, then save or copy the report. Pure Rust and GPU-accelerated (wgpu, wit
 fallback) — no webview and no bundled runtime.
 
 ```sh
-winget install agentjp.bdinfo-rs-gui              # Windows (pending — see note)
+winget install agentjp.bdinfo-rs-gui              # Windows
 brew install --cask agentjp/tap/bdinfo-rs-gui     # macOS / Linux
 yay -S bdinfo-rs-gui-bin                          # Arch
 ```
-
-> [!WARNING]
-> The desktop app's WinGet package is still in review
-> ([winget-pkgs#405038](https://github.com/microsoft/winget-pkgs/pull/405038)); until it merges,
-> `winget install agentjp.bdinfo-rs-gui` fails with *No package found*. Use the `.msi`, the
-> Homebrew cask, or the AUR meanwhile.
 
 | Windows | macOS | Linux |
 |---|---|---|


### PR DESCRIPTION
microsoft/winget-pkgs#405038 merged, publishing agentjp.bdinfo-rs-gui 2.0.0 to the WinGet community repository.

- README.md, INSTALL.md: remove the in-review warning blocks and the pending markers on the desktop install command; state upgrade and uninstall without the publication caveat, matching the CLI section.
- gui-publish.yml: the winget sequencing note records the completed bootstrap instead of describing the package id as not yet creatable.