### PR TITLE
fix(packaging): show agentjp as the publisher in installer metadata

### DIFF
--- a/.github/scripts/gui-install-smoke.ps1
+++ b/.github/scripts/gui-install-smoke.ps1
@@ -136,7 +136,7 @@ switch ($Kind) {
                 $v = [string]$arp[0].GetValue('DisplayVersion')
                 $pub = [string]$arp[0].GetValue('Publisher')
                 Assert ($v -eq $Version) "ARP DisplayVersion is $Version (got '$v')"
-                Assert ($pub -eq 'bdinfo-rs contributors') "ARP Publisher is 'bdinfo-rs contributors' (got '$pub')"
+                Assert ($pub -eq 'agentjp') "ARP Publisher is 'agentjp' (got '$pub')"
             }
             # The PathEnvironment feature (setup.wxs) sits above the default
             # INSTALLLEVEL, so the silent road winget and unattended installs

--- a/crates/bdinfo-rs-gui/Cargo.toml
+++ b/crates/bdinfo-rs-gui/Cargo.toml
@@ -100,7 +100,7 @@ proptest = "1"
 # AppStream id rather than their source name, which is what the desktop file's
 # Icon= key names.
 [package.metadata.deb]
-maintainer = "bdinfo-rs contributors <bdinfo-rs@users.noreply.github.com>"
+maintainer = "agentjp <bdinfo-rs@users.noreply.github.com>"
 section = "utils"
 priority = "optional"
 depends = "$auto"

--- a/crates/bdinfo-rs-gui/build.rs
+++ b/crates/bdinfo-rs-gui/build.rs
@@ -55,7 +55,7 @@ fn main() {
     let info = winres::version_info(
         quad,
         &[
-            ("CompanyName", "bdinfo-rs contributors"),
+            ("CompanyName", "agentjp"),
             ("FileDescription", "bdinfo-rs GUI"),
             ("FileVersion", &version),
             ("InternalName", "bdinfo-rs-gui"),

--- a/crates/bdinfo-rs-gui/packaging/io.github.agentjp.bdinfo-rs.metainfo.xml
+++ b/crates/bdinfo-rs-gui/packaging/io.github.agentjp.bdinfo-rs.metainfo.xml
@@ -36,7 +36,7 @@
   </provides>
   <url type="homepage">https://github.com/agentjp/bdinfo-rs</url>
   <url type="bugtracker">https://github.com/agentjp/bdinfo-rs/issues</url>
-  <developer_name>bdinfo-rs contributors</developer_name>
+  <developer_name>agentjp</developer_name>
   <releases>
     <release version="2.0.0" date="2026-07-20"/>
   </releases>

--- a/crates/bdinfo-rs-gui/packaging/setup.wxs
+++ b/crates/bdinfo-rs-gui/packaging/setup.wxs
@@ -44,7 +44,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*"
            Name="bdinfo-rs GUI"
-           Manufacturer="bdinfo-rs contributors"
+           Manufacturer="agentjp"
            Version="$(var.Version)"
            UpgradeCode="EBF0C1DC-6418-4BBA-A01E-B0382088969A"
            Language="1033">

--- a/crates/bdinfo-rs/Cargo.toml
+++ b/crates/bdinfo-rs/Cargo.toml
@@ -73,7 +73,7 @@ bin-dir = "{ bin }{ binary-ext }"
 # the license paragraph) as the canonical-path asset; cargo-deb uses it verbatim
 # instead of generating one. The path is resolved relative to this crate dir.
 [package.metadata.deb]
-maintainer = "bdinfo-rs contributors <bdinfo-rs@users.noreply.github.com>"
+maintainer = "agentjp <bdinfo-rs@users.noreply.github.com>"
 section = "utils"
 priority = "optional"
 depends = ""


### PR DESCRIPTION
The installed app surfaces "bdinfo-rs contributors" as its publisher; every user-facing publisher field now reads agentjp, matching the winget manifest's Publisher.

- setup.wxs Manufacturer - the Apps & features Publisher column for the MSI install.
- build.rs CompanyName - the exe version-info Details tab.
- metainfo.xml developer_name - Linux software centers.
- deb Maintainer for both the CLI and GUI packages.
- gui-install-smoke.ps1 - the ARP Publisher assertion moves in lockstep with setup.wxs.

winget upgrade correlation is unaffected: AppsAndFeaturesEntries are regenerated by komac from each release's MSI, and correlation keys on the UpgradeCode, which is unchanged. Copyright and license attribution lines (NOTICE, license.rtf, debian/copyright, LegalCopyright) are deliberately untouched.

Reaches users at the next gui-v* and v* releases; the installed 2.0.0 keeps the old string until upgraded.