### PR TITLE
ci: bump the Node, npm and setup-homebrew pins

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           # Keep in lockstep with wasm.yml + publish-npm.yml (version-freshness.yml
           # cross-checks the three agree). The active Node line: 26 -> LTS Oct 2026.
-          node-version: "26.5.0"
+          node-version: "26.5.1"
 
       - name: Install the web toolchain (binaryen / typescript / biome)
         working-directory: crates/bdinfo-rs-wasm/web

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -55,7 +55,7 @@ jobs:
       # nags (files an issue) when Homebrew master moves past this SHA, and the bump
       # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
       # releases, and this repo has none).
-      - uses: Homebrew/actions/setup-homebrew@9af03b7ae3f9e2ae5c174f659d5c3909f7e7dbac # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@9651e3cfa42dae9ae90ca79eaa6d36dcd8569168 # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its
@@ -118,7 +118,7 @@ jobs:
     steps:
       # A SHA-frozen Homebrew/actions pin — the full rationale sits on the
       # homebrew job's identical line above.
-      - uses: Homebrew/actions/setup-homebrew@9af03b7ae3f9e2ae5c174f659d5c3909f7e7dbac # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@9651e3cfa42dae9ae90ca79eaa6d36dcd8569168 # zizmor: ignore[ref-version-mismatch]
 
       # The same tap-trust story as the homebrew job above, for its reasons.
       - name: Trust the taps (ours + the runner's pre-tapped ones)

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -154,7 +154,7 @@ jobs:
         with:
           # The active Node line (26 -> LTS Oct 2026); kept in lockstep with
           # wasm.yml + deploy-pages.yml (version-freshness.yml cross-checks the three).
-          node-version: "26.5.0"
+          node-version: "26.5.1"
 
       # Staged publishing (`npm stage publish`) needs npm >= 11.15.0, and
       # `--provenance` needs a working bundled `sigstore`. npm 12.0.0 shipped
@@ -169,7 +169,7 @@ jobs:
       # lockstep with version-freshness.yml (its "behind latest" nag is the
       # reminder to bump).
       - name: Pin npm to a staged-publishing-capable version
-        run: npm install -g npm@12.0.1 # zizmor: ignore[adhoc-packages]
+        run: npm install -g npm@12.0.2 # zizmor: ignore[adhoc-packages]
 
       - name: Verify Node >= 26 and npm >= 11.15.0
         shell: pwsh

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -33,7 +33,7 @@ permissions:
 
 env:
   NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + ci.yml
-  NODE_VERSION: "26.5.0"      # the active Node line (26 -> LTS Oct 2026); watched by version-freshness.yml
+  NODE_VERSION: "26.5.1"      # the active Node line (26 -> LTS Oct 2026); watched by version-freshness.yml
 
 jobs:
   gate:


### PR DESCRIPTION
Bumps the pins the daily version-freshness check flagged.

- Node `26.5.0` -> `26.5.1` in `wasm.yml`, `deploy-pages.yml` and `publish-npm.yml`, kept in lockstep across the three.
- npm `12.0.1` -> `12.0.2` in `publish-npm.yml`.
- `Homebrew/actions/setup-homebrew` re-pinned `9af03b7ae3f9` -> `9651e3cfa42d` (both uses in `install-smoke-test.yml`). The upstream range is 7 commits touching only that repository's own CI configuration; the action code is unchanged.

The Node and npm pins are exercised only by the tag-triggered publish workflow, so they first run at the next release.

Closes #196
