### PR TITLE
ci: bump the wrangler, cloudsmith-cli and setup-homebrew pins

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -101,4 +101,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx --yes wrangler@4.115.0 pages deploy site --project-name=bdinfo-rs --branch=master
+        run: npx --yes wrangler@4.118.0 pages deploy site --project-name=bdinfo-rs --branch=master

--- a/.github/workflows/gui-publish.yml
+++ b/.github/workflows/gui-publish.yml
@@ -105,7 +105,7 @@ env:
   # Tool pins, hand-bumped (invisible to Dependabot; version-freshness.yml
   # watches them and asserts they agree with packages.yml's copies).
   KOMAC_VERSION: 2.16.0
-  CLOUDSMITH_CLI_VERSION: 1.19.0
+  CLOUDSMITH_CLI_VERSION: 1.20.2
 
 jobs:
   # Resolve tag/channels/mode from either trigger (the packages.yml gate

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -55,7 +55,7 @@ jobs:
       # nags (files an issue) when Homebrew master moves past this SHA, and the bump
       # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
       # releases, and this repo has none).
-      - uses: Homebrew/actions/setup-homebrew@9651e3cfa42dae9ae90ca79eaa6d36dcd8569168 # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@5037c6f1012cc5ea0b9f03fedbaf9955ed9e51e0 # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its
@@ -118,7 +118,7 @@ jobs:
     steps:
       # A SHA-frozen Homebrew/actions pin — the full rationale sits on the
       # homebrew job's identical line above.
-      - uses: Homebrew/actions/setup-homebrew@9651e3cfa42dae9ae90ca79eaa6d36dcd8569168 # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@5037c6f1012cc5ea0b9f03fedbaf9955ed9e51e0 # zizmor: ignore[ref-version-mismatch]
 
       # The same tap-trust story as the homebrew job above, for its reasons.
       - name: Trust the taps (ours + the runner's pre-tapped ones)

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -284,7 +284,7 @@ jobs:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
           set -euo pipefail
-          pipx install cloudsmith-cli==1.19.0 >/dev/null
+          pipx install cloudsmith-cli==1.20.2 >/dev/null
           ver="${VERSION#v}"
           repo=bdinfo-rs/bdinfo-rs
           file="dl/bdinfo-rs-${{ matrix.triple }}.deb"
@@ -363,7 +363,7 @@ jobs:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
           set -euo pipefail
-          pipx install cloudsmith-cli==1.19.0 >/dev/null
+          pipx install cloudsmith-cli==1.20.2 >/dev/null
           ver="${VERSION#v}"
           repo=bdinfo-rs/bdinfo-rs
           file="dl/bdinfo-rs-${{ matrix.triple }}.rpm"


### PR DESCRIPTION
Bumps the three hand-maintained pins the version-freshness check flagged, to the versions current at the time of the bump (each has moved past the number in the issue since it was filed):

- wrangler `4.115.0` -> `4.118.0` (deploy-pages.yml)
- cloudsmith-cli `1.19.0` -> `1.20.2` (packages.yml deb + rpm push jobs, gui-publish.yml `CLOUDSMITH_CLI_VERSION`; the three stay lockstepped)
- Homebrew/actions/setup-homebrew `9651e3cfa42d` -> `5037c6f1012c` (install-smoke-test.yml, both jobs) — master HEAD; the tagless action stays SHA-frozen with its inline zizmor ignore

action-validator, ryl and zizmor (online) pass locally. No cargo-dist-generated workflow is touched.

Closes #200