### PR TITLE
feat(cli): compact single-screen help with a solid banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ bdinfo-rs D:\Rips\MY_MOVIE --mpls 00800,00801    # scan exactly these playlists
 bdinfo-rs D:\Rips\MY_MOVIE --whole               # scan everything the table lists
 ```
 
+The table hides playlists shorter than 20 seconds and looping ones, and names what it withheld.
+`--show-short-playlists` and `--show-looping-playlists` put each category back — into the table,
+the picker, and `--whole`.
+
 Unreadable files on a damaged disc are collected into a `WARNING` block and the rest is scanned
 (exit code 3). Release archives ship bash / zsh / fish / PowerShell completions and a
 `bdinfo-rs.1` man page.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ The table hides playlists shorter than 20 seconds and looping ones, and names wh
 `--show-short-playlists` and `--show-looping-playlists` put each category back — into the table,
 the picker, and `--whole`.
 
+A run on a terminal opens with the bdinfo-rs banner; `--no-banner` drops it. Piped or redirected
+output never carries it.
+
 Unreadable files on a damaged disc are collected into a `WARNING` block and the rest is scanned
 (exit code 3). Release archives ship bash / zsh / fish / PowerShell completions and a
 `bdinfo-rs.1` man page.

--- a/crates/bdinfo-rs/README.md
+++ b/crates/bdinfo-rs/README.md
@@ -37,6 +37,10 @@ bdinfo-rs /path/to/disc --mpls 00800,00801    # scan exactly these playlists
 bdinfo-rs /path/to/disc --whole               # scan everything the table lists
 ```
 
+The table hides playlists shorter than 20 seconds and looping ones, and names what it withheld.
+`--show-short-playlists` and `--show-looping-playlists` put each category back — into the table,
+the picker, and `--whole`.
+
 | Exit code | Meaning |
 |---|---|
 | 0 | Scan completed |

--- a/crates/bdinfo-rs/README.md
+++ b/crates/bdinfo-rs/README.md
@@ -41,6 +41,9 @@ The table hides playlists shorter than 20 seconds and looping ones, and names wh
 `--show-short-playlists` and `--show-looping-playlists` put each category back — into the table,
 the picker, and `--whole`.
 
+A run on a terminal opens with the bdinfo-rs banner; `--no-banner` drops it. Piped or redirected
+output never carries it.
+
 | Exit code | Meaning |
 |---|---|
 | 0 | Scan completed |

--- a/crates/bdinfo-rs/build.rs
+++ b/crates/bdinfo-rs/build.rs
@@ -29,6 +29,14 @@
 //! from the same `src/cli.rs` the binary parses. That guarantees the completions
 //! and the man page can never drift from the shipped flags, help text, or
 //! defaults.
+//!
+//! The man page carries more prose than `--help` does. `src/cli.rs` deliberately
+//! holds no `long_about`, `long_help` or `after_long_help` — that is what keeps
+//! the help one screen and identical for `-h` and `--help` — so the long-form
+//! text lives here instead ([`LONG_ABOUT`], [`EXAMPLES`], [`LONG_HELP`]) and is
+//! attached to the shared command by [`man_command`] just before rendering. The
+//! completions are generated from the command untouched: they read only the
+//! short help.
 #![forbid(unsafe_code)]
 
 use std::fs;
@@ -40,6 +48,99 @@ use clap_complete::{Shell, generate_to};
 
 // Pull in the exact `Cli` the binary uses (brings `use clap::Parser;` with it).
 include!("src/cli.rs");
+
+/// What the tool is, for the man page's DESCRIPTION section.
+const LONG_ABOUT: &str = "bdinfo-rs is a memory-safe, cross-platform Blu-ray analyzer — a drop-in \
+                          replacement for the classic BDInfo tool. It inspects a Blu-ray (a BDMV \
+                          folder or a .iso image) and writes the familiar human-readable disc \
+                          report: the playlists and clips, the M2TS stream layout, and the \
+                          per-stream video and audio technical specs — codecs, measured bitrates, \
+                          resolution, and HDR, Dolby Vision, or HDR10+ metadata.\n\n\
+                          It ships as a single statically-linked binary with no runtime, no \
+                          shared libraries, and nothing to install: the disc structures, the \
+                          codec scanners, and the read-only UDF 2.50 reader for .iso images are \
+                          all pure Rust.\n\n\
+                          Point BD_PATH at the disc and bdinfo-rs scans its metadata, presents \
+                          the playlist selection table, measures the chosen playlists, and writes \
+                          BDINFO.<volume label>.txt into REPORT_DEST.";
+
+/// The worked invocations the man page closes with.
+const EXAMPLES: &str = "Examples:\n  \
+    # Scan a ripped disc folder; pick playlists interactively, writing the\n  \
+    # report back into the same folder.\n  \
+    bdinfo-rs /media/MY_MOVIE\n\n  \
+    # Scan a disc image. A .iso has no folder to write into, so name a\n  \
+    # report destination explicitly.\n  \
+    bdinfo-rs MY_MOVIE.iso /tmp/reports\n\n  \
+    # Print the playlist selection table and stop, scanning nothing.\n  \
+    bdinfo-rs /media/MY_MOVIE --list\n\n  \
+    # Scan exactly the named playlists, in the given order.\n  \
+    bdinfo-rs /media/MY_MOVIE --mpls 00800,00801\n\n  \
+    # Scan every playlist the table lists.\n  \
+    bdinfo-rs /media/MY_MOVIE --whole";
+
+/// The man page's per-argument descriptions, keyed by the derive's argument id
+/// — the `Cli` field name. `mut_arg` panics on an id that no longer exists, so
+/// a renamed field fails this build rather than silently dropping its prose.
+const LONG_HELP: [(&str, &str); 8] = [
+    (
+        "bd_path",
+        "The Blu-ray to analyze. This may be the disc root (the folder containing BDMV), the \
+         BDMV folder itself, any folder inside it, or a .iso disc image. Folder input is read \
+         through the filesystem; a .iso is read through the in-house pure-Rust UDF 2.50 reader. \
+         A folder's disc label is taken from the directory name, while a .iso reports the real \
+         UDF volume label, so the same disc can differ on that one line.",
+    ),
+    (
+        "report_dest",
+        "The folder the report is written into, as BDINFO.<volume label>.txt. It defaults to \
+         BD_PATH, which works for folder input; a .iso image has no folder to fall back on, so a \
+         report destination must then be given explicitly. The destination must be an existing \
+         directory.",
+    ),
+    (
+        "list",
+        "Print the playlist selection table — the standard filtered set of playlists with their \
+         length and size — then exit without measuring anything or writing a report.",
+    ),
+    (
+        "mpls",
+        "Select playlists by name instead of from the table, as a comma-separated list (for \
+         example 00800,00801). Names are matched case-insensitively and the .MPLS extension may \
+         be omitted. The named playlists are scanned in the order given, unfiltered, so this \
+         reaches playlists the table would hide. It takes precedence over --whole and the \
+         interactive picker.",
+    ),
+    (
+        "whole",
+        "Select every playlist shown in the selection table — the standard filtered set — and \
+         scan them all, rather than choosing interactively.",
+    ),
+    (
+        "show_short_playlists",
+        "Include playlists shorter than 20 seconds in the selection table. They are hidden by \
+         default — a disc's menu, logo and transition playlists are usually short — so this \
+         widens what --list prints, what the interactive picker offers, and what --whole scans.",
+    ),
+    (
+        "show_looping_playlists",
+        "Include looping playlists — those repeating a play item — in the selection table. They \
+         are hidden by default as authoring artefacts, so this widens what --list prints, what \
+         the interactive picker offers, and what --whole scans. A disc that disguises its main \
+         feature as a loop needs this flag to make that playlist selectable.",
+    ),
+    ("version", "Print the bdinfo-rs version and exit."),
+];
+
+/// The shared command with the long-form prose attached — the man page's input,
+/// and the only place that prose exists.
+fn man_command() -> clap::Command {
+    let mut cmd = Cli::command().long_about(LONG_ABOUT).after_long_help(EXAMPLES);
+    for (id, long_help) in LONG_HELP {
+        cmd = cmd.mut_arg(id, |arg| arg.long_help(long_help));
+    }
+    cmd
+}
 
 fn main() -> Result<(), Error> {
     // Only regenerate when the CLI surface or this script changes.
@@ -58,9 +159,10 @@ fn main() -> Result<(), Error> {
         generate_to(shell, &mut cmd, bin, &assets)?;
     }
 
-    // Man page (section 1, user commands), rendered from the same command.
+    // Man page (section 1, user commands), rendered from the same command with
+    // the long-form prose reattached.
     let mut page = Vec::new();
-    clap_mangen::Man::new(cmd).render(&mut page)?;
+    clap_mangen::Man::new(man_command()).render(&mut page)?;
     fs::write(assets.join("bdinfo-rs.1"), page)?;
 
     Ok(())

--- a/crates/bdinfo-rs/build.rs
+++ b/crates/bdinfo-rs/build.rs
@@ -82,7 +82,7 @@ const EXAMPLES: &str = "Examples:\n  \
 /// The man page's per-argument descriptions, keyed by the derive's argument id
 /// — the `Cli` field name. `mut_arg` panics on an id that no longer exists, so
 /// a renamed field fails this build rather than silently dropping its prose.
-const LONG_HELP: [(&str, &str); 9] = [
+const LONG_HELP: [(&str, &str); 10] = [
     (
         "bd_path",
         "The Blu-ray to analyze. This may be the disc root (the folder containing BDMV), the \
@@ -128,6 +128,12 @@ const LONG_HELP: [(&str, &str); 9] = [
          are hidden by default as authoring artefacts, so this widens what --list prints, what \
          the interactive picker offers, and what --whole scans. A disc that disguises its main \
          feature as a loop needs this flag to make that playlist selectable.",
+    ),
+    (
+        "no_banner",
+        "Never print the bdinfo-rs banner — the wordmark above the help card and above the scan \
+         flow. It is only ever printed when stdout is a terminal, so a piped or redirected run \
+         needs no flag; this switch silences it on a terminal too.",
     ),
     ("version", "Print the bdinfo-rs version and exit."),
     ("help", "Print the one-screen help card and exit. -h and --help print the same card."),

--- a/crates/bdinfo-rs/build.rs
+++ b/crates/bdinfo-rs/build.rs
@@ -82,7 +82,7 @@ const EXAMPLES: &str = "Examples:\n  \
 /// The man page's per-argument descriptions, keyed by the derive's argument id
 /// — the `Cli` field name. `mut_arg` panics on an id that no longer exists, so
 /// a renamed field fails this build rather than silently dropping its prose.
-const LONG_HELP: [(&str, &str); 8] = [
+const LONG_HELP: [(&str, &str); 9] = [
     (
         "bd_path",
         "The Blu-ray to analyze. This may be the disc root (the folder containing BDMV), the \
@@ -130,6 +130,7 @@ const LONG_HELP: [(&str, &str); 8] = [
          feature as a loop needs this flag to make that playlist selectable.",
     ),
     ("version", "Print the bdinfo-rs version and exit."),
+    ("help", "Print the one-screen help card and exit. -h and --help print the same card."),
 ];
 
 /// The shared command with the long-form prose attached — the man page's input,

--- a/crates/bdinfo-rs/src/banner.rs
+++ b/crates/bdinfo-rs/src/banner.rs
@@ -2,9 +2,10 @@
 //! terminal can render: a framed wordmark, a one-line colour chip, or a plain
 //! ASCII line.
 //!
-//! It is a help-path affordance only. No other flow prints it, so a piped scan,
-//! `--list`, `--mpls` and `--version` emit the same bytes with or without this
-//! module.
+//! Two flows print it: the help paths, and the opening of an interactive
+//! picker session on a terminal. Every flag-driven mode (`--list`, `--whole`,
+//! `--mpls`, `--version`) and every piped or redirected run emit the same bytes
+//! with or without this module.
 
 // In a binary, `pub` items are unexported (`unreachable_pub`), so the reachable
 // visibility for these helpers is `pub(crate)` — which the nursery
@@ -107,6 +108,17 @@ pub(crate) fn header(caps: &Capabilities, version: &str) -> String {
     }
 }
 
+/// The header a scan session opens with, followed by a blank line — or nothing
+/// at all unless `interactive` and stdout is a terminal.
+///
+/// Only the interactive picker has a human at the keyboard to greet. A
+/// flag-driven mode, or any run whose stdout is piped or redirected, gets the
+/// empty string, so its output is byte-for-byte what it would be without a
+/// header at all.
+pub(crate) fn session_header(caps: &Capabilities, version: &str, interactive: bool) -> String {
+    if interactive && caps.tty { format!("{}\n", header(caps, version)) } else { String::new() }
+}
+
 /// The framed wordmark: the accent-painted rows between uncoloured block rails,
 /// closed top and bottom, then the [`plain`] line.
 fn banner(version: &str) -> String {
@@ -134,7 +146,9 @@ fn plain(version: &str) -> String {
 mod tests {
     use clap::CommandFactory as _;
 
-    use super::{BANNER_CELLS, Capabilities, TAGLINE, WORDMARK, WORDMARK_CELLS, header};
+    use super::{
+        BANNER_CELLS, Capabilities, TAGLINE, WORDMARK, WORDMARK_CELLS, header, session_header,
+    };
 
     /// A wide terminal with colour — the banner tier.
     fn wide() -> Capabilities {
@@ -220,6 +234,20 @@ mod tests {
             assert!(!out.contains('\u{1b}'), "no escape byte: {out:?}");
         }
         assert!(wide().colors());
+    }
+
+    #[test]
+    fn only_an_interactive_run_on_a_terminal_opens_with_a_header() {
+        let piped = Capabilities { tty: false, ansi: false, no_color: false, columns: 120 };
+        // The header, then a blank line before the flow narration.
+        assert_eq!(
+            session_header(&wide(), "9.9.9", true),
+            format!("{}\n", header(&wide(), "9.9.9"))
+        );
+        // A flag-driven mode, a pipe, or both: not a byte.
+        assert_eq!(session_header(&wide(), "9.9.9", false), "");
+        assert_eq!(session_header(&piped, "9.9.9", true), "");
+        assert_eq!(session_header(&piped, "9.9.9", false), "");
     }
 
     #[test]

--- a/crates/bdinfo-rs/src/banner.rs
+++ b/crates/bdinfo-rs/src/banner.rs
@@ -1,0 +1,237 @@
+//! The header printed above the CLI's help card, in the widest spelling the
+//! terminal can render: a framed wordmark, a one-line colour chip, or a plain
+//! ASCII line.
+//!
+//! It is a help-path affordance only. No other flow prints it, so a piped scan,
+//! `--list`, `--mpls` and `--version` emit the same bytes with or without this
+//! module.
+
+// In a binary, `pub` items are unexported (`unreachable_pub`), so the reachable
+// visibility for these helpers is `pub(crate)` — which the nursery
+// `redundant_pub_crate` then flags. `pub(crate)` is the correct choice here.
+#![expect(clippy::redundant_pub_crate, reason = "pub is unreachable_pub in a binary")]
+
+use std::fmt::Write as _;
+use std::io::IsTerminal as _;
+
+/// The one-line description every header tier carries. It repeats the clap
+/// command's `about` — the two are pinned together by a test — because the
+/// help card's body no longer prints it.
+pub(crate) const TAGLINE: &str = "BDInfo-style Blu-ray disc reports";
+
+// The colours below are written as SGR escapes rather than built through
+// crossterm's `Stylize`: crossterm drops every colour whenever `NO_COLOR` holds
+// a non-empty value (`Colored::ansi_color_disabled`, crossterm 0.29), emitting
+// an empty `ESC [ m` in its place. That would silently override the tier
+// [`Capabilities`] chose and make the painted bytes depend on the environment
+// the code runs in.
+
+/// The wordmark's colour, `rgb(242, 166, 90)`: the desktop app's dark-theme
+/// accent, restated here rather than shared, because the CLI does not depend on
+/// the GUI crate.
+const ACCENT_FG: &str = "\u{1b}[38;2;242;166;90m";
+
+/// The same accent as a fill, for the chip's background.
+const ACCENT_BG: &str = "\u{1b}[48;2;242;166;90m";
+
+/// The text colour on an accent-filled cell, `rgb(20, 17, 12)` — the chip's
+/// label.
+const ON_ACCENT_FG: &str = "\u{1b}[38;2;20;17;12m";
+
+/// Closes a painted run, returning every attribute to the terminal's default.
+const RESET: &str = "\u{1b}[0m";
+
+/// The `bdinfo-rs` wordmark in the Coder Mini figlet font, one string per row,
+/// each right-padded to [`WORDMARK_CELLS`] so the frame closes square.
+const WORDMARK: [&str; 5] = [
+    "▄▄       ▄▄             ▄▄                        ",
+    "██       ██ ▀▀         ██                         ",
+    "████▄ ▄████ ██  ████▄ ▀██▀ ▄███▄       ████▄ ▄█▀▀▀",
+    "██ ██ ██ ██ ██  ██ ██  ██  ██ ██ ▀▀▀▀▀ ██ ▀▀ ▀███▄",
+    "████▀ ▀████ ██▄ ██ ██  ██  ▀███▀       ██    ▄▄▄█▀",
+];
+
+/// The display width of one [`WORDMARK`] row, in terminal cells.
+const WORDMARK_CELLS: usize = 50;
+
+/// The display width of a framed banner line: a [`WORDMARK`] row, one space
+/// either side, and the two block side rails. Also the narrowest terminal the
+/// banner is offered to — below it the header falls back to the chip.
+const BANNER_CELLS: usize = WORDMARK_CELLS.saturating_add(4);
+
+/// What the terminal receiving the help can render.
+///
+/// Probed from stdout once per run and stated outright in tests, which is why
+/// [`header`] takes it as an argument instead of reading the environment
+/// itself.
+#[derive(Debug)]
+pub(crate) struct Capabilities {
+    /// Whether stdout is a terminal rather than a pipe or a file.
+    pub(crate) tty: bool,
+    /// Whether that terminal renders ANSI escape sequences.
+    pub(crate) ansi: bool,
+    /// Whether `NO_COLOR` is set to anything at all (<https://no-color.org>).
+    pub(crate) no_color: bool,
+    /// The terminal's width in cells.
+    pub(crate) columns: usize,
+}
+
+impl Capabilities {
+    /// Probes the running process's stdout.
+    pub(crate) fn probe() -> Self {
+        Self {
+            tty: std::io::stdout().is_terminal(),
+            ansi: crate::ansi_supported(),
+            no_color: std::env::var_os("NO_COLOR").is_some(),
+            columns: crate::terminal_columns(),
+        }
+    }
+
+    /// Whether colour may be emitted at all: a terminal that renders ANSI
+    /// sequences, with `NO_COLOR` unset.
+    pub(crate) const fn colors(&self) -> bool {
+        self.tty && self.ansi && !self.no_color
+    }
+}
+
+/// The header for `caps`, always ending in a newline: the framed wordmark when
+/// there is colour and room for it, the chip when there is colour but no room,
+/// and the plain line otherwise.
+pub(crate) fn header(caps: &Capabilities, version: &str) -> String {
+    if !caps.colors() {
+        plain(version)
+    } else if caps.columns < BANNER_CELLS {
+        chip(version)
+    } else {
+        banner(version)
+    }
+}
+
+/// The framed wordmark: the accent-painted rows between uncoloured block rails,
+/// closed top and bottom, then the [`plain`] line.
+fn banner(version: &str) -> String {
+    let inner = BANNER_CELLS.saturating_sub(2);
+    let rows = WORDMARK.iter().fold(String::new(), |mut rows, row| {
+        let _ = writeln!(rows, "█ {ACCENT_FG}{row}{RESET} █").is_ok();
+        rows
+    });
+    format!("█{}█\n{rows}█{}█\n{}", "▀".repeat(inner), "▄".repeat(inner), plain(version))
+}
+
+/// The narrow-terminal header: the name and version in an accent-filled chip,
+/// then the tagline.
+fn chip(version: &str) -> String {
+    format!("{ACCENT_BG}{ON_ACCENT_FG} bdinfo-rs {version} {RESET}  {TAGLINE}\n")
+}
+
+/// The colourless header — one ASCII line, no escape sequences at all, for a
+/// pipe, a redirect, a terminal without ANSI, or `NO_COLOR`.
+fn plain(version: &str) -> String {
+    format!("bdinfo-rs {version} - {TAGLINE}\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory as _;
+
+    use super::{BANNER_CELLS, Capabilities, TAGLINE, WORDMARK, WORDMARK_CELLS, header};
+
+    /// A wide terminal with colour — the banner tier.
+    fn wide() -> Capabilities {
+        Capabilities { tty: true, ansi: true, no_color: false, columns: 120 }
+    }
+
+    /// `text` with every ANSI escape sequence dropped, so a painted line can be
+    /// measured in cells.
+    fn unstyled(text: &str) -> String {
+        let mut out = String::new();
+        let mut chars = text.chars();
+        while let Some(ch) = chars.next() {
+            if ch == '\u{1b}' {
+                // Every sequence the header emits is an SGR one, ending in `m`.
+                while chars.next().is_some_and(|next| next != 'm') {}
+            } else {
+                out.push(ch);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn every_wordmark_row_and_frame_line_is_one_width() {
+        for row in WORDMARK {
+            assert_eq!(row.chars().count(), WORDMARK_CELLS, "row {row:?}");
+        }
+        // The art is 50 cells wide, framed to 54 — the width the banner tier
+        // needs before it is offered at all.
+        assert_eq!((WORDMARK_CELLS, BANNER_CELLS), (50, 54));
+    }
+
+    #[test]
+    fn the_banner_frames_the_painted_wordmark_and_ends_with_the_plain_line() {
+        let out = header(&wide(), "9.9.9");
+        let lines: Vec<&str> = out.lines().collect();
+        let rail = |fill: &str| format!("█{}█", fill.repeat(BANNER_CELLS.saturating_sub(2)));
+        let (top, bottom) = (rail("▀"), rail("▄"));
+        let tail = format!("bdinfo-rs 9.9.9 - {TAGLINE}");
+
+        // Five wordmark rows between two borders, then the plain line.
+        assert_eq!(lines.len(), 8, "{out}");
+        assert_eq!(lines.first().copied(), Some(top.as_str()));
+        assert_eq!(lines.get(6).copied(), Some(bottom.as_str()));
+        assert_eq!(lines.get(7).copied(), Some(tail.as_str()));
+        // Only the wordmark cells are painted — the rails stay uncoloured.
+        for (line, row) in lines.iter().skip(1).zip(WORDMARK) {
+            assert_eq!(*line, format!("█ \u{1b}[38;2;242;166;90m{row}\u{1b}[0m █"));
+        }
+        for line in lines.iter().take(7) {
+            assert_eq!(unstyled(line).chars().count(), BANNER_CELLS, "line {line:?}");
+        }
+    }
+
+    #[test]
+    fn a_terminal_narrower_than_the_banner_falls_back_to_the_chip() {
+        let narrow = Capabilities {
+            tty: true,
+            ansi: true,
+            no_color: false,
+            columns: BANNER_CELLS.saturating_sub(1),
+        };
+        let out = header(&narrow, "9.9.9");
+        assert_eq!(unstyled(&out), format!(" bdinfo-rs 9.9.9   {TAGLINE}\n"));
+        assert!(out.contains("48;2;242;166;90"), "the chip fills with the accent: {out:?}");
+        assert!(out.contains("38;2;20;17;12"), "its label reads on the accent: {out:?}");
+        // Exactly at the banner's width the banner still fits.
+        let exact = Capabilities { tty: true, ansi: true, no_color: false, columns: BANNER_CELLS };
+        assert!(header(&exact, "9.9.9").starts_with('█'));
+    }
+
+    #[test]
+    fn no_terminal_no_ansi_or_no_color_all_give_the_plain_line() {
+        let expected = format!("bdinfo-rs 9.9.9 - {TAGLINE}\n");
+        for caps in [
+            Capabilities { tty: false, ansi: true, no_color: false, columns: 120 },
+            Capabilities { tty: true, ansi: false, no_color: false, columns: 120 },
+            Capabilities { tty: true, ansi: true, no_color: true, columns: 120 },
+        ] {
+            assert!(!caps.colors(), "{caps:?}");
+            let out = header(&caps, "9.9.9");
+            assert_eq!(out, expected, "{caps:?}");
+            assert!(!out.contains('\u{1b}'), "no escape byte: {out:?}");
+        }
+        assert!(wide().colors());
+    }
+
+    #[test]
+    fn the_probe_always_answers_with_a_usable_width() {
+        // Environment-bound — under a test harness stdout is captured, so the
+        // tiers themselves are exercised through stated capabilities above.
+        assert!(Capabilities::probe().columns > 0, "the width probe falls back, never to 0");
+    }
+
+    #[test]
+    fn the_tagline_is_the_commands_about() {
+        let about = crate::Cli::command().get_about().map(ToString::to_string);
+        assert_eq!(about.as_deref(), Some(TAGLINE));
+    }
+}

--- a/crates/bdinfo-rs/src/banner.rs
+++ b/crates/bdinfo-rs/src/banner.rs
@@ -108,15 +108,14 @@ pub(crate) fn header(caps: &Capabilities, version: &str) -> String {
     }
 }
 
-/// The header a scan session opens with, followed by a blank line — or nothing
-/// at all unless `interactive` and stdout is a terminal.
+/// The header a scan opens with, followed by a blank line — or nothing at all
+/// when `wanted` is false or stdout is not a terminal.
 ///
-/// Only the interactive picker has a human at the keyboard to greet. A
-/// flag-driven mode, or any run whose stdout is piped or redirected, gets the
-/// empty string, so its output is byte-for-byte what it would be without a
-/// header at all.
-pub(crate) fn session_header(caps: &Capabilities, version: &str, interactive: bool) -> String {
-    if interactive && caps.tty { format!("{}\n", header(caps, version)) } else { String::new() }
+/// The terminal check is what keeps automation unchanged: a piped or redirected
+/// run gets the empty string, so its output is byte-for-byte what it would be
+/// without this module, whatever `wanted` says.
+pub(crate) fn session_header(caps: &Capabilities, version: &str, wanted: bool) -> String {
+    if wanted && caps.tty { format!("{}\n", header(caps, version)) } else { String::new() }
 }
 
 /// The framed wordmark: the accent-painted rows between uncoloured block rails,
@@ -237,14 +236,14 @@ mod tests {
     }
 
     #[test]
-    fn only_an_interactive_run_on_a_terminal_opens_with_a_header() {
+    fn only_a_wanted_header_on_a_terminal_opens_a_scan() {
         let piped = Capabilities { tty: false, ansi: false, no_color: false, columns: 120 };
         // The header, then a blank line before the flow narration.
         assert_eq!(
             session_header(&wide(), "9.9.9", true),
             format!("{}\n", header(&wide(), "9.9.9"))
         );
-        // A flag-driven mode, a pipe, or both: not a byte.
+        // Declined, piped, or both: not a byte.
         assert_eq!(session_header(&wide(), "9.9.9", false), "");
         assert_eq!(session_header(&piped, "9.9.9", true), "");
         assert_eq!(session_header(&piped, "9.9.9", false), "");

--- a/crates/bdinfo-rs/src/cli.rs
+++ b/crates/bdinfo-rs/src/cli.rs
@@ -18,12 +18,14 @@
 // prose living on the man page instead — `build.rs` reattaches it to this same
 // `Command` before rendering it, so nothing documented here is lost.
 //
-// Three settings hold that card in shape. `-h`/`--help` is declared here with
+// Four settings hold that card in shape. `-h`/`--help` is declared here with
 // `HelpShort` (clap's own flag renders the long help for `--help`, which would
 // make the two spellings two different pages). `arg_required_else_help` routes a
-// bare invocation to the same card. And `help_template` drops clap's leading
-// `about` line, because the tagline already sits on the header line the binary
-// prints above the card.
+// bare invocation to the same card. `help_template` drops clap's leading `about`
+// line, because the tagline already sits on the header line the binary prints
+// above the card. And `bin_name` fixes the program name in the usage line, which
+// clap otherwise echoes from the invoked file — `bdinfo-rs.exe` on Windows — so
+// the card reads identically on every platform.
 //
 // NB: no `//!` inner doc comments here — this file is pasted into another module
 // by `include!`, where inner attributes are not allowed. Plain `//` only.
@@ -34,6 +36,7 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 #[command(
     name = "bdinfo-rs",
+    bin_name = "bdinfo-rs",
     version,
     about = "BDInfo-style Blu-ray disc reports",
     arg_required_else_help = true,

--- a/crates/bdinfo-rs/src/cli.rs
+++ b/crates/bdinfo-rs/src/cli.rs
@@ -73,6 +73,8 @@ struct Cli {
     show_short_playlists: bool,
     #[arg(long, help = "Also list looping playlists")]
     show_looping_playlists: bool,
+    #[arg(long, help = "Never print the banner")]
+    no_banner: bool,
     #[arg(
         short = 'v',
         long,

--- a/crates/bdinfo-rs/src/cli.rs
+++ b/crates/bdinfo-rs/src/cli.rs
@@ -14,17 +14,16 @@
 // Keeping it in one file means the completions and the man page can never drift
 // from the binary's actual flags, defaults, or help text.
 //
-// The help is one screen: a single short line per argument, and no `long_about`,
-// `long_help` or `after_long_help` anywhere. That absence is load-bearing —
-// clap renders the short card for `--help` only while no long help exists at
-// all (`Command::long_help_exists`), so removing one of those fields silently
-// splits `-h` and `--help` into two different pages. The long-form prose lives
-// on the man page instead: `build.rs` reattaches it to this same `Command`
-// before rendering it, so nothing documented here is lost.
+// The help is one screen: a single short line per argument, with the long-form
+// prose living on the man page instead — `build.rs` reattaches it to this same
+// `Command` before rendering it, so nothing documented here is lost.
 //
-// `arg_required_else_help` routes a bare invocation to that same card, and
-// `help_template` drops clap's leading `about` line because the tagline already
-// sits on the header line the binary prints above the card.
+// Three settings hold that card in shape. `-h`/`--help` is declared here with
+// `HelpShort` (clap's own flag renders the long help for `--help`, which would
+// make the two spellings two different pages). `arg_required_else_help` routes a
+// bare invocation to the same card. And `help_template` drops clap's leading
+// `about` line, because the tagline already sits on the header line the binary
+// prints above the card.
 //
 // NB: no `//!` inner doc comments here — this file is pasted into another module
 // by `include!`, where inner attributes are not allowed. Plain `//` only.
@@ -39,6 +38,7 @@ use clap::Parser;
     about = "BDInfo-style Blu-ray disc reports",
     arg_required_else_help = true,
     help_template = "{usage-heading} {usage}\n\n{all-args}",
+    disable_help_flag = true,
     disable_version_flag = true
 )]
 #[expect(
@@ -78,4 +78,12 @@ struct Cli {
         help = "Print version"
     )]
     version: Option<bool>,
+    #[arg(
+        short = 'h',
+        long,
+        action = clap::ArgAction::HelpShort,
+        value_parser = clap::value_parser!(bool),
+        help = "Print help"
+    )]
+    help: Option<bool>,
 }

--- a/crates/bdinfo-rs/src/cli.rs
+++ b/crates/bdinfo-rs/src/cli.rs
@@ -14,43 +14,31 @@
 // Keeping it in one file means the completions and the man page can never drift
 // from the binary's actual flags, defaults, or help text.
 //
+// The help is one screen: a single short line per argument, and no `long_about`,
+// `long_help` or `after_long_help` anywhere. That absence is load-bearing —
+// clap renders the short card for `--help` only while no long help exists at
+// all (`Command::long_help_exists`), so removing one of those fields silently
+// splits `-h` and `--help` into two different pages. The long-form prose lives
+// on the man page instead: `build.rs` reattaches it to this same `Command`
+// before rendering it, so nothing documented here is lost.
+//
+// `arg_required_else_help` routes a bare invocation to that same card, and
+// `help_template` drops clap's leading `about` line because the tagline already
+// sits on the header line the binary prints above the card.
+//
 // NB: no `//!` inner doc comments here — this file is pasted into another module
 // by `include!`, where inner attributes are not allowed. Plain `//` only.
 
 use clap::Parser;
 
-/// Memory-safe Blu-ray disc, folder, and image analyzer.
+/// The parsed `bdinfo-rs` command line.
 #[derive(Debug, Parser)]
 #[command(
     name = "bdinfo-rs",
     version,
-    about = "Memory-safe Blu-ray disc, folder, and image analyzer.",
-    long_about = "bdinfo-rs is a memory-safe, cross-platform Blu-ray analyzer — a drop-in \
-                  replacement for the classic BDInfo tool. It inspects a Blu-ray (a BDMV \
-                  folder or a .iso image) and writes the familiar human-readable disc \
-                  report: the playlists and clips, the M2TS stream layout, and the \
-                  per-stream video and audio technical specs — codecs, measured bitrates, \
-                  resolution, and HDR, Dolby Vision, or HDR10+ metadata.\n\n\
-                  It ships as a single statically-linked binary with no runtime, no shared \
-                  libraries, and nothing to install: the disc structures, the codec \
-                  scanners, and the read-only UDF 2.50 reader for .iso images are all pure \
-                  Rust.\n\n\
-                  Point BD_PATH at the disc and bdinfo-rs scans its metadata, presents the \
-                  playlist selection table, measures the chosen playlists, and writes \
-                  BDINFO.<volume label>.txt into REPORT_DEST.",
-    after_long_help = "Examples:\n  \
-        # Scan a ripped disc folder; pick playlists interactively, writing the\n  \
-        # report back into the same folder.\n  \
-        bdinfo-rs /media/MY_MOVIE\n\n  \
-        # Scan a disc image. A .iso has no folder to write into, so name a\n  \
-        # report destination explicitly.\n  \
-        bdinfo-rs MY_MOVIE.iso /tmp/reports\n\n  \
-        # Print the playlist selection table and stop, scanning nothing.\n  \
-        bdinfo-rs /media/MY_MOVIE --list\n\n  \
-        # Scan exactly the named playlists, in the given order.\n  \
-        bdinfo-rs /media/MY_MOVIE --mpls 00800,00801\n\n  \
-        # Scan every playlist the table lists.\n  \
-        bdinfo-rs /media/MY_MOVIE --whole",
+    about = "BDInfo-style Blu-ray disc reports",
+    arg_required_else_help = true,
+    help_template = "{usage-heading} {usage}\n\n{all-args}",
     disable_version_flag = true
 )]
 #[expect(
@@ -59,83 +47,35 @@ use clap::Parser;
               switches are orthogonal — no state machine or two-variant enum fits them"
 )]
 struct Cli {
-    #[arg(
-        value_name = "BD_PATH",
-        help = "The disc to analyze: a BDMV folder or a .iso image",
-        long_help = "The Blu-ray to analyze. This may be the disc root (the folder \
-                     containing BDMV), the BDMV folder itself, any folder inside it, or a \
-                     .iso disc image. Folder input is read through the filesystem; a .iso \
-                     is read through the in-house pure-Rust UDF 2.50 reader. A folder's \
-                     disc label is taken from the directory name, while a .iso reports the \
-                     real UDF volume label, so the same disc can differ on that one line."
-    )]
+    #[arg(value_name = "BD_PATH", help = "BDMV folder or .iso image")]
     bd_path: String,
     #[arg(
         value_name = "REPORT_DEST",
-        help = "Folder to write BDINFO.<volume label>.txt into [default: the disc folder]",
-        long_help = "The folder the report is written into, as BDINFO.<volume label>.txt. \
-                     It defaults to BD_PATH, which works for folder input; a .iso image has \
-                     no folder to fall back on, so a report destination must then be given \
-                     explicitly. The destination must be an existing directory."
+        help = "Report folder (default: BD_PATH; required for .iso)"
     )]
     report_dest: Option<String>,
-    #[arg(
-        short = 'l',
-        long,
-        help = "Print the playlist table and exit without scanning",
-        long_help = "Print the playlist selection table — the standard filtered set of \
-                     playlists with their length and size — then exit without measuring \
-                     anything or writing a report."
-    )]
+    #[arg(short = 'l', long, help = "List playlists and exit")]
     list: bool,
     #[arg(
         short = 'm',
         long,
         value_name = "NAME,...",
         value_delimiter = ',',
-        help = "Scan exactly these playlists, by name, in the given order",
-        long_help = "Select playlists by name instead of from the table, as a \
-                     comma-separated list (for example 00800,00801). Names are matched \
-                     case-insensitively and the .MPLS extension may be omitted. The named \
-                     playlists are scanned in the order given, unfiltered, so this reaches \
-                     playlists the table would hide. It takes precedence over --whole and \
-                     the interactive picker."
+        help = "Scan only the named playlists (00800,00801)"
     )]
     mpls: Vec<String>,
-    #[arg(
-        short = 'w',
-        long,
-        help = "Scan every playlist the table lists",
-        long_help = "Select every playlist shown in the selection table — the standard \
-                     filtered set — and scan them all, rather than choosing interactively."
-    )]
+    #[arg(short = 'w', long, help = "Scan every listed playlist")]
     whole: bool,
-    #[arg(
-        long,
-        help = "Also list playlists shorter than 20s",
-        long_help = "Include playlists shorter than 20 seconds in the selection table. They are \
-                     hidden by default — a disc's menu, logo and transition playlists are \
-                     usually short — so this widens what --list prints, what the interactive \
-                     picker offers, and what --whole scans."
-    )]
+    #[arg(long, help = "Also list playlists shorter than 20s")]
     show_short_playlists: bool,
-    #[arg(
-        long,
-        help = "Also list looping playlists",
-        long_help = "Include looping playlists — those repeating a play item — in the selection \
-                     table. They are hidden by default as authoring artefacts, so this widens \
-                     what --list prints, what the interactive picker offers, and what --whole \
-                     scans. A disc that disguises its main feature as a loop needs this flag to \
-                     make that playlist selectable."
-    )]
+    #[arg(long, help = "Also list looping playlists")]
     show_looping_playlists: bool,
     #[arg(
         short = 'v',
         long,
         action = clap::ArgAction::Version,
         value_parser = clap::value_parser!(bool),
-        help = "Print version",
-        long_help = "Print the bdinfo-rs version and exit."
+        help = "Print version"
     )]
     version: Option<bool>,
 }

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -37,15 +37,16 @@
 //!
 //! `-h`/`--help` and a bare invocation all print the same one-screen help
 //! card, headed by a banner, a colour chip or a plain line depending on what
-//! the terminal can render (see [`banner`]). The long-form documentation is
+//! the terminal can render (see [`banner`]); the same header opens an
+//! interactive picker session on a terminal. The long-form documentation is
 //! the man page `build.rs` generates from the same command.
 //!
-//! Exit codes: `0` success, `1` malformed/not a BD structure or no matching
-//! playlist, `2` no such path / unusable `REPORT_DEST` / unwritable report
-//! file / a bare invocation (whose required `BD_PATH` is missing), `3`
-//! completed with errors (a partial report was written), `130` scan cancelled
-//! by Ctrl+C (the Unix `128 + SIGINT` spelling, used on every platform; no
-//! report is written).
+//! Exit codes: `0` success (a bare invocation prints the help and lands here
+//! too), `1` malformed/not a BD structure or no matching playlist, `2` no such
+//! path / unusable `REPORT_DEST` / unwritable report file / an invalid
+//! argument, `3` completed with errors (a partial report was written), `130`
+//! scan cancelled by Ctrl+C (the Unix `128 + SIGINT` spelling, used on every
+//! platform; no report is written).
 //!
 //! Ctrl+C during the packet scan, on the styled (ANSI-terminal) progress
 //! path, cancels cooperatively: the terminal is put in raw mode for the scan
@@ -98,24 +99,27 @@ fn main() -> ExitCode {
     }
 }
 
-/// Prints what clap could not parse, and returns the exit code clap itself
-/// would have exited with.
+/// Prints what clap could not parse, and returns the process exit code.
 ///
 /// The two help kinds — `-h`/`--help`, and the bare invocation
 /// `arg_required_else_help` answers with that same card — print the
-/// capability-chosen header above clap's card on stdout, keeping clap's exit
-/// codes: `0` for a help that was asked for, `2` for the bare run, whose
-/// required `BD_PATH` is still missing. Every other kind, `--version` included,
-/// is clap's own output on clap's own stream.
+/// capability-chosen header above clap's card on stdout and exit `0`. Every
+/// other kind, `--version` included, is clap's own output on clap's own stream,
+/// with clap's own exit code.
 fn report_parse_failure(err: &clap::Error) -> u8 {
     if matches!(
         err.kind(),
         ErrorKind::DisplayHelp | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
     ) {
         print!("{}", help_page(&banner::Capabilities::probe(), err));
-    } else {
-        let _ = err.print().is_ok();
+        // A bare run is a help request, not a usage error, so it exits 0 where
+        // clap would exit 2: package-manager install validators smoke-run the
+        // executable with no arguments, and a non-zero exit there reads as a
+        // broken install (CHANGELOG.md, v1.0.1). An actual but invalid argument
+        // still takes the usage-error path below.
+        return 0;
     }
+    let _ = err.print().is_ok();
     u8::try_from(err.exit_code()).unwrap_or(2)
 }
 
@@ -234,6 +238,14 @@ fn report_errors(errors: &[ScanError]) {
     }
 }
 
+/// Whether this invocation ends at the interactive picker: no mode flag, so the
+/// table is offered to a person rather than consumed by one of `--list`,
+/// `--whole` or `--mpls`. The one flow with someone at the keyboard, and so the
+/// only scan flow [`banner::session_header`] greets.
+const fn picks_interactively(cli: &Cli) -> bool {
+    cli.mpls.is_empty() && !cli.list && !cli.whole
+}
+
 /// Executes the parsed CLI, returning the process exit code.
 ///
 /// The classic console flow: validate `BD_PATH`, resolve and validate
@@ -251,6 +263,15 @@ fn run(cli: &Cli) -> u8 {
         Err(code) => return code,
     };
 
+    // After the argument checks, so a bad path stays a bare error message.
+    print!(
+        "{}",
+        banner::session_header(
+            &banner::Capabilities::probe(),
+            env!("CARGO_PKG_VERSION"),
+            picks_interactively(cli),
+        )
+    );
     println!("Please wait while we scan the disc...");
     let (bdrom, errors) =
         match scan_disc(&cli.bd_path, false, None, &mut no_progress, &AtomicBool::new(false)) {
@@ -1111,9 +1132,9 @@ mod tests {
     use super::{
         BAR_MAX_CELLS, Cli, ProgressDisplay, analyze_preamble, banner, compose_progress,
         compose_styled_progress, erase_sequence, finish_early, group_n0, help_page, hidden_hint,
-        hms, named_selection, normalize_playlist_name, pick_playlists, redraw_sequence,
-        report_parse_failure, row_names, run, selection_order, selection_stream_files,
-        selection_table, table_length, table_rows,
+        hms, named_selection, normalize_playlist_name, pick_playlists, picks_interactively,
+        redraw_sequence, report_parse_failure, row_names, run, selection_order,
+        selection_stream_files, selection_table, table_length, table_rows,
     };
 
     /// A throwaway minimal BD folder (`BDMV/PLAYLIST` + `BDMV/CLIPINF`, both empty)
@@ -1714,17 +1735,35 @@ Options:
     }
 
     #[test]
-    fn the_help_paths_keep_claps_exit_codes() {
+    fn the_help_paths_exit_zero_and_bad_arguments_exit_two() {
         for (args, code) in [
-            (["bdinfo-rs"].as_slice(), 2),
+            // A bare run is a help request, not a usage error.
+            (["bdinfo-rs"].as_slice(), 0),
             (&["bdinfo-rs", "-h"], 0),
             (&["bdinfo-rs", "--help"], 0),
             (&["bdinfo-rs", "-v"], 0),
+            // An actual argument that cannot parse still is one.
             (&["bdinfo-rs", "--nope"], 2),
             (&["bdinfo-rs", "--list"], 2),
         ] {
             let err = Cli::try_parse_from(args.iter()).expect_err("none of these parse");
             assert_eq!(report_parse_failure(&err), code, "{args:?}");
+        }
+    }
+
+    #[test]
+    fn only_a_mode_free_invocation_reaches_the_picker() {
+        let bd = TempBd::new();
+        let path = bd.root.to_string_lossy().into_owned();
+        let parse = |args: &[&str]| {
+            let mut full = vec!["bdinfo-rs", &path];
+            full.extend_from_slice(args);
+            Cli::try_parse_from(full).expect("parse args")
+        };
+        assert!(picks_interactively(&parse(&[])));
+        assert!(picks_interactively(&parse(&["--show-looping-playlists"])));
+        for mode in [["--list"].as_slice(), &["--whole"], &["--mpls", "00000"]] {
+            assert!(!picks_interactively(&parse(mode)), "{mode:?}");
         }
     }
 

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -35,11 +35,17 @@
 //! draws on stderr; the flow narration (table, picker, analysis preamble,
 //! classic epilogue, saved-report message) prints on stdout.
 //!
+//! `-h`/`--help` and a bare invocation all print the same one-screen help
+//! card, headed by a banner, a colour chip or a plain line depending on what
+//! the terminal can render (see [`banner`]). The long-form documentation is
+//! the man page `build.rs` generates from the same command.
+//!
 //! Exit codes: `0` success, `1` malformed/not a BD structure or no matching
 //! playlist, `2` no such path / unusable `REPORT_DEST` / unwritable report
-//! file, `3` completed with errors (a partial report was written), `130` scan
-//! cancelled by Ctrl+C (the Unix `128 + SIGINT` spelling, used on every
-//! platform; no report is written).
+//! file / a bare invocation (whose required `BD_PATH` is missing), `3`
+//! completed with errors (a partial report was written), `130` scan cancelled
+//! by Ctrl+C (the Unix `128 + SIGINT` spelling, used on every platform; no
+//! report is written).
 //!
 //! Ctrl+C during the packet scan, on the styled (ANSI-terminal) progress
 //! path, cancels cooperatively: the terminal is put in raw mode for the scan
@@ -71,7 +77,7 @@ use bdinfo_rs_core::error::{BdError, ScanError};
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 use bdinfo_rs_core::vfs::fs::FsDir;
 use bdinfo_rs_core::vfs::udf::source::{PathIso, UdfSource};
-use clap::CommandFactory as _;
+use clap::error::ErrorKind;
 use crossterm::style::Stylize as _;
 use crossterm::{Command as _, cursor, terminal};
 
@@ -82,22 +88,45 @@ use crossterm::{Command as _, cursor, terminal};
 // `use clap::Parser;` along with it, so `Cli::parse()` below resolves.
 include!("cli.rs");
 
+mod banner;
 mod volume;
 
 fn main() -> ExitCode {
-    // A bare invocation (no arguments at all) prints the help to stdout and
-    // exits 0, rather than letting clap reject the missing required BD_PATH with
-    // a usage error on stderr (exit 2). Treating "no arguments" as a help request
-    // is friendlier for a double-clicked binary, and keeps package-manager
-    // install validators that smoke-run the executable from reading a clean run
-    // as a failure. Any actual argument still parses normally — a missing or bad
-    // path remains the usual exit-2 usage error. `args_os` (not `args`) so a
-    // non-UTF-8 argument can't panic this check.
-    if std::env::args_os().nth(1).is_none() {
-        let _ = Cli::command().print_long_help().is_ok();
-        return ExitCode::SUCCESS;
+    match Cli::try_parse() {
+        Ok(cli) => ExitCode::from(run(&cli)),
+        Err(err) => ExitCode::from(report_parse_failure(&err)),
     }
-    ExitCode::from(run(&Cli::parse()))
+}
+
+/// Prints what clap could not parse, and returns the exit code clap itself
+/// would have exited with.
+///
+/// The two help kinds — `-h`/`--help`, and the bare invocation
+/// `arg_required_else_help` answers with that same card — print the
+/// capability-chosen header above clap's card on stdout, keeping clap's exit
+/// codes: `0` for a help that was asked for, `2` for the bare run, whose
+/// required `BD_PATH` is still missing. Every other kind, `--version` included,
+/// is clap's own output on clap's own stream.
+fn report_parse_failure(err: &clap::Error) -> u8 {
+    if matches!(
+        err.kind(),
+        ErrorKind::DisplayHelp | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+    ) {
+        print!("{}", help_page(&banner::Capabilities::probe(), err));
+    } else {
+        let _ = err.print().is_ok();
+    }
+    u8::try_from(err.exit_code()).unwrap_or(2)
+}
+
+/// The help page as printed: the header for `caps`, a blank line, then clap's
+/// rendered card. The card is ANSI-styled only where `caps` allows colour, so a
+/// piped or `NO_COLOR` run carries no escape byte at all — header and card
+/// alike.
+fn help_page(caps: &banner::Capabilities, err: &clap::Error) -> String {
+    let card = err.render();
+    let card = if caps.colors() { card.ansi().to_string() } else { card.to_string() };
+    format!("{}\n{card}", banner::header(caps, env!("CARGO_PKG_VERSION")))
 }
 
 /// Whether `path` is an `.iso` image (a file with the `.iso` extension,
@@ -1080,10 +1109,11 @@ mod tests {
     use clap::error::ErrorKind;
 
     use super::{
-        BAR_MAX_CELLS, Cli, ProgressDisplay, analyze_preamble, compose_progress,
-        compose_styled_progress, erase_sequence, finish_early, group_n0, hidden_hint, hms,
-        named_selection, normalize_playlist_name, pick_playlists, redraw_sequence, row_names, run,
-        selection_order, selection_stream_files, selection_table, table_length, table_rows,
+        BAR_MAX_CELLS, Cli, ProgressDisplay, analyze_preamble, banner, compose_progress,
+        compose_styled_progress, erase_sequence, finish_early, group_n0, help_page, hidden_hint,
+        hms, named_selection, normalize_playlist_name, pick_playlists, redraw_sequence,
+        report_parse_failure, row_names, run, selection_order, selection_stream_files,
+        selection_table, table_length, table_rows,
     };
 
     /// A throwaway minimal BD folder (`BDMV/PLAYLIST` + `BDMV/CLIPINF`, both empty)
@@ -1621,6 +1651,97 @@ mod tests {
         let bd = TempBd::new();
         let cli = Cli::try_parse_from(["bdinfo-rs", &bd.root.to_string_lossy()]).expect("parse");
         assert!(!format!("{cli:?}").is_empty());
+    }
+
+    /// The compact help card, byte for byte: the body every help path prints,
+    /// under whichever header the terminal earns.
+    const CARD: &str = "\
+Usage: bdinfo-rs [OPTIONS] <BD_PATH> [REPORT_DEST]
+
+Arguments:
+  <BD_PATH>      BDMV folder or .iso image
+  [REPORT_DEST]  Report folder (default: BD_PATH; required for .iso)
+
+Options:
+  -l, --list                    List playlists and exit
+  -m, --mpls <NAME,...>         Scan only the named playlists (00800,00801)
+  -w, --whole                   Scan every listed playlist
+      --show-short-playlists    Also list playlists shorter than 20s
+      --show-looping-playlists  Also list looping playlists
+  -v, --version                 Print version
+  -h, --help                    Print help
+";
+
+    /// A piped, colourless stdout — the header tier that pins a stable page.
+    fn piped_caps() -> banner::Capabilities {
+        banner::Capabilities { tty: false, ansi: false, no_color: false, columns: 80 }
+    }
+
+    /// The whole page a piped help path prints: the plain header, a blank line,
+    /// then [`CARD`].
+    fn plain_page() -> String {
+        format!("bdinfo-rs {} - {}\n\n{CARD}", env!("CARGO_PKG_VERSION"), banner::TAGLINE)
+    }
+
+    #[test]
+    fn every_help_path_prints_the_same_one_screen_card() {
+        let bare = Cli::try_parse_from(["bdinfo-rs"]).expect_err("a bare run asks for the help");
+        assert_eq!(bare.kind(), ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand);
+        assert_eq!(help_page(&piped_caps(), &bare), plain_page());
+        // `--help` matches `-h` only while no long help exists anywhere in the
+        // command; adding one back would split them into two pages.
+        for flag in ["-h", "--help"] {
+            let err = Cli::try_parse_from(["bdinfo-rs", flag]).expect_err("help exits parsing");
+            assert_eq!(err.kind(), ErrorKind::DisplayHelp, "{flag}");
+            assert_eq!(help_page(&piped_caps(), &err), plain_page(), "{flag}");
+        }
+        // One screen: nothing wraps at the classic 80 columns.
+        for line in plain_page().lines() {
+            assert!(line.chars().count() <= 80, "{line:?}");
+        }
+    }
+
+    #[test]
+    fn a_colour_terminal_heads_the_card_with_the_banner() {
+        let err = Cli::try_parse_from(["bdinfo-rs", "-h"]).expect_err("help exits parsing");
+        let caps = banner::Capabilities { tty: true, ansi: true, no_color: false, columns: 120 };
+        let page = help_page(&caps, &err);
+        assert!(page.starts_with('█'), "the banner heads the page: {page}");
+        assert!(page.contains("\u{1b}[38;2;242;166;90m"), "the wordmark is painted: {page}");
+        assert!(page.contains("--show-looping-playlists"), "the card follows: {page}");
+        // The same card is styled here and bare when piped.
+        assert!(!plain_page().contains('\u{1b}'), "a piped page carries no escape byte");
+    }
+
+    #[test]
+    fn the_help_paths_keep_claps_exit_codes() {
+        for (args, code) in [
+            (["bdinfo-rs"].as_slice(), 2),
+            (&["bdinfo-rs", "-h"], 0),
+            (&["bdinfo-rs", "--help"], 0),
+            (&["bdinfo-rs", "-v"], 0),
+            (&["bdinfo-rs", "--nope"], 2),
+            (&["bdinfo-rs", "--list"], 2),
+        ] {
+            let err = Cli::try_parse_from(args.iter()).expect_err("none of these parse");
+            assert_eq!(report_parse_failure(&err), code, "{args:?}");
+        }
+    }
+
+    #[test]
+    fn the_generated_man_page_carries_the_long_form_prose() {
+        // The card drops the long-form prose; `build.rs` reattaches it to the
+        // same command before rendering the man page. roff escapes every
+        // hyphen, so these probes carry none.
+        let man = include_str!(concat!(env!("OUT_DIR"), "/assets/bdinfo-rs.1"));
+        for prose in [
+            "It ships as a single statically",
+            "Scan a ripped disc folder",
+            "the .MPLS extension may be omitted",
+            "authoring artefacts",
+        ] {
+            assert!(man.contains(prose), "the man page is missing {prose:?}");
+        }
     }
 
     #[test]

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -37,9 +37,10 @@
 //!
 //! `-h`/`--help` and a bare invocation all print the same one-screen help
 //! card, headed by a banner, a colour chip or a plain line depending on what
-//! the terminal can render (see [`banner`]); the same header opens an
-//! interactive picker session on a terminal. The long-form documentation is
-//! the man page `build.rs` generates from the same command.
+//! the terminal can render (see [`banner`]); the same header opens every scan
+//! run whose stdout is a terminal. `--no-banner` drops it everywhere, and a
+//! piped or redirected run never prints it at all. The long-form documentation
+//! is the man page `build.rs` generates from the same command.
 //!
 //! Exit codes: `0` success (a bare invocation prints the help and lands here
 //! too), `1` malformed/not a BD structure or no matching playlist, `2` no such
@@ -111,7 +112,7 @@ fn report_parse_failure(err: &clap::Error) -> u8 {
         err.kind(),
         ErrorKind::DisplayHelp | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
     ) {
-        print!("{}", help_page(&banner::Capabilities::probe(), err));
+        print!("{}", help_page(&banner::Capabilities::probe(), err, !banner_declined()));
         // A bare run is a help request, not a usage error, so it exits 0 where
         // clap would exit 2: package-manager install validators smoke-run the
         // executable with no arguments, and a non-zero exit there reads as a
@@ -123,13 +124,23 @@ fn report_parse_failure(err: &clap::Error) -> u8 {
     u8::try_from(err.exit_code()).unwrap_or(2)
 }
 
+/// Whether `--no-banner` is on the command line, read from the raw arguments:
+/// the help paths answer before clap has produced a `Cli` to ask, and the
+/// switch is a plain flag, so its presence is the whole question.
+fn banner_declined() -> bool {
+    std::env::args_os().any(|arg| arg == "--no-banner")
+}
+
 /// The help page as printed: the header for `caps`, a blank line, then clap's
-/// rendered card. The card is ANSI-styled only where `caps` allows colour, so a
-/// piped or `NO_COLOR` run carries no escape byte at all — header and card
-/// alike.
-fn help_page(caps: &banner::Capabilities, err: &clap::Error) -> String {
+/// rendered card — or the card alone when `header` is false. The card is
+/// ANSI-styled only where `caps` allows colour, so a piped or `NO_COLOR` run
+/// carries no escape byte at all, header and card alike.
+fn help_page(caps: &banner::Capabilities, err: &clap::Error, header: bool) -> String {
     let card = err.render();
     let card = if caps.colors() { card.ansi().to_string() } else { card.to_string() };
+    if !header {
+        return card;
+    }
     format!("{}\n{card}", banner::header(caps, env!("CARGO_PKG_VERSION")))
 }
 
@@ -238,14 +249,6 @@ fn report_errors(errors: &[ScanError]) {
     }
 }
 
-/// Whether this invocation ends at the interactive picker: no mode flag, so the
-/// table is offered to a person rather than consumed by one of `--list`,
-/// `--whole` or `--mpls`. The one flow with someone at the keyboard, and so the
-/// only scan flow [`banner::session_header`] greets.
-const fn picks_interactively(cli: &Cli) -> bool {
-    cli.mpls.is_empty() && !cli.list && !cli.whole
-}
-
 /// Executes the parsed CLI, returning the process exit code.
 ///
 /// The classic console flow: validate `BD_PATH`, resolve and validate
@@ -269,7 +272,7 @@ fn run(cli: &Cli) -> u8 {
         banner::session_header(
             &banner::Capabilities::probe(),
             env!("CARGO_PKG_VERSION"),
-            picks_interactively(cli),
+            !cli.no_banner,
         )
     );
     println!("Please wait while we scan the disc...");
@@ -1132,9 +1135,9 @@ mod tests {
     use super::{
         BAR_MAX_CELLS, Cli, ProgressDisplay, analyze_preamble, banner, compose_progress,
         compose_styled_progress, erase_sequence, finish_early, group_n0, help_page, hidden_hint,
-        hms, named_selection, normalize_playlist_name, pick_playlists, picks_interactively,
-        redraw_sequence, report_parse_failure, row_names, run, selection_order,
-        selection_stream_files, selection_table, table_length, table_rows,
+        hms, named_selection, normalize_playlist_name, pick_playlists, redraw_sequence,
+        report_parse_failure, row_names, run, selection_order, selection_stream_files,
+        selection_table, table_length, table_rows,
     };
 
     /// A throwaway minimal BD folder (`BDMV/PLAYLIST` + `BDMV/CLIPINF`, both empty)
@@ -1689,6 +1692,7 @@ Options:
   -w, --whole                   Scan every listed playlist
       --show-short-playlists    Also list playlists shorter than 20s
       --show-looping-playlists  Also list looping playlists
+      --no-banner               Never print the banner
   -v, --version                 Print version
   -h, --help                    Print help
 ";
@@ -1708,13 +1712,13 @@ Options:
     fn every_help_path_prints_the_same_one_screen_card() {
         let bare = Cli::try_parse_from(["bdinfo-rs"]).expect_err("a bare run asks for the help");
         assert_eq!(bare.kind(), ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand);
-        assert_eq!(help_page(&piped_caps(), &bare), plain_page());
+        assert_eq!(help_page(&piped_caps(), &bare, true), plain_page());
         // `--help` matches `-h` only while no long help exists anywhere in the
         // command; adding one back would split them into two pages.
         for flag in ["-h", "--help"] {
             let err = Cli::try_parse_from(["bdinfo-rs", flag]).expect_err("help exits parsing");
             assert_eq!(err.kind(), ErrorKind::DisplayHelp, "{flag}");
-            assert_eq!(help_page(&piped_caps(), &err), plain_page(), "{flag}");
+            assert_eq!(help_page(&piped_caps(), &err, true), plain_page(), "{flag}");
         }
         // One screen: nothing wraps at the classic 80 columns.
         for line in plain_page().lines() {
@@ -1726,7 +1730,7 @@ Options:
     fn a_colour_terminal_heads_the_card_with_the_banner() {
         let err = Cli::try_parse_from(["bdinfo-rs", "-h"]).expect_err("help exits parsing");
         let caps = banner::Capabilities { tty: true, ansi: true, no_color: false, columns: 120 };
-        let page = help_page(&caps, &err);
+        let page = help_page(&caps, &err, true);
         assert!(page.starts_with('█'), "the banner heads the page: {page}");
         assert!(page.contains("\u{1b}[38;2;242;166;90m"), "the wordmark is painted: {page}");
         assert!(page.contains("--show-looping-playlists"), "the card follows: {page}");
@@ -1752,19 +1756,14 @@ Options:
     }
 
     #[test]
-    fn only_a_mode_free_invocation_reaches_the_picker() {
-        let bd = TempBd::new();
-        let path = bd.root.to_string_lossy().into_owned();
-        let parse = |args: &[&str]| {
-            let mut full = vec!["bdinfo-rs", &path];
-            full.extend_from_slice(args);
-            Cli::try_parse_from(full).expect("parse args")
-        };
-        assert!(picks_interactively(&parse(&[])));
-        assert!(picks_interactively(&parse(&["--show-looping-playlists"])));
-        for mode in [["--list"].as_slice(), &["--whole"], &["--mpls", "00000"]] {
-            assert!(!picks_interactively(&parse(mode)), "{mode:?}");
-        }
+    fn no_banner_drops_the_header_and_leaves_the_card() {
+        let err = Cli::try_parse_from(["bdinfo-rs", "-h"]).expect_err("help exits parsing");
+        assert_eq!(help_page(&piped_caps(), &err, false), CARD);
+        // The switch is read from the real command line, which under a test
+        // harness is the harness's own — so the help path keeps its header.
+        assert!(!super::banner_declined());
+        let cli = Cli::try_parse_from(["bdinfo-rs", "disc", "--no-banner"]).expect("parse");
+        assert!(cli.no_banner);
     }
 
     #[test]

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -55,11 +55,12 @@ fn every_help_path_prints_the_same_compact_card() {
     let short = bdinfo_rs().arg("-h").output().expect("spawn bdinfo-rs");
     let bare = bdinfo_rs().output().expect("spawn bdinfo-rs");
 
-    // Asking for the help succeeds; a bare run prints the same page but is
-    // still a missing required argument, which is clap's exit 2.
+    // Every help path succeeds, the bare run included: it is a help request,
+    // not a usage error, so an install validator smoke-running the executable
+    // sees a clean exit.
     assert!(long.status.success(), "--help: {:?}", long.status.code());
     assert!(short.status.success(), "-h: {:?}", short.status.code());
-    assert_eq!(bare.status.code(), Some(2));
+    assert!(bare.status.success(), "bare run: {:?}", bare.status.code());
     assert_eq!(short.stdout, long.stdout, "-h and --help differ");
     assert_eq!(bare.stdout, long.stdout, "a bare run and --help differ");
     for output in [&long, &short, &bare] {
@@ -554,6 +555,9 @@ fn the_interactive_picker_selects_by_table_index() {
     assert!(output.status.success());
     assert!(saved, "the picked playlist reports");
     let stdout = String::from_utf8_lossy(&output.stdout);
+    // The session header greets a terminal only: piped here, so the picker
+    // session opens on the scan notice like every other mode.
+    assert!(stdout.starts_with("Please wait while we scan the disc..."), "opening: {stdout}");
     assert!(stdout.contains("Select (q when finished): "), "prompts: {stdout}");
     assert!(stdout.contains("Invalid Input!"), "rejects words: {stdout}");
     assert!(stdout.contains("Invalid Selection!"), "rejects out-of-range: {stdout}");

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -29,35 +29,61 @@ fn version_prints_and_succeeds() {
     }
 }
 
+/// The help card below its usage line, byte for byte. The usage line itself is
+/// excluded because clap names the program as it was invoked, which carries the
+/// `.exe` suffix on Windows.
+const CARD_BODY: &str = "\
+Arguments:
+  <BD_PATH>      BDMV folder or .iso image
+  [REPORT_DEST]  Report folder (default: BD_PATH; required for .iso)
+
+Options:
+  -l, --list                    List playlists and exit
+  -m, --mpls <NAME,...>         Scan only the named playlists (00800,00801)
+  -w, --whole                   Scan every listed playlist
+      --show-short-playlists    Also list playlists shorter than 20s
+      --show-looping-playlists  Also list looping playlists
+  -v, --version                 Print version
+  -h, --help                    Print help
+";
+
 #[test]
-fn help_shows_the_normalized_surface_and_exits_zero() {
-    let output = bdinfo_rs().arg("--help").output().expect("spawn bdinfo-rs");
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    // The positional surface plus the four flags…
-    assert!(stdout.contains("<BD_PATH>"), "help: {stdout}");
-    assert!(stdout.contains("[REPORT_DEST]"), "help: {stdout}");
-    for flag in ["-l, --list", "-m, --mpls", "-w, --whole", "-h, --help", "-v, --version"] {
-        assert!(stdout.contains(flag), "help is missing {flag}: {stdout}");
+fn every_help_path_prints_the_same_compact_card() {
+    let long = bdinfo_rs().arg("--help").output().expect("spawn bdinfo-rs");
+    let short = bdinfo_rs().arg("-h").output().expect("spawn bdinfo-rs");
+    let bare = bdinfo_rs().output().expect("spawn bdinfo-rs");
+
+    // Asking for the help succeeds; a bare run prints the same page but is
+    // still a missing required argument, which is clap's exit 2.
+    assert!(long.status.success(), "--help: {:?}", long.status.code());
+    assert!(short.status.success(), "-h: {:?}", short.status.code());
+    assert_eq!(bare.status.code(), Some(2));
+    assert_eq!(short.stdout, long.stdout, "-h and --help differ");
+    assert_eq!(bare.stdout, long.stdout, "a bare run and --help differ");
+    for output in [&long, &short, &bare] {
+        assert!(output.stderr.is_empty(), "the help is not an error report: {:?}", output.stderr);
     }
-    // …and nothing else: no subcommands, no removed switches.
+
+    let stdout = String::from_utf8_lossy(&long.stdout);
+    let mut lines = stdout.lines();
+    let header =
+        format!("bdinfo-rs {} - BDInfo-style Blu-ray disc reports", env!("CARGO_PKG_VERSION"));
+    // A pipe gets the plain header, a blank line, then the card.
+    assert_eq!(lines.next(), Some(header.as_str()), "header: {stdout}");
+    assert_eq!(lines.next(), Some(""), "blank line under the header: {stdout}");
+    let usage = lines.next().unwrap_or_default();
+    assert!(usage.starts_with("Usage: "), "usage line: {stdout}");
+    assert!(usage.ends_with(" [OPTIONS] <BD_PATH> [REPORT_DEST]"), "usage line: {stdout}");
+    assert!(stdout.ends_with(CARD_BODY), "the card drifted: {stdout}");
+    // No colour when piped, and one screen wide.
+    assert!(!stdout.contains('\u{1b}'), "escape codes in a piped help: {stdout:?}");
+    for line in stdout.lines() {
+        assert!(line.chars().count() <= 80, "wider than 80 columns: {line:?}");
+    }
+    // No subcommands and no removed switches.
     for gone in ["dump", "--strict", "--output", "--save", "--no-", "--level"] {
         assert!(!stdout.contains(gone), "help still shows {gone}: {stdout}");
     }
-}
-
-#[test]
-fn no_arguments_print_help_and_exit_zero() {
-    // A bare invocation is treated as a help request: the long help goes to
-    // stdout and the process exits 0 (not clap's exit-2 usage error), with
-    // nothing on stderr. Any actual argument still parses — see
-    // `a_subcommand_style_invocation_is_just_a_bad_path` for the exit-2 path.
-    let output = bdinfo_rs().output().expect("spawn bdinfo-rs");
-    assert!(output.status.success(), "no-args exits 0: {:?}", output.status.code());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Usage:"), "no-args prints usage: {stdout}");
-    assert!(stdout.contains("<BD_PATH>"), "no-args prints help: {stdout}");
-    assert!(output.stderr.is_empty(), "no error output on a help request: {:?}", output.stderr);
 }
 
 /// A valid zero-item `*.mpls` (magic `MPLS0300`, one empty `PlayList`, no marks)
@@ -359,6 +385,9 @@ fn list_prints_the_playlist_table_and_exits() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
+    // A scan flow opens on the scan notice: the help header reaches no other
+    // path than the help itself.
+    assert!(stdout.starts_with("Please wait while we scan the disc..."), "opening: {stdout}");
     assert!(
         stdout.contains("#   Group  Playlist File  Length    Estimated Bytes Measured Bytes"),
         "table: {stdout}"

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -29,10 +29,12 @@ fn version_prints_and_succeeds() {
     }
 }
 
-/// The help card below its usage line, byte for byte. The usage line itself is
-/// excluded because clap names the program as it was invoked, which carries the
-/// `.exe` suffix on Windows.
-const CARD_BODY: &str = "\
+/// The help card the binary prints, byte for byte — usage line included, which
+/// holds only because the command pins `bin_name`: clap otherwise names the
+/// program as it was invoked, `.exe` suffix and all.
+const CARD: &str = "\
+Usage: bdinfo-rs [OPTIONS] <BD_PATH> [REPORT_DEST]
+
 Arguments:
   <BD_PATH>      BDMV folder or .iso image
   [REPORT_DEST]  Report folder (default: BD_PATH; required for .iso)
@@ -64,17 +66,13 @@ fn every_help_path_prints_the_same_compact_card() {
         assert!(output.stderr.is_empty(), "the help is not an error report: {:?}", output.stderr);
     }
 
-    let stdout = String::from_utf8_lossy(&long.stdout);
-    let mut lines = stdout.lines();
-    let header =
-        format!("bdinfo-rs {} - BDInfo-style Blu-ray disc reports", env!("CARGO_PKG_VERSION"));
     // A pipe gets the plain header, a blank line, then the card.
-    assert_eq!(lines.next(), Some(header.as_str()), "header: {stdout}");
-    assert_eq!(lines.next(), Some(""), "blank line under the header: {stdout}");
-    let usage = lines.next().unwrap_or_default();
-    assert!(usage.starts_with("Usage: "), "usage line: {stdout}");
-    assert!(usage.ends_with(" [OPTIONS] <BD_PATH> [REPORT_DEST]"), "usage line: {stdout}");
-    assert!(stdout.ends_with(CARD_BODY), "the card drifted: {stdout}");
+    let stdout = String::from_utf8_lossy(&long.stdout);
+    let expected = format!(
+        "bdinfo-rs {} - BDInfo-style Blu-ray disc reports\n\n{CARD}",
+        env!("CARGO_PKG_VERSION")
+    );
+    assert_eq!(stdout, expected, "the help page drifted");
     // No colour when piped, and one screen wide.
     assert!(!stdout.contains('\u{1b}'), "escape codes in a piped help: {stdout:?}");
     for line in stdout.lines() {

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -45,6 +45,7 @@ Options:
   -w, --whole                   Scan every listed playlist
       --show-short-playlists    Also list playlists shorter than 20s
       --show-looping-playlists  Also list looping playlists
+      --no-banner               Never print the banner
   -v, --version                 Print version
   -h, --help                    Print help
 ";
@@ -79,10 +80,14 @@ fn every_help_path_prints_the_same_compact_card() {
     for line in stdout.lines() {
         assert!(line.chars().count() <= 80, "wider than 80 columns: {line:?}");
     }
-    // No subcommands and no removed switches.
-    for gone in ["dump", "--strict", "--output", "--save", "--no-", "--level"] {
-        assert!(!stdout.contains(gone), "help still shows {gone}: {stdout}");
-    }
+}
+
+#[test]
+fn no_banner_drops_the_header_from_the_help_page() {
+    let output = bdinfo_rs().args(["--no-banner", "-h"]).output().expect("spawn bdinfo-rs");
+    assert!(output.status.success());
+    // The card alone: no header line, no blank line above it.
+    assert_eq!(String::from_utf8_lossy(&output.stdout), CARD);
 }
 
 /// A valid zero-item `*.mpls` (magic `MPLS0300`, one empty `PlayList`, no marks)


### PR DESCRIPTION
Replaces the two-tier clap help with a single-screen card and adds a
capability-chosen header above it.

## Help card

- One short line per argument, and no long_about, long_help or after_long_help
  anywhere, so -h and --help render the same page.
- A bare invocation prints that same card through arg_required_else_help, and
  still exits 0 as it has since v1.0.1: it is a help request rather than a usage
  error, and package-manager install validators smoke-run the executable with no
  arguments. An actual but invalid argument still exits 2.
- The help flag is declared with HelpShort, so the two spellings stay one page by
  construction instead of by the absence of long help elsewhere.
- bin_name pins the program name in the usage line, which clap otherwise echoes
  from the invoked file, so the card reads identically on every platform.

## Banner

Three tiers, chosen at runtime: a framed wordmark when stdout is a terminal with
colour and at least 54 columns, a one-line accent chip below that width, and a
plain ASCII line when there is no terminal, no ANSI support, or NO_COLOR is set.

It heads the help page and every scan run whose stdout is a terminal. The new
--no-banner switch drops it in both places. A piped or redirected run never
prints it at all, so scripts, pipes and CI see the same bytes as before.

## Man page

The long-form prose the card no longer carries moves to the man page: build.rs
reattaches the long description, the per-argument detail and the examples to the
same clap command before rendering it, so nothing documented is lost. The shell
completions are unchanged, since they read only the short help.

## Tests

The card is pinned byte for byte at unit and end-to-end level, every line is
asserted to fit 80 columns, each header tier is covered through an injectable
capability struct, and the generated man page is checked for the relocated
prose. Coverage floors hold and the change carries no surviving mutants.
