### PR TITLE
ci: disable incremental compilation and trim debuginfo in the gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,24 @@ env:
   # The nightly that backs the `fmt` step (rustfmt.toml has nightly-only options).
   # Keep in lockstep with $script:Nightly in scripts/_common.ps1.
   NIGHTLY: nightly-2026-07-06
+  # Two knobs that exist to keep the SAVED target/ small, set here rather than
+  # in a tracked Cargo profile so local dev loops keep both. A hosted job builds
+  # from a restored cache, near enough from scratch that incremental
+  # compilation buys no rebuild it can amortise — it only writes
+  # dependency-tracking metadata into the tree rust-cache then archives.
+  # Debuginfo is the other bulk contributor; `line-tables-only` rather than `0`
+  # so a failing test still prints file:line backtraces.
+  #
+  # Why size is the thing being optimised: a repository's Actions cache store
+  # is capped (10 GB at the time of writing) and evicted least-recently-used
+  # across ALL entries, so oversized Rust archives push out the few-MB
+  # compiled-tool caches, whose miss costs minutes of `cargo install` on the
+  # pull-request path. Smaller archives also restore faster, on every job.
+  #
+  # Jobs running cargo-mutants override CARGO_INCREMENTAL back to 1 — see the
+  # `mutants` job.
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
 
 concurrency:
   # Namespaced by event so that, should a workflow_call invocation from
@@ -442,6 +460,13 @@ jobs:
     needs: plan
     if: github.event_name == 'pull_request' && needs.plan.outputs.core == 'true'
     runs-on: ubuntu-latest
+    env:
+      # cargo-mutants rebuilds the tree once per mutant, each rebuild differing
+      # from the last by one function body — exactly the case incremental
+      # compilation is built for, and the reason a mutation run is affordable
+      # at all. So every job that runs cargo-mutants overrides the
+      # workflow-level 0, trading a larger target/ for the rebuild time.
+      CARGO_INCREMENTAL: "1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -491,6 +516,7 @@ jobs:
       # deterministic software backend is what makes them run on a GPU-less
       # runner at all (same as gui.yml).
       ICED_TEST_BACKEND: tiny-skia
+      CARGO_INCREMENTAL: "1"   # cargo-mutants' rebuild model — see the `mutants` job
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -544,6 +570,8 @@ jobs:
     needs: plan
     if: github.event_name == 'pull_request' && needs.plan.outputs.wasm == 'true'
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "1"   # cargo-mutants' rebuild model — see the `mutants` job
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -52,6 +52,12 @@ env:
   # never a GPU whose pixels vary by driver. Also what makes the suites run on
   # GPU-less runners at all.
   ICED_TEST_BACKEND: tiny-skia
+  # Keep the cached target/ small: no incremental-compilation metadata, and
+  # line tables instead of full DWARF (still enough for file:line in a test
+  # backtrace). A called workflow inherits none of its caller's env, so these
+  # are declared here as well as in ci.yml — which carries the rationale.
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
 
 jobs:
   # Build + the full test suite on every shipped arch — where per-platform bugs

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -61,6 +61,20 @@ on:
 permissions:
   contents: read
 
+env:
+  # Line tables instead of full DWARF, to hold down the target/ this workflow's
+  # legs archive through rust-cache — cache entries compete for one
+  # least-recently-used store across the whole repository, so a fat archive
+  # here evicts a cache a pull request needs. Enough debuginfo remains for
+  # file:line in a backtrace. Declared here because a called workflow inherits
+  # none of its caller's env; ci.yml carries the full rationale.
+  #
+  # CARGO_INCREMENTAL is deliberately absent: every job here that builds Rust
+  # is a cargo-mutants leg, and incremental rebuilds are what make mutation
+  # affordable (ci.yml sets 0 workflow-wide and overrides it back on exactly
+  # those jobs).
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+
 concurrency:
   group: sweep-${{ github.ref }}
   # Never cancel a running sweep: a half-finished mutants pass saves no marker,

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -34,6 +34,12 @@ permissions:
 env:
   NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + ci.yml
   NODE_VERSION: "26.5.1"      # the active Node line (26 -> LTS Oct 2026); watched by version-freshness.yml
+  # Keep the cached target/ small: no incremental-compilation metadata, and
+  # line tables instead of full DWARF (still enough for file:line in a test
+  # backtrace). A called workflow inherits none of its caller's env, so these
+  # are declared here as well as in ci.yml — which carries the rationale.
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
 
 jobs:
   gate:


### PR DESCRIPTION
Sets `CARGO_INCREMENTAL=0` and `CARGO_PROFILE_DEV_DEBUG=line-tables-only` at the workflow level in `ci.yml`, `gui.yml` and `wasm.yml`, and the debuginfo knob alone in `sweep.yml`. Both are set via workflow `env:` rather than the tracked Cargo profiles, so local dev loops keep incremental compilation and full debuginfo.

Mechanism: a hosted job builds from a restored cache, so incremental compilation only writes dependency-tracking metadata into the tree rust-cache then archives; debuginfo is the other bulk contributor. Cache entries compete for one least-recently-used store per repository, so oversized Rust archives evict the few-MB compiled-tool caches, whose miss costs a from-source install on the pull-request path. `line-tables-only` rather than `0` keeps file:line in test backtraces.

Jobs running cargo-mutants override `CARGO_INCREMENTAL` back to `1` — `mutants`, `gui-mutants` and `wasm-mutants` in `ci.yml`. `sweep.yml` sets no incremental knob at all: every job there that builds Rust is a cargo-mutants leg, so a workflow-level `0` would be overridden in every place it applied.

The diff is workflow-only, so no mutation ran on this pull request: the core mutants job is gated off, and the gui and wasm ones fired with an empty crate diff. The next sweep exercises the override.

Expected effect: smaller cache saves once a master run writes fresh entries. No measurement is claimed here, since a pull-request run restores the existing master caches.