### PR TITLE
ci: pin every tool install to a verified prebuilt or explicit compile lane

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -36,10 +36,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # `fallback: none`: install only from install-action's checksummed manifest,
+      # never its runtime-resolved cargo-binstall fallback (rationale in ci.yml).
       - name: Install cargo-deny (prebuilt, no from-source compile)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-deny
+          fallback: none
 
       - name: Audit advisories (root workspace)
         run: cargo deny check advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,33 +284,44 @@ jobs:
   # Drift guard: the committed v-release.yml is generated from dist-workspace.toml by
   # dist. This regenerates it in-memory and fails if it differs from the on-disk
   # file, so v-release.yml can never silently fall out of sync with the dist config.
-  # Pinned to the same dist version (cargo-dist-version) that v-release.yml installs.
   release-yaml:
     name: release workflow in sync (dist generate --check)
     needs: plan
     if: needs.plan.outputs.dist == 'true'
     runs-on: ubuntu-latest
+    env:
+      # MUST equal `cargo-dist-version` in dist-workspace.toml — the version that
+      # generated the committed v-release.yml, so anything else makes the check
+      # below compare against the wrong generator. version-freshness.yml enforces
+      # the equality and nags when a newer dist ships.
+      DIST_VERSION: 0.32.0
+      # sha256 of the release asset named in the install step, copied once from
+      # the `.sha256` file axodotdev publishes beside it. Committing the digest is
+      # what makes the download verifiable: the archive is checked against this
+      # value before anything inside it runs. Re-take it on every DIST_VERSION bump.
+      DIST_SHA256: 0d9dc001b0e937e9cc18e0dc11784aa7a3fd566656b07828d5e1d10ce1c1c48c
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      # No prebuilt channel passes the pinning bar (the upstream installer is
-      # an unhashed curl|sh — Scorecard pinned-dependencies / downloadThenRun),
-      # so the version-pinned binary is compiled from crates.io once and
-      # cached. Keying on dist-workspace.toml couples the cache to
-      # cargo-dist-version, which version-freshness.yml keeps equal to the
-      # install pin below.
-      - name: Cache the pinned dist binary
-        id: dist-bin
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/dist
-          key: cargo-dist-${{ runner.os }}-${{ hashFiles('dist-workspace.toml') }}
-
-      - name: Install pinned dist (cache miss)
-        if: steps.dist-bin.outputs.cache-hit != 'true'
-        run: cargo install cargo-dist@0.32.0 --locked
+      # The upstream `.sh` installer is an unhashed curl|sh (Scorecard
+      # pinned-dependencies / downloadThenRun), but the release it installs from
+      # also carries plain archives with published checksums — so fetch the archive
+      # at a version-pinned URL and verify it here instead, which is both faster
+      # than a from-source compile and pinned end to end. musl: the binary is
+      # statically linked, so it is independent of the runner image's glibc.
+      - name: Install pinned dist (checksum-verified prebuilt)
+        run: |
+          set -euo pipefail
+          dir="cargo-dist-x86_64-unknown-linux-musl"
+          curl -fsSL --retry 3 -o "$dir.tar.xz" \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v$DIST_VERSION/$dir.tar.xz"
+          echo "$DIST_SHA256  $dir.tar.xz" | sha256sum --check --strict -
+          tar -xJf "$dir.tar.xz" "$dir/dist"
+          sudo install -m755 "$dir/dist" /usr/local/bin/dist
+          rm -rf "$dir" "$dir.tar.xz"
+          dist --version
 
       - name: Check v-release.yml is in sync with dist-workspace.toml
         run: dist generate --check
@@ -364,10 +375,21 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
+      # `fallback: none` on EVERY taiki-e/install-action step in this repo. The
+      # action's manifest path is the only channel that inherits the pinned action
+      # revision's guarantees: it resolves a fixed upstream release asset and
+      # verifies its committed checksum. The default fallback instead resolves at
+      # run time through crates.io metadata to a GitHub release asset or the
+      # third-party quickinstall build farm (cargo-binstall) — neither pinned by
+      # this repo nor checksum-verified against anything committed here. Disabling
+      # it turns a tool the manifest lacks into a loud failure rather than a silent
+      # downgrade to that path, and does the same for a pinned `tool@version` the
+      # manifest stops carrying.
       - name: Install gate tools
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-machete,cargo-shear,cargo-semver-checks
+          fallback: none
 
       # House rules with no clippy equivalent (big-endian-only + no HashMap/HashSet
       # in the deterministic output path), mirrored from the local gate via the
@@ -435,6 +457,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-llvm-cov,cargo-nextest
+          fallback: none
 
       - name: Coverage (100% lines/regions/functions)
         run: cargo +${{ env.NIGHTLY }} llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100
@@ -482,6 +505,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-mutants,cargo-nextest
+          fallback: none
 
       - name: Mutate the PR diff
         run: |
@@ -546,6 +570,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-mutants,cargo-nextest
+          fallback: none
 
       - name: Mutate the crate's PR diff
         if: steps.marker.outputs.cache-hit != 'true'
@@ -600,6 +625,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-mutants,cargo-nextest
+          fallback: none
 
       - name: Mutate the crate's PR diff
         if: steps.marker.outputs.cache-hit != 'true'
@@ -761,6 +787,7 @@ jobs:
           # red-X an unrelated PR; version-freshness watches it against crates.io
           # and the bump stays deliberate, like rustfmt's nightly pin.
           tool: taplo-cli@0.10.0
+          fallback: none
 
       # taplo auto-discovers taplo.toml (include/exclude + formatting). --check
       # fails on any unformatted file; --diff prints exactly what differs.
@@ -795,6 +822,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: zizmor
+          fallback: none
 
       - name: Audit the workflows
         run: zizmor .github/workflows
@@ -827,6 +855,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: typos
+          fallback: none
 
       - name: Typos
         run: typos
@@ -897,6 +926,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-deny
+          fallback: none
 
       - name: Audit bans + licenses + sources (deterministic on the lockfile)
         run: cargo deny check bans licenses sources
@@ -978,10 +1008,21 @@ jobs:
           workspaces: fuzz
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
-      - name: Install cargo-fuzz
-        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+      # cargo-fuzz is absent from taiki-e/install-action's manifest (101 tools at
+      # the revision pinned in this file), so with the binstall fallback disabled
+      # it has no prebuilt channel here. Compile the pinned version from crates.io
+      # once and cache the binary, the same lane cargo-vet uses; keep the pin equal
+      # to fuzz.yml's, which version-freshness.yml enforces and watches.
+      - name: Cache the pinned cargo-fuzz binary
+        id: fuzz-bin
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          tool: cargo-fuzz
+          path: ~/.cargo/bin/cargo-fuzz
+          key: cargo-fuzz-${{ runner.os }}-0.13.2
+
+      - name: Install cargo-fuzz 0.13.2 (cache miss)
+        if: steps.fuzz-bin.outputs.cache-hit != 'true'
+        run: cargo install cargo-fuzz --version 0.13.2 --locked
 
       - name: Verify the committed fuzz lockfile is in sync
         # cargo-fuzz's `run` has no --locked flag (it forwards everything after
@@ -1046,13 +1087,30 @@ jobs:
       - name: Build the binary (generates completions + man page)
         run: cargo build --release --locked --target "$HOST" -p bdinfo-rs
 
-      # Prebuilt, at the SAME versions build-linux-packages.sh pins — so the script's
+      # Both at the SAME versions build-linux-packages.sh pins — so the script's
       # `command -v cargo-deb` guard finds them and skips its (slower) source compile,
       # and the smoke test packages with the exact release tools.
-      - name: Install cargo-deb + cargo-generate-rpm (release pins)
+      - name: Install cargo-deb (release pin, prebuilt)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
-          tool: cargo-deb@3.7.0,cargo-generate-rpm@0.21.0
+          tool: cargo-deb@3.7.0
+          fallback: none
+
+      # cargo-generate-rpm is absent from taiki-e/install-action's manifest (101
+      # tools at the revision pinned in this file), so with the binstall fallback
+      # disabled it gets the same compile-once-and-cache lane as cargo-fuzz and
+      # cargo-vet. The `@0.21.0` pin is the one build-linux-packages.sh and gui.yml
+      # carry; version-freshness.yml cross-checks all three.
+      - name: Cache the pinned cargo-generate-rpm binary
+        id: rpm-bin
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-generate-rpm
+          key: cargo-generate-rpm-${{ runner.os }}-0.21.0
+
+      - name: Install cargo-generate-rpm (cache miss)
+        if: steps.rpm-bin.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-generate-rpm@0.21.0
 
       # Synthesize the two dist archives the script consumes, in dist's exact
       # `<pkg>-<triple>/` layout, from the host build (binary stand-in + real assets).

--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -49,10 +49,13 @@ jobs:
       - name: Fetch full history without blobs
         run: git fetch --no-tags --filter=blob:none --unshallow origin
 
+      # `fallback: none`: install only from install-action's checksummed manifest,
+      # never its runtime-resolved cargo-binstall fallback (rationale in ci.yml).
       - name: Install convco (prebuilt, no from-source compile)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: convco@0.7.0
+          fallback: none
 
       # Prove the banned-word regex still rejects attribution and passes innocent
       # prose, so the policy script can never silently rot.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -57,10 +57,13 @@ jobs:
       - name: Add the wasm32 target
         run: rustup target add wasm32-unknown-unknown
 
+      # `fallback: none`: install only from install-action's checksummed manifest,
+      # never its runtime-resolved cargo-binstall fallback (rationale in ci.yml).
       - name: Install wasm-bindgen-cli (pinned to the crate version)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: wasm-bindgen-cli@0.2.126
+          fallback: none
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -69,10 +69,16 @@ jobs:
           # the fuzz build cache is used and (on master) saved.
           lookup-only: true
 
-      - name: Install cargo-fuzz
-        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
-        with:
-          tool: cargo-fuzz
+      # cargo-fuzz is absent from taiki-e/install-action's manifest, and this repo
+      # runs that action with `fallback: none` so a manifest-missing tool fails
+      # loudly instead of resolving through its unpinned cargo-binstall fallback
+      # (rationale in ci.yml). Compile the pinned version from crates.io; ci.yml's
+      # replay job caches the same pin, but this workflow runs only on release tags
+      # and restores no cache that a non-tag run could have written (see the
+      # rust-cache note above), so it pays the compile. Keep the pin equal to
+      # ci.yml's — version-freshness.yml enforces it.
+      - name: Install cargo-fuzz 0.13.2
+        run: cargo install cargo-fuzz --version 0.13.2 --locked
 
       - name: Verify the committed fuzz lockfile is in sync
         # cargo-fuzz's `run` has no --locked flag (it forwards everything after

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -89,10 +89,14 @@ jobs:
           # save; PRs restore the master-seeded cache.
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
+      # `fallback: none` on every install-action step here: install only from the
+      # action's checksummed manifest, never its runtime-resolved cargo-binstall
+      # fallback (rationale in ci.yml).
       - name: Install cargo-nextest
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-nextest
+          fallback: none
 
       - name: Clippy (calibrated, -D warnings)
         working-directory: crates/bdinfo-rs-gui
@@ -208,6 +212,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-llvm-cov,cargo-nextest,cargo-machete,cargo-shear,cargo-deny,typos-cli
+          fallback: none
 
       # The no-C tripwire (cargo tree over the 6 shipped targets: GTK/C bans,
       # the -sys/-dl allowlist, verified-inert cc/pkg-config wrappers, and the
@@ -364,13 +369,29 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends desktop-file-utils appstream-util rpm
 
-      # Pinned to the exact versions the packaging script would compile from
-      # source if missing — this pre-install just makes the smoke fast.
-      - name: Install cargo-deb + cargo-generate-rpm (release-pinned)
+      # Both packagers at the exact versions the packaging script would compile
+      # from source if missing — this pre-install just makes the smoke fast.
+      - name: Install cargo-deb (release-pinned, prebuilt)
         if: runner.os == 'Linux'
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
-          tool: cargo-deb@3.7.0,cargo-generate-rpm@0.21.0
+          tool: cargo-deb@3.7.0
+          fallback: none
+
+      # cargo-generate-rpm is absent from taiki-e/install-action's manifest, so
+      # with the binstall fallback disabled it is compiled from crates.io once and
+      # cached, the lane ci.yml's cargo-fuzz and cargo-vet use.
+      - name: Cache the pinned cargo-generate-rpm binary
+        if: runner.os == 'Linux'
+        id: rpm-bin
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-generate-rpm
+          key: cargo-generate-rpm-${{ runner.os }}-0.21.0
+
+      - name: Install cargo-generate-rpm (cache miss)
+        if: runner.os == 'Linux' && steps.rpm-bin.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-generate-rpm@0.21.0
 
       - name: Build (release profile)
         working-directory: crates/bdinfo-rs-gui

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -139,10 +139,13 @@ jobs:
       - name: Add the wasm32 target
         run: rustup target add wasm32-unknown-unknown
 
+      # `fallback: none`: install only from install-action's checksummed manifest,
+      # never its runtime-resolved cargo-binstall fallback (rationale in ci.yml).
       - name: Install wasm-bindgen-cli (pinned to the crate version)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: wasm-bindgen-cli@0.2.126
+          fallback: none
 
       # zizmor flags setup-node in this tag-triggered (publishing) workflow as a
       # cache-poisoning vector, but no `cache:` input is set, so it neither restores

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -157,11 +157,15 @@ jobs:
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
+      # `fallback: none` on every install-action step here: install only from the
+      # action's checksummed manifest, never its runtime-resolved cargo-binstall
+      # fallback (rationale in ci.yml).
       - name: Install mutation tools
         if: steps.marker.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-mutants,cargo-nextest
+          fallback: none
 
       - name: Mutants (0 missed, this shard)
         if: steps.marker.outputs.cache-hit != 'true'
@@ -256,6 +260,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-mutants,cargo-nextest
+          fallback: none
 
       # --workspace: without it cargo-mutants scopes to the root package and
       # silently skips the assets-gen member (whose byte-tie tests are its
@@ -325,6 +330,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-mutants,cargo-nextest
+          fallback: none
 
       - name: Mutants (Tier A 0 missed)
         if: steps.marker.outputs.cache-hit != 'true'

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -6,8 +6,11 @@ name: version-freshness
 #     hardcoded in ci.yml + fuzz.yml + wasm.yml + gui.yml + publish-npm.yml and
 #     cross-checked for agreement here so a bump to one can't silently drift the
 #     rest),
-#   - cargo-dist (dist-workspace.toml `cargo-dist-version` AND the `cargo-dist@X`
-#     install in ci.yml — the two must stay equal),
+#   - cargo-dist (dist-workspace.toml `cargo-dist-version` AND the `DIST_VERSION`
+#     env in ci.yml's release-yaml job, which downloads that release's prebuilt
+#     archive — the two must stay equal; the `DIST_SHA256` committed beside it is
+#     the archive's published digest, so it is re-checked against upstream here
+#     because a version bump that forgets it only fails on the next dist-area PR),
 #   - the four action SHAs in dist-workspace.toml `[dist.github-action-commits]`
 #     (checkout, upload-/download-artifact, attest) — the SOURCE dist generates
 #     v-release.yml from, invisible to Dependabot (it bumps the GENERATED file,
@@ -15,6 +18,9 @@ name: version-freshness
 #     hand-maintained workflows' pins for the same actions so the drift becomes
 #     a scheduled nag instead of a red X on an unrelated Dependabot PR,
 #   - cargo-vet (the `--version` pin in ci.yml's vet job),
+#   - cargo-fuzz (the `--version` pins in ci.yml's replay job and fuzz.yml — absent
+#     from taiki-e/install-action's manifest, so both compile it from crates.io and
+#     the two pins must stay equal),
 #   - ryl (the `cargo install ryl --version` pin in ci.yml's YAML-lint job),
 #   - taplo (the `tool: taplo-cli@X` pin in ci.yml's TOML job — a formatter, pinned like
 #     rustfmt so a new release can't reformat/relint the tree out from under a PR),
@@ -44,9 +50,9 @@ name: version-freshness
 #     INSIDE dist's fail-fast release, so they are version-pinned there so a broken
 #     upstream release can't abort the whole release; both checked vs crates.io, and
 #     both cross-checked against every other copy — ci.yml's pkg job, the GUI
-#     packaging script (.github/scripts/gui-package-linux.ps1), and the taiki-e
-#     install in gui.yml's packaging smoke — which must all stay EQUAL so the PR
-#     smoke tests package with the exact release tools),
+#     packaging script (.github/scripts/gui-package-linux.ps1), and gui.yml's
+#     packaging smoke — which must all stay EQUAL so the PR smoke tests package
+#     with the exact release tools),
 #   - appimagetool (the `$appimagetoolVersion` curl-download pin in
 #     .github/scripts/gui-package-linux.ps1 — the GUI lane's AppImage packer,
 #     fetched at a static version invisible to Dependabot; checked vs the highest
@@ -246,9 +252,9 @@ jobs:
 
           # --- cargo-dist: two pins must agree, both vs axodotdev/cargo-dist ----
           $distCfg = Read-Pin 'dist-workspace.toml' '^\s*cargo-dist-version\s*=\s*"([0-9.]+)"'
-          $distCi  = Read-Pin '.github/workflows/ci.yml' 'cargo-dist@([0-9.]+)'
+          $distCi  = Read-Pin '.github/workflows/ci.yml' 'DIST_VERSION:\s*([0-9.]+)'
           if (-not $distCfg) { throw 'No cargo-dist-version in dist-workspace.toml' }
-          if (-not $distCi)  { throw 'No cargo-dist@<version> install in ci.yml' }
+          if (-not $distCi)  { throw 'No DIST_VERSION pin in ci.yml' }
           if ($distCfg -ne $distCi) {
             Add-Problem 'cargo-dist pins disagree' "- cargo-dist pin mismatch: dist-workspace.toml has ``$distCfg`` but ci.yml installs ``$distCi`` — they must be identical"
           }
@@ -256,7 +262,27 @@ jobs:
           if (-not $distLatest) {
             Add-Problem 'cargo-dist (query failed)' '- could not query the latest cargo-dist release (axodotdev/cargo-dist)'
           } elseif ([version]$distLatest -gt [version]$distCfg) {
-            Add-Problem "cargo-dist $distCfg->$distLatest" "- cargo-dist pin ``$distCfg`` (dist-workspace.toml + ci.yml) is behind the latest release ``$distLatest`` — bump both pins, then re-run ``dist generate``"
+            Add-Problem "cargo-dist $distCfg->$distLatest" "- cargo-dist pin ``$distCfg`` (dist-workspace.toml + ci.yml) is behind the latest release ``$distLatest`` — bump both pins, re-take DIST_SHA256 from the release's ``.sha256`` asset, then re-run ``dist generate``"
+          }
+
+          # --- DIST_SHA256: ci.yml's committed digest vs the published .sha256 ---
+          # ci.yml verifies the downloaded dist archive against this digest before
+          # running it, so a DIST_VERSION bump that leaves the old digest behind
+          # breaks that job — but only once a dist-area diff makes it fire. Compare
+          # the two here so the mismatch surfaces the next morning instead.
+          $distSha = Read-Pin '.github/workflows/ci.yml' 'DIST_SHA256:\s*([0-9a-f]{64})'
+          if (-not $distSha) { throw 'No DIST_SHA256 pin in ci.yml' }
+          $distShaUpstream = $null
+          try {
+            $distShaUpstream = (Invoke-RestMethod -ErrorAction Stop `
+                -Uri "https://github.com/axodotdev/cargo-dist/releases/download/v$distCi/cargo-dist-x86_64-unknown-linux-musl.tar.xz.sha256" `
+                -Headers @{ 'User-Agent' = 'bdinfo-rs-version-freshness (github actions)' }).Trim().Split(' ')[0]
+          }
+          catch { }
+          if (-not $distShaUpstream) {
+            Add-Problem 'cargo-dist digest (query failed)' "- could not fetch the published sha256 for cargo-dist ``v$distCi``'s x86_64-unknown-linux-musl archive"
+          } elseif ($distSha -ne $distShaUpstream) {
+            Add-Problem 'cargo-dist digest mismatch' "- ci.yml pins ``DIST_SHA256: $distSha`` but cargo-dist ``v$distCi`` publishes ``$distShaUpstream`` for its x86_64-unknown-linux-musl archive — set the committed digest to the published value"
           }
 
           # --- dist [dist.github-action-commits]: TOML pins vs the workflows -----
@@ -297,6 +323,26 @@ jobs:
             Add-Problem 'cargo-vet (query failed)' '- could not query the latest cargo-vet release (mozilla/cargo-vet)'
           } elseif ([version]$vetLatest -gt [version]$vetPin) {
             Add-Problem "cargo-vet $vetPin->$vetLatest" "- cargo-vet pin ``$vetPin`` (ci.yml) is behind the latest release ``$vetLatest``"
+          }
+
+          # --- cargo-fuzz: ci.yml + fuzz.yml pins vs crates.io -----------------
+          # taiki-e/install-action's manifest has no cargo-fuzz entry, so both the
+          # per-PR corpus replay (ci.yml) and the tag-time fresh-fuzz pass
+          # (fuzz.yml) compile a pinned version from crates.io. The two must agree
+          # — a one-sided bump would fuzz the release tag with a different tool
+          # than the gate proved green.
+          $fuzzCi   = Read-Pin '.github/workflows/ci.yml' 'cargo install cargo-fuzz --version ([0-9.]+)'
+          $fuzzTag  = Read-Pin '.github/workflows/fuzz.yml' 'cargo install cargo-fuzz --version ([0-9.]+)'
+          if (-not $fuzzCi)  { throw 'No `cargo install cargo-fuzz --version` pin in ci.yml' }
+          if (-not $fuzzTag) { throw 'No `cargo install cargo-fuzz --version` pin in fuzz.yml' }
+          if ($fuzzCi -ne $fuzzTag) {
+            Add-Problem 'cargo-fuzz pins disagree' "- cargo-fuzz pin mismatch: ci.yml ``$fuzzCi`` / fuzz.yml ``$fuzzTag`` — both must be identical"
+          }
+          $fuzzLatest = Latest-CratesIo 'cargo-fuzz'
+          if (-not $fuzzLatest) {
+            Add-Problem 'cargo-fuzz (query failed)' '- could not query the latest cargo-fuzz release (crates.io)'
+          } elseif ([version]$fuzzLatest -gt [version]$fuzzCi) {
+            Add-Problem "cargo-fuzz $fuzzCi->$fuzzLatest" "- cargo-fuzz pin ``$fuzzCi`` (ci.yml + fuzz.yml) is behind the latest release ``$fuzzLatest`` — bump both pins together"
           }
 
           # --- ryl: ci.yml YAML-lint pin vs crates.io --------------------------
@@ -593,7 +639,7 @@ jobs:
             Add-Problem "cloudsmith-cli $cloudsmithPin->$cloudsmithLatest" "- cloudsmith-cli pin ``$cloudsmithPin`` (packages.yml) is behind the latest release ``$cloudsmithLatest``"
           }
 
-          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  ryl: $rylPin (latest $rylLatest)  taplo: $taploPin (latest $taploLatest)  convco: $convcoPin (latest $convcoLatest)  wasm-bindgen-cli: $wbGate (latest $wbLatest)  binaryen: $binPin (latest $binLatest)  biome-schema: $biomeSchema (dep $biomeLock)  node: $nodePin (latest-on-major $nodeLatestOnMajor, newest-even $nodeNewestEven)  npm: $npmPin (latest $npmLatest)  wrangler: $wranglerPin (latest $wranglerLatest)  brew: $brewPinShort (head $brewHeadShort)  komac: $komacPin (latest $komacLatest)  cargo-deb: $cargoDebPin (latest $cargoDebLatest)  cargo-generate-rpm: $cargoRpmPin (latest $cargoRpmLatest)  appimagetool: $appimagetoolPin (latest $appimagetoolLatest)  cloudsmith-cli: $cloudsmithPin (latest $cloudsmithLatest)"
+          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  cargo-fuzz: $fuzzCi (latest $fuzzLatest)  ryl: $rylPin (latest $rylLatest)  taplo: $taploPin (latest $taploLatest)  convco: $convcoPin (latest $convcoLatest)  wasm-bindgen-cli: $wbGate (latest $wbLatest)  binaryen: $binPin (latest $binLatest)  biome-schema: $biomeSchema (dep $biomeLock)  node: $nodePin (latest-on-major $nodeLatestOnMajor, newest-even $nodeNewestEven)  npm: $npmPin (latest $npmLatest)  wrangler: $wranglerPin (latest $wranglerLatest)  brew: $brewPinShort (head $brewHeadShort)  komac: $komacPin (latest $komacLatest)  cargo-deb: $cargoDebPin (latest $cargoDebLatest)  cargo-generate-rpm: $cargoRpmPin (latest $cargoRpmLatest)  appimagetool: $appimagetoolPin (latest $appimagetoolLatest)  cloudsmith-cli: $cloudsmithPin (latest $cloudsmithLatest)"
           if ($problems.Count -eq 0) { Write-Host 'All pinned versions are fresh and consistent.'; exit 0 }
 
           $bodyLines = @($problems | ForEach-Object { $_.line })
@@ -616,7 +662,7 @@ jobs:
             ''
             $bodyLines
             ''
-            'Bump deliberately: update the pin(s) in the file(s) named above, keep the five NIGHTLY pins (ci.yml / fuzz.yml / wasm.yml / gui.yml / publish-npm.yml) identical, and re-run `dist generate` after any cargo-dist bump. CI re-validates on the next push.'
+            'Bump deliberately: update the pin(s) in the file(s) named above, keep the five NIGHTLY pins (ci.yml / fuzz.yml / wasm.yml / gui.yml / publish-npm.yml) identical, and after any cargo-dist bump re-take `DIST_SHA256` from the release''s `.sha256` asset and re-run `dist generate`. CI re-validates on the next push.'
           ) -join "`n"
 
           # One rolling issue, tracked by a stable label — the title varies with the

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -80,10 +80,14 @@ jobs:
           # save; PRs restore the master-seeded cache.
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
+      # `fallback: none` on every install-action step here: install only from the
+      # action's checksummed manifest, never its runtime-resolved cargo-binstall
+      # fallback (rationale in ci.yml).
       - name: Install wasm-bindgen-cli (pinned to the crate version)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: wasm-bindgen-cli@0.2.126
+          fallback: none
 
       # The pinned wasm-bindgen-cli MUST equal the wasm-bindgen version resolved in
       # Cargo.lock — wasm-bindgen hard-errors on any crate<->CLI mismatch. A
@@ -106,6 +110,7 @@ jobs:
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-llvm-cov,cargo-nextest,cargo-machete,cargo-shear,cargo-deny,typos-cli
+          fallback: none
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -34,10 +34,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # `fallback: none`: install only from install-action's checksummed manifest,
+      # never its runtime-resolved cargo-binstall fallback (rationale in ci.yml).
       - name: Install zizmor (prebuilt, no from-source compile)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: zizmor
+          fallback: none
 
       # Audit every workflow at full strength. The token enables the online audits
       # (impostor-commit, known-vulnerable-actions); .github/zizmor.yml is


### PR DESCRIPTION
Every CI tool install now resolves through a channel whose provenance is
verifiable and whose failure is loud. All 25 taiki-e/install-action steps set
fallback: none, so installs come only from the action's checksummed manifest at
the pinned action revision; the cargo-binstall fallback it would otherwise take
resolves at run time through crates.io metadata to a GitHub release asset or the
third-party quickinstall build farm, neither pinned here nor checked against
anything committed. Tools the manifest lacks get an explicit lane instead:
cargo-fuzz and cargo-generate-rpm are compiled from crates.io at their current
pinned versions and cached, the lane cargo-vet already uses. dist is no longer
compiled at all in the release-yaml job: it downloads the v0.32.0
x86_64-unknown-linux-musl archive at a version-pinned URL and verifies it
against a sha256 committed in the workflow before extracting, replacing a ~215 s
from-source build on every cache miss. Tool versions are unchanged throughout.

Audit result: cross-checking every tool named in a taiki-e/install-action step
against the 101 manifests carried at the pinned revision found two on the
fallback path, not one. cargo-fuzz was the known case. cargo-generate-rpm is the
second, in ci.yml's pkg job and gui.yml's packaging smoke; it gets the same
compile-and-cache lane. The three -cli spellings used here (taplo-cli,
typos-cli, wasm-bindgen-cli) are aliases the action rewrites to real manifest
entries, and every pinned version in the tree (taplo 0.10.0, convco 0.7.0,
cargo-deb 3.7.0, wasm-bindgen 0.2.126) is present in its manifest, so no other
step changes channel.

version-freshness.yml follows the new pin forms: DIST_VERSION replaces the
cargo-dist install line as the ci.yml half of the cargo-dist equality check,
DIST_SHA256 is cross-checked against the digest axodotdev publishes for that
archive so a version bump cannot silently leave a stale digest behind, and the
two cargo-fuzz pins are checked for agreement and against crates.io. Every
scraper in that file was re-run against the edited tree; all 22 pins resolve and
all cross-checks agree.

fuzz.yml is tag-triggered and will not run on this PR; its edited install step
is schema-validated by action-validator and style-linted by ryl. The ci-full
label is applied so every lane executes here, including release workflow in
sync.
