### PR TITLE
ci(gate): group the root-workspace and scanner gates as reusable workflows

### DIFF
--- a/.github/scripts/classify-diff.ps1
+++ b/.github/scripts/classify-diff.ps1
@@ -235,8 +235,22 @@ begin {
             Name       = 'orchestrator workflow'
             Areas      = @('yaml', 'workflows', 'canary')
             Structural = $true
-            Why        = 'Editing the file that defines the checkout, cache and tool-install steps must exercise them; one leg per shell family is enough to do that.'
+            Why        = 'Editing the file that routes every gate job must exercise that routing end to end; one build and test leg per shell family runs the plan, a caller and an inner job.'
             Match      = { param($f) $f -eq '.github/workflows/ci.yml' }
+        },
+        @{
+            Name       = 'root-workspace reusable workflow'
+            Areas      = @('yaml', 'workflows', 'core', 'deps', 'dist', 'fuzz', 'pkg')
+            Structural = $true
+            Why        = 'The file is the root-workspace gate: an edit to it, including a pinned action digest, changes what its build, lint, coverage, install, packaging, audit, drift-guard and corpus-replay jobs do. Each of those keeps its own area gate inside the file, so every area they consume has to fire for the edit to reach them.'
+            Match      = { param($f) $f -eq '.github/workflows/core.yml' }
+        },
+        @{
+            Name       = 'whole-tree scanner reusable workflow'
+            Areas      = @('yaml', 'workflows', 'toml', 'typos', 'links')
+            Structural = $true
+            Why        = 'The file is the gate for the scanners that read the whole repository; see the root-workspace reusable workflow.'
+            Match      = { param($f) $f -eq '.github/workflows/repo.yml' }
         },
         @{
             Name       = 'gui reusable workflow'
@@ -470,6 +484,8 @@ end {
             @{ Path = 'scorecard.yml'; Areas = 'links typos yaml' }
             @{ Path = '.github/dependabot.yml'; Areas = 'links typos yaml' }
             @{ Path = '.github/workflows/ci.yml'; Areas = 'canary links typos workflows yaml' }
+            @{ Path = '.github/workflows/core.yml'; Areas = 'core deps dist fuzz links pkg typos workflows yaml' }
+            @{ Path = '.github/workflows/repo.yml'; Areas = 'links toml typos workflows yaml' }
             @{ Path = '.github/workflows/gui.yml'; Areas = 'gui links typos workflows yaml' }
             @{ Path = '.github/workflows/docker.yml'; Areas = 'links typos workflows yaml' }
             @{ Path = '.github/scripts/gui-package-windows.ps1'; Areas = 'gui links typos' }

--- a/.github/scripts/source-rules.ps1
+++ b/.github/scripts/source-rules.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 # Source-rule guard for the bdinfo-rs-core LIBRARY — two house rules that no clippy
 # lint covers, enforced IDENTICALLY by the local gate (scripts/compliance.ps1) and
-# CI (the `lint` job in ci.yml). This script is the single source of truth for both,
+# CI (the `lint` job in core.yml). This script is the single source of truth for both,
 # exactly like .github/scripts/check-banned-words.ps1.
 #
 #   (1) Big-endian only. Disc structures are big-endian, so from_ne_bytes /

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,7 +9,7 @@ name: audit
 # sweep.yml running wasm.yml's own deny).
 #
 # The DETERMINISTIC half (bans — incl. the no-C-dependencies guard behind the
-# static binary — licenses, sources) plus cargo-vet moved to ci.yml as
+# static binary — licenses, sources) plus cargo-vet moved to core.yml as
 # plan-gated jobs on the `deps` area: those are pure functions of the
 # committed manifests/lockfile, so a red there is always caused by the change
 # under test; the daily sweep re-verifies them ungated. dependency-review
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       # `fallback: none`: install only from install-action's checksummed manifest,
-      # never its runtime-resolved cargo-binstall fallback (rationale in ci.yml).
+      # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install cargo-deny (prebuilt, no from-source compile)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ name: CI
 # area fired, and a final `ci-ok` fan-in job is the single branch-protection
 # context.
 #
+# The gate jobs themselves live in four workflow_call reusables, one caller job
+# each: core.yml (the root workspace), repo.yml (the whole-tree scanners),
+# gui.yml and wasm.yml (the sibling crates). A caller fires when ANY of the
+# areas its inner jobs consume fired, and passes the plan's outputs through as
+# INPUTS so each inner job keeps its own per-area `if:`; the check runs render
+# prefixed (`core / build + test (…)`, `repo / lint YAML (action-validator +
+# ryl)`). The three mutation jobs stay HERE rather than inside a reusable: a
+# failure inside a called workflow reddens its caller and so reaches ci-ok,
+# which would silently promote an advisory job to a gating one.
+#
 # A job fires if and only if the diff could change that job's verdict, so the
 # classifier asks what KIND of input a file is before it asks which directory
 # holds it — see .github/scripts/classify-diff.ps1, which owns the rules, the
@@ -24,13 +34,6 @@ name: CI
 # only the job-level result feeds ci-ok, which is what branch protection
 # requires. For the same reason, never rename or delete a job whose `name:`
 # string is a live required context (contexts match on that string).
-#
-# Build and test on every supported OS. The pinned stable toolchain installs
-# itself from rust-toolchain.toml on first cargo use; `unsafe` is forbidden at
-# compile time, so a green build is also the memory-safety guarantee. Every
-# dependency-resolving cargo call is --locked for reproducible builds (the one
-# exception is cargo-semver-checks, which builds its own baseline + current
-# checkouts and takes no --locked flag).
 
 on:
   push:
@@ -46,9 +49,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # The nightly that backs the `fmt` step (rustfmt.toml has nightly-only options).
-  # Keep in lockstep with $script:Nightly in scripts/_common.ps1.
-  NIGHTLY: nightly-2026-07-06
   # Two knobs that exist to keep the SAVED target/ small, set here rather than
   # in a tracked Cargo profile so local dev loops keep both. A hosted job builds
   # from a restored cache, near enough from scratch that incremental
@@ -182,286 +182,6 @@ jobs:
           Write-Host 'areas:'
           $areas | ForEach-Object { Write-Host "  $_" }
 
-  test:
-    name: build + test (${{ matrix.os }})
-    needs: plan
-    if: needs.plan.outputs.test == 'true'
-    runs-on: ${{ matrix.os }}
-    # One native runner per RELEASED binary — x86_64 AND aarch64 across Linux,
-    # Windows and macOS — so `cargo test` (including the real-disc end-to-end scan
-    # in tests/cli.rs) runs on every architecture we ship: no shipped arch goes
-    # unscanned. arm64 Linux/Windows and Intel macOS are standard GitHub-hosted
-    # runners, free for public repos. The OS list is plan output — the full six
-    # for `core`, one leg per shell family for `canary`; keep the list in
-    # classify-diff.ps1 in lockstep with the six dist-workspace.toml targets.
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ${{ fromJson(needs.plan.outputs.test-os) }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          # Cache write-discipline (wgpu): PR-branch saves are invisible to
-          # every other PR, so only master runs (pushes + the daily sweep)
-          # save; PRs restore the master-seeded cache.
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      # Clippy on EVERY build+test leg: the ubuntu-only lint job never clips
-      # the #[cfg(windows)] arms (e.g. the vfs/fs.rs raw-volume reader), so a
-      # per-arch lint bug reaches master unless every leg lints.
-      # Cheap: shares this leg's dep build. The alias is the tracked `lt`
-      # (clippy --workspace --all-targets --locked -- -D warnings).
-      - name: Clippy (-D warnings, pedantic/nursery/restriction)
-        run: cargo lt
-
-      - name: Build
-        run: cargo build --workspace --locked
-
-      - name: Test
-        run: cargo test --workspace --locked
-
-  # Lint the config YAML two ways, both with Rust tools. action-validator
-  # schema-checks the workflow files (catches schema errors + invalid-YAML traps
-  # like an unquoted colon in a step name). ryl (a Rust yamllint) style/syntax-
-  # lints EVERY tracked YAML against .yamllint.yml — duplicate keys, trailing
-  # whitespace, bad indentation, missing final newline, etc. — and covers the
-  # non-workflow YAML (dependabot, issue templates, scorecard) that
-  # action-validator's workflow-only schema can't read. Mirrors the local gate.
-  yaml:
-    name: lint YAML (action-validator + ryl)
-    needs: plan
-    if: needs.plan.outputs.yaml == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # Neither tool ships via taiki-e/install-action, so cache the compiled
-      # binaries instead of paying the from-source compile every run. ryl is
-      # version-pinned (reproducible lint verdicts; watched by
-      # version-freshness.yml); action-validator deliberately floats at latest
-      # (a schema checker self-updates), so its half of the key tracks the
-      # latest crates.io release — a new release recompiles once, then caches.
-      # A failed lookup salts the key with the run id: a guaranteed miss and a
-      # fresh install rather than a silently stale binary.
-      - name: Resolve the latest action-validator (cache key)
-        id: av
-        run: |
-          v=$(curl -fsSL --retry 3 -A 'bdinfo-rs-ci (github actions)' https://crates.io/api/v1/crates/action-validator | jq -r '.crate.max_stable_version // empty') || v=""
-          echo "version=${v:-unknown-$GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
-          echo "latest action-validator: ${v:-unknown (cache bypassed this run)}"
-
-      - name: Cache the YAML lint binaries
-        id: yaml-tools
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/bin/action-validator
-            ~/.cargo/bin/ryl
-          key: yaml-tools-${{ runner.os }}-av-${{ steps.av.outputs.version }}-ryl-0.21.0
-
-      - name: Install action-validator + ryl (cache miss)
-        if: steps.yaml-tools.outputs.cache-hit != 'true'
-        run: |
-          cargo install action-validator --locked
-          cargo install ryl --version 0.21.0 --locked
-
-      - name: Schema-validate the workflow YAML (action-validator)
-        run: |
-          for f in .github/workflows/*.yml; do
-            echo "validating $f"
-            action-validator "$f"
-          done
-
-      - name: Style/syntax-lint all YAML (ryl, strict)
-        run: ryl -f github -o - -s .
-
-  # Drift guard: the committed v-release.yml is generated from dist-workspace.toml by
-  # dist. This regenerates it in-memory and fails if it differs from the on-disk
-  # file, so v-release.yml can never silently fall out of sync with the dist config.
-  release-yaml:
-    name: release workflow in sync (dist generate --check)
-    needs: plan
-    if: needs.plan.outputs.dist == 'true'
-    runs-on: ubuntu-latest
-    env:
-      # MUST equal `cargo-dist-version` in dist-workspace.toml — the version that
-      # generated the committed v-release.yml, so anything else makes the check
-      # below compare against the wrong generator. version-freshness.yml enforces
-      # the equality and nags when a newer dist ships.
-      DIST_VERSION: 0.32.0
-      # sha256 of the release asset named in the install step, copied once from
-      # the `.sha256` file axodotdev publishes beside it. Committing the digest is
-      # what makes the download verifiable: the archive is checked against this
-      # value before anything inside it runs. Re-take it on every DIST_VERSION bump.
-      DIST_SHA256: 0d9dc001b0e937e9cc18e0dc11784aa7a3fd566656b07828d5e1d10ce1c1c48c
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # The upstream `.sh` installer is an unhashed curl|sh (Scorecard
-      # pinned-dependencies / downloadThenRun), but the release it installs from
-      # also carries plain archives with published checksums — so fetch the archive
-      # at a version-pinned URL and verify it here instead, which is both faster
-      # than a from-source compile and pinned end to end. musl: the binary is
-      # statically linked, so it is independent of the runner image's glibc.
-      - name: Install pinned dist (checksum-verified prebuilt)
-        run: |
-          set -euo pipefail
-          dir="cargo-dist-x86_64-unknown-linux-musl"
-          curl -fsSL --retry 3 -o "$dir.tar.xz" \
-            "https://github.com/axodotdev/cargo-dist/releases/download/v$DIST_VERSION/$dir.tar.xz"
-          echo "$DIST_SHA256  $dir.tar.xz" | sha256sum --check --strict -
-          tar -xJf "$dir.tar.xz" "$dir/dist"
-          sudo install -m755 "$dir/dist" /usr/local/bin/dist
-          rm -rf "$dir" "$dir.tar.xz"
-          dist --version
-
-      - name: Check v-release.yml is in sync with dist-workspace.toml
-        run: dist generate --check
-
-      # Make the drift self-explanatory (no token / no extra permission — just an
-      # annotation). The usual cause is a Dependabot bump of an action that appears
-      # in the GENERATED v-release.yml (checkout, upload-/download-artifact, attest):
-      # it edits v-release.yml but cannot edit dist-workspace.toml, so the pins drift.
-      - name: Explain the drift if the check failed
-        if: failure()
-        run: |
-          echo "::group::v-release.yml is out of sync with dist-workspace.toml"
-          drift=0
-          for a in actions/checkout actions/upload-artifact actions/download-artifact actions/attest; do
-            rel=$(grep -oP "uses:\s*${a}@\K[0-9a-f]{40}\s*#\s*\S+" .github/workflows/v-release.yml | head -1)
-            cfg=$(grep -oP "\"${a}\"\s*=\s*\"\K[^\"]+" dist-workspace.toml | head -1)
-            if [ -n "$rel" ] && [ "$rel" != "$cfg" ]; then
-              echo "::error::dist-workspace.toml pin stale for ${a} — set:  \"${a}\" = \"${rel}\""
-              drift=1
-            fi
-          done
-          if [ "$drift" -eq 0 ]; then
-            echo "::error::v-release.yml differs from dist generate output, but not via a tracked action pin — run 'dist generate' locally and inspect the diff."
-          fi
-          echo "Fix: run 'pwsh scripts/dist-sync.ps1 -Pr <this-PR> -Push' (cockpit helper), or paste the line(s) above into dist-workspace.toml and run 'dist generate', then commit on this branch."
-          echo "::endgroup::"
-
-  # The quality gate mirrored from the local runner. The gate commands are the
-  # tracked cargo aliases in .cargo/config.toml (ck/lt/mc/dc + cov); clippy.toml +
-  # typos.toml are tracked so clippy/typos behave identically. Format uses the
-  # pinned nightly (rustfmt.toml has nightly-only options). Public repo = free
-  # minutes, so the heavy quality checks run here too — incremental mutants run
-  # per-PR (the `mutants` job below), the fuzz corpus replays per-PR (the
-  # `replay` job), and the full mutants sweeps for every crate live in
-  # sweep.yml; only the Windows-via-Docker fuzz runner stays local.
-  lint:
-    name: lint (clippy, fmt, doc, deps, semver)
-    needs: plan
-    if: needs.plan.outputs.core == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0   # semver-checks needs the v* baseline tag
-          persist-credentials: false
-
-      - name: Install pinned nightly rustfmt
-        run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component rustfmt
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      # `fallback: none` on EVERY taiki-e/install-action step in this repo. The
-      # action's manifest path is the only channel that inherits the pinned action
-      # revision's guarantees: it resolves a fixed upstream release asset and
-      # verifies its committed checksum. The default fallback instead resolves at
-      # run time through crates.io metadata to a GitHub release asset or the
-      # third-party quickinstall build farm (cargo-binstall) — neither pinned by
-      # this repo nor checksum-verified against anything committed here. Disabling
-      # it turns a tool the manifest lacks into a loud failure rather than a silent
-      # downgrade to that path, and does the same for a pinned `tool@version` the
-      # manifest stops carrying.
-      - name: Install gate tools
-        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
-        with:
-          tool: cargo-machete,cargo-shear,cargo-semver-checks
-          fallback: none
-
-      # House rules with no clippy equivalent (big-endian-only + no HashMap/HashSet
-      # in the deterministic output path), mirrored from the local gate via the
-      # shared script so local and CI enforce the SAME rule. pwsh ships on the
-      # ubuntu runner.
-      - name: Source rules (big-endian + determinism)
-        shell: pwsh
-        run: ./.github/scripts/source-rules.ps1
-
-      - name: Format (nightly rustfmt)
-        run: cargo +${{ env.NIGHTLY }} fmt --all --check
-
-      - name: Clippy (-D warnings, pedantic/nursery/restriction)
-        run: cargo lt
-
-      - name: Unused deps (machete)
-        run: cargo mc
-
-      - name: Docs (warnings = errors)
-        run: cargo dc
-
-      - name: Unused deps (shear)
-        run: cargo sh
-
-      - name: API stability (semver-checks vs latest v* tag)
-        run: |
-          base="$(git tag -l 'v*' --sort=-version:refname | head -1)"
-          if [ -n "$base" ]; then
-            echo "baseline: $base"
-            cargo semver-checks check-release -p bdinfo-rs-core --baseline-rev "$base"
-          else
-            echo "no v* tag yet; skipping"
-          fi
-
-  # 100% line/region/function coverage. Runs on the pinned NIGHTLY rather than
-  # the stable `cov` alias: the CLI excludes a couple of environment/platform-
-  # bound functions with `#[cfg_attr(coverage_nightly, coverage(off))]`, and that
-  # cfg is only set by cargo-llvm-cov on a nightly toolchain. On stable those
-  # exclusions are inert, so the off-Windows platform arms count as uncovered and
-  # the floor can't be met on Linux. The 97%/91% branch floors stay in the LOCAL
-  # gate (scripts/compliance.ps1) — NOT because they need nightly (this job is
-  # already on nightly) but because branch coverage is platform-VARIANT: the
-  # library carries #[cfg(windows)] arms (e.g. vfs/fs.rs) whose branch count
-  # differs by OS, so one CI floor calibrated on a single platform would misfire
-  # on another. CI gates the platform-INVARIANT 100% line/region/function floor;
-  # the contributor's local gate enforces the branch floors on their own platform.
-  coverage:
-    name: coverage (100% lines/regions/functions)
-    needs: plan
-    if: needs.plan.outputs.core == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install pinned nightly with llvm-tools
-        run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component llvm-tools-preview
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      - name: Install coverage tools
-        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
-        with:
-          tool: cargo-llvm-cov,cargo-nextest
-          fallback: none
-
-      - name: Coverage (100% lines/regions/functions)
-        run: cargo +${{ env.NIGHTLY }} llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100
-
   # Incremental mutation testing on the PR diff: every line a pull request
   # changes must be killed by a test that FAILS when the line is mutated. The
   # full-tree sweep (~hours) lives in sweep.yml (sharded, daily + release
@@ -476,8 +196,9 @@ jobs:
   # it would let an environment artifact block an unrelated PR. The
   # AUTHORITATIVE "0 missed mutants" gate is sweep.yml's sharded full sweep
   # (daily when the workspace changed + release tags); this surfaces
-  # regressions early but does not block. Keep it out of the required set and
-  # out of ci-ok.
+  # regressions early but does not block. Keep it out of the required set,
+  # out of ci-ok, and out of core.yml — a failure inside a called workflow
+  # reddens its caller, which is in ci-ok's `needs`.
   mutants:
     name: mutation testing (PR diff)
     needs: plan
@@ -501,6 +222,9 @@ jobs:
       # PR.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      # `fallback: none` on every install-action step here: install only from the
+      # action's checksummed manifest, never its runtime-resolved cargo-binstall
+      # fallback (rationale in core.yml).
       - name: Install mutation tools
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
@@ -519,8 +243,9 @@ jobs:
   # ../bdinfo-rs-core path dep. When the `gui` area fired via the core edge
   # only, the crate's own diff is empty and there is nothing to mutate. Same
   # ADVISORY posture and false-TIMEOUT rationale as `mutants` above: not
-  # required, not in ci-ok's needs. The authoritative full-crate 0-missed bar
-  # lives in sweep.yml (daily when the crate changed + release tags).
+  # required, not in ci-ok's needs, not inside a reusable. The authoritative
+  # full-crate 0-missed bar lives in sweep.yml (daily when the crate changed +
+  # release tags).
   #
   # The sweep's tree-hash marker short-circuits this job too, RESTORE-ONLY: a
   # marker hit means this byte-identical crate tree (+ toolchain) already
@@ -589,7 +314,8 @@ jobs:
   # crate's own PR diff (--relative + --in-place for the same path-dep reason;
   # the crate-local .cargo/mutants.toml carries the Tier-B cfg(wasm32)
   # exclusions), with the same restore-only full-sweep marker short-circuit.
-  # Not required, not in ci-ok's needs; the full-crate bar lives in sweep.yml.
+  # Not required, not in ci-ok's needs, not inside a reusable; the full-crate
+  # bar lives in sweep.yml.
   wasm-mutants:
     name: wasm mutation testing (PR diff)
     needs: plan
@@ -638,564 +364,50 @@ jobs:
           fi
           cargo mutants --in-place --no-shuffle --in-diff "$RUNNER_TEMP/crate.diff"
 
-  # The ultimate real-world gate: do exactly what a user does — install bdinfo-rs
-  # the traditional way (build it from source; no package managers), scan the
-  # committed fixture disc, and confirm the report is byte-identical to the golden.
-  # One native runner per SHIPPED binary (x86_64 AND aarch64 × Linux/Windows/macOS),
-  # so this exercises the actual RELEASE/static artifact (not the debug test binary)
-  # on hardware we don't own — Linux builds the static musl target it ships.
-  # Deliberately NOT `needs:`-chained behind test/lint/coverage: such a chain is
-  # pure scheduling — ci-ok requires e2e green either way, so running it in
-  # parallel costs nothing but wall-clock. (Running the binary in TOTAL
-  # isolation — FROM scratch, zero runtime deps — is the separate `isolation`
-  # job below; docker.yml ships that same scratch image on release.)
-  e2e:
-    name: real-world install + scan (${{ matrix.os }})
+  # The root-workspace gate: build + test, the quality gate, coverage, the
+  # install + scan and FROM-scratch scans, the .deb/.rpm smoke, the two
+  # dependency audits, the release-workflow drift guard and the corpus replay.
+  # The `if:` is the UNION of the areas those jobs consume — a caller that
+  # never starts cannot skip its inner jobs individually — and every area it
+  # unions is passed through, so each inner job keeps its own per-area `if:`.
+  core:
+    name: core
     needs: plan
-    if: needs.plan.outputs.core == 'true'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - {os: ubuntu-latest, target: x86_64-unknown-linux-musl}
-          - {os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl}
-          - {os: windows-2025, target: ""}
-          - {os: windows-11-arm, target: ""}
-          - {os: macos-15-intel, target: ""}
-          - {os: macos-15, target: ""}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+    if: >-
+      needs.plan.outputs.core == 'true' ||
+      needs.plan.outputs.deps == 'true' ||
+      needs.plan.outputs.dist == 'true' ||
+      needs.plan.outputs.fuzz == 'true' ||
+      needs.plan.outputs.pkg == 'true' ||
+      needs.plan.outputs.test == 'true'
+    uses: ./.github/workflows/core.yml
+    with:
+      core: ${{ needs.plan.outputs.core }}
+      deps: ${{ needs.plan.outputs.deps }}
+      dist: ${{ needs.plan.outputs.dist }}
+      fuzz: ${{ needs.plan.outputs.fuzz }}
+      pkg: ${{ needs.plan.outputs.pkg }}
+      test: ${{ needs.plan.outputs.test }}
+      test-os: ${{ needs.plan.outputs.test-os }}
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      # "Install" the way a user would: build from source and drop the binary in a
-      # bin dir — exactly what `cargo install bdinfo-rs` does off crates.io. On Linux
-      # we target static musl so it matches the shipped artifact byte-for-byte.
-      - name: Install bdinfo-rs from source
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -n "${{ matrix.target }}" ]; then
-            rustup target add "${{ matrix.target }}"
-            cargo install --path crates/bdinfo-rs --locked --root "$RUNNER_TEMP/inst" --target "${{ matrix.target }}"
-          else
-            cargo install --path crates/bdinfo-rs --locked --root "$RUNNER_TEMP/inst"
-          fi
-
-      # Scan both fixture discs with the installed binary and assert each report is
-      # byte-identical to its golden — the eyeball check a person does, made exact.
-      - name: Scan the fixture disc and diff against the golden
-        shell: bash
-        run: |
-          set -euo pipefail
-          bin="$RUNNER_TEMP/inst/bin/bdinfo-rs"
-          fix="crates/bdinfo-rs/tests/fixtures"
-          out="$RUNNER_TEMP/out"; mkdir -p "$out"
-          "$bin" --version
-          "$bin" -m 00000 "$fix/BigBuckBunny"     "$out"
-          "$bin" -m 00000 "$fix/BigBuckBunny.iso" "$out"
-          cmp "$out/BDINFO.BigBuckBunny.txt" "$fix/golden/folder.txt"
-          cmp "$out/BDINFO.Blu-Ray.txt"      "$fix/golden/iso.txt"
-          # The 30 s playlist clears the default filter, so the default
-          # selection path is real-disc-testable: `--whole` (no `-m`) must
-          # produce the very bytes `-m 00000` does.
-          whole="$RUNNER_TEMP/out-whole"; mkdir -p "$whole"
-          "$bin" -w "$fix/BigBuckBunny" "$whole"
-          cmp "$whole/BDINFO.BigBuckBunny.txt" "$fix/golden/folder.txt"
-          echo "OK — both reports byte-identical to the golden (incl. --whole)"
-
-  # The "drop one file, it runs" proof, as its OWN job (not a step wedged into the
-  # e2e matrix): build the shipped static musl binary, bake it into an EMPTY `FROM
-  # scratch` image — no libc, no shell, no /tmp, nothing — and scan the fixture disc
-  # from inside it, byte-checked against the golden. A binary with any runtime dep
-  # could not even start in scratch, so green = the zero-deps guarantee, functional.
-  # Linux x86_64 + aarch64 (the two static-musl targets we ship; Windows/macOS have
-  # no empty-container equivalent). docker.yml ships this same image on release.
-  isolation:
-    name: zero-deps scan FROM scratch (${{ matrix.target }})
+  # The whole-tree scanners: YAML, TOML, workflow security, spelling, links.
+  # Same caller shape as `core` above.
+  repo:
+    name: repo
     needs: plan
-    if: needs.plan.outputs.core == 'true'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - {os: ubuntu-latest, target: x86_64-unknown-linux-musl}
-          - {os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      # Build the actual shipped artifact: the fully static musl release binary.
-      # Pure-Rust (no C deps), so the musl target needs no C toolchain.
-      - name: Build the static musl binary
-        run: |
-          rustup target add ${{ matrix.target }}
-          cargo build --release --locked -p bdinfo-rs --target ${{ matrix.target }}
-
-      - name: Scan the fixture disc FROM scratch
-        shell: bash
-        run: |
-          set -euo pipefail
-          ctx="$RUNNER_TEMP/ctx"
-          mkdir -p "$ctx/out"
-          install -D "target/${{ matrix.target }}/release/bdinfo-rs" "$ctx/bdinfo-rs"
-          printf 'FROM scratch\nCOPY bdinfo-rs /bdinfo-rs\nENTRYPOINT ["/bdinfo-rs"]\n' > "$ctx/Dockerfile"
-          docker build -t bdinfo-scratch "$ctx"
-          fix="$PWD/crates/bdinfo-rs/tests/fixtures"
-          docker run --rm -v "$fix:/fix:ro" -v "$ctx/out:/out" bdinfo-scratch -m 00000 /fix/BigBuckBunny     /out
-          docker run --rm -v "$fix:/fix:ro" -v "$ctx/out:/out" bdinfo-scratch -m 00000 /fix/BigBuckBunny.iso /out
-          cmp "$ctx/out/BDINFO.BigBuckBunny.txt" "$fix/golden/folder.txt"
-          cmp "$ctx/out/BDINFO.Blu-Ray.txt"      "$fix/golden/iso.txt"
-          # The 30 s playlist clears the default filter, so the default `--whole`
-          # selection is testable too — FROM scratch, into a fresh out dir.
-          mkdir -p "$ctx/out-whole"
-          docker run --rm -v "$fix:/fix:ro" -v "$ctx/out-whole:/out" bdinfo-scratch -w /fix/BigBuckBunny /out
-          cmp "$ctx/out-whole/BDINFO.BigBuckBunny.txt" "$fix/golden/folder.txt"
-          echo "OK — scanned both discs FROM scratch, byte-identical to golden (incl. --whole)"
-
-  # TOML formatting + lint gate (taplo): every tracked TOML — the Cargo manifests,
-  # the gate configs (clippy/deny/nextest/mutants/typos), dist-workspace.toml — must
-  # match `taplo fmt` and pass `taplo lint`, against the committed taplo.toml. Mirrors
-  # the local gate's `tp` step. Cargo.lock and the cargo-vet-managed
-  # supply-chain/*.toml are excluded in taplo.toml so taplo never fights a generator.
-  # (Folded in from the former toml.yml; the job name is a live required context.)
-  taplo:
-    name: lint TOML (taplo)
-    needs: plan
-    if: needs.plan.outputs.toml == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install taplo (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
-        with:
-          # Pinned (not latest) so a new taplo can't reformat/relint the tree and
-          # red-X an unrelated PR; version-freshness watches it against crates.io
-          # and the bump stays deliberate, like rustfmt's nightly pin.
-          tool: taplo-cli@0.10.0
-          fallback: none
-
-      # taplo auto-discovers taplo.toml (include/exclude + formatting). --check
-      # fails on any unformatted file; --diff prints exactly what differs.
-      - name: Check formatting (taplo fmt --check)
-        run: taplo fmt --check --diff
-
-      - name: Lint (taplo lint)
-        run: taplo lint
-
-  # Static security analysis of the GitHub Actions workflows themselves (zizmor):
-  # template injection, token over-permissioning, unpinned/impostor actions, cache
-  # poisoning, dangerous triggers, credential persistence, and more. Runs the FULL
-  # audit set online — the GITHUB_TOKEN enables the impostor-commit /
-  # known-vulnerable-actions checks that need the GitHub API — and hard-fails on any
-  # finding, like the other quality gates. The only accepted residuals live in
-  # .github/zizmor.yml (the cargo-dist-generated v-release.yml, which cannot be
-  # hand-edited) and inline (the two architecturally-required workflow_run triggers);
-  # every hand-maintained workflow is fixed in place, not suppressed. This is the
-  # PR/push leg; the daily cron leg (newly-disclosed action vulns surface between
-  # pushes) stays in zizmor.yml.
-  zizmor:
-    name: zizmor (workflow security)
-    needs: plan
-    if: needs.plan.outputs.workflows == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install zizmor (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
-        with:
-          tool: zizmor
-          fallback: none
-
-      - name: Audit the workflows
-        run: zizmor .github/workflows
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Stale-link guard: lychee verifies every URL and relative/file link across the
-  # repo (README, CHANGELOG, DIFFERENCES, CONTRIBUTING, the issue templates, the
-  # Cargo/audit metadata, and the doc-comment URLs in src). Cheap: lychee caches
-  # its results and only re-checks day-old links; a residual rate-limit (429) is
-  # accepted rather than failed, so an external host can't red-X an unrelated
-  # push. This is the PR/push leg (`docs` = any .md or .rs, since doc-comments
-  # carry links); the daily cron leg (links rot after merge without touching our
-  # code) stays in link-check.yml.
-  # typos reads the whole working tree (minus files.extend-exclude in
-  # typos.toml), so prose changes reach it while changing no Rust source. It is
-  # its own job rather than a step of `lint` for that reason: the rest of that
-  # job compiles the workspace, which a Markdown edit cannot affect.
-  typos:
-    name: spell-check (typos)
-    needs: plan
-    if: needs.plan.outputs.typos == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install typos
-        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
-        with:
-          tool: typos
-          fallback: none
-
-      - name: Typos
-        run: typos
-
-  links:
-    name: Check links
-    needs: plan
-    if: needs.plan.outputs.links == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # Persist lychee's response cache so reruns only re-check day-old links.
-      - name: Restore the lychee cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .lycheecache
-          key: lychee-${{ github.run_id }}
-          restore-keys: lychee-
-
-      - name: Check links
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
-        with:
-          # Whole repo; skip the generated lockfile and the binary fuzz seed
-          # corpus (the binary disc fixtures are skipped automatically by their
-          # non-text extensions). The golden disc reports are byte-exact BDInfo
-          # output: the two URLs they carry (cinemasquid/avsforum) are part of
-          # the locked format and reproduce a defunct tool's text verbatim, so
-          # they're pinned, not maintainable link surface — exclude them.
-          # Accept 429 so an external host's rate-limit can't fail the gate;
-          # fail:true turns any broken link into a failure.
-          args: >-
-            --cache
-            --max-cache-age 1d
-            --no-progress
-            --accept 200..=299,429
-            --exclude-path Cargo.lock
-            --exclude-path fuzz/corpus
-            --exclude-path crates/bdinfo-rs/tests/fixtures/golden
-            --exclude-path crates/bdinfo-rs-wasm/tests/golden_report.txt
-            .
-          fail: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # The DETERMINISTIC half of the supply-chain audit (the wgpu split): bans —
-  # including the no-C-dependencies guard behind the static binary — plus the
-  # license allowlist and crates.io-only sources, all functions of the committed
-  # manifests/lockfile alone, so a red here is always caused by the PR under
-  # test. The VOLATILE half (RustSec advisories: a CVE can publish any time)
-  # deliberately does NOT run on the PR path — an unrelated disclosure must not
-  # redden a PR — and lives in audit.yml's daily cron, with dependency-review
-  # catching advisories a PR's own dependency changes would introduce. The job
-  # name predates the split and is a live required context — keep the string.
-  deny:
-    name: cargo deny check
-    needs: plan
-    if: needs.plan.outputs.deps == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install cargo-deny (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
-        with:
-          tool: cargo-deny
-          fallback: none
-
-      - name: Audit bans + licenses + sources (deterministic on the lockfile)
-        run: cargo deny check bans licenses sources
-
-  # Supply-chain audit: every dependency must be covered by a trusted third-party
-  # audit, a recorded publisher-trust, or an explicit exemption in supply-chain/.
-  # --locked uses the committed imports.lock (no network refetch) so the result is
-  # deterministic; a newly-introduced unvetted dep fails here. (Folded in from
-  # audit.yml; the job name is a live required context.)
-  vet:
-    name: cargo vet
-    needs: plan
-    if: needs.plan.outputs.deps == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # The committed imports.lock omits the `user-id` publisher field that
-      # cargo-vet 0.10.0 still rejects; 0.10.1+ relaxed it. Only 0.10.0 ships a
-      # prebuilt binary anywhere (mozilla's release page and the install-action
-      # manifest both stop there), so 0.10.2 is compiled from crates.io once and
-      # cached — keep the cache key in lockstep with the install pin below,
-      # which version-freshness.yml watches. Keep both in lockstep with the
-      # version that writes supply-chain/.
-      - name: Cache the pinned cargo-vet binary
-        id: vet-bin
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/cargo-vet
-          key: cargo-vet-${{ runner.os }}-0.10.2
-
-      - name: Install cargo-vet 0.10.2 (cache miss)
-        if: steps.vet-bin.outputs.cache-hit != 'true'
-        run: cargo install cargo-vet --version 0.10.2 --locked
-
-      - name: Vet the dependency tree against the committed store
-        run: cargo vet --locked
-
-  # Adversarial regression gate over the untrusted-input parsers (Blu-ray bytes
-  # are attacker-controlled): replay the committed seed corpus with zero fresh
-  # iterations — a deterministic check that the parsers still handle every
-  # recorded boundary/garbage input without panicking, hanging, or blowing up
-  # memory. cargo-fuzz / libFuzzer need a nightly toolchain and have no Windows
-  # MSVC support, so this runs on Linux only; the local mirror is
-  # scripts/fuzz-docker.{ps1,sh}. The tag-triggered extended fresh-fuzz pass
-  # stays in fuzz.yml. (Folded in from fuzz.yml; the job name is a live
-  # required context.)
-  replay:
-    name: corpus replay (regression gate)
-    needs: plan
-    if: needs.plan.outputs.fuzz == 'true'
-    runs-on: ubuntu-latest
-    env:
-      # The 10 libFuzzer targets (fuzz/Cargo.toml). Keep in lockstep with it and
-      # with scripts/fuzz-docker.sh + fuzz.yml.
-      TARGETS: read_be discovery bitstream clpi mpls m2ts codec udf source parse_report
-      # Fuzz on the gnu host, NOT the workspace default. The repo's .cargo/config.toml
-      # sets build.target = x86_64-unknown-linux-musl (the static-binary build), which
-      # cargo-fuzz would otherwise inherit — but libFuzzer's sanitizers are incompatible
-      # with a statically linked musl libc and need a musl C++ cross-compiler the runner
-      # lacks. The gnu host has the dynamic libc + system C++ that libFuzzer needs.
-      FUZZ_TARGET: x86_64-unknown-linux-gnu
-      # Per-unit guards (mirror scripts/fuzz-docker.sh): -timeout bounds a single
-      # unit's wall time (non-termination guard); -rss_limit_mb bounds its memory
-      # (allocation-amplification guard).
-      GUARDS: -timeout=25 -rss_limit_mb=2048
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install pinned nightly
-        run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: fuzz
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      # cargo-fuzz is absent from taiki-e/install-action's manifest (101 tools at
-      # the revision pinned in this file), so with the binstall fallback disabled
-      # it has no prebuilt channel here. Compile the pinned version from crates.io
-      # once and cache the binary, the same lane cargo-vet uses; keep the pin equal
-      # to fuzz.yml's, which version-freshness.yml enforces and watches.
-      - name: Cache the pinned cargo-fuzz binary
-        id: fuzz-bin
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/cargo-fuzz
-          key: cargo-fuzz-${{ runner.os }}-0.13.2
-
-      - name: Install cargo-fuzz 0.13.2 (cache miss)
-        if: steps.fuzz-bin.outputs.cache-hit != 'true'
-        run: cargo install cargo-fuzz --version 0.13.2 --locked
-
-      - name: Verify the committed fuzz lockfile is in sync
-        # cargo-fuzz's `run` has no --locked flag (it forwards everything after
-        # `--` to libFuzzer), so enforce the committed fuzz/Cargo.lock with a real
-        # cargo command up front; this also pre-fetches the deps for the build.
-        run: cargo +"$NIGHTLY" fetch --locked --manifest-path fuzz/Cargo.toml
-
-      - name: Replay the committed corpus through every target
-        run: |
-          fail=0
-          for t in $TARGETS; do
-            echo "::group::replay $t"
-            cargo +"$NIGHTLY" fuzz run "$t" --target "$FUZZ_TARGET" -- -runs=0 $GUARDS || fail=1
-            echo "::endgroup::"
-          done
-          exit $fail
-
-  # PR-time smoke test for the .deb / .rpm packaging. The packages are built INSIDE
-  # the release (dist `extra-artifacts` -> .github/build-linux-packages.sh), and a
-  # failure there ABORTS the whole release (dist fail-fast) — so a broken packaging
-  # change must be caught BEFORE a tag, not at release time.
-  #
-  # This job runs the REAL build-linux-packages.sh end to end, exercising the two paths
-  # that otherwise first execute only at a tag: the archive-EXTRACTION glue (it unpacks
-  # each dist `bdinfo-rs-<triple>.tar.gz` and stages the binary + man + completions) and
-  # the AARCH64 packaging (cross-arch `cargo deb/generate-rpm --target aarch64-...` on an
-  # x86_64 host). We can't produce real dist archives on a PR (no `dist build`), so we
-  # synthesize them in dist's exact `<pkg>-<triple>/` layout from a host build — using a
-  # host binary as a stand-in, which is fine because packaging is arch/libc-agnostic (the
-  # package's arch label comes from --target, not the binary; the static musl binaries
-  # themselves are e2e-tested elsewhere in this workflow). cargo-deb / cargo-generate-rpm
-  # are installed prebuilt at the SAME versions build-linux-packages.sh pins, so the
-  # script's "already on PATH" check skips its source compile and the test uses the
-  # release tools.
-  #
-  # Residual it does NOT catch: dist itself CHANGING its archive layout out from under
-  # the script (that needs a real tag) — but it does catch us breaking the script, the
-  # real risk. The x86_64 package (native arch, runnable stand-in binary) is
-  # install-verified; the aarch64 package is contents-verified (its binary is an x86_64
-  # stand-in, unrunnable here — but the packaging, metadata, and file layout are what
-  # this asserts). (Folded in from the former linux-packages.yml, whose `on.paths`
-  # filter became the `pkg` area; landing under ci-ok promotes it from
-  # deliberately-not-required to gating, which its determinism supports.)
-  pkg:
-    name: build + install .deb/.rpm (x64 + arm64)
-    needs: plan
-    if: needs.plan.outputs.pkg == 'true'
-    runs-on: ubuntu-latest
-    # Build the HOST gnu triple: this verifies the PACKAGING (extraction, metadata, the
-    # --target path rewrite, install + contents), for which the binary's libc/arch is
-    # irrelevant. gnu is the runner's native target, so there is no musl-linker friction.
-    env:
-      HOST: x86_64-unknown-linux-gnu
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # build.rs writes the shell completions + man page into OUT_DIR during the build;
-      # the host triple nests output under target/<triple>/ (mirroring what the release
-      # archives carry). --locked keeps the smoke build honest against the lockfile.
-      - name: Build the binary (generates completions + man page)
-        run: cargo build --release --locked --target "$HOST" -p bdinfo-rs
-
-      # Both at the SAME versions build-linux-packages.sh pins — so the script's
-      # `command -v cargo-deb` guard finds them and skips its (slower) source compile,
-      # and the smoke test packages with the exact release tools.
-      - name: Install cargo-deb (release pin, prebuilt)
-        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
-        with:
-          tool: cargo-deb@3.7.0
-          fallback: none
-
-      # cargo-generate-rpm is absent from taiki-e/install-action's manifest (101
-      # tools at the revision pinned in this file), so with the binstall fallback
-      # disabled it gets the same compile-once-and-cache lane as cargo-fuzz and
-      # cargo-vet. The `@0.21.0` pin is the one build-linux-packages.sh and gui.yml
-      # carry; version-freshness.yml cross-checks all three.
-      - name: Cache the pinned cargo-generate-rpm binary
-        id: rpm-bin
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/cargo-generate-rpm
-          key: cargo-generate-rpm-${{ runner.os }}-0.21.0
-
-      - name: Install cargo-generate-rpm (cache miss)
-        if: steps.rpm-bin.outputs.cache-hit != 'true'
-        run: cargo install --locked cargo-generate-rpm@0.21.0
-
-      # Synthesize the two dist archives the script consumes, in dist's exact
-      # `<pkg>-<triple>/` layout, from the host build (binary stand-in + real assets).
-      - name: Synthesize the dist release archives (both musl arches)
-        shell: bash
-        run: |
-          set -euo pipefail
-          bin="target/$HOST/release/bdinfo-rs"
-          assets="$(dirname "$(ls target/"$HOST"/release/build/bdinfo-rs-*/out/assets/bdinfo-rs.1 | head -n1)")"
-          mkdir -p target/distrib
-          for triple in x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
-            d="target/distrib/bdinfo-rs-${triple}"
-            mkdir -p "$d"
-            cp "$bin" "$d/bdinfo-rs"
-            for f in bdinfo-rs.1 bdinfo-rs.bash _bdinfo-rs bdinfo-rs.fish; do cp "$assets/$f" "$d/"; done
-            tar czf "target/distrib/bdinfo-rs-${triple}.tar.gz" -C target/distrib "bdinfo-rs-${triple}"
-            rm -rf "$d" # the script re-extracts from the tarball, so this truly tests extraction
-          done
-          ls -l target/distrib
-
-      - name: Run build-linux-packages.sh (the real release packaging path)
-        shell: bash
-        run: bash .github/build-linux-packages.sh
-
-      - name: Verify the x86_64 .deb + .rpm (install + run + man/completions/copyright)
-        shell: bash
-        run: |
-          set -euo pipefail
-          deb="dist-extra/bdinfo-rs-x86_64-unknown-linux-musl.deb"
-          echo "== $deb =="; dpkg-deb --contents "$deb"
-          sudo dpkg -i "$deb"
-          bdinfo-rs --version
-          # cargo-deb gzips the man page (.1.gz); cargo-generate-rpm keeps it (.1) — accept either.
-          ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
-          for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
-            test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
-          done
-          grep -q '^License: LGPL-2.1-or-later' /usr/share/doc/bdinfo-rs/copyright || { echo "NOT INSTALLED: DEP-5 copyright License field"; exit 1; }
-          sudo dpkg -r bdinfo-rs
-          echo "x86_64 .deb OK"
-
-          sudo apt-get update -qq && sudo apt-get install -y -qq rpm
-          sudo rpm --initdb 2>/dev/null || true
-          rpmf="dist-extra/bdinfo-rs-x86_64-unknown-linux-musl.rpm"
-          echo "== $rpmf =="; rpm -qpl "$rpmf"
-          sudo rpm -i --nodeps --ignorearch --force "$rpmf"
-          bdinfo-rs --version
-          ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
-          for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
-            test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
-          done
-          echo "x86_64 .rpm OK"
-
-      - name: Verify the aarch64 .deb + .rpm (packaging + contents)
-        shell: bash
-        run: |
-          set -euo pipefail
-          deb="dist-extra/bdinfo-rs-aarch64-unknown-linux-musl.deb"
-          rpmf="dist-extra/bdinfo-rs-aarch64-unknown-linux-musl.rpm"
-          test -f "$deb" || { echo "MISSING: $deb"; exit 1; }
-          test -f "$rpmf" || { echo "MISSING: $rpmf"; exit 1; }
-          # The arm64 binary here is an x86_64 stand-in, so don't run it — assert the
-          # packaging produced the right arch label and shipped the binary + man +
-          # completions (the metadata/layout that a broken aarch64 package would drop).
-          echo "== $deb =="
-          arch=$(dpkg-deb -f "$deb" Architecture)
-          [ "$arch" = "arm64" ] || { echo "wrong deb arch label: $arch (expected arm64)"; exit 1; }
-          debc=$(dpkg-deb --contents "$deb")
-          echo "$debc"
-          for p in ./usr/bin/bdinfo-rs ./usr/share/bash-completion/completions/bdinfo-rs ./usr/share/zsh/site-functions/_bdinfo-rs ./usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
-            echo "$debc" | grep -q " $p\$" || { echo "MISSING in .deb: $p"; exit 1; }
-          done
-          echo "$debc" | grep -qE ' \./usr/share/man/man1/bdinfo-rs\.1' || { echo "MISSING in .deb: man page"; exit 1; }
-          echo "aarch64 .deb OK"
-
-          echo "== $rpmf =="
-          rarch=$(rpm -qp --qf '%{ARCH}' "$rpmf")
-          case "$rarch" in aarch64|arm64) ;; *) echo "wrong rpm arch label: $rarch (expected aarch64)"; exit 1;; esac
-          rpmc=$(rpm -qpl "$rpmf")
-          echo "$rpmc"
-          for p in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
-            echo "$rpmc" | grep -qx "$p" || { echo "MISSING in .rpm: $p"; exit 1; }
-          done
-          echo "$rpmc" | grep -qE '/usr/share/man/man1/bdinfo-rs\.1' || { echo "MISSING in .rpm: man page"; exit 1; }
-          echo "aarch64 .rpm OK"
+    if: >-
+      needs.plan.outputs.yaml == 'true' ||
+      needs.plan.outputs.toml == 'true' ||
+      needs.plan.outputs.workflows == 'true' ||
+      needs.plan.outputs.typos == 'true' ||
+      needs.plan.outputs.links == 'true'
+    uses: ./.github/workflows/repo.yml
+    with:
+      yaml: ${{ needs.plan.outputs.yaml }}
+      toml: ${{ needs.plan.outputs.toml }}
+      workflows: ${{ needs.plan.outputs.workflows }}
+      typos: ${{ needs.plan.outputs.typos }}
+      links: ${{ needs.plan.outputs.links }}
 
   # The sibling-crate gates, invoked as workflow_call reusables so their job
   # content stays with their crates while the plan gates them here. Their
@@ -1203,7 +415,8 @@ jobs:
   # `wasm / wasm gate (…)`); a red anywhere inside reddens the caller job and
   # therefore ci-ok. When the area is skipped, the single caller job reports
   # `skipped` — the inner jobs never appear, which is fine because only the
-  # caller jobs feed ci-ok and no inner name is a required context.
+  # caller jobs feed ci-ok and no inner name is a required context. One area
+  # each, so these two need no input plumbing.
   gui:
     name: gui
     needs: plan
@@ -1216,23 +429,24 @@ jobs:
     if: needs.plan.outputs.wasm == 'true'
     uses: ./.github/workflows/wasm.yml
 
-  # The fan-in: the ONE result branch protection will require (the protection
-  # cutover swaps the 28 name-matched contexts for this job + the three
-  # standalone checks). Green = every gate job either succeeded or was skipped
-  # by the plan; red = anything failed, was cancelled, or never ran because a
-  # `needs` upstream failed.
+  # The fan-in: the ONE result branch protection requires (plus the three
+  # standalone checks outside this workflow). Green = every gate job either
+  # succeeded or was skipped by the plan; red = anything failed, was
+  # cancelled, or never ran because a `needs` upstream failed.
   #
   # A skipped job is considered a success by GitHub, so overwrite `if:`.
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
   # (cargo's warning, kept verbatim: a job missing from `needs` silently stops
-  # gating merges.) The deliberate exceptions are the ADVISORY mutation jobs
-  # (`mutants`, `gui-mutants`, `wasm-mutants` — see their headers:
-  # false-TIMEOUTs on 4-core runners must not block unrelated PRs), which stay
-  # visible on the PR but do not gate. `!cancelled()` rather than `always()`:
-  # a manually-cancelled run must not end green.
+  # gating merges.) With the gate jobs inside the four called workflows, that
+  # means every CALLER job — a red inside a reusable reddens its caller. The
+  # deliberate exceptions are the ADVISORY mutation jobs (`mutants`,
+  # `gui-mutants`, `wasm-mutants` — see their headers: false-TIMEOUTs on
+  # 4-core runners must not block unrelated PRs), which stay visible on the PR
+  # but do not gate. `!cancelled()` rather than `always()`: a manually-
+  # cancelled run must not end green.
   ci-ok:
     name: ci-ok
-    needs: [plan, test, yaml, release-yaml, lint, coverage, e2e, isolation, taplo, zizmor, typos, links, deny, vet, replay, pkg, gui, wasm]
+    needs: [plan, core, repo, gui, wasm]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -50,7 +50,7 @@ jobs:
         run: git fetch --no-tags --filter=blob:none --unshallow origin
 
       # `fallback: none`: install only from install-action's checksummed manifest,
-      # never its runtime-resolved cargo-binstall fallback (rationale in ci.yml).
+      # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install convco (prebuilt, no from-source compile)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,0 +1,703 @@
+name: core
+
+# The ROOT-WORKSPACE half of the PR/master gate: build + test on every shipped
+# arch, the quality gate (clippy/fmt/doc/deps/semver), coverage, the real-world
+# install + scan, the zero-deps scan FROM scratch, the .deb/.rpm packaging
+# smoke, the two dependency audits, the release-workflow drift guard and the
+# fuzz-corpus replay.
+#
+# A workflow_call REUSABLE, the shape gui.yml and wasm.yml already use: ci.yml's
+# plan job classifies the event's diff into areas and passes each one through as
+# an input, so every job below keeps the per-area `if:` it carries when the plan
+# sits beside it. The caller invokes this file when ANY of those areas fired; a
+# job whose own area did not fire reports `skipped`, which counts as success in
+# the caller's `ci-ok` fan-in. Check runs render prefixed (`core / build + test
+# (…)`). This file carries no triggers and no concurrency of its own — both are
+# the caller's — so it can never fire on its own and never needs a paths filter.
+#
+# Build and test on every supported OS. The pinned stable toolchain installs
+# itself from rust-toolchain.toml on first cargo use; `unsafe` is forbidden at
+# compile time, so a green build is also the memory-safety guarantee. Every
+# dependency-resolving cargo call is --locked for reproducible builds (the one
+# exception is cargo-semver-checks, which builds its own baseline + current
+# checkouts and takes no --locked flag).
+
+on:
+  workflow_call:
+    inputs:
+      core:
+        description: The root workspace's sources, manifests or lockfile changed.
+        required: true
+        type: string
+      deps:
+        description: The dependency graph or the audit policy changed.
+        required: true
+        type: string
+      dist:
+        description: The release configuration or its generated workflow changed.
+        required: true
+        type: string
+      fuzz:
+        description: The fuzz workspace, its targets or its seed corpus changed.
+        required: true
+        type: string
+      pkg:
+        description: The Linux packaging inputs or their build script changed.
+        required: true
+        type: string
+      test:
+        description: Whether build + test runs at all — true when `core` or `canary` fired.
+        required: true
+        type: string
+      test-os:
+        description: The build + test matrix as a JSON array — six legs for `core`, two for `canary`.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  # The nightly that backs the `fmt` step (rustfmt.toml has nightly-only options).
+  # Keep in lockstep with $script:Nightly in scripts/_common.ps1.
+  NIGHTLY: nightly-2026-07-06
+  # Keep the cached target/ small: no incremental-compilation metadata, and line
+  # tables instead of full DWARF (still enough for file:line in a test
+  # backtrace). A called workflow inherits none of its caller's env, so these are
+  # declared here as well as in ci.yml — which carries the rationale.
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+
+jobs:
+  test:
+    name: build + test (${{ matrix.os }})
+    if: inputs.test == 'true'
+    runs-on: ${{ matrix.os }}
+    # One native runner per RELEASED binary — x86_64 AND aarch64 across Linux,
+    # Windows and macOS — so `cargo test` (including the real-disc end-to-end scan
+    # in tests/cli.rs) runs on every architecture we ship: no shipped arch goes
+    # unscanned. arm64 Linux/Windows and Intel macOS are standard GitHub-hosted
+    # runners, free for public repos. The OS list arrives as an input — the full
+    # six for `core`, one leg per shell family for `canary`; keep the list in
+    # classify-diff.ps1 in lockstep with the six dist-workspace.toml targets.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJson(inputs.test-os) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Cache write-discipline (wgpu): PR-branch saves are invisible to
+          # every other PR, so only master runs (pushes + the daily sweep)
+          # save; PRs restore the master-seeded cache.
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # Clippy on EVERY build+test leg: the ubuntu-only lint job never clips
+      # the #[cfg(windows)] arms (e.g. the vfs/fs.rs raw-volume reader), so a
+      # per-arch lint bug reaches master unless every leg lints.
+      # Cheap: shares this leg's dep build. The alias is the tracked `lt`
+      # (clippy --workspace --all-targets --locked -- -D warnings).
+      - name: Clippy (-D warnings, pedantic/nursery/restriction)
+        run: cargo lt
+
+      - name: Build
+        run: cargo build --workspace --locked
+
+      - name: Test
+        run: cargo test --workspace --locked
+
+  # Drift guard: the committed v-release.yml is generated from dist-workspace.toml by
+  # dist. This regenerates it in-memory and fails if it differs from the on-disk
+  # file, so v-release.yml can never silently fall out of sync with the dist config.
+  release-yaml:
+    name: release workflow in sync (dist generate --check)
+    if: inputs.dist == 'true'
+    runs-on: ubuntu-latest
+    env:
+      # MUST equal `cargo-dist-version` in dist-workspace.toml — the version that
+      # generated the committed v-release.yml, so anything else makes the check
+      # below compare against the wrong generator. version-freshness.yml enforces
+      # the equality and nags when a newer dist ships.
+      DIST_VERSION: 0.32.0
+      # sha256 of the release asset named in the install step, copied once from
+      # the `.sha256` file axodotdev publishes beside it. Committing the digest is
+      # what makes the download verifiable: the archive is checked against this
+      # value before anything inside it runs. Re-take it on every DIST_VERSION bump.
+      DIST_SHA256: 0d9dc001b0e937e9cc18e0dc11784aa7a3fd566656b07828d5e1d10ce1c1c48c
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The upstream `.sh` installer is an unhashed curl|sh (Scorecard
+      # pinned-dependencies / downloadThenRun), but the release it installs from
+      # also carries plain archives with published checksums — so fetch the archive
+      # at a version-pinned URL and verify it here instead, which is both faster
+      # than a from-source compile and pinned end to end. musl: the binary is
+      # statically linked, so it is independent of the runner image's glibc.
+      - name: Install pinned dist (checksum-verified prebuilt)
+        run: |
+          set -euo pipefail
+          dir="cargo-dist-x86_64-unknown-linux-musl"
+          curl -fsSL --retry 3 -o "$dir.tar.xz" \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v$DIST_VERSION/$dir.tar.xz"
+          echo "$DIST_SHA256  $dir.tar.xz" | sha256sum --check --strict -
+          tar -xJf "$dir.tar.xz" "$dir/dist"
+          sudo install -m755 "$dir/dist" /usr/local/bin/dist
+          rm -rf "$dir" "$dir.tar.xz"
+          dist --version
+
+      - name: Check v-release.yml is in sync with dist-workspace.toml
+        run: dist generate --check
+
+      # Make the drift self-explanatory (no token / no extra permission — just an
+      # annotation). The usual cause is a Dependabot bump of an action that appears
+      # in the GENERATED v-release.yml (checkout, upload-/download-artifact, attest):
+      # it edits v-release.yml but cannot edit dist-workspace.toml, so the pins drift.
+      - name: Explain the drift if the check failed
+        if: failure()
+        run: |
+          echo "::group::v-release.yml is out of sync with dist-workspace.toml"
+          drift=0
+          for a in actions/checkout actions/upload-artifact actions/download-artifact actions/attest; do
+            rel=$(grep -oP "uses:\s*${a}@\K[0-9a-f]{40}\s*#\s*\S+" .github/workflows/v-release.yml | head -1)
+            cfg=$(grep -oP "\"${a}\"\s*=\s*\"\K[^\"]+" dist-workspace.toml | head -1)
+            if [ -n "$rel" ] && [ "$rel" != "$cfg" ]; then
+              echo "::error::dist-workspace.toml pin stale for ${a} — set:  \"${a}\" = \"${rel}\""
+              drift=1
+            fi
+          done
+          if [ "$drift" -eq 0 ]; then
+            echo "::error::v-release.yml differs from dist generate output, but not via a tracked action pin — run 'dist generate' locally and inspect the diff."
+          fi
+          echo "Fix: run 'pwsh scripts/dist-sync.ps1 -Pr <this-PR> -Push' (cockpit helper), or paste the line(s) above into dist-workspace.toml and run 'dist generate', then commit on this branch."
+          echo "::endgroup::"
+
+  # The quality gate mirrored from the local runner. The gate commands are the
+  # tracked cargo aliases in .cargo/config.toml (ck/lt/mc/dc + cov); clippy.toml +
+  # typos.toml are tracked so clippy/typos behave identically. Format uses the
+  # pinned nightly (rustfmt.toml has nightly-only options). Public repo = free
+  # minutes, so the heavy quality checks run here too — incremental mutants run
+  # per-PR (the `mutants` job in ci.yml), the fuzz corpus replays per-PR (the
+  # `replay` job below), and the full mutants sweeps for every crate live in
+  # sweep.yml; only the Windows-via-Docker fuzz runner stays local.
+  lint:
+    name: lint (clippy, fmt, doc, deps, semver)
+    if: inputs.core == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0   # semver-checks needs the v* baseline tag
+          persist-credentials: false
+
+      - name: Install pinned nightly rustfmt
+        run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component rustfmt
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # `fallback: none` on EVERY taiki-e/install-action step in this repo. The
+      # action's manifest path is the only channel that inherits the pinned action
+      # revision's guarantees: it resolves a fixed upstream release asset and
+      # verifies its committed checksum. The default fallback instead resolves at
+      # run time through crates.io metadata to a GitHub release asset or the
+      # third-party quickinstall build farm (cargo-binstall) — neither pinned by
+      # this repo nor checksum-verified against anything committed here. Disabling
+      # it turns a tool the manifest lacks into a loud failure rather than a silent
+      # downgrade to that path, and does the same for a pinned `tool@version` the
+      # manifest stops carrying.
+      - name: Install gate tools
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+        with:
+          tool: cargo-machete,cargo-shear,cargo-semver-checks
+          fallback: none
+
+      # House rules with no clippy equivalent (big-endian-only + no HashMap/HashSet
+      # in the deterministic output path), mirrored from the local gate via the
+      # shared script so local and CI enforce the SAME rule. pwsh ships on the
+      # ubuntu runner.
+      - name: Source rules (big-endian + determinism)
+        shell: pwsh
+        run: ./.github/scripts/source-rules.ps1
+
+      - name: Format (nightly rustfmt)
+        run: cargo +${{ env.NIGHTLY }} fmt --all --check
+
+      - name: Clippy (-D warnings, pedantic/nursery/restriction)
+        run: cargo lt
+
+      - name: Unused deps (machete)
+        run: cargo mc
+
+      - name: Docs (warnings = errors)
+        run: cargo dc
+
+      - name: Unused deps (shear)
+        run: cargo sh
+
+      - name: API stability (semver-checks vs latest v* tag)
+        run: |
+          base="$(git tag -l 'v*' --sort=-version:refname | head -1)"
+          if [ -n "$base" ]; then
+            echo "baseline: $base"
+            cargo semver-checks check-release -p bdinfo-rs-core --baseline-rev "$base"
+          else
+            echo "no v* tag yet; skipping"
+          fi
+
+  # 100% line/region/function coverage. Runs on the pinned NIGHTLY rather than
+  # the stable `cov` alias: the CLI excludes a couple of environment/platform-
+  # bound functions with `#[cfg_attr(coverage_nightly, coverage(off))]`, and that
+  # cfg is only set by cargo-llvm-cov on a nightly toolchain. On stable those
+  # exclusions are inert, so the off-Windows platform arms count as uncovered and
+  # the floor can't be met on Linux. The 97%/91% branch floors stay in the LOCAL
+  # gate (scripts/compliance.ps1) — NOT because they need nightly (this job is
+  # already on nightly) but because branch coverage is platform-VARIANT: the
+  # library carries #[cfg(windows)] arms (e.g. vfs/fs.rs) whose branch count
+  # differs by OS, so one CI floor calibrated on a single platform would misfire
+  # on another. CI gates the platform-INVARIANT 100% line/region/function floor;
+  # the contributor's local gate enforces the branch floors on their own platform.
+  coverage:
+    name: coverage (100% lines/regions/functions)
+    if: inputs.core == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pinned nightly with llvm-tools
+        run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Install coverage tools
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
+          fallback: none
+
+      - name: Coverage (100% lines/regions/functions)
+        run: cargo +${{ env.NIGHTLY }} llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100
+
+  # The ultimate real-world gate: do exactly what a user does — install bdinfo-rs
+  # the traditional way (build it from source; no package managers), scan the
+  # committed fixture disc, and confirm the report is byte-identical to the golden.
+  # One native runner per SHIPPED binary (x86_64 AND aarch64 × Linux/Windows/macOS),
+  # so this exercises the actual RELEASE/static artifact (not the debug test binary)
+  # on hardware we don't own — Linux builds the static musl target it ships.
+  # Deliberately NOT `needs:`-chained behind test/lint/coverage: such a chain is
+  # pure scheduling — ci-ok requires e2e green either way, so running it in
+  # parallel costs nothing but wall-clock. (Running the binary in TOTAL
+  # isolation — FROM scratch, zero runtime deps — is the separate `isolation`
+  # job below; docker.yml ships that same scratch image on release.)
+  e2e:
+    name: real-world install + scan (${{ matrix.os }})
+    if: inputs.core == 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: ubuntu-latest, target: x86_64-unknown-linux-musl}
+          - {os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl}
+          - {os: windows-2025, target: ""}
+          - {os: windows-11-arm, target: ""}
+          - {os: macos-15-intel, target: ""}
+          - {os: macos-15, target: ""}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # "Install" the way a user would: build from source and drop the binary in a
+      # bin dir — exactly what `cargo install bdinfo-rs` does off crates.io. On Linux
+      # we target static musl so it matches the shipped artifact byte-for-byte.
+      - name: Install bdinfo-rs from source
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${{ matrix.target }}" ]; then
+            rustup target add "${{ matrix.target }}"
+            cargo install --path crates/bdinfo-rs --locked --root "$RUNNER_TEMP/inst" --target "${{ matrix.target }}"
+          else
+            cargo install --path crates/bdinfo-rs --locked --root "$RUNNER_TEMP/inst"
+          fi
+
+      # Scan both fixture discs with the installed binary and assert each report is
+      # byte-identical to its golden — the eyeball check a person does, made exact.
+      - name: Scan the fixture disc and diff against the golden
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin="$RUNNER_TEMP/inst/bin/bdinfo-rs"
+          fix="crates/bdinfo-rs/tests/fixtures"
+          out="$RUNNER_TEMP/out"; mkdir -p "$out"
+          "$bin" --version
+          "$bin" -m 00000 "$fix/BigBuckBunny"     "$out"
+          "$bin" -m 00000 "$fix/BigBuckBunny.iso" "$out"
+          cmp "$out/BDINFO.BigBuckBunny.txt" "$fix/golden/folder.txt"
+          cmp "$out/BDINFO.Blu-Ray.txt"      "$fix/golden/iso.txt"
+          # The 30 s playlist clears the default filter, so the default
+          # selection path is real-disc-testable: `--whole` (no `-m`) must
+          # produce the very bytes `-m 00000` does.
+          whole="$RUNNER_TEMP/out-whole"; mkdir -p "$whole"
+          "$bin" -w "$fix/BigBuckBunny" "$whole"
+          cmp "$whole/BDINFO.BigBuckBunny.txt" "$fix/golden/folder.txt"
+          echo "OK — both reports byte-identical to the golden (incl. --whole)"
+
+  # The "drop one file, it runs" proof, as its OWN job (not a step wedged into the
+  # e2e matrix): build the shipped static musl binary, bake it into an EMPTY `FROM
+  # scratch` image — no libc, no shell, no /tmp, nothing — and scan the fixture disc
+  # from inside it, byte-checked against the golden. A binary with any runtime dep
+  # could not even start in scratch, so green = the zero-deps guarantee, functional.
+  # Linux x86_64 + aarch64 (the two static-musl targets we ship; Windows/macOS have
+  # no empty-container equivalent). docker.yml ships this same image on release.
+  isolation:
+    name: zero-deps scan FROM scratch (${{ matrix.target }})
+    if: inputs.core == 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: ubuntu-latest, target: x86_64-unknown-linux-musl}
+          - {os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # Build the actual shipped artifact: the fully static musl release binary.
+      # Pure-Rust (no C deps), so the musl target needs no C toolchain.
+      - name: Build the static musl binary
+        run: |
+          rustup target add ${{ matrix.target }}
+          cargo build --release --locked -p bdinfo-rs --target ${{ matrix.target }}
+
+      - name: Scan the fixture disc FROM scratch
+        shell: bash
+        run: |
+          set -euo pipefail
+          ctx="$RUNNER_TEMP/ctx"
+          mkdir -p "$ctx/out"
+          install -D "target/${{ matrix.target }}/release/bdinfo-rs" "$ctx/bdinfo-rs"
+          printf 'FROM scratch\nCOPY bdinfo-rs /bdinfo-rs\nENTRYPOINT ["/bdinfo-rs"]\n' > "$ctx/Dockerfile"
+          docker build -t bdinfo-scratch "$ctx"
+          fix="$PWD/crates/bdinfo-rs/tests/fixtures"
+          docker run --rm -v "$fix:/fix:ro" -v "$ctx/out:/out" bdinfo-scratch -m 00000 /fix/BigBuckBunny     /out
+          docker run --rm -v "$fix:/fix:ro" -v "$ctx/out:/out" bdinfo-scratch -m 00000 /fix/BigBuckBunny.iso /out
+          cmp "$ctx/out/BDINFO.BigBuckBunny.txt" "$fix/golden/folder.txt"
+          cmp "$ctx/out/BDINFO.Blu-Ray.txt"      "$fix/golden/iso.txt"
+          # The 30 s playlist clears the default filter, so the default `--whole`
+          # selection is testable too — FROM scratch, into a fresh out dir.
+          mkdir -p "$ctx/out-whole"
+          docker run --rm -v "$fix:/fix:ro" -v "$ctx/out-whole:/out" bdinfo-scratch -w /fix/BigBuckBunny /out
+          cmp "$ctx/out-whole/BDINFO.BigBuckBunny.txt" "$fix/golden/folder.txt"
+          echo "OK — scanned both discs FROM scratch, byte-identical to golden (incl. --whole)"
+
+  # The DETERMINISTIC half of the supply-chain audit (the wgpu split): bans —
+  # including the no-C-dependencies guard behind the static binary — plus the
+  # license allowlist and crates.io-only sources, all functions of the committed
+  # manifests/lockfile alone, so a red here is always caused by the PR under
+  # test. The VOLATILE half (RustSec advisories: a CVE can publish any time)
+  # deliberately does NOT run on the PR path — an unrelated disclosure must not
+  # redden a PR — and lives in audit.yml's daily cron, with dependency-review
+  # catching advisories a PR's own dependency changes would introduce. The job
+  # name predates the split.
+  deny:
+    name: cargo deny check
+    if: inputs.deps == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-deny (prebuilt, no from-source compile)
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+        with:
+          tool: cargo-deny
+          fallback: none
+
+      - name: Audit bans + licenses + sources (deterministic on the lockfile)
+        run: cargo deny check bans licenses sources
+
+  # Supply-chain audit: every dependency must be covered by a trusted third-party
+  # audit, a recorded publisher-trust, or an explicit exemption in supply-chain/.
+  # --locked uses the committed imports.lock (no network refetch) so the result is
+  # deterministic; a newly-introduced unvetted dep fails here. (Folded in from
+  # audit.yml, which keeps the daily advisory cron.)
+  vet:
+    name: cargo vet
+    if: inputs.deps == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The committed imports.lock omits the `user-id` publisher field that
+      # cargo-vet 0.10.0 still rejects; 0.10.1+ relaxed it. Only 0.10.0 ships a
+      # prebuilt binary anywhere (mozilla's release page and the install-action
+      # manifest both stop there), so 0.10.2 is compiled from crates.io once and
+      # cached — keep the cache key in lockstep with the install pin below,
+      # which version-freshness.yml watches. Keep both in lockstep with the
+      # version that writes supply-chain/.
+      - name: Cache the pinned cargo-vet binary
+        id: vet-bin
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-vet
+          key: cargo-vet-${{ runner.os }}-0.10.2
+
+      - name: Install cargo-vet 0.10.2 (cache miss)
+        if: steps.vet-bin.outputs.cache-hit != 'true'
+        run: cargo install cargo-vet --version 0.10.2 --locked
+
+      - name: Vet the dependency tree against the committed store
+        run: cargo vet --locked
+
+  # Adversarial regression gate over the untrusted-input parsers (Blu-ray bytes
+  # are attacker-controlled): replay the committed seed corpus with zero fresh
+  # iterations — a deterministic check that the parsers still handle every
+  # recorded boundary/garbage input without panicking, hanging, or blowing up
+  # memory. cargo-fuzz / libFuzzer need a nightly toolchain and have no Windows
+  # MSVC support, so this runs on Linux only; the local mirror is
+  # scripts/fuzz-docker.{ps1,sh}. The tag-triggered extended fresh-fuzz pass
+  # stays in fuzz.yml.
+  replay:
+    name: corpus replay (regression gate)
+    if: inputs.fuzz == 'true'
+    runs-on: ubuntu-latest
+    env:
+      # The 10 libFuzzer targets (fuzz/Cargo.toml). Keep in lockstep with it and
+      # with scripts/fuzz-docker.sh + fuzz.yml.
+      TARGETS: read_be discovery bitstream clpi mpls m2ts codec udf source parse_report
+      # Fuzz on the gnu host, NOT the workspace default. The repo's .cargo/config.toml
+      # sets build.target = x86_64-unknown-linux-musl (the static-binary build), which
+      # cargo-fuzz would otherwise inherit — but libFuzzer's sanitizers are incompatible
+      # with a statically linked musl libc and need a musl C++ cross-compiler the runner
+      # lacks. The gnu host has the dynamic libc + system C++ that libFuzzer needs.
+      FUZZ_TARGET: x86_64-unknown-linux-gnu
+      # Per-unit guards (mirror scripts/fuzz-docker.sh): -timeout bounds a single
+      # unit's wall time (non-termination guard); -rss_limit_mb bounds its memory
+      # (allocation-amplification guard).
+      GUARDS: -timeout=25 -rss_limit_mb=2048
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pinned nightly
+        run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: fuzz
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # cargo-fuzz is absent from taiki-e/install-action's manifest (101 tools at
+      # the revision pinned in this file), so with the binstall fallback disabled
+      # it has no prebuilt channel here. Compile the pinned version from crates.io
+      # once and cache the binary, the same lane cargo-vet uses; keep the pin equal
+      # to fuzz.yml's, which version-freshness.yml enforces and watches.
+      - name: Cache the pinned cargo-fuzz binary
+        id: fuzz-bin
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-fuzz
+          key: cargo-fuzz-${{ runner.os }}-0.13.2
+
+      - name: Install cargo-fuzz 0.13.2 (cache miss)
+        if: steps.fuzz-bin.outputs.cache-hit != 'true'
+        run: cargo install cargo-fuzz --version 0.13.2 --locked
+
+      - name: Verify the committed fuzz lockfile is in sync
+        # cargo-fuzz's `run` has no --locked flag (it forwards everything after
+        # `--` to libFuzzer), so enforce the committed fuzz/Cargo.lock with a real
+        # cargo command up front; this also pre-fetches the deps for the build.
+        run: cargo +"$NIGHTLY" fetch --locked --manifest-path fuzz/Cargo.toml
+
+      - name: Replay the committed corpus through every target
+        run: |
+          fail=0
+          for t in $TARGETS; do
+            echo "::group::replay $t"
+            cargo +"$NIGHTLY" fuzz run "$t" --target "$FUZZ_TARGET" -- -runs=0 $GUARDS || fail=1
+            echo "::endgroup::"
+          done
+          exit $fail
+
+  # PR-time smoke test for the .deb / .rpm packaging. The packages are built INSIDE
+  # the release (dist `extra-artifacts` -> .github/build-linux-packages.sh), and a
+  # failure there ABORTS the whole release (dist fail-fast) — so a broken packaging
+  # change must be caught BEFORE a tag, not at release time.
+  #
+  # This job runs the REAL build-linux-packages.sh end to end, exercising the two paths
+  # that otherwise first execute only at a tag: the archive-EXTRACTION glue (it unpacks
+  # each dist `bdinfo-rs-<triple>.tar.gz` and stages the binary + man + completions) and
+  # the AARCH64 packaging (cross-arch `cargo deb/generate-rpm --target aarch64-...` on an
+  # x86_64 host). We can't produce real dist archives on a PR (no `dist build`), so we
+  # synthesize them in dist's exact `<pkg>-<triple>/` layout from a host build — using a
+  # host binary as a stand-in, which is fine because packaging is arch/libc-agnostic (the
+  # package's arch label comes from --target, not the binary; the static musl binaries
+  # themselves are e2e-tested elsewhere in this workflow). cargo-deb / cargo-generate-rpm
+  # are installed prebuilt at the SAME versions build-linux-packages.sh pins, so the
+  # script's "already on PATH" check skips its source compile and the test uses the
+  # release tools.
+  #
+  # Residual it does NOT catch: dist itself CHANGING its archive layout out from under
+  # the script (that needs a real tag) — but it does catch us breaking the script, the
+  # real risk. The x86_64 package (native arch, runnable stand-in binary) is
+  # install-verified; the aarch64 package is contents-verified (its binary is an x86_64
+  # stand-in, unrunnable here — but the packaging, metadata, and file layout are what
+  # this asserts). (Folded in from the former linux-packages.yml, whose `on.paths`
+  # filter became the `pkg` area; landing under ci-ok promotes it from
+  # deliberately-not-required to gating, which its determinism supports.)
+  pkg:
+    name: build + install .deb/.rpm (x64 + arm64)
+    if: inputs.pkg == 'true'
+    runs-on: ubuntu-latest
+    # Build the HOST gnu triple: this verifies the PACKAGING (extraction, metadata, the
+    # --target path rewrite, install + contents), for which the binary's libc/arch is
+    # irrelevant. gnu is the runner's native target, so there is no musl-linker friction.
+    env:
+      HOST: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # build.rs writes the shell completions + man page into OUT_DIR during the build;
+      # the host triple nests output under target/<triple>/ (mirroring what the release
+      # archives carry). --locked keeps the smoke build honest against the lockfile.
+      - name: Build the binary (generates completions + man page)
+        run: cargo build --release --locked --target "$HOST" -p bdinfo-rs
+
+      # Both at the SAME versions build-linux-packages.sh pins — so the script's
+      # `command -v cargo-deb` guard finds them and skips its (slower) source compile,
+      # and the smoke test packages with the exact release tools.
+      - name: Install cargo-deb (release pin, prebuilt)
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+        with:
+          tool: cargo-deb@3.7.0
+          fallback: none
+
+      # cargo-generate-rpm is absent from taiki-e/install-action's manifest (101
+      # tools at the revision pinned in this file), so with the binstall fallback
+      # disabled it gets the same compile-once-and-cache lane as cargo-fuzz and
+      # cargo-vet. The `@0.21.0` pin is the one build-linux-packages.sh and gui.yml
+      # carry; version-freshness.yml cross-checks all three.
+      - name: Cache the pinned cargo-generate-rpm binary
+        id: rpm-bin
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-generate-rpm
+          key: cargo-generate-rpm-${{ runner.os }}-0.21.0
+
+      - name: Install cargo-generate-rpm (cache miss)
+        if: steps.rpm-bin.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-generate-rpm@0.21.0
+
+      # Synthesize the two dist archives the script consumes, in dist's exact
+      # `<pkg>-<triple>/` layout, from the host build (binary stand-in + real assets).
+      - name: Synthesize the dist release archives (both musl arches)
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin="target/$HOST/release/bdinfo-rs"
+          assets="$(dirname "$(ls target/"$HOST"/release/build/bdinfo-rs-*/out/assets/bdinfo-rs.1 | head -n1)")"
+          mkdir -p target/distrib
+          for triple in x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
+            d="target/distrib/bdinfo-rs-${triple}"
+            mkdir -p "$d"
+            cp "$bin" "$d/bdinfo-rs"
+            for f in bdinfo-rs.1 bdinfo-rs.bash _bdinfo-rs bdinfo-rs.fish; do cp "$assets/$f" "$d/"; done
+            tar czf "target/distrib/bdinfo-rs-${triple}.tar.gz" -C target/distrib "bdinfo-rs-${triple}"
+            rm -rf "$d" # the script re-extracts from the tarball, so this truly tests extraction
+          done
+          ls -l target/distrib
+
+      - name: Run build-linux-packages.sh (the real release packaging path)
+        shell: bash
+        run: bash .github/build-linux-packages.sh
+
+      - name: Verify the x86_64 .deb + .rpm (install + run + man/completions/copyright)
+        shell: bash
+        run: |
+          set -euo pipefail
+          deb="dist-extra/bdinfo-rs-x86_64-unknown-linux-musl.deb"
+          echo "== $deb =="; dpkg-deb --contents "$deb"
+          sudo dpkg -i "$deb"
+          bdinfo-rs --version
+          # cargo-deb gzips the man page (.1.gz); cargo-generate-rpm keeps it (.1) — accept either.
+          ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
+          for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+            test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
+          done
+          grep -q '^License: LGPL-2.1-or-later' /usr/share/doc/bdinfo-rs/copyright || { echo "NOT INSTALLED: DEP-5 copyright License field"; exit 1; }
+          sudo dpkg -r bdinfo-rs
+          echo "x86_64 .deb OK"
+
+          sudo apt-get update -qq && sudo apt-get install -y -qq rpm
+          sudo rpm --initdb 2>/dev/null || true
+          rpmf="dist-extra/bdinfo-rs-x86_64-unknown-linux-musl.rpm"
+          echo "== $rpmf =="; rpm -qpl "$rpmf"
+          sudo rpm -i --nodeps --ignorearch --force "$rpmf"
+          bdinfo-rs --version
+          ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
+          for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+            test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
+          done
+          echo "x86_64 .rpm OK"
+
+      - name: Verify the aarch64 .deb + .rpm (packaging + contents)
+        shell: bash
+        run: |
+          set -euo pipefail
+          deb="dist-extra/bdinfo-rs-aarch64-unknown-linux-musl.deb"
+          rpmf="dist-extra/bdinfo-rs-aarch64-unknown-linux-musl.rpm"
+          test -f "$deb" || { echo "MISSING: $deb"; exit 1; }
+          test -f "$rpmf" || { echo "MISSING: $rpmf"; exit 1; }
+          # The arm64 binary here is an x86_64 stand-in, so don't run it — assert the
+          # packaging produced the right arch label and shipped the binary + man +
+          # completions (the metadata/layout that a broken aarch64 package would drop).
+          echo "== $deb =="
+          arch=$(dpkg-deb -f "$deb" Architecture)
+          [ "$arch" = "arm64" ] || { echo "wrong deb arch label: $arch (expected arm64)"; exit 1; }
+          debc=$(dpkg-deb --contents "$deb")
+          echo "$debc"
+          for p in ./usr/bin/bdinfo-rs ./usr/share/bash-completion/completions/bdinfo-rs ./usr/share/zsh/site-functions/_bdinfo-rs ./usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+            echo "$debc" | grep -q " $p\$" || { echo "MISSING in .deb: $p"; exit 1; }
+          done
+          echo "$debc" | grep -qE ' \./usr/share/man/man1/bdinfo-rs\.1' || { echo "MISSING in .deb: man page"; exit 1; }
+          echo "aarch64 .deb OK"
+
+          echo "== $rpmf =="
+          rarch=$(rpm -qp --qf '%{ARCH}' "$rpmf")
+          case "$rarch" in aarch64|arm64) ;; *) echo "wrong rpm arch label: $rarch (expected aarch64)"; exit 1;; esac
+          rpmc=$(rpm -qpl "$rpmf")
+          echo "$rpmc"
+          for p in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
+            echo "$rpmc" | grep -qx "$p" || { echo "MISSING in .rpm: $p"; exit 1; }
+          done
+          echo "$rpmc" | grep -qE '/usr/share/man/man1/bdinfo-rs\.1' || { echo "MISSING in .rpm: man page"; exit 1; }
+          echo "aarch64 .rpm OK"

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -58,7 +58,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       # `fallback: none`: install only from install-action's checksummed manifest,
-      # never its runtime-resolved cargo-binstall fallback (rationale in ci.yml).
+      # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install wasm-bindgen-cli (pinned to the crate version)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,7 +6,7 @@ name: fuzz
 # local mirror is scripts/fuzz-docker.{ps1,sh} (Windows via Docker) — the
 # guards here match it. The fast per-PR/push leg — replaying the committed
 # seed corpus with -runs=0 (the required `corpus replay (regression gate)`
-# check) — moved to ci.yml as a plan-gated job on the `fuzz` area; the daily
+# check) — moved to core.yml as a plan-gated job on the `fuzz` area; the daily
 # sweep re-runs it ungated.
 #
 # This pass runs ALONGSIDE the publish workflows the same tag triggers
@@ -26,11 +26,11 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # cargo-fuzz needs nightly. Keep in lockstep with ci.yml NIGHTLY and
+  # cargo-fuzz needs nightly. Keep in lockstep with core.yml NIGHTLY and
   # $script:Nightly in scripts/_common.ps1.
   NIGHTLY: nightly-2026-07-06
   # The 10 libFuzzer targets (fuzz/Cargo.toml). Keep in lockstep with it and
-  # with scripts/fuzz-docker.sh + ci.yml's replay job.
+  # with scripts/fuzz-docker.sh + core.yml's replay job.
   TARGETS: read_be discovery bitstream clpi mpls m2ts codec udf source parse_report
   # Fuzz on the gnu host, NOT the workspace default. The repo's .cargo/config.toml
   # sets build.target = x86_64-unknown-linux-musl (the static-binary build), which
@@ -65,18 +65,18 @@ jobs:
           workspaces: fuzz
           # Lookup-only: this workflow runs exclusively on release tags, and
           # a cache poisoned elsewhere must not taint a release-adjacent run
-          # (zizmor cache-poisoning); the per-PR replay leg in ci.yml is where
+          # (zizmor cache-poisoning); the per-PR replay leg in core.yml is where
           # the fuzz build cache is used and (on master) saved.
           lookup-only: true
 
       # cargo-fuzz is absent from taiki-e/install-action's manifest, and this repo
       # runs that action with `fallback: none` so a manifest-missing tool fails
       # loudly instead of resolving through its unpinned cargo-binstall fallback
-      # (rationale in ci.yml). Compile the pinned version from crates.io; ci.yml's
-      # replay job caches the same pin, but this workflow runs only on release tags
-      # and restores no cache that a non-tag run could have written (see the
-      # rust-cache note above), so it pays the compile. Keep the pin equal to
-      # ci.yml's — version-freshness.yml enforces it.
+      # (rationale in core.yml). Compile the pinned version from crates.io;
+      # core.yml's replay job caches the same pin, but this workflow runs only on
+      # release tags and restores no cache that a non-tag run could have written
+      # (see the rust-cache note above), so it pays the compile. Keep the pin
+      # equal to core.yml's — version-freshness.yml enforces it.
       - name: Install cargo-fuzz 0.13.2
         run: cargo install cargo-fuzz --version 0.13.2 --locked
 

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -27,7 +27,7 @@ name: gui
 # instead.
 #
 # Job shape — the repo's standing pattern (same reasoning as the core/CLI in
-# ci.yml): arch bugs live in build + test, which runs on all six shipped
+# core.yml): arch bugs live in build + test, which runs on all six shipped
 # arches; coverage measures test quality of platform-independent logic, so
 # once (ubuntu) is the signal. The snapshot-hash ties are a hard per-arch
 # gate: the first 6-arch runs proved tiny-skia renders byte-identically per OS
@@ -46,7 +46,7 @@ permissions:
   contents: read
 
 env:
-  NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + ci.yml (cross-checked by version-freshness.yml)
+  NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + core.yml (cross-checked by version-freshness.yml)
   # Every iced_test renderer (interaction, snapshots, and the same tests under
   # coverage/mutants) must be the deterministic tiny-skia software backend —
   # never a GPU whose pixels vary by driver. Also what makes the suites run on
@@ -91,7 +91,7 @@ jobs:
 
       # `fallback: none` on every install-action step here: install only from the
       # action's checksummed manifest, never its runtime-resolved cargo-binstall
-      # fallback (rationale in ci.yml).
+      # fallback (rationale in core.yml).
       - name: Install cargo-nextest
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
@@ -328,7 +328,7 @@ jobs:
   # tag, .app/dmg structure + ad-hoc signature, AppImage root entries, deb/rpm
   # payloads + weak deps, desktop-file/AppStream validation) — the PR-time
   # proof that keeps the release lane's tag-only surface thin, the same
-  # pattern ci.yml's pkg job uses for the CLI's .deb/.rpm. One leg per OS
+  # pattern core.yml's pkg job uses for the CLI's .deb/.rpm. One leg per OS
   # family: the packaging logic is arch-independent (the release lane's
   # native arm legs run the identical scripts; its check script asserts the
   # arm64 MSI's platform tag there). The cargo-deb/cargo-generate-rpm pins
@@ -380,7 +380,7 @@ jobs:
 
       # cargo-generate-rpm is absent from taiki-e/install-action's manifest, so
       # with the binstall fallback disabled it is compiled from crates.io once and
-      # cached, the lane ci.yml's cargo-fuzz and cargo-vet use.
+      # cached, the lane core.yml's cargo-fuzz and cargo-vet use.
       - name: Cache the pinned cargo-generate-rpm binary
         if: runner.os == 'Linux'
         id: rpm-bin

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -5,8 +5,8 @@ name: link-check
 # CONTRIBUTING, the issue templates, the Cargo/audit metadata, and the
 # doc-comment URLs in src), daily — external pages move without touching our
 # code, so links rot after merge. The PR/push leg is the identically-named job
-# in ci.yml, plan-gated on the `docs` area (any .md or .rs). Cheap: lychee
-# caches its results and only re-checks day-old links; a residual rate-limit
+# in repo.yml, plan-gated on the `links` area. Cheap: lychee caches its results
+# and only re-checks day-old links; a residual rate-limit
 # (429) is accepted rather than failed, so an external host can't red-X an
 # unrelated run.
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -140,7 +140,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       # `fallback: none`: install only from install-action's checksummed manifest,
-      # never its runtime-resolved cargo-binstall fallback (rationale in ci.yml).
+      # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install wasm-bindgen-cli (pinned to the crate version)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -1,0 +1,240 @@
+name: repo
+
+# The WHOLE-TREE half of the PR/master gate: the scanners that read the
+# repository rather than one crate — YAML schema + style, TOML format + lint,
+# workflow security, spell-check and link-check.
+#
+# A workflow_call REUSABLE invoked by ci.yml exactly as core.yml is: the plan
+# job classifies the event's diff into areas and passes each one through as an
+# input, so every job below keeps the per-area `if:` it carries when the plan
+# sits beside it. The caller invokes this file when ANY of those areas fired; a
+# job whose own area did not fire reports `skipped`, which counts as success in
+# the caller's `ci-ok` fan-in. Check runs render prefixed (`repo / lint YAML
+# (action-validator + ryl)`). No triggers and no concurrency of its own — both
+# are the caller's — so it can never fire on its own and never needs a paths
+# filter.
+
+on:
+  workflow_call:
+    inputs:
+      yaml:
+        description: A tracked YAML file changed.
+        required: true
+        type: string
+      toml:
+        description: A tracked TOML file taplo reads changed.
+        required: true
+        type: string
+      workflows:
+        description: A workflow file or the zizmor suppression list changed.
+        required: true
+        type: string
+      typos:
+        description: A file typos spell-checks changed.
+        required: true
+        type: string
+      links:
+        description: A file lychee can read a URL out of changed.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  # The only cargo here is the YAML job's two `cargo install` compiles, which
+  # build the release profile — so the dev-profile size knobs ci.yml and core.yml
+  # declare have nothing to act on in this file.
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Lint the config YAML two ways, both with Rust tools. action-validator
+  # schema-checks the workflow files (catches schema errors + invalid-YAML traps
+  # like an unquoted colon in a step name). ryl (a Rust yamllint) style/syntax-
+  # lints EVERY tracked YAML against .yamllint.yml — duplicate keys, trailing
+  # whitespace, bad indentation, missing final newline, etc. — and covers the
+  # non-workflow YAML (dependabot, issue templates, scorecard) that
+  # action-validator's workflow-only schema can't read. Mirrors the local gate.
+  yaml:
+    name: lint YAML (action-validator + ryl)
+    if: inputs.yaml == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Neither tool ships via taiki-e/install-action, so cache the compiled
+      # binaries instead of paying the from-source compile every run. ryl is
+      # version-pinned (reproducible lint verdicts; watched by
+      # version-freshness.yml); action-validator deliberately floats at latest
+      # (a schema checker self-updates), so its half of the key tracks the
+      # latest crates.io release — a new release recompiles once, then caches.
+      # A failed lookup salts the key with the run id: a guaranteed miss and a
+      # fresh install rather than a silently stale binary.
+      - name: Resolve the latest action-validator (cache key)
+        id: av
+        run: |
+          v=$(curl -fsSL --retry 3 -A 'bdinfo-rs-ci (github actions)' https://crates.io/api/v1/crates/action-validator | jq -r '.crate.max_stable_version // empty') || v=""
+          echo "version=${v:-unknown-$GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "latest action-validator: ${v:-unknown (cache bypassed this run)}"
+
+      - name: Cache the YAML lint binaries
+        id: yaml-tools
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin/action-validator
+            ~/.cargo/bin/ryl
+          key: yaml-tools-${{ runner.os }}-av-${{ steps.av.outputs.version }}-ryl-0.21.0
+
+      - name: Install action-validator + ryl (cache miss)
+        if: steps.yaml-tools.outputs.cache-hit != 'true'
+        run: |
+          cargo install action-validator --locked
+          cargo install ryl --version 0.21.0 --locked
+
+      - name: Schema-validate the workflow YAML (action-validator)
+        run: |
+          for f in .github/workflows/*.yml; do
+            echo "validating $f"
+            action-validator "$f"
+          done
+
+      - name: Style/syntax-lint all YAML (ryl, strict)
+        run: ryl -f github -o - -s .
+
+  # TOML formatting + lint gate (taplo): every tracked TOML — the Cargo manifests,
+  # the gate configs (clippy/deny/nextest/mutants/typos), dist-workspace.toml — must
+  # match `taplo fmt` and pass `taplo lint`, against the committed taplo.toml. Mirrors
+  # the local gate's `tp` step. Cargo.lock and the cargo-vet-managed
+  # supply-chain/*.toml are excluded in taplo.toml so taplo never fights a generator.
+  # (Folded in from the former toml.yml.)
+  taplo:
+    name: lint TOML (taplo)
+    if: inputs.toml == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install taplo (prebuilt, no from-source compile)
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+        with:
+          # Pinned (not latest) so a new taplo can't reformat/relint the tree and
+          # red-X an unrelated PR; version-freshness watches it against crates.io
+          # and the bump stays deliberate, like rustfmt's nightly pin.
+          tool: taplo-cli@0.10.0
+          fallback: none
+
+      # taplo auto-discovers taplo.toml (include/exclude + formatting). --check
+      # fails on any unformatted file; --diff prints exactly what differs.
+      - name: Check formatting (taplo fmt --check)
+        run: taplo fmt --check --diff
+
+      - name: Lint (taplo lint)
+        run: taplo lint
+
+  # Static security analysis of the GitHub Actions workflows themselves (zizmor):
+  # template injection, token over-permissioning, unpinned/impostor actions, cache
+  # poisoning, dangerous triggers, credential persistence, and more. Runs the FULL
+  # audit set online — the GITHUB_TOKEN enables the impostor-commit /
+  # known-vulnerable-actions checks that need the GitHub API — and hard-fails on any
+  # finding, like the other quality gates. The only accepted residuals live in
+  # .github/zizmor.yml (the cargo-dist-generated v-release.yml, which cannot be
+  # hand-edited) and inline (the two architecturally-required workflow_run triggers);
+  # every hand-maintained workflow is fixed in place, not suppressed. This is the
+  # PR/push leg; the daily cron leg (newly-disclosed action vulns surface between
+  # pushes) stays in zizmor.yml.
+  zizmor:
+    name: zizmor (workflow security)
+    if: inputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor (prebuilt, no from-source compile)
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+        with:
+          tool: zizmor
+          fallback: none
+
+      - name: Audit the workflows
+        run: zizmor .github/workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Stale-link guard: lychee verifies every URL and relative/file link across the
+  # repo (README, CHANGELOG, DIFFERENCES, CONTRIBUTING, the issue templates, the
+  # Cargo/audit metadata, and the doc-comment URLs in src). Cheap: lychee caches
+  # its results and only re-checks day-old links; a residual rate-limit (429) is
+  # accepted rather than failed, so an external host can't red-X an unrelated
+  # push. This is the PR/push leg (`docs` = any .md or .rs, since doc-comments
+  # carry links); the daily cron leg (links rot after merge without touching our
+  # code) stays in link-check.yml.
+  # typos reads the whole working tree (minus files.extend-exclude in
+  # typos.toml), so prose changes reach it while changing no Rust source. It is
+  # its own job rather than a step of `lint` for that reason: the rest of that
+  # job compiles the workspace, which a Markdown edit cannot affect.
+  typos:
+    name: spell-check (typos)
+    if: inputs.typos == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install typos
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
+        with:
+          tool: typos
+          fallback: none
+
+      - name: Typos
+        run: typos
+
+  links:
+    name: Check links
+    if: inputs.links == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Persist lychee's response cache so reruns only re-check day-old links.
+      - name: Restore the lychee cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .lycheecache
+          key: lychee-${{ github.run_id }}
+          restore-keys: lychee-
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          # Whole repo; skip the generated lockfile and the binary fuzz seed
+          # corpus (the binary disc fixtures are skipped automatically by their
+          # non-text extensions). The golden disc reports are byte-exact BDInfo
+          # output: the two URLs they carry (cinemasquid/avsforum) are part of
+          # the locked format and reproduce a defunct tool's text verbatim, so
+          # they're pinned, not maintainable link surface — exclude them.
+          # Accept 429 so an external host's rate-limit can't fail the gate;
+          # fail:true turns any broken link into a failure.
+          args: >-
+            --cache
+            --max-cache-age 1d
+            --no-progress
+            --accept 200..=299,429
+            --exclude-path Cargo.lock
+            --exclude-path fuzz/corpus
+            --exclude-path crates/bdinfo-rs/tests/fixtures/golden
+            --exclude-path crates/bdinfo-rs-wasm/tests/golden_report.txt
+            .
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -159,7 +159,7 @@ jobs:
 
       # `fallback: none` on every install-action step here: install only from the
       # action's checksummed manifest, never its runtime-resolved cargo-binstall
-      # fallback (rationale in ci.yml).
+      # fallback (rationale in core.yml).
       - name: Install mutation tools
         if: steps.marker.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -3,11 +3,11 @@ name: version-freshness
 # Several versions in this repo are pinned for reproducibility but rot SILENTLY —
 # nothing else watches them:
 #   - the Rust toolchains (rust-toolchain.toml stable + the NIGHTLY pin, which is
-#     hardcoded in ci.yml + fuzz.yml + wasm.yml + gui.yml + publish-npm.yml and
+#     hardcoded in core.yml + fuzz.yml + wasm.yml + gui.yml + publish-npm.yml and
 #     cross-checked for agreement here so a bump to one can't silently drift the
 #     rest),
 #   - cargo-dist (dist-workspace.toml `cargo-dist-version` AND the `DIST_VERSION`
-#     env in ci.yml's release-yaml job, which downloads that release's prebuilt
+#     env in core.yml's release-yaml job, which downloads that release's prebuilt
 #     archive — the two must stay equal; the `DIST_SHA256` committed beside it is
 #     the archive's published digest, so it is re-checked against upstream here
 #     because a version bump that forgets it only fails on the next dist-area PR),
@@ -17,12 +17,12 @@ name: version-freshness
 #     which then fails `dist generate --check`) — cross-checked against the
 #     hand-maintained workflows' pins for the same actions so the drift becomes
 #     a scheduled nag instead of a red X on an unrelated Dependabot PR,
-#   - cargo-vet (the `--version` pin in ci.yml's vet job),
-#   - cargo-fuzz (the `--version` pins in ci.yml's replay job and fuzz.yml — absent
+#   - cargo-vet (the `--version` pin in core.yml's vet job),
+#   - cargo-fuzz (the `--version` pins in core.yml's replay job and fuzz.yml — absent
 #     from taiki-e/install-action's manifest, so both compile it from crates.io and
 #     the two pins must stay equal),
-#   - ryl (the `cargo install ryl --version` pin in ci.yml's YAML-lint job),
-#   - taplo (the `tool: taplo-cli@X` pin in ci.yml's TOML job — a formatter, pinned like
+#   - ryl (the `cargo install ryl --version` pin in repo.yml's YAML-lint job),
+#   - taplo (the `tool: taplo-cli@X` pin in repo.yml's TOML job — a formatter, pinned like
 #     rustfmt so a new release can't reformat/relint the tree out from under a PR),
 #   - convco (the `tool: convco@X` pin in conventional.yml — pinned because its
 #     output drives a reproducible changelog/version format, like taplo/rustfmt),
@@ -49,7 +49,7 @@ name: version-freshness
 #     in build-linux-packages.sh — the .deb/.rpm packagers are compiled from source
 #     INSIDE dist's fail-fast release, so they are version-pinned there so a broken
 #     upstream release can't abort the whole release; both checked vs crates.io, and
-#     both cross-checked against every other copy — ci.yml's pkg job, the GUI
+#     both cross-checked against every other copy — core.yml's pkg job, the GUI
 #     packaging script (.github/scripts/gui-package-linux.ps1), and gui.yml's
 #     packaging smoke — which must all stay EQUAL so the PR smoke tests package
 #     with the exact release tools),
@@ -227,14 +227,14 @@ jobs:
             Add-Problem "Rust stable $stablePin->$stableLatest" "- stable Rust pin ``$stablePin`` (rust-toolchain.toml) is behind the latest release ``$stableLatest``"
           }
 
-          # --- Rust nightly: age of the ci.yml NIGHTLY pin ---------------------
-          $nightlyPin = Read-Pin '.github/workflows/ci.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
-          if (-not $nightlyPin) { throw 'No NIGHTLY pin in ci.yml' }
+          # --- Rust nightly: age of the core.yml NIGHTLY pin -------------------
+          $nightlyPin = Read-Pin '.github/workflows/core.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
+          if (-not $nightlyPin) { throw 'No NIGHTLY pin in core.yml' }
           $nightlyAgeDays = [int]((Get-Date) - [datetime]::ParseExact($nightlyPin, 'yyyy-MM-dd', $null)).TotalDays
           if ($nightlyAgeDays -gt 30) {
-            Add-Problem "nightly-$nightlyPin ($nightlyAgeDays d old)" "- nightly pin ``nightly-$nightlyPin`` (ci.yml NIGHTLY) is $nightlyAgeDays days old"
+            Add-Problem "nightly-$nightlyPin ($nightlyAgeDays d old)" "- nightly pin ``nightly-$nightlyPin`` (core.yml NIGHTLY) is $nightlyAgeDays days old"
           }
-          # The nightly is hardcoded in FIVE places (ci.yml/fuzz.yml/wasm.yml/gui.yml
+          # The nightly is hardcoded in FIVE places (core.yml/fuzz.yml/wasm.yml/gui.yml
           # NIGHTLY env + publish-npm.yml's rustup install) that Dependabot can't see,
           # so a bump to one silently drifts the rest. Cross-check they AGREE (like
           # the cargo-dist / wasm-bindgen-cli / Node pin agreements).
@@ -247,31 +247,31 @@ jobs:
           if (-not $nightlyGui)  { throw 'No NIGHTLY pin in gui.yml' }
           if (-not $nightlyNpm)  { throw 'No nightly install pin in publish-npm.yml' }
           if (($nightlyPin -ne $nightlyFuzz) -or ($nightlyPin -ne $nightlyWasm) -or ($nightlyPin -ne $nightlyGui) -or ($nightlyPin -ne $nightlyNpm)) {
-            Add-Problem 'nightly pins disagree' "- nightly pin mismatch: ci.yml ``$nightlyPin`` / fuzz.yml ``$nightlyFuzz`` / wasm.yml ``$nightlyWasm`` / gui.yml ``$nightlyGui`` / publish-npm.yml ``$nightlyNpm`` — all must be identical"
+            Add-Problem 'nightly pins disagree' "- nightly pin mismatch: core.yml ``$nightlyPin`` / fuzz.yml ``$nightlyFuzz`` / wasm.yml ``$nightlyWasm`` / gui.yml ``$nightlyGui`` / publish-npm.yml ``$nightlyNpm`` — all must be identical"
           }
 
           # --- cargo-dist: two pins must agree, both vs axodotdev/cargo-dist ----
           $distCfg = Read-Pin 'dist-workspace.toml' '^\s*cargo-dist-version\s*=\s*"([0-9.]+)"'
-          $distCi  = Read-Pin '.github/workflows/ci.yml' 'DIST_VERSION:\s*([0-9.]+)'
+          $distCi  = Read-Pin '.github/workflows/core.yml' 'DIST_VERSION:\s*([0-9.]+)'
           if (-not $distCfg) { throw 'No cargo-dist-version in dist-workspace.toml' }
-          if (-not $distCi)  { throw 'No DIST_VERSION pin in ci.yml' }
+          if (-not $distCi)  { throw 'No DIST_VERSION pin in core.yml' }
           if ($distCfg -ne $distCi) {
-            Add-Problem 'cargo-dist pins disagree' "- cargo-dist pin mismatch: dist-workspace.toml has ``$distCfg`` but ci.yml installs ``$distCi`` — they must be identical"
+            Add-Problem 'cargo-dist pins disagree' "- cargo-dist pin mismatch: dist-workspace.toml has ``$distCfg`` but core.yml installs ``$distCi`` — they must be identical"
           }
           $distLatest = Latest-Semver 'axodotdev/cargo-dist'
           if (-not $distLatest) {
             Add-Problem 'cargo-dist (query failed)' '- could not query the latest cargo-dist release (axodotdev/cargo-dist)'
           } elseif ([version]$distLatest -gt [version]$distCfg) {
-            Add-Problem "cargo-dist $distCfg->$distLatest" "- cargo-dist pin ``$distCfg`` (dist-workspace.toml + ci.yml) is behind the latest release ``$distLatest`` — bump both pins, re-take DIST_SHA256 from the release's ``.sha256`` asset, then re-run ``dist generate``"
+            Add-Problem "cargo-dist $distCfg->$distLatest" "- cargo-dist pin ``$distCfg`` (dist-workspace.toml + core.yml) is behind the latest release ``$distLatest`` — bump both pins, re-take DIST_SHA256 from the release's ``.sha256`` asset, then re-run ``dist generate``"
           }
 
-          # --- DIST_SHA256: ci.yml's committed digest vs the published .sha256 ---
-          # ci.yml verifies the downloaded dist archive against this digest before
+          # --- DIST_SHA256: core.yml's committed digest vs the published .sha256 -
+          # core.yml verifies the downloaded dist archive against this digest before
           # running it, so a DIST_VERSION bump that leaves the old digest behind
           # breaks that job — but only once a dist-area diff makes it fire. Compare
           # the two here so the mismatch surfaces the next morning instead.
-          $distSha = Read-Pin '.github/workflows/ci.yml' 'DIST_SHA256:\s*([0-9a-f]{64})'
-          if (-not $distSha) { throw 'No DIST_SHA256 pin in ci.yml' }
+          $distSha = Read-Pin '.github/workflows/core.yml' 'DIST_SHA256:\s*([0-9a-f]{64})'
+          if (-not $distSha) { throw 'No DIST_SHA256 pin in core.yml' }
           $distShaUpstream = $null
           try {
             $distShaUpstream = (Invoke-RestMethod -ErrorAction Stop `
@@ -282,7 +282,7 @@ jobs:
           if (-not $distShaUpstream) {
             Add-Problem 'cargo-dist digest (query failed)' "- could not fetch the published sha256 for cargo-dist ``v$distCi``'s x86_64-unknown-linux-musl archive"
           } elseif ($distSha -ne $distShaUpstream) {
-            Add-Problem 'cargo-dist digest mismatch' "- ci.yml pins ``DIST_SHA256: $distSha`` but cargo-dist ``v$distCi`` publishes ``$distShaUpstream`` for its x86_64-unknown-linux-musl archive — set the committed digest to the published value"
+            Add-Problem 'cargo-dist digest mismatch' "- core.yml pins ``DIST_SHA256: $distSha`` but cargo-dist ``v$distCi`` publishes ``$distShaUpstream`` for its x86_64-unknown-linux-musl archive — set the committed digest to the published value"
           }
 
           # --- dist [dist.github-action-commits]: TOML pins vs the workflows -----
@@ -315,58 +315,58 @@ jobs:
             }
           }
 
-          # --- cargo-vet: ci.yml vs mozilla/cargo-vet --------------------------
-          $vetPin = Read-Pin '.github/workflows/ci.yml' 'cargo-vet --version ([0-9.]+)'
-          if (-not $vetPin) { throw 'No cargo-vet --version pin in ci.yml' }
+          # --- cargo-vet: core.yml vs mozilla/cargo-vet ------------------------
+          $vetPin = Read-Pin '.github/workflows/core.yml' 'cargo-vet --version ([0-9.]+)'
+          if (-not $vetPin) { throw 'No cargo-vet --version pin in core.yml' }
           $vetLatest = Latest-Semver 'mozilla/cargo-vet'
           if (-not $vetLatest) {
             Add-Problem 'cargo-vet (query failed)' '- could not query the latest cargo-vet release (mozilla/cargo-vet)'
           } elseif ([version]$vetLatest -gt [version]$vetPin) {
-            Add-Problem "cargo-vet $vetPin->$vetLatest" "- cargo-vet pin ``$vetPin`` (ci.yml) is behind the latest release ``$vetLatest``"
+            Add-Problem "cargo-vet $vetPin->$vetLatest" "- cargo-vet pin ``$vetPin`` (core.yml) is behind the latest release ``$vetLatest``"
           }
 
-          # --- cargo-fuzz: ci.yml + fuzz.yml pins vs crates.io -----------------
+          # --- cargo-fuzz: core.yml + fuzz.yml pins vs crates.io ---------------
           # taiki-e/install-action's manifest has no cargo-fuzz entry, so both the
-          # per-PR corpus replay (ci.yml) and the tag-time fresh-fuzz pass
+          # per-PR corpus replay (core.yml) and the tag-time fresh-fuzz pass
           # (fuzz.yml) compile a pinned version from crates.io. The two must agree
           # — a one-sided bump would fuzz the release tag with a different tool
           # than the gate proved green.
-          $fuzzCi   = Read-Pin '.github/workflows/ci.yml' 'cargo install cargo-fuzz --version ([0-9.]+)'
+          $fuzzCi   = Read-Pin '.github/workflows/core.yml' 'cargo install cargo-fuzz --version ([0-9.]+)'
           $fuzzTag  = Read-Pin '.github/workflows/fuzz.yml' 'cargo install cargo-fuzz --version ([0-9.]+)'
-          if (-not $fuzzCi)  { throw 'No `cargo install cargo-fuzz --version` pin in ci.yml' }
+          if (-not $fuzzCi)  { throw 'No `cargo install cargo-fuzz --version` pin in core.yml' }
           if (-not $fuzzTag) { throw 'No `cargo install cargo-fuzz --version` pin in fuzz.yml' }
           if ($fuzzCi -ne $fuzzTag) {
-            Add-Problem 'cargo-fuzz pins disagree' "- cargo-fuzz pin mismatch: ci.yml ``$fuzzCi`` / fuzz.yml ``$fuzzTag`` — both must be identical"
+            Add-Problem 'cargo-fuzz pins disagree' "- cargo-fuzz pin mismatch: core.yml ``$fuzzCi`` / fuzz.yml ``$fuzzTag`` — both must be identical"
           }
           $fuzzLatest = Latest-CratesIo 'cargo-fuzz'
           if (-not $fuzzLatest) {
             Add-Problem 'cargo-fuzz (query failed)' '- could not query the latest cargo-fuzz release (crates.io)'
           } elseif ([version]$fuzzLatest -gt [version]$fuzzCi) {
-            Add-Problem "cargo-fuzz $fuzzCi->$fuzzLatest" "- cargo-fuzz pin ``$fuzzCi`` (ci.yml + fuzz.yml) is behind the latest release ``$fuzzLatest`` — bump both pins together"
+            Add-Problem "cargo-fuzz $fuzzCi->$fuzzLatest" "- cargo-fuzz pin ``$fuzzCi`` (core.yml + fuzz.yml) is behind the latest release ``$fuzzLatest`` — bump both pins together"
           }
 
-          # --- ryl: ci.yml YAML-lint pin vs crates.io --------------------------
+          # --- ryl: repo.yml YAML-lint pin vs crates.io ------------------------
           # ryl is pinned (`cargo install ryl --version X`) so the YAML lint stays
           # reproducible; nothing else watches it, so check it here like cargo-vet.
-          $rylPin = Read-Pin '.github/workflows/ci.yml' 'cargo install ryl --version ([0-9.]+)'
-          if (-not $rylPin) { throw 'No `cargo install ryl --version` pin in ci.yml' }
+          $rylPin = Read-Pin '.github/workflows/repo.yml' 'cargo install ryl --version ([0-9.]+)'
+          if (-not $rylPin) { throw 'No `cargo install ryl --version` pin in repo.yml' }
           $rylLatest = Latest-CratesIo 'ryl'
           if (-not $rylLatest) {
             Add-Problem 'ryl (query failed)' '- could not query the latest ryl release (crates.io)'
           } elseif ([version]$rylLatest -gt [version]$rylPin) {
-            Add-Problem "ryl $rylPin->$rylLatest" "- ryl pin ``$rylPin`` (ci.yml) is behind the latest release ``$rylLatest``"
+            Add-Problem "ryl $rylPin->$rylLatest" "- ryl pin ``$rylPin`` (repo.yml) is behind the latest release ``$rylLatest``"
           }
 
-          # --- taplo: ci.yml `tool: taplo-cli@X` pin vs crates.io ---------------
+          # --- taplo: repo.yml `tool: taplo-cli@X` pin vs crates.io -------------
           # Pinned like ryl so the TOML format/lint stays reproducible; nothing
           # else watches it.
-          $taploPin = Read-Pin '.github/workflows/ci.yml' 'tool:\s*taplo-cli@([0-9.]+)'
-          if (-not $taploPin) { throw 'No `tool: taplo-cli@<version>` pin in ci.yml' }
+          $taploPin = Read-Pin '.github/workflows/repo.yml' 'tool:\s*taplo-cli@([0-9.]+)'
+          if (-not $taploPin) { throw 'No `tool: taplo-cli@<version>` pin in repo.yml' }
           $taploLatest = Latest-CratesIo 'taplo-cli'
           if (-not $taploLatest) {
             Add-Problem 'taplo (query failed)' '- could not query the latest taplo release (crates.io taplo-cli)'
           } elseif ([version]$taploLatest -gt [version]$taploPin) {
-            Add-Problem "taplo $taploPin->$taploLatest" "- taplo pin ``$taploPin`` (ci.yml) is behind the latest release ``$taploLatest``"
+            Add-Problem "taplo $taploPin->$taploLatest" "- taplo pin ``$taploPin`` (repo.yml) is behind the latest release ``$taploLatest``"
           }
 
           # --- convco: conventional.yml `tool: convco@X` pin vs crates.io -------
@@ -403,22 +403,22 @@ jobs:
           } elseif ([version]$cargoRpmLatest -gt [version]$cargoRpmPin) {
             Add-Problem "cargo-generate-rpm $cargoRpmPin->$cargoRpmLatest" "- cargo-generate-rpm pin ``$cargoRpmPin`` (build-linux-packages.sh) is behind the latest release ``$cargoRpmLatest``"
           }
-          # Both pins exist a SECOND time in ci.yml's pkg job (`tool:
+          # Both pins exist a SECOND time in core.yml's pkg job (`tool:
           # cargo-deb@…,cargo-generate-rpm@…`) — deliberately equal so the PR
           # smoke test packages with the exact release tools (the script's
           # already-on-PATH guard then skips its source compile). A one-sided
           # bump silently de-syncs the smoke test from the release path, so
           # cross-check agreement like the NIGHTLY pins; freshness of the value
           # itself is already covered above.
-          $cargoDebCi = Read-Pin '.github/workflows/ci.yml' 'cargo-deb@([0-9.]+)'
-          $cargoRpmCi = Read-Pin '.github/workflows/ci.yml' 'cargo-generate-rpm@([0-9.]+)'
-          if (-not $cargoDebCi) { throw 'No cargo-deb@<version> pin in ci.yml (pkg job)' }
-          if (-not $cargoRpmCi) { throw 'No cargo-generate-rpm@<version> pin in ci.yml (pkg job)' }
+          $cargoDebCi = Read-Pin '.github/workflows/core.yml' 'cargo-deb@([0-9.]+)'
+          $cargoRpmCi = Read-Pin '.github/workflows/core.yml' 'cargo-generate-rpm@([0-9.]+)'
+          if (-not $cargoDebCi) { throw 'No cargo-deb@<version> pin in core.yml (pkg job)' }
+          if (-not $cargoRpmCi) { throw 'No cargo-generate-rpm@<version> pin in core.yml (pkg job)' }
           if ($cargoDebCi -ne $cargoDebPin) {
-            Add-Problem 'cargo-deb pins disagree' "- cargo-deb pin mismatch: build-linux-packages.sh has ``$cargoDebPin`` but ci.yml's pkg job installs ``$cargoDebCi`` — they must be identical (the smoke test must use the exact release tools)"
+            Add-Problem 'cargo-deb pins disagree' "- cargo-deb pin mismatch: build-linux-packages.sh has ``$cargoDebPin`` but core.yml's pkg job installs ``$cargoDebCi`` — they must be identical (the smoke test must use the exact release tools)"
           }
           if ($cargoRpmCi -ne $cargoRpmPin) {
-            Add-Problem 'cargo-generate-rpm pins disagree' "- cargo-generate-rpm pin mismatch: build-linux-packages.sh has ``$cargoRpmPin`` but ci.yml's pkg job installs ``$cargoRpmCi`` — they must be identical (the smoke test must use the exact release tools)"
+            Add-Problem 'cargo-generate-rpm pins disagree' "- cargo-generate-rpm pin mismatch: build-linux-packages.sh has ``$cargoRpmPin`` but core.yml's pkg job installs ``$cargoRpmCi`` — they must be identical (the smoke test must use the exact release tools)"
           }
           # The GUI lane carries two MORE copies of the same two pins: the
           # packaging script's source-compile pins (what the release legs run
@@ -662,7 +662,7 @@ jobs:
             ''
             $bodyLines
             ''
-            'Bump deliberately: update the pin(s) in the file(s) named above, keep the five NIGHTLY pins (ci.yml / fuzz.yml / wasm.yml / gui.yml / publish-npm.yml) identical, and after any cargo-dist bump re-take `DIST_SHA256` from the release''s `.sha256` asset and re-run `dist generate`. CI re-validates on the next push.'
+            'Bump deliberately: update the pin(s) in the file(s) named above, keep the five NIGHTLY pins (core.yml / fuzz.yml / wasm.yml / gui.yml / publish-npm.yml) identical, and after any cargo-dist bump re-take `DIST_SHA256` from the release''s `.sha256` asset and re-run `dist generate`. CI re-validates on the next push.'
           ) -join "`n"
 
           # One rolling issue, tracked by a stable label — the title varies with the

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -32,7 +32,7 @@ permissions:
   contents: read
 
 env:
-  NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + ci.yml
+  NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + core.yml
   NODE_VERSION: "26.5.1"      # the active Node line (26 -> LTS Oct 2026); watched by version-freshness.yml
   # Keep the cached target/ small: no incremental-compilation metadata, and
   # line tables instead of full DWARF (still enough for file:line in a test
@@ -82,7 +82,7 @@ jobs:
 
       # `fallback: none` on every install-action step here: install only from the
       # action's checksummed manifest, never its runtime-resolved cargo-binstall
-      # fallback (rationale in ci.yml).
+      # fallback (rationale in core.yml).
       - name: Install wasm-bindgen-cli (pinned to the crate version)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,8 +6,8 @@ name: zizmor
 # persistence, and more), daily — zizmor floats at latest and the audits are
 # partly ONLINE (impostor-commit / known-vulnerable-actions via the GitHub
 # API), so a newly-disclosed vulnerable action surfaces between pushes. The
-# PR/push leg is the identically-named job in ci.yml, plan-gated on the `meta`
-# area; the daily sweep re-runs that leg ungated too. The only accepted
+# PR/push leg is the identically-named job in repo.yml, plan-gated on the
+# `workflows` area; the daily sweep re-runs that leg ungated too. The only accepted
 # residuals live in .github/zizmor.yml (the cargo-dist-generated v-release.yml,
 # which cannot be hand-edited) and inline (the two architecturally-required
 # workflow_run triggers); every hand-maintained workflow is fixed in place, not
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       # `fallback: none`: install only from install-action's checksummed manifest,
-      # never its runtime-resolved cargo-binstall fallback (rationale in ci.yml).
+      # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install zizmor (prebuilt, no from-source compile)
         uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@
 # Local development plumbing (kept on disk, not published).
 # NOTE: deny.toml, supply-chain/, clippy.toml, typos.toml, .config/nextest.toml,
 # .cargo/mutants.toml, and fuzz/ ARE tracked — CI reads them (cargo deny + vet +
-# clippy + typos + nextest, plus the incremental-mutants and corpus-replay jobs
-# in ci.yml and the tag-time extended fuzz in fuzz.yml).
+# clippy + typos + nextest, plus the incremental-mutants job in ci.yml, the
+# corpus-replay job in core.yml and the tag-time extended fuzz in fuzz.yml).
 /scripts/
 /CLAUDE.md
 /.claude/

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,4 +1,4 @@
-# ryl (a Rust yamllint) config — enforced by the `yaml` job in ci.yml and the
+# ryl (a Rust yamllint) config — enforced by the `yaml` job in repo.yml and the
 # local gate (scripts/compliance.ps1). Starts from yamllint's `default` ruleset.
 # Only THREE rules are relaxed, and each is forced by the dist-GENERATED
 # v-release.yml (which must pass unmodified — `dist generate --check` forbids

--- a/crates/bdinfo-rs/build.rs
+++ b/crates/bdinfo-rs/build.rs
@@ -3,7 +3,7 @@
 //!
 //! WHERE THE ARTIFACTS LAND (the contract `.github/build-setup.yml` — the
 //! cargo-dist build-setup step wired in by `dist-workspace.toml`'s
-//! `github-build-setup` — and `.github/workflows/ci.yml`'s packaging step both
+//! `github-build-setup` — and `.github/workflows/core.yml`'s packaging step both
 //! rely on; do not change without updating them):
 //!
 //! Every generated file is written into a single `assets/` directory rooted at

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -14,7 +14,7 @@ cargo-dist-version = "0.32.0"
 ci = "github"
 
 # Tag-only, like the hand-rolled workflow: do not spin a release run on every PR
-# (the `dist generate --check` guard in ci.yml already covers config/workflow
+# (the `dist generate --check` guard in core.yml already covers config/workflow
 # drift on PRs).
 pr-run-mode = "skip"
 
@@ -26,7 +26,7 @@ pr-run-mode = "skip"
 # existing vX.Y.Z release flow is unchanged. Side effect (dist hardcodes it, "to
 # co-exist with other release workflows"): the generated workflow is written to
 # v-release.yml, not the unprefixed default name — .github/zizmor.yml's
-# whole-file ignores and ci.yml's pin-drift grep are keyed to the new filename.
+# whole-file ignores and core.yml's pin-drift grep are keyed to the new filename.
 tag-namespace = "v"
 
 # The six shipped targets, every one a single static binary. musl is fully
@@ -172,7 +172,7 @@ host = "aarch64-pc-windows-msvc"
 
 # Pin every action dist emits to a full-length commit SHA so the GENERATED
 # v-release.yml satisfies Scorecard's pinned-dependencies check — without detaching
-# from dist (the `dist generate --check` drift guard in ci.yml stays green because
+# from dist (the `dist generate --check` drift guard in core.yml stays green because
 # this IS what dist now generates). The trailing comment names the EXACT immutable
 # tag the SHA resolves to (`# vX.Y.Z`, not the moving major `# vN`): it rides along
 # in the value (dist renders `{name}@{value}` verbatim) so v-release.yml satisfies

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,5 +1,5 @@
 # taplo configuration — TOML formatter + linter, enforced by the orchestrator's
-# `taplo` job (ci.yml, `toml` area) and the local gate (scripts/compliance.ps1 `tp`
+# `taplo` job (repo.yml, `toml` area) and the local gate (scripts/compliance.ps1 `tp`
 # step). The formatting options below
 # are tuned to match the repo's existing hand-formatting, so the one-time baseline
 # reformat normalizes only spacing/commas and never re-flows the author's chosen


### PR DESCRIPTION
The orchestrator's flat gate jobs move into two workflow_call reusables, invoked
the way gui.yml and wasm.yml already are, so the checks tree renders core / ...,
repo / ..., gui / ..., wasm / ...

- core.yml: test, lint, coverage, e2e, isolation, pkg, deny, vet, release-yaml,
  replay.
- repo.yml: yaml, taplo, zizmor, typos, links.
- ci.yml keeps plan, the three advisory mutation jobs, the four caller jobs and
  ci-ok.

Each caller fires on the union of the areas its inner jobs consume and passes
the plan's outputs through as workflow_call inputs, so every inner job keeps its
exact per-area condition. ci-ok's needs becomes plan plus the four callers; the
job name is unchanged, so the required-context list is untouched.

The diff is the moved blocks, the caller and input plumbing, and nothing else:
every job body is byte-identical apart from dropping its needs on plan,
rewriting needs.plan.outputs.<area> to inputs.<area>, and deleting the four
claims that an inner job name is a live required context - claims the move
falsifies, since inner check runs render prefixed.

Supporting changes the move forces:

- classify-diff.ps1 gains a structural rule and a golden case per new file.
- version-freshness.yml reads the NIGHTLY, cargo-dist, cargo-vet, cargo-fuzz,
  cargo-deb and cargo-generate-rpm pins from core.yml, and the ryl and taplo
  pins from repo.yml.
- Comments that named ci.yml for a job that moved now name the file holding it.

The advisory mutation jobs stay top-level in ci.yml: inside core.yml a failure
would redden the core caller and therefore ci-ok, promoting an advisory job to a
gating one.

Every area fires from this diff, so the run exercises every lane.
