### PR TITLE
ci: verify the declared msrv builds the root and wasm workspaces

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -289,6 +289,51 @@ jobs:
       - name: Coverage (100% lines/regions/functions)
         run: cargo +${{ env.NIGHTLY }} llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100
 
+  # The declared MSRV is enforced, not decorative: build the whole root workspace
+  # with exactly the rust-version toolchain from Cargo.toml, read from the
+  # manifest at run time so an MSRV bump touches Cargo.toml ONLY (no version
+  # literals here to drift; the version also stays out of the job `name:` —
+  # static YAML can't interpolate step outputs there). This is what stops a
+  # dependency bump or a newer language feature from silently raising the real
+  # floor under a downstream user who pins the declared one. Build-only by
+  # design: rust-version is a claim about building the packages, not about the
+  # dev-dependency tree — the test suites run on the pinned stable in the
+  # build + test matrix above. `gui msrv` in gui.yml holds the same bar for the
+  # GUI crate, `msrv` in wasm.yml for the wasm crate.
+  msrv:
+    name: msrv
+    if: inputs.core == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Read the MSRV floor from Cargo.toml
+        id: msrv
+        # Both workspace members inherit `rust-version.workspace`, so the set of
+        # declared floors must be a single value — `unique | length == 1` asserts
+        # that rather than assuming it, and jq -er fails loudly if rust-version
+        # ever disappears from the manifest.
+        run: |
+          v="$(cargo metadata --no-deps --format-version 1 | jq -er '[.packages[].rust_version] | unique | if length == 1 then .[0] else error("the root workspace packages declare different rust-version floors") end')"
+          echo "MSRV floor: $v"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Install the MSRV toolchain
+        env:
+          MSRV: ${{ steps.msrv.outputs.version }}
+        run: rustup toolchain install "$MSRV" --profile minimal
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build with the declared rust-version
+        env:
+          MSRV: ${{ steps.msrv.outputs.version }}
+        run: cargo "+$MSRV" build --workspace --locked
+
   # The ultimate real-world gate: do exactly what a user does — install bdinfo-rs
   # the traditional way (build it from source; no package managers), scan the
   # committed fixture disc, and confirm the report is byte-identical to the golden.

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -263,3 +263,58 @@ jobs:
         # CHROMEWEBDRIVER is a runner OS env var (the chromedriver dir) — read it in
         # the shell ($CHROMEWEBDRIVER); the ${{ env.* }} context resolves empty.
         run: CHROMEDRIVER="$CHROMEWEBDRIVER/chromedriver" cargo test --target wasm32-unknown-unknown --release --locked --test parity
+
+  # The declared MSRV is enforced, not decorative: build with exactly the
+  # rust-version toolchain from crates/bdinfo-rs-wasm/Cargo.toml, read from the
+  # manifest at run time so an MSRV bump touches Cargo.toml ONLY (no version
+  # literals here to drift; the version also stays out of the job `name:` —
+  # static YAML can't interpolate step outputs there). This is what stops a
+  # dependency bump or a newer language feature from silently raising the real
+  # floor under a downstream user who pins the declared one. Build-only by
+  # design: rust-version is a claim about building the package, not about the
+  # dev-dependency tree (wasm-bindgen-test may float its own MSRV) — the gate
+  # job above runs the suites on the pinned stable. Both targets, because the
+  # crate SHIPS as wasm32: the native check is what `cargo check` covers on any
+  # host, and the wasm32 release build is the configuration published to npm, so
+  # target-specific MSRV breakage in js-sys/web-sys/wasm-bindgen would otherwise
+  # pass unnoticed. `msrv` in core.yml and `gui msrv` in gui.yml hold the same
+  # bar for the other two shipping surfaces.
+  msrv:
+    name: msrv
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Read the MSRV floor from Cargo.toml
+        id: msrv
+        # jq -e fails loudly if rust-version ever disappears from the manifest.
+        run: |
+          v="$(cargo metadata --no-deps --format-version 1 --manifest-path crates/bdinfo-rs-wasm/Cargo.toml | jq -er '.packages[] | select(.name == "bdinfo-rs-wasm") | .rust_version')"
+          echo "MSRV floor: $v"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Install the MSRV toolchain with the wasm32 target
+        env:
+          MSRV: ${{ steps.msrv.outputs.version }}
+        run: |
+          rustup toolchain install "$MSRV" --profile minimal
+          rustup target add wasm32-unknown-unknown --toolchain "$MSRV"
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: crates/bdinfo-rs-wasm
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Check with the declared rust-version (native)
+        working-directory: crates/bdinfo-rs-wasm
+        env:
+          MSRV: ${{ steps.msrv.outputs.version }}
+        run: cargo "+$MSRV" check --locked
+
+      - name: Build with the declared rust-version (wasm32, release)
+        working-directory: crates/bdinfo-rs-wasm
+        env:
+          MSRV: ${{ steps.msrv.outputs.version }}
+        run: cargo "+$MSRV" build --target wasm32-unknown-unknown --release --locked


### PR DESCRIPTION
All three shipping surfaces declare rust-version 1.96, but only the GUI crate proved it builds; the root workspace and the wasm crate now carry the same build-only check.