### PR TITLE
ci: run the single-runner gates on the arm linux runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,10 @@ jobs:
     name: mutation testing (PR diff)
     needs: plan
     if: github.event_name == 'pull_request' && needs.plan.outputs.core == 'true'
+    # x64: taiki-e/install-action's cargo-mutants manifest carries no aarch64
+    # Linux asset (x86_64-unknown-linux-gnu, x86_64 macOS and x86_64 Windows
+    # only), and `fallback: none` turns a missing prebuilt into a hard failure.
+    # Same for gui-mutants and wasm-mutants below.
     runs-on: ubuntu-latest
     env:
       # cargo-mutants rebuilds the tree once per mutant, each rebuild differing
@@ -259,7 +263,7 @@ jobs:
     name: gui mutation testing (PR diff)
     needs: plan
     if: github.event_name == 'pull_request' && needs.plan.outputs.gui == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest   # no aarch64 cargo-mutants prebuilt — see `mutants`
     env:
       # The suite the mutants face includes the iced_test snapshot ties; the
       # deterministic software backend is what makes them run on a GPU-less
@@ -320,7 +324,7 @@ jobs:
     name: wasm mutation testing (PR diff)
     needs: plan
     if: github.event_name == 'pull_request' && needs.plan.outputs.wasm == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest   # no aarch64 cargo-mutants prebuilt — see `mutants`
     env:
       CARGO_INCREMENTAL: "1"   # cargo-mutants' rebuild model — see the `mutants` job
     steps:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -15,6 +15,18 @@ name: core
 # (…)`). This file carries no triggers and no concurrency of its own — both are
 # the caller's — so it can never fire on its own and never needs a paths filter.
 #
+# RUNNER ARCH — a job that runs on exactly ONE Linux runner and whose verdict is
+# arch-INVARIANT runs on `ubuntu-24.04-arm` (here: lint, coverage, msrv, deny,
+# vet, release-yaml). Measured on this repository's runs (2026-08-02), the arm
+# runners built the GUI legs in 208 s average against 301 s on `ubuntu-latest`
+# at comparable queue times, so for such a job the arch buys speed and changes
+# nothing else. Everything else stays on `ubuntu-latest` (x64): the matrices
+# that pin one runner per SHIPPED target (build + test, e2e, isolation), the
+# jobs whose verdict is arch-BOUND or whose tooling has no arm64 build — each
+# states its mechanism where it declares `runs-on` — and the seconds-long glue
+# jobs, where the arch buys nothing measurable. repo.yml, gui.yml, wasm.yml and
+# ci.yml apply the same rule and refer here.
+#
 # Build and test on every supported OS. The pinned stable toolchain installs
 # itself from rust-toolchain.toml on first cargo use; `unsafe` is forbidden at
 # compile time, so a green build is also the memory-safety guarantee. Every
@@ -117,7 +129,7 @@ jobs:
   release-yaml:
     name: release workflow in sync (dist generate --check)
     if: inputs.dist == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       # MUST equal `cargo-dist-version` in dist-workspace.toml — the version that
       # generated the committed v-release.yml, so anything else makes the check
@@ -128,7 +140,7 @@ jobs:
       # the `.sha256` file axodotdev publishes beside it. Committing the digest is
       # what makes the download verifiable: the archive is checked against this
       # value before anything inside it runs. Re-take it on every DIST_VERSION bump.
-      DIST_SHA256: 0d9dc001b0e937e9cc18e0dc11784aa7a3fd566656b07828d5e1d10ce1c1c48c
+      DIST_SHA256: 16d4394af9b91366ca92cb4601a72dd0a209a49301ef535749e2141039e26ed6
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -143,7 +155,7 @@ jobs:
       - name: Install pinned dist (checksum-verified prebuilt)
         run: |
           set -euo pipefail
-          dir="cargo-dist-x86_64-unknown-linux-musl"
+          dir="cargo-dist-aarch64-unknown-linux-musl"
           curl -fsSL --retry 3 -o "$dir.tar.xz" \
             "https://github.com/axodotdev/cargo-dist/releases/download/v$DIST_VERSION/$dir.tar.xz"
           echo "$DIST_SHA256  $dir.tar.xz" | sha256sum --check --strict -
@@ -189,7 +201,7 @@ jobs:
   lint:
     name: lint (clippy, fmt, doc, deps, semver)
     if: inputs.core == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -267,7 +279,7 @@ jobs:
   coverage:
     name: coverage (100% lines/regions/functions)
     if: inputs.core == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -303,7 +315,7 @@ jobs:
   msrv:
     name: msrv
     if: inputs.core == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -470,7 +482,7 @@ jobs:
   deny:
     name: cargo deny check
     if: inputs.deps == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -493,7 +505,7 @@ jobs:
   vet:
     name: cargo vet
     if: inputs.deps == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -506,12 +518,15 @@ jobs:
       # cached — keep the cache key in lockstep with the install pin below,
       # which version-freshness.yml watches. Keep both in lockstep with the
       # version that writes supply-chain/.
+      # The key carries `runner.arch` because the entry holds an EXECUTABLE and
+      # `runner.os` is `Linux` on both the x64 and the arm64 runners: without it
+      # an x86_64 binary would restore onto an arm64 host and fail to run.
       - name: Cache the pinned cargo-vet binary
         id: vet-bin
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/cargo-vet
-          key: cargo-vet-${{ runner.os }}-0.10.2
+          key: cargo-vet-${{ runner.os }}-${{ runner.arch }}-0.10.2
 
       - name: Install cargo-vet 0.10.2 (cache miss)
         if: steps.vet-bin.outputs.cache-hit != 'true'
@@ -531,6 +546,8 @@ jobs:
   replay:
     name: corpus replay (regression gate)
     if: inputs.fuzz == 'true'
+    # x64: FUZZ_TARGET below pins the libFuzzer binary to x86_64-unknown-linux-gnu,
+    # which an arm64 host cannot execute.
     runs-on: ubuntu-latest
     env:
       # The 10 libFuzzer targets (fuzz/Cargo.toml). Keep in lockstep with it and
@@ -620,6 +637,8 @@ jobs:
   pkg:
     name: build + install .deb/.rpm (x64 + arm64)
     if: inputs.pkg == 'true'
+    # x64: the install-verify step below RUNS the packaged x86_64 stand-in binary
+    # natively, which an arm64 host cannot do.
     runs-on: ubuntu-latest
     # Build the HOST gnu triple: this verifies the PACKAGING (extraction, metadata, the
     # --target path rewrite, install + contents), for which the binary's libc/arch is

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -276,7 +276,11 @@ jobs:
   # moved to sweep.yml + the release-tag leg; see the header.)
   checks:
     name: gui checks (lint + coverage + deny)
-    runs-on: ubuntu-latest
+    # One Linux runner, arch-invariant verdict — arm64 (rationale in core.yml).
+    # The snapshot ties this job's coverage step runs are pinned per OS FAMILY
+    # and hold across arches within one, which is what `gui build + test`
+    # asserts on its ubuntu-latest and ubuntu-24.04-arm legs.
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -375,7 +379,8 @@ jobs:
   # (iced_test may float its own MSRV).
   msrv:
     name: gui msrv
-    runs-on: ubuntu-latest
+    # One Linux runner, arch-invariant verdict — arm64 (rationale in core.yml).
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -13,6 +13,10 @@ name: repo
 # (action-validator + ryl)`). No triggers and no concurrency of its own — both
 # are the caller's — so it can never fire on its own and never needs a paths
 # filter.
+#
+# Every job here scans the tree rather than producing an artifact from it, so
+# every verdict is arch-invariant and each job runs on `ubuntu-24.04-arm`
+# (rationale in core.yml).
 
 on:
   workflow_call:
@@ -58,7 +62,7 @@ jobs:
   yaml:
     name: lint YAML (action-validator + ryl)
     if: inputs.yaml == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -79,6 +83,9 @@ jobs:
           echo "version=${v:-unknown-$GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "latest action-validator: ${v:-unknown (cache bypassed this run)}"
 
+      # The key carries `runner.arch` because the entry holds EXECUTABLES and
+      # `runner.os` is `Linux` on both the x64 and the arm64 runners: without it
+      # x86_64 binaries would restore onto an arm64 host and fail to run.
       - name: Cache the YAML lint binaries
         id: yaml-tools
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -86,7 +93,7 @@ jobs:
           path: |
             ~/.cargo/bin/action-validator
             ~/.cargo/bin/ryl
-          key: yaml-tools-${{ runner.os }}-av-${{ steps.av.outputs.version }}-ryl-0.21.0
+          key: yaml-tools-${{ runner.os }}-${{ runner.arch }}-av-${{ steps.av.outputs.version }}-ryl-0.21.0
 
       - name: Install action-validator + ryl (cache miss)
         if: steps.yaml-tools.outputs.cache-hit != 'true'
@@ -113,7 +120,7 @@ jobs:
   taplo:
     name: lint TOML (taplo)
     if: inputs.toml == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -150,7 +157,7 @@ jobs:
   zizmor:
     name: zizmor (workflow security)
     if: inputs.workflows == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -182,7 +189,7 @@ jobs:
   typos:
     name: spell-check (typos)
     if: inputs.typos == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -200,7 +207,7 @@ jobs:
   links:
     name: Check links
     if: inputs.links == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -275,14 +275,14 @@ jobs:
           $distShaUpstream = $null
           try {
             $distShaUpstream = (Invoke-RestMethod -ErrorAction Stop `
-                -Uri "https://github.com/axodotdev/cargo-dist/releases/download/v$distCi/cargo-dist-x86_64-unknown-linux-musl.tar.xz.sha256" `
+                -Uri "https://github.com/axodotdev/cargo-dist/releases/download/v$distCi/cargo-dist-aarch64-unknown-linux-musl.tar.xz.sha256" `
                 -Headers @{ 'User-Agent' = 'bdinfo-rs-version-freshness (github actions)' }).Trim().Split(' ')[0]
           }
           catch { }
           if (-not $distShaUpstream) {
-            Add-Problem 'cargo-dist digest (query failed)' "- could not fetch the published sha256 for cargo-dist ``v$distCi``'s x86_64-unknown-linux-musl archive"
+            Add-Problem 'cargo-dist digest (query failed)' "- could not fetch the published sha256 for cargo-dist ``v$distCi``'s aarch64-unknown-linux-musl archive"
           } elseif ($distSha -ne $distShaUpstream) {
-            Add-Problem 'cargo-dist digest mismatch' "- core.yml pins ``DIST_SHA256: $distSha`` but cargo-dist ``v$distCi`` publishes ``$distShaUpstream`` for its x86_64-unknown-linux-musl archive — set the committed digest to the published value"
+            Add-Problem 'cargo-dist digest mismatch' "- core.yml pins ``DIST_SHA256: $distSha`` but cargo-dist ``v$distCi`` publishes ``$distShaUpstream`` for its aarch64-unknown-linux-musl archive — set the committed digest to the published value"
           }
 
           # --- dist [dist.github-action-commits]: TOML pins vs the workflows -----

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -44,6 +44,10 @@ env:
 jobs:
   gate:
     name: wasm gate (build + size + parity)
+    # x64: two steps below need Google Chrome and chromedriver, and the arm64
+    # Ubuntu runner image ships neither (its browser set is Firefox +
+    # geckodriver; CHROMEWEBDRIVER is empty there). `msrv` below stays beside
+    # this job so both legs of this gate share one arch and one cache lineage.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Moves every gate job that runs on exactly one Linux runner and whose verdict is arch-invariant to `ubuntu-24.04-arm`.

**Moved to arm64** — core.yml `lint`, `coverage`, `msrv`, `deny`, `vet`, `release-yaml`; repo.yml `yaml`, `taplo`, `zizmor`, `typos`, `links`; gui.yml `checks`, `msrv`. All thirteen install their tooling from taiki-e/install-action manifest entries that carry an aarch64 Linux asset, or compile it from crates.io.

**Left on x64, with the mechanism at each `runs-on`**
- `mutants`, `gui-mutants`, `wasm-mutants` — taiki-e/install-action's cargo-mutants manifest has no aarch64 Linux asset (x86_64 linux-gnu / macOS / Windows only), and `fallback: none` turns a missing prebuilt into a hard failure.
- wasm.yml `gate` and its `msrv` companion — the arm64 Ubuntu image ships Firefox and geckodriver but no Google Chrome or chromedriver, which two gate steps drive.
- `replay` (libFuzzer binary pinned to x86_64-unknown-linux-gnu), `pkg` (runs the packaged x86_64 binary natively), `plan`, `ci-ok`, `drive-mosaic` (seconds-long glue), and the per-target matrices.

**Other changes the move requires**
- `release-yaml` downloads cargo-dist's `aarch64-unknown-linux-musl` archive and verifies it against that asset's published sha256; version-freshness.yml re-checks the committed digest against the same asset.
- The cargo-vet and YAML-tool cache keys gain `runner.arch`: both hold executables, and `runner.os` is `Linux` on x64 and arm64 alike.

**Expected on this run**: each moved job cold-starts once, since compiled-tool and rust-cache keys carry the arch. cargo-vet recompiles (~2 min) on its first arm run, then caches; the orphaned x64 entries age out in 7 days.

Durations against the survey baselines and the cache-store figure follow once the run completes.