### PR TITLE
feat(wasm): playlist filter options with hiddenBy metadata and demo settings

### DIFF
--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -720,21 +720,58 @@ struct PlaylistRow {
     estimated_bytes: Option<u64>,
     /// Whether the playlist hides any stream (the CLI's `(*)` note).
     has_hidden_streams: bool,
+    /// The filter rules that classify this playlist as withheld (see
+    /// [`hidden_by`]) — empty for a row the standard filters keep.
+    hidden_by: Vec<&'static str>,
 }
 
 /// The playlist table rows as `(group number, playlist index)` pairs in table
-/// order: the standard filtered set (short and looping playlists dropped),
-/// grouped by shared clips, each group longest-first. Mirrors the CLI's
-/// `table_rows`.
+/// order: the playlists `filter` keeps, grouped by shared clips, each group
+/// longest-first. Mirrors the CLI's `table_rows`.
 #[cfg(any(target_arch = "wasm32", test))]
-fn table_rows(playlists: &[PlaylistSummary]) -> Vec<(usize, usize)> {
-    presentation_groups(playlists, &PlaylistFilter::default())
+fn table_rows(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> Vec<(usize, usize)> {
+    presentation_groups(playlists, filter)
         .into_iter()
         .enumerate()
         .flat_map(|(group, members)| {
             members.into_iter().map(move |index| (group.saturating_add(1), index))
         })
         .collect()
+}
+
+/// The listing exports' filter: the standard filtered set with each rule
+/// switched off by its option. An absent option (`None`) means `false` — the
+/// rule stays on — so a call that passes neither option lists exactly the set
+/// the CLI's plain `--list` prints.
+#[cfg(any(target_arch = "wasm32", test))]
+fn listing_filter(show_short: Option<bool>, show_looping: Option<bool>) -> PlaylistFilter {
+    PlaylistFilter {
+        filter_short_playlists: !show_short.unwrap_or(false),
+        filter_looping_playlists: !show_looping.unwrap_or(false),
+        ..PlaylistFilter::default()
+    }
+}
+
+/// Which filter rules classify `playlist` as withheld — `"short"`, `"looping"`,
+/// both, or neither. Each rule is judged on its own against the whole disc, the
+/// same classification the CLI's `Hidden by filters (…)` hint lines make: a
+/// playlist that is both short and looping names both rules and is only listed
+/// when both options are passed.
+///
+/// The judgement deliberately ignores `filter`'s two switches and reads only its
+/// threshold, so it is the same whether the caller listed the standard set or a
+/// widened one. That is what lets a caller list once with both options on and
+/// re-apply either rule to the rows itself.
+#[cfg(any(target_arch = "wasm32", test))]
+fn hidden_by(playlist: &PlaylistSummary, filter: &PlaylistFilter) -> Vec<&'static str> {
+    let mut rules = Vec::new();
+    if playlist.total_length < filter.short_playlist_seconds {
+        rules.push("short");
+    }
+    if playlist.has_loops {
+        rules.push("looping");
+    }
+    rules
 }
 
 /// `hh:mm:ss` from playlist seconds, truncated to the tick like the CLI table
@@ -761,10 +798,10 @@ const fn estimated_bytes(playlist: &PlaylistSummary) -> Option<u64> {
     }
 }
 
-/// Builds the selection-table rows over the standard filtered set.
+/// Builds the selection-table rows over the set `filter` keeps.
 #[cfg(any(target_arch = "wasm32", test))]
-fn playlist_rows(playlists: &[PlaylistSummary]) -> Vec<PlaylistRow> {
-    table_rows(playlists)
+fn playlist_rows(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> Vec<PlaylistRow> {
+    table_rows(playlists, filter)
         .into_iter()
         .enumerate()
         .filter_map(|(position, (group, index))| {
@@ -775,6 +812,7 @@ fn playlist_rows(playlists: &[PlaylistSummary]) -> Vec<PlaylistRow> {
                 length: table_length(playlist.total_length),
                 estimated_bytes: estimated_bytes(playlist),
                 has_hidden_streams: playlist.has_hidden_streams(),
+                hidden_by: hidden_by(playlist, filter),
             })
         })
         .collect()
@@ -823,7 +861,16 @@ fn rows_to_json(rows: &[PlaylistRow]) -> String {
         }
         out.push_str(",\"hasHidden\":");
         out.push_str(if row.has_hidden_streams { "true" } else { "false" });
-        out.push('}');
+        // The rule names are fixed ASCII literals (see `hidden_by`), so they go
+        // out unescaped where every other string field is escaped.
+        out.push_str(",\"hiddenBy\":[");
+        for (rule_index, rule) in row.hidden_by.iter().enumerate() {
+            if rule_index > 0 {
+                out.push(',');
+            }
+            let _ = write!(out, "\"{rule}\"");
+        }
+        out.push_str("]}");
     }
     out.push(']');
     out
@@ -1133,19 +1180,34 @@ pub fn scan_iso(
 ///
 /// Runs only the **structural** scan — no packet demux — so it is fast: it reads
 /// the playlist/clip metadata, not the multi-GB stream files. Each element is
-/// `{ position, group, name, length, estimatedBytes, hasHidden }`; pass the
-/// chosen `name`s back to [`scan_files`] to measure just those playlists.
+/// `{ position, group, name, length, estimatedBytes, hasHidden, hiddenBy }`;
+/// pass the chosen `name`s back to [`scan_files`] to measure just those
+/// playlists.
+///
+/// The listing drops short and looping playlists like the CLI's `--list`.
+/// `show_short_playlists` / `show_looping_playlists` switch off one rule each
+/// (the CLI's `--show-short-playlists` / `--show-looping-playlists`); omitting
+/// them, or passing `false`, keeps the standard set. Every row carries the rules
+/// that classify it as withheld in `hiddenBy` — empty for a row the standard
+/// filters keep — so a caller can list once with both options on and re-apply
+/// either rule to the rows without re-scanning.
 ///
 /// # Errors
 /// As [`scan_files`]: `paths`/`files` length mismatch, a non-`File` entry, an
 /// incoherent selection, or no readable Blu-ray structure.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn list_playlists(paths: Vec<String>, files: js_sys::Array) -> Result<String, JsValue> {
+pub fn list_playlists(
+    paths: Vec<String>,
+    files: js_sys::Array,
+    show_short_playlists: Option<bool>,
+    show_looping_playlists: Option<bool>,
+) -> Result<String, JsValue> {
     let root = build_web_tree(&paths, &files)?;
     let report = BdRom::open_resilient(&root, ScanMode::Metadata)
         .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
-    Ok(rows_to_json(&playlist_rows(&report.bdrom.playlists)))
+    let filter = listing_filter(show_short_playlists, show_looping_playlists);
+    Ok(rows_to_json(&playlist_rows(&report.bdrom.playlists, &filter)))
 }
 
 /// The structural-scan `.iso` entry point: the playlist selection table as JSON.
@@ -1155,19 +1217,26 @@ pub fn list_playlists(paths: Vec<String>, files: js_sys::Array) -> Result<String
 /// ([`UdfSource`]) instead of a `(relativePath, File)` list. Runs only the
 /// **structural** scan (no packet demux), so it is fast; pass the chosen
 /// `name`s back to [`scan_iso`] to measure just those playlists.
+/// `show_short_playlists` / `show_looping_playlists` and the rows' `hiddenBy`
+/// behave exactly as in [`list_playlists`].
 ///
 /// # Errors
 /// Returns a `JsValue` if the image is not a readable UDF `.iso`, or holds no
 /// readable Blu-ray structure.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn list_iso_playlists(file: web_sys::File) -> Result<String, JsValue> {
+pub fn list_iso_playlists(
+    file: web_sys::File,
+    show_short_playlists: Option<bool>,
+    show_looping_playlists: Option<bool>,
+) -> Result<String, JsValue> {
     let length = file.size() as u64;
     let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
         .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
     let report = BdRom::open_resilient(&source.root(), ScanMode::Metadata)
         .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
-    Ok(rows_to_json(&playlist_rows(&report.bdrom.playlists)))
+    let filter = listing_filter(show_short_playlists, show_looping_playlists);
+    Ok(rows_to_json(&playlist_rows(&report.bdrom.playlists, &filter)))
 }
 
 #[cfg(test)]
@@ -1618,11 +1687,12 @@ mod tests {
     /// by-name measured scan, native-tested.
     mod selection {
         use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary};
+        use bdinfo_rs_core::bdrom::order::PlaylistFilter;
 
         use crate::{
-            PlaylistRow, estimated_bytes, json_escape, named_selection, normalize_playlist_name,
-            playlist_rows, rows_to_json, selection_order, selection_stream_files, table_length,
-            table_rows,
+            PlaylistRow, estimated_bytes, hidden_by, json_escape, listing_filter, named_selection,
+            normalize_playlist_name, playlist_rows, rows_to_json, selection_order,
+            selection_stream_files, table_length, table_rows,
         };
 
         /// A `ClipSummary` carrying just a name + length (the fields the
@@ -1668,6 +1738,12 @@ mod tests {
             }
         }
 
+        /// [`sample_playlist`] marked as looping — the input of the second
+        /// filter rule, which reads only `has_loops`.
+        fn looping_playlist(name: &str, total_length: f64, clips: &[&str]) -> PlaylistSummary {
+            PlaylistSummary { has_loops: true, ..sample_playlist(name, total_length, 0, 0, clips) }
+        }
+
         /// A four-playlist disc: 00000 (100 s) shares clip A with 00001 (50 s) →
         /// group 1; 00002 (70 s, clip B) → group 2; 00003 (5 s) is dropped by
         /// the short filter.
@@ -1680,15 +1756,114 @@ mod tests {
             ]
         }
 
+        /// A disc holding one playlist per filter classification, each over its
+        /// own clip (so every kept playlist is its own group): 00000 (100 s) is
+        /// listed by every filter, 00001 (200 s) is looping, 00002 (5 s) is
+        /// short, and 00003 (5 s) is both.
+        fn mixed_disc() -> [PlaylistSummary; 4] {
+            [
+                sample_playlist("00000.MPLS", 100.0, 1000, 0, &["A.M2TS"]),
+                looping_playlist("00001.MPLS", 200.0, &["B.M2TS"]),
+                sample_playlist("00002.MPLS", 5.0, 100, 0, &["C.M2TS"]),
+                looping_playlist("00003.MPLS", 5.0, &["D.M2TS"]),
+            ]
+        }
+
+        /// The listed names under `filter`, in table order.
+        fn listed(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> Vec<String> {
+            playlist_rows(playlists, filter).into_iter().map(|row| row.name).collect()
+        }
+
         #[test]
         fn table_rows_groups_and_filters_like_the_cli() {
             // Sorted by length desc, grouped by shared clip, the short row dropped.
-            assert_eq!(table_rows(&disc()), [(1, 0), (1, 1), (2, 2)]);
+            assert_eq!(table_rows(&disc(), &PlaylistFilter::default()), [(1, 0), (1, 1), (2, 2)]);
+        }
+
+        #[test]
+        fn listing_filter_switches_off_one_rule_per_option() {
+            // An absent option reads as `false`, so the plain call is the
+            // standard filtered set; each option switches off only its own rule.
+            // Comparing whole filters also pins what neither option touches: the
+            // short threshold stays at the default 20 s.
+            for (show_short, show_looping, short_on, looping_on) in [
+                (None, None, true, true),
+                (Some(false), Some(false), true, true),
+                (Some(true), None, false, true),
+                (None, Some(true), true, false),
+                (Some(true), Some(true), false, false),
+            ] {
+                assert_eq!(
+                    listing_filter(show_short, show_looping),
+                    PlaylistFilter {
+                        filter_short_playlists: short_on,
+                        filter_looping_playlists: looping_on,
+                        ..PlaylistFilter::default()
+                    },
+                    "{show_short:?} / {show_looping:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn hidden_by_names_each_rule_independently() {
+            let filter = PlaylistFilter::default();
+            let names: Vec<Vec<&str>> =
+                mixed_disc().iter().map(|playlist| hidden_by(playlist, &filter)).collect();
+            assert_eq!(names, [vec![], vec!["looping"], vec!["short"], vec!["short", "looping"]]);
+            // A playlist of exactly the threshold length is kept, so it names no
+            // rule — the same boundary `PlaylistFilter::keeps` draws.
+            assert!(
+                hidden_by(&sample_playlist("X", 20.0, 0, 0, &[]), &filter).is_empty(),
+                "20 s is not short"
+            );
+        }
+
+        #[test]
+        fn hidden_by_is_the_same_whatever_the_options_are() {
+            // The classification reads the rules, not the switches: a row listed
+            // only because its option was passed still names the rule that would
+            // have withheld it — the field a client re-filters on.
+            let widened = listing_filter(Some(true), Some(true));
+            let rows = playlist_rows(&mixed_disc(), &widened);
+            let view: Vec<(&str, &[&str])> =
+                rows.iter().map(|row| (row.name.as_str(), row.hidden_by.as_slice())).collect();
+            assert_eq!(
+                view,
+                [
+                    ("00001.MPLS", ["looping"].as_slice()),
+                    ("00000.MPLS", [].as_slice()),
+                    ("00002.MPLS", ["short"].as_slice()),
+                    ("00003.MPLS", ["short", "looping"].as_slice()),
+                ]
+            );
+        }
+
+        #[test]
+        fn each_option_widens_the_listing_by_its_own_rule() {
+            let playlists = mixed_disc();
+            // The standard set lists neither the looping nor the short playlist.
+            assert_eq!(listed(&playlists, &listing_filter(None, None)), ["00000.MPLS"]);
+            // Showing short playlists reveals the short one but NOT the playlist
+            // that is short *and* looping — the rules are independent.
+            assert_eq!(
+                listed(&playlists, &listing_filter(Some(true), None)),
+                ["00000.MPLS", "00002.MPLS"]
+            );
+            assert_eq!(
+                listed(&playlists, &listing_filter(None, Some(true))),
+                ["00001.MPLS", "00000.MPLS"]
+            );
+            // Both options list the whole disc, longest first.
+            assert_eq!(
+                listed(&playlists, &listing_filter(Some(true), Some(true))),
+                ["00001.MPLS", "00000.MPLS", "00002.MPLS", "00003.MPLS"]
+            );
         }
 
         #[test]
         fn playlist_rows_carry_the_table_columns() {
-            let rows = playlist_rows(&disc());
+            let rows = playlist_rows(&disc(), &PlaylistFilter::default());
             let view: Vec<_> = rows
                 .iter()
                 .map(|row| {
@@ -1699,16 +1874,17 @@ mod tests {
                         row.length.as_str(),
                         row.estimated_bytes,
                         row.has_hidden_streams,
+                        row.hidden_by.clone(),
                     )
                 })
                 .collect();
             assert_eq!(
                 view,
                 [
-                    (1, 1, "00000.MPLS", "00:01:40", Some(1000), false),
-                    (2, 1, "00001.MPLS", "00:00:50", Some(500), false),
+                    (1, 1, "00000.MPLS", "00:01:40", Some(1000), false, vec![]),
+                    (2, 1, "00001.MPLS", "00:00:50", Some(500), false, vec![]),
                     // group 2; the interleaved size is preferred over the m2ts size.
-                    (3, 2, "00002.MPLS", "00:01:10", Some(2000), false),
+                    (3, 2, "00002.MPLS", "00:01:10", Some(2000), false, vec![]),
                 ]
             );
         }
@@ -1801,6 +1977,7 @@ mod tests {
                     length: "00:01:40".to_owned(),
                     estimated_bytes: Some(1000),
                     has_hidden_streams: false,
+                    hidden_by: Vec::new(),
                 },
                 PlaylistRow {
                     position: 2,
@@ -1809,12 +1986,13 @@ mod tests {
                     length: "00:00:50".to_owned(),
                     estimated_bytes: None,
                     has_hidden_streams: true,
+                    hidden_by: vec!["short", "looping"],
                 },
             ];
             assert_eq!(
                 rows_to_json(&rows),
-                "[{\"position\":1,\"group\":1,\"name\":\"00000.MPLS\",\"length\":\"00:01:40\",\"estimatedBytes\":1000,\"hasHidden\":false},\
-                 {\"position\":2,\"group\":2,\"name\":\"00001.MPLS\",\"length\":\"00:00:50\",\"estimatedBytes\":null,\"hasHidden\":true}]"
+                "[{\"position\":1,\"group\":1,\"name\":\"00000.MPLS\",\"length\":\"00:01:40\",\"estimatedBytes\":1000,\"hasHidden\":false,\"hiddenBy\":[]},\
+                 {\"position\":2,\"group\":2,\"name\":\"00001.MPLS\",\"length\":\"00:00:50\",\"estimatedBytes\":null,\"hasHidden\":true,\"hiddenBy\":[\"short\",\"looping\"]}]"
             );
             assert_eq!(rows_to_json(&[]), "[]");
         }

--- a/crates/bdinfo-rs-wasm/wasm-size-budget.txt
+++ b/crates/bdinfo-rs-wasm/wasm-size-budget.txt
@@ -4,9 +4,10 @@
 # A RATCHET: the gate (scripts/wasm-compliance.ps1) and CI (wasm.yml) fail if the
 # optimized .wasm exceeds this. Lower it deliberately when the figure drops;
 # NEVER raise it without a written reason in the commit. Current optimized size
-# is ~400,697 B (rustc 1.96.0 + wasm-bindgen 0.2.126 + binaryen 130) — up from
-# ~362,471 B after linking the read-only UDF 2.50 reader for `.iso` input (the
-# scan_iso / list_iso_playlists exports + WebIso); the core was previously
-# dead-code-eliminated out because nothing called it. The ceiling (400 KiB)
-# carries a small headroom for patch-level toolchain drift (binaryen is ^130.x).
+# is ~402,504 B (rustc 1.96.0 + wasm-bindgen 0.2.126 + binaryen 131.0.0). The
+# bulk of the growth over the ~362,471 B this crate started at came from linking
+# the read-only UDF 2.50 reader for `.iso` input (the scan_iso /
+# list_iso_playlists exports + WebIso); the core was previously dead-code-
+# eliminated out because nothing called it. The ceiling (400 KiB) carries a
+# small headroom for patch-level toolchain drift (binaryen is ^131.x).
 409600

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -59,9 +59,26 @@ console.log(report); // the classic BDInfo-style disc report
 ```
 
 `listPlaylists` resolves with the selection-table rows (`position`, `group`,
-`name`, `length`, `estimatedBytes`, `hasHidden`); `analyze` spawns the scan
-Worker, relays demux progress, and resolves with the report string. Omit both
-`onProgress` and `selection` for the simplest whole-disc scan. See `index.html`
+`name`, `length`, `estimatedBytes`, `hasHidden`, `hiddenBy`); `analyze` spawns
+the scan Worker, relays demux progress, and resolves with the report string.
+Omit both `onProgress` and `selection` for the simplest whole-disc scan.
+
+Like the classic report, the listing hides playlists shorter than 20 seconds and
+looping ones. Pass `showShortPlaylists` / `showLoopingPlaylists` to list them
+too; each row's `hiddenBy` names the rules that classify it as withheld
+(`"short"`, `"looping"`, both, or none), whichever options were passed — so one
+widened listing can be re-filtered in your UI without re-scanning:
+
+```ts
+const all = await listPlaylists(picked, {
+  showShortPlaylists: true,
+  showLoopingPlaylists: true,
+});
+const standard = all.filter((row) => row.hiddenBy.length === 0);
+```
+
+The options only widen what `listPlaylists` returns. `analyze` measures its
+`selection` unfiltered either way, and the report is unchanged. See `index.html`
 in the source repository for a complete vanilla example (the demo is not shipped
 in the npm package).
 

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -172,6 +172,9 @@
         padding: 0.35rem 0.6rem;
         font-size: 0.8rem;
       }
+      .icon-only {
+        padding: 0.45rem;
+      }
       svg {
         flex: none;
       }
@@ -394,6 +397,54 @@
         border-top: 1px solid var(--border);
       }
 
+      /* the filter hint under the playlist table: one line per filter rule
+         that is on and withheld a playlist. */
+      .hint {
+        margin: 0;
+        padding: 0.7rem 1.1rem;
+        border-top: 1px solid var(--border);
+        color: var(--muted);
+        font-size: 0.82rem;
+        white-space: pre-line;
+      }
+
+      /* ── settings dialog ─────────────────────────────────────── */
+      .settings {
+        width: min(26rem, calc(100vw - 2rem));
+        padding: 1.1rem 1.25rem 1rem;
+        color: var(--text);
+        background: var(--surface);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius);
+        box-shadow: 0 18px 50px rgba(0, 0, 0, 0.55);
+      }
+      .settings::backdrop {
+        background: rgba(4, 6, 9, 0.62);
+      }
+      .settings h2 {
+        margin: 0 0 0.9rem;
+        font-size: 1rem;
+        font-weight: 600;
+      }
+      .setting {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.4rem 0;
+        font-size: 0.9rem;
+        cursor: pointer;
+      }
+      .setting-note {
+        margin: 0.7rem 0 0;
+        color: var(--muted);
+        font-size: 0.8rem;
+      }
+      .dialog-foot {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 1.1rem;
+      }
+
       /* ── progress ────────────────────────────────────────────── */
       .progress-card .body {
         padding: 1.1rem;
@@ -532,6 +583,12 @@
           </div>
         </div>
         <nav class="links">
+          <button class="iconlink icon-only" id="settings-btn" type="button" aria-label="Settings" title="Settings">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+          </button>
           <a class="iconlink" href="https://github.com/agentjp/bdinfo-rs" target="_blank" rel="noopener">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
@@ -613,6 +670,7 @@
               <tbody id="playlist-body"></tbody>
             </table>
           </div>
+          <p class="hint" id="hidden-hint" hidden></p>
           <div class="card-foot">
             <span class="muted" id="sel-count">0 selected</span>
             <button class="btn primary" id="scan-btn" type="button" disabled>
@@ -661,6 +719,26 @@
           <pre class="report" id="report"></pre>
         </section>
       </main>
+
+      <!-- settings: a native modal dialog (Esc closes, the backdrop dims) -->
+      <dialog class="settings" id="settings-dialog" aria-labelledby="settings-title">
+        <h2 id="settings-title">Settings</h2>
+        <label class="setting">
+          <input type="checkbox" id="opt-short" />
+          <span>Show short playlists</span>
+        </label>
+        <label class="setting">
+          <input type="checkbox" id="opt-looping" />
+          <span>Show looping playlists</span>
+        </label>
+        <p class="setting-note">
+          The playlist table hides playlists shorter than 20 seconds and looping ones, like the
+          classic report. Showing them never changes the report a scan produces.
+        </p>
+        <div class="dialog-foot">
+          <button class="btn primary" id="settings-close" type="button">Done</button>
+        </div>
+      </dialog>
 
       <footer class="footer">
         <span>bdinfo-rs · memory-safe Rust → WebAssembly</span>

--- a/crates/bdinfo-rs-wasm/web/src/analyze.ts
+++ b/crates/bdinfo-rs-wasm/web/src/analyze.ts
@@ -50,6 +50,16 @@ export interface PlaylistRow {
   estimatedBytes: number | null;
   /** Whether the playlist hides any stream (the CLI's `(*)` note). */
   hasHidden: boolean;
+  /**
+   * The filter rules that classify this playlist as withheld: `"short"` (under
+   * 20 s), `"looping"`, both, or none. {@link listPlaylists} drops such
+   * playlists unless the matching option ({@link AnalyzeOptions.showShortPlaylists}
+   * / {@link AnalyzeOptions.showLoopingPlaylists}) was passed, so a row with a
+   * non-empty `hiddenBy` only appears when it was — but the rules it names are
+   * the same either way, so you can list once with both options on and re-apply
+   * either rule to the rows without re-scanning.
+   */
+  hiddenBy: ("short" | "looping")[];
 }
 
 /** Optional overrides for {@link analyze} and {@link listPlaylists}. */
@@ -71,6 +81,20 @@ export interface AnalyzeOptions {
    * {@link listPlaylists}.
    */
   selection?: string[];
+  /**
+   * List playlists shorter than 20 seconds too — the CLI's
+   * `--show-short-playlists`. Used by {@link listPlaylists} /
+   * {@link listPlaylistsIso}, which drop them by default; ignored by
+   * {@link analyze} / {@link analyzeIso}, which measure `selection` unfiltered.
+   */
+  showShortPlaylists?: boolean;
+  /**
+   * List looping playlists too — the CLI's `--show-looping-playlists`. Used by
+   * {@link listPlaylists} / {@link listPlaylistsIso}, which drop them by
+   * default; ignored by {@link analyze} / {@link analyzeIso}, which measure
+   * `selection` unfiltered.
+   */
+  showLoopingPlaylists?: boolean;
   /**
    * An optional {@link AbortSignal} that cancels an in-progress measured scan
    * ({@link analyze} / {@link analyzeIso}): when it aborts, the scan Worker is
@@ -110,6 +134,17 @@ function payload(files: BdmvFile[]): { paths: string[]; files: File[] } {
   };
 }
 
+/** The two playlist-filter opt-outs a listing request carries, defaulted off. */
+function listingOptions(options?: AnalyzeOptions): {
+  showShortPlaylists: boolean;
+  showLoopingPlaylists: boolean;
+} {
+  return {
+    showShortPlaylists: options?.showShortPlaylists ?? false,
+    showLoopingPlaylists: options?.showLoopingPlaylists ?? false,
+  };
+}
+
 /**
  * The reject reason for a cancelled scan. Always an `AbortError` (the signal's
  * own reason when present, else a fresh one), so callers can tell a user cancel
@@ -127,6 +162,10 @@ function cancelledError(signal?: AbortSignal): DOMException {
  * selection-table rows (see {@link PlaylistRow}). No stream files are demuxed,
  * so it returns quickly; show the rows as a checklist, then hand the chosen
  * names to {@link analyze}'s `options.selection`.
+ *
+ * Short and looping playlists are dropped like the CLI's `--list`; pass
+ * `options.showShortPlaylists` / `options.showLoopingPlaylists` to list them
+ * too, and read each row's {@link PlaylistRow.hiddenBy} to tell them apart.
  *
  * Everything runs locally: no bytes leave the page.
  */
@@ -150,7 +189,7 @@ export function listPlaylists(files: BdmvFile[], options?: AnalyzeOptions): Prom
       reject(new Error(event.message || "scan worker failed"));
     };
 
-    worker.postMessage({ kind: "list", ...payload(files) });
+    worker.postMessage({ kind: "list", ...payload(files), ...listingOptions(options) });
   });
 }
 
@@ -160,6 +199,10 @@ export function listPlaylists(files: BdmvFile[], options?: AnalyzeOptions): Prom
  * counterpart of {@link listPlaylists}. The image is opened through the UDF
  * reader; no stream data is demuxed, so it returns quickly. Hand the chosen
  * names to {@link analyzeIso}'s `options.selection`.
+ *
+ * Short and looping playlists are dropped like the CLI's `--list`; pass
+ * `options.showShortPlaylists` / `options.showLoopingPlaylists` to list them
+ * too, and read each row's {@link PlaylistRow.hiddenBy} to tell them apart.
  *
  * Everything runs locally: no bytes leave the page.
  */
@@ -183,7 +226,7 @@ export function listPlaylistsIso(file: File, options?: AnalyzeOptions): Promise<
       reject(new Error(event.message || "scan worker failed"));
     };
 
-    worker.postMessage({ kind: "list-iso", file });
+    worker.postMessage({ kind: "list-iso", file, ...listingOptions(options) });
   });
 }
 

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -1,7 +1,9 @@
 // The vanilla (no-framework) demo driving the package's public API: pick or drop
 // a BDMV folder, list its playlists (structural scan), let the user select some,
 // run the measured scan in a Worker, and show the rendered report with copy +
-// download. No upload — everything stays in the browser.
+// download. No upload — everything stays in the browser. The settings dialog
+// holds the two playlist-filter opt-outs; they only widen what the table lists,
+// never what a scan measures or what the report says.
 import {
   analyze,
   analyzeIso,
@@ -46,6 +48,12 @@ const errorBox = el("error");
 const errorText = el("error-text");
 const mainEl = el("main");
 const listingBox = el("listing");
+const settingsBtn = el<HTMLButtonElement>("settings-btn");
+const settingsDialog = el<HTMLDialogElement>("settings-dialog");
+const settingsClose = el<HTMLButtonElement>("settings-close");
+const optShort = el<HTMLInputElement>("opt-short");
+const optLooping = el<HTMLInputElement>("opt-looping");
+const hiddenHint = el("hidden-hint");
 
 /** The picked disc — a `webkitdirectory` BDMV folder, or a single `.iso`. */
 type Source =
@@ -57,6 +65,57 @@ let reportText = "";
 let discName = "disc";
 /** Aborts the in-progress measured scan; null when no scan is running. */
 let scanController: AbortController | null = null;
+/**
+ * Every playlist of the picked disc: the listing is always made with BOTH
+ * filter options on, and the settings are applied to these rows in the page. So
+ * toggling a setting redraws the table instantly instead of re-scanning.
+ */
+let allRows: PlaylistRow[] = [];
+/** The playlists the user has unticked, by name — persists across a redraw. */
+const unchecked = new Set<string>();
+
+// ── settings ─────────────────────────────────────────────────────────────────
+
+/** The two playlist-filter opt-outs, mirroring the CLI's two switches. */
+interface Settings {
+  showShortPlaylists: boolean;
+  showLoopingPlaylists: boolean;
+}
+
+/** Where the settings persist between visits. */
+const SETTINGS_KEY = "bdinfo-rs.settings";
+
+/**
+ * Reads the stored settings, defaulting both off (the standard filtered set).
+ * `localStorage` throws outright when the page is sandboxed or site data is
+ * blocked, so every access is guarded — the demo then runs with the defaults
+ * and the choice simply does not survive a reload.
+ */
+function loadSettings(): Settings {
+  let stored: Partial<Settings> = {};
+  try {
+    const raw = window.localStorage.getItem(SETTINGS_KEY);
+    if (raw !== null) {
+      stored = JSON.parse(raw);
+    }
+  } catch {
+    stored = {};
+  }
+  return {
+    showShortPlaylists: stored.showShortPlaylists === true,
+    showLoopingPlaylists: stored.showLoopingPlaylists === true,
+  };
+}
+
+const settings = loadSettings();
+
+function saveSettings(): void {
+  try {
+    window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  } catch {
+    return;
+  }
+}
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -165,8 +224,12 @@ async function loadSource(src: Source): Promise<void> {
   hide(playlistsCard);
   show(listingBox);
   try {
+    // Always the widened set: the settings are applied to `allRows` in the page.
+    const options = { showShortPlaylists: true, showLoopingPlaylists: true };
     const rows =
-      src.kind === "folder" ? await listPlaylists(src.files) : await listPlaylistsIso(src.file);
+      src.kind === "folder"
+        ? await listPlaylists(src.files, options)
+        : await listPlaylistsIso(src.file, options);
     if (rows.length === 0) {
       showError(
         src.kind === "folder"
@@ -184,14 +247,72 @@ async function loadSource(src: Source): Promise<void> {
 }
 
 function renderPlaylists(rows: PlaylistRow[]): void {
-  playlistBody.replaceChildren();
-  for (const row of rows) {
-    playlistBody.appendChild(playlistRow(row));
-  }
+  allRows = rows;
+  unchecked.clear();
+  renderRows();
   discLabel.textContent = discName;
-  updateSelection();
   show(playlistsCard);
   playlistsCard.scrollIntoView({ behavior: "smooth", block: "nearest" });
+}
+
+/**
+ * Whether the settings list `row`: every rule that classifies it as withheld
+ * must be switched on.
+ */
+function isShown(row: PlaylistRow): boolean {
+  return row.hiddenBy.every((rule) =>
+    rule === "short" ? settings.showShortPlaylists : settings.showLoopingPlaylists,
+  );
+}
+
+/** Draws the rows the settings show, and the hint for the ones they do not. */
+function renderRows(): void {
+  const shown = allRows.filter(isShown);
+  // Both numbered columns are renumbered over the shown rows, so the table
+  // reads like a scan made with these settings rather than like the widened
+  // listing it is sliced from. Group numbers keep their identity because the
+  // rows arrive grouped: the distinct values, in order, are the new 1, 2, 3.
+  const groups = [...new Set(shown.map((row) => row.group))];
+  playlistBody.replaceChildren(
+    ...shown.map((row, index) => playlistRow(row, index + 1, groups.indexOf(row.group) + 1)),
+  );
+  renderHint();
+  updateSelection();
+}
+
+/** How many playlist names a hint line spells out before it counts the rest. */
+const HINT_NAMES = 3;
+
+/**
+ * The hint under the table: one line per filter rule that is on *and* withheld
+ * a playlist, looping first. Each rule is judged on its own against the whole
+ * disc, mirroring the CLI's `Hidden by filters (…)` block — a playlist that is
+ * both short and looping is named on both lines and takes both settings to
+ * reveal.
+ */
+function renderHint(): void {
+  const lines: string[] = [];
+  if (!settings.showLoopingPlaylists) {
+    lines.push(...hintLine("looping"));
+  }
+  if (!settings.showShortPlaylists) {
+    lines.push(...hintLine("short"));
+  }
+  hiddenHint.textContent = lines.join("\n");
+  hiddenHint.hidden = lines.length === 0;
+}
+
+/** The hint line for `rule`, or nothing when the rule withheld no playlist. */
+function hintLine(rule: "short" | "looping"): string[] {
+  const names = allRows.filter((row) => row.hiddenBy.includes(rule)).map((row) => row.name);
+  if (names.length === 0) {
+    return [];
+  }
+  const rest = names.length - HINT_NAMES;
+  const more = rest > 0 ? ` and ${rest} more` : "";
+  return [
+    `Hidden by filters (${rule}): ${names.slice(0, HINT_NAMES).join(", ")}${more} - enable in settings`,
+  ];
 }
 
 function cell(className?: string): HTMLTableCellElement {
@@ -207,18 +328,18 @@ function textCell(text: string, className?: string): HTMLTableCellElement {
   return td;
 }
 
-function playlistRow(row: PlaylistRow): HTMLTableRowElement {
+function playlistRow(row: PlaylistRow, position: number, group: number): HTMLTableRowElement {
   const tr = document.createElement("tr");
   tr.dataset.name = row.name;
 
   const check = document.createElement("input");
   check.type = "checkbox";
-  check.checked = true;
+  check.checked = !unchecked.has(row.name);
   const checkCell = cell("col-check");
   checkCell.appendChild(check);
   tr.appendChild(checkCell);
 
-  tr.appendChild(textCell(String(row.position)));
+  tr.appendChild(textCell(String(position)));
 
   const nameCell = cell("name");
   nameCell.textContent = row.name;
@@ -231,7 +352,7 @@ function playlistRow(row: PlaylistRow): HTMLTableRowElement {
   }
   tr.appendChild(nameCell);
 
-  tr.appendChild(textCell(String(row.group)));
+  tr.appendChild(textCell(String(group)));
   tr.appendChild(textCell(row.length));
   tr.appendChild(textCell(humanBytes(row.estimatedBytes), "num"));
 
@@ -255,6 +376,16 @@ function updateSelection(): void {
   for (const box of rowBoxes()) {
     const tr = box.closest("tr");
     tr?.classList.toggle("sel", box.checked);
+    const name = tr?.dataset.name;
+    if (name !== undefined) {
+      // Remembered by name, so a row the settings hide and later show again
+      // comes back with the tick the user left it with.
+      if (box.checked) {
+        unchecked.delete(name);
+      } else {
+        unchecked.add(name);
+      }
+    }
     if (box.checked) {
       count += 1;
     }
@@ -409,6 +540,24 @@ dropzone.addEventListener("drop", (event) => {
   }
   void collectAndLoad(roots);
 });
+
+optShort.checked = settings.showShortPlaylists;
+optLooping.checked = settings.showLoopingPlaylists;
+
+settingsBtn.addEventListener("click", () => {
+  settingsDialog.showModal();
+});
+settingsClose.addEventListener("click", () => {
+  settingsDialog.close();
+});
+for (const box of [optShort, optLooping]) {
+  box.addEventListener("change", () => {
+    settings.showShortPlaylists = optShort.checked;
+    settings.showLoopingPlaylists = optLooping.checked;
+    saveSettings();
+    renderRows();
+  });
+}
 
 selectAllBtn.addEventListener("click", () => {
   setAll(true);

--- a/crates/bdinfo-rs-wasm/web/src/worker.ts
+++ b/crates/bdinfo-rs-wasm/web/src/worker.ts
@@ -16,8 +16,14 @@ import init, {
   scan_iso,
 } from "../pkg/bdinfo_rs_wasm.js";
 
+/** The two playlist-filter opt-outs a listing request carries (see `analyze.ts`). */
+interface ListOptions {
+  showShortPlaylists: boolean;
+  showLoopingPlaylists: boolean;
+}
+
 /** List the playlists (structural scan) of the picked BDMV folder. */
-interface ListRequest {
+interface ListRequest extends ListOptions {
   kind: "list";
   paths: string[];
   files: File[];
@@ -32,7 +38,7 @@ interface ScanRequest {
 }
 
 /** List the playlists (structural scan) of a single picked `.iso`. */
-interface ListIsoRequest {
+interface ListIsoRequest extends ListOptions {
   kind: "list-iso";
   file: File;
 }
@@ -64,11 +70,23 @@ self.onmessage = async (event: MessageEvent<Request>) => {
       case "list":
         self.postMessage({
           type: "rows",
-          rows: JSON.parse(list_playlists(data.paths, data.files)),
+          rows: JSON.parse(
+            list_playlists(
+              data.paths,
+              data.files,
+              data.showShortPlaylists,
+              data.showLoopingPlaylists,
+            ),
+          ),
         });
         break;
       case "list-iso":
-        self.postMessage({ type: "rows", rows: JSON.parse(list_iso_playlists(data.file)) });
+        self.postMessage({
+          type: "rows",
+          rows: JSON.parse(
+            list_iso_playlists(data.file, data.showShortPlaylists, data.showLoopingPlaylists),
+          ),
+        });
         break;
       case "scan":
         self.postMessage({

--- a/crates/bdinfo-rs-wasm/web/test/harness.html
+++ b/crates/bdinfo-rs-wasm/web/test/harness.html
@@ -6,14 +6,16 @@
     <title>bdinfo-rs wasm parity harness</title>
   </head>
   <body>
-    <!-- Headless-Chrome parity harness: exposes the package's `analyze` and
-         `analyzeIso` on the window so the Playwright test can hand them File
-         objects (a folder pick, and a single `.iso`) built from the committed
-         Big Buck Bunny fixture and compare each result to its golden. -->
+    <!-- Headless-Chrome parity harness: exposes the package's `analyze`,
+         `analyzeIso` and `listPlaylists` on the window so the Playwright test can
+         hand them File objects (a folder pick, and a single `.iso`) built from
+         the committed Big Buck Bunny fixture, compare each report to its golden,
+         and drive the listing's filter options through the real Worker. -->
     <script type="module">
-      import { analyze, analyzeIso } from "/dist/analyze.js";
+      import { analyze, analyzeIso, listPlaylists } from "/dist/analyze.js";
       window.__analyze = analyze;
       window.__analyzeIso = analyzeIso;
+      window.__listPlaylists = listPlaylists;
       window.__ready = true;
     </script>
   </body>

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -96,6 +96,7 @@ async function main() {
 
   let report;
   let isoReport;
+  let listings;
   try {
     const page = await browser.newPage();
     page.on("console", (msg) => console.log(`  [page] ${msg.text()}`));
@@ -104,9 +105,9 @@ async function main() {
     await page.goto(`${base}/test/harness.html`);
     await page.waitForFunction(() => window.__ready === true, { timeout: 30000 });
 
-    // The folder path: the fixture handed in as a `(relativePath, File)` list.
-    report = await page.evaluate(async (items) => {
-      const files = items.map((item) => {
+    // The in-page `(relativePath, File)` list the folder calls take.
+    await page.evaluate((items) => {
+      window.__files = items.map((item) => {
         const binary = atob(item.b64);
         const bytes = new Uint8Array(binary.length);
         for (let i = 0; i < binary.length; i++) {
@@ -115,8 +116,34 @@ async function main() {
         const name = item.path.split("/").pop();
         return { path: item.path, file: new File([bytes], name) };
       });
-      return await window.__analyze(files);
     }, entries);
+
+    // The folder path: the fixture handed in as a `(relativePath, File)` list.
+    report = await page.evaluate(async () => await window.__analyze(window.__files));
+
+    // The listing's filter options, driven through the real Worker: the same
+    // disc plus a second playlist over the same clip patched to ~10 s (the first
+    // PlayItem's OUT_time is a u32-BE at file offset 86, 45_000 ticks a second),
+    // which the short-playlist rule withholds unless the option is passed.
+    listings = await page.evaluate(async () => {
+      const source = window.__files.find((entry) => entry.path.endsWith("00000.mpls"));
+      const bytes = new Uint8Array(await source.file.arrayBuffer());
+      new DataView(bytes.buffer).setUint32(86, 27_000_000 + 45_000 * 10);
+      const files = [
+        ...window.__files,
+        {
+          path: "WASMDISC/BDMV/PLAYLIST/00001.mpls",
+          file: new File([bytes], "00001.mpls"),
+        },
+      ];
+      const names = async (options) =>
+        (await window.__listPlaylists(files, options)).map((row) => `${row.name}:${row.hiddenBy}`);
+      return {
+        standard: await names(),
+        widened: await names({ showShortPlaylists: true }),
+        looping: await names({ showLoopingPlaylists: true }),
+      };
+    });
 
     // The `.iso` path: the same disc fetched as one `File` and opened through the
     // UDF reader — the real-browser Worker + FileReaderSync `scan_iso` seam.
@@ -155,7 +182,21 @@ async function main() {
 
   const folderOk = compare("measured scan", report, golden);
   const isoOk = compare(".iso scan", isoReport, isoGolden);
-  process.exit(folderOk && isoOk ? 0 : 1);
+
+  // Each listing is `name:hiddenBy` per row: the short playlist is listed only
+  // with its own option, and always names the rule that withholds it.
+  const want = {
+    standard: ["00000.MPLS:"],
+    widened: ["00000.MPLS:", "00001.MPLS:short"],
+    looping: ["00000.MPLS:"],
+  };
+  const listOk = JSON.stringify(listings) === JSON.stringify(want);
+  if (listOk) {
+    console.log("PASS — Worker listing options widen the table by their own rule.");
+  } else {
+    console.error(`FAIL — listing options: got ${JSON.stringify(listings)}`);
+  }
+  process.exit(folderOk && isoOk && listOk ? 0 : 1);
 }
 
 main().catch((err) => {

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -75,6 +75,17 @@ const LAYOUT = [
   { path: "WASMDISC/BDMV/META/DL/bdmt_eng.xml", file: null },
 ];
 
+/**
+ * The fixture playlist patched to a ~10 s duration, so the short-playlist filter
+ * withholds it. The first PlayItem's OUT_time is a u32-BE at file offset 86
+ * (IN_time is 27_000_000 at 82) and a second is 45_000 ticks.
+ */
+function shortPlaylist(mpls) {
+  const bytes = new Uint8Array(mpls);
+  new DataView(bytes.buffer).setUint32(86, 27_000_000 + 45_000 * 10);
+  return bytes;
+}
+
 async function main() {
   const golden = await readFile(goldenPath);
 
@@ -105,10 +116,34 @@ async function main() {
     Array.isArray(rows) &&
     rows.length === 1 &&
     rows[0].name === "00000.MPLS" &&
-    rows[0].position === 1;
+    rows[0].position === 1 &&
+    Array.isArray(rows[0].hiddenBy) &&
+    rows[0].hiddenBy.length === 0;
   const selOk = selReport.equals(golden);
   if (!listOk) {
     console.error(`FAIL — list_playlists rows unexpected: ${JSON.stringify(rows)}`);
+  }
+
+  // The filter options: the same disc plus a second playlist over the same clip,
+  // patched to ~10 s so the short rule withholds it. Omitting the options (and
+  // passing `false`) must list only the feature; passing `show_short_playlists`
+  // must add the short playlist, tagged `hiddenBy: ["short"]`.
+  const mpls = new Uint8Array(await readFile(join(fixtures, "PLAYLIST/00000.mpls")));
+  const shortPaths = [...paths, "WASMDISC/BDMV/PLAYLIST/00001.mpls"];
+  const shortFiles = [...files, new ShimFile(shortPlaylist(mpls), "00001.mpls")];
+  const listNames = (...options) =>
+    JSON.parse(list_playlists(shortPaths, shortFiles, ...options)).map((row) => row.name);
+  const widened = JSON.parse(list_playlists(shortPaths, shortFiles, true));
+  const optionsOk =
+    JSON.stringify(listNames()) === '["00000.MPLS"]' &&
+    JSON.stringify(listNames(false, false)) === '["00000.MPLS"]' &&
+    JSON.stringify(listNames(false, true)) === '["00000.MPLS"]' &&
+    JSON.stringify(widened.map((row) => row.name)) === '["00000.MPLS","00001.MPLS"]' &&
+    JSON.stringify(widened.map((row) => row.hiddenBy)) === '[[],["short"]]';
+  if (!optionsOk) {
+    console.error(
+      `FAIL — filter options unexpected: ${JSON.stringify(listNames())} / ${JSON.stringify(widened)}`,
+    );
   }
   if (!selOk) {
     console.error(
@@ -130,7 +165,9 @@ async function main() {
     Array.isArray(isoRows) &&
     isoRows.length === 1 &&
     isoRows[0].name === "00000.MPLS" &&
-    isoRows[0].position === 1;
+    isoRows[0].position === 1 &&
+    Array.isArray(isoRows[0].hiddenBy) &&
+    isoRows[0].hiddenBy.length === 0;
   const isoSelOk = isoSelReport.equals(isoGolden);
   if (!isoListOk) {
     console.error(`FAIL — list_iso_playlists rows unexpected: ${JSON.stringify(isoRows)}`);
@@ -157,9 +194,9 @@ async function main() {
     }
   }
 
-  if (got.equals(golden) && listOk && selOk && isoOk && isoListOk && isoSelOk) {
+  if (got.equals(golden) && listOk && selOk && optionsOk && isoOk && isoListOk && isoSelOk) {
     console.log(
-      `PASS — Node measured scan matches the golden (${golden.length} bytes); list + selection + .iso OK.`,
+      `PASS — Node measured scan matches the golden (${golden.length} bytes); list + options + selection + .iso OK.`,
     );
     process.exit(0);
   }


### PR DESCRIPTION
The browser package's playlist listing hid short and looping playlists with no
way to opt out and no trace. It now mirrors the CLI's two switches, additively.

Rust exports
- list_playlists and list_iso_playlists take show_short_playlists and
  show_looping_playlists as optional booleans. Absent, or false, lists exactly
  the previous set, so existing calls are unaffected.
- Every emitted row carries an always-present hiddenBy array naming the filter
  rules that classify it as withheld: short, looping, both, or none. Each rule
  is judged on its own and independently of the options passed, so one widened
  listing can be re-filtered by a caller without re-scanning.
- table_rows and playlist_rows take the filter, mirroring their CLI siblings.
- The measured scan is untouched: an explicit selection still measures
  unfiltered, and no report byte changes.

npm surface (additive, minor-class)
- AnalyzeOptions gains showShortPlaylists and showLoopingPlaylists, used by
  listPlaylists and listPlaylistsIso, ignored by analyze and analyzeIso.
- PlaylistRow gains hiddenBy. The worker protocol threads the options through.

Demo
- A gear in the header opens a native modal settings dialog holding the two
  toggles, persisted in localStorage.
- The listing runs once with both options on and the settings apply in the
  page, so toggling redraws the table instantly with no re-scan.
- A hint line under the table names what the filters withhold, one line per
  rule, in the wording the CLI and desktop app use.

Tests
- Native unit tests for the classification, the option-to-rule mapping, the
  widened listing and the JSON shape.
- The Node and headless-Chrome parity tests cover the new options and hiddenBy,
  the latter through the real Worker.
- Optimized wasm is 402,504 B against the unchanged 409,600 B budget.
