### PR TITLE
feat(wasm): expose the structured disc model and report re-rendering

### DIFF
--- a/crates/bdinfo-rs-wasm/.cargo/mutants.toml
+++ b/crates/bdinfo-rs-wasm/.cargo/mutants.toml
@@ -25,6 +25,8 @@ exclude_re = [
     "scan_iso", # the #[wasm_bindgen] .iso streaming export
     "list_playlists", # the #[wasm_bindgen] structural-listing export
     "list_iso_playlists", # the #[wasm_bindgen] .iso structural-listing export
+    "inspect_files", # the #[wasm_bindgen] structural disc-model export
+    "inspect_iso", # the #[wasm_bindgen] .iso structural disc-model export
 ]
 
 # Enforce the committed lockfile on every mutant build (mirrors CI).

--- a/crates/bdinfo-rs-wasm/.cargo/mutants.toml
+++ b/crates/bdinfo-rs-wasm/.cargo/mutants.toml
@@ -20,13 +20,16 @@ exclude_re = [
     "WebIso", # impl IsoReader for WebIso (the .iso FileReaderSync factory)
     "for JsValue", # impl From<TreeError> for JsValue
     "build_web_tree", # &js_sys::Array -> Node<WebFile>
-    "render_root", # the wasm32 scan_files/scan_iso render dispatch -> JsValue
-    "scan_files", # the #[wasm_bindgen] streaming export
-    "scan_iso", # the #[wasm_bindgen] .iso streaming export
+    "notify", # the wasm32 progress-callback shim -> js_sys::Function
+    "scan_root", # the wasm32 whole-disc/by-name scan dispatch -> JsValue
+    "render_root", # the wasm32 scan dispatch rendered -> JsValue
+    "scan_files", # the #[wasm_bindgen] streaming exports (scan_files + scan_files_full)
+    "scan_iso", # the #[wasm_bindgen] .iso streaming exports (scan_iso + scan_iso_full)
     "list_playlists", # the #[wasm_bindgen] structural-listing export
     "list_iso_playlists", # the #[wasm_bindgen] .iso structural-listing export
     "inspect_files", # the #[wasm_bindgen] structural disc-model export
     "inspect_iso", # the #[wasm_bindgen] .iso structural disc-model export
+    "render_report", # the #[wasm_bindgen] re-render-from-a-disc export
 ]
 
 # Enforce the committed lockfile on every mutant build (mirrors CI).

--- a/crates/bdinfo-rs-wasm/Cargo.lock
+++ b/crates/bdinfo-rs-wasm/Cargo.lock
@@ -34,6 +34,9 @@ dependencies = [
  "bdinfo-rs-core",
  "js-sys",
  "proptest",
+ "serde",
+ "serde_json",
+ "tsify",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
@@ -419,6 +422,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +450,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -516,6 +541,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tsify"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
+dependencies = [
+ "serde",
+ "serde-wasm-bindgen",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crates/bdinfo-rs-wasm/Cargo.toml
+++ b/crates/bdinfo-rs-wasm/Cargo.toml
@@ -25,6 +25,14 @@ bdinfo-rs-core = { path = "../bdinfo-rs-core" }
 # All-target: `#[wasm_bindgen]` on `scan_report` expands on every target (the
 # native rlib parity test links it), so the macro crate must be present natively.
 wasm-bindgen = "0.2"
+serde = { version = "1", features = ["derive"] }
+# Pinned EXACT: tsify's generated TypeScript text is part of the published
+# package's type surface (`@bdinfo-rs/wasm/wasm` maps to the .d.ts wasm-bindgen
+# assembles from it), so a patch-level change in its emitter is a change to
+# published types. `default-features = false, features = ["js"]` selects the
+# serde-wasm-bindgen backend: mirror values cross the boundary as real
+# JavaScript objects rather than a JSON string the consumer must parse.
+tsify = { version = "=0.5.6", default-features = false, features = ["js"] }
 
 # js-sys / web-sys are referenced ONLY under #[cfg(target_arch = "wasm32")] (the
 # WebReader/WebFile FileReaderSync seam + scan_files/build_web_tree), so they are
@@ -37,6 +45,10 @@ web-sys = { version = "0.3", features = ["Blob", "File", "FileReaderSync"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+# The native stand-in for the browser serializer: the mirror wire-format tests
+# assert property names and value shapes, which are the same whichever
+# `Serializer` produces them, and serde_json runs on both targets.
+serde_json = "1"
 
 # The reader-math proptests run only on the native (Tier-A) build: proptest's
 # fork/timeout backend does not build for wasm32, where the parity tests use

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -57,7 +57,7 @@ use std::sync::atomic::AtomicBool;
 use bdinfo_rs_core::bdrom::chapters::seconds_to_ticks;
 #[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::bdrom::disc::PlaylistSummary;
-use bdinfo_rs_core::bdrom::disc::{BdRom, ScanMode, ScanProgress};
+use bdinfo_rs_core::bdrom::disc::{BdRom, ScanMode, ScanProgress, ScanReport};
 use bdinfo_rs_core::bdrom::order::PlaylistFilter;
 #[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::bdrom::order::presentation_groups;
@@ -76,9 +76,11 @@ use wasm_bindgen::{JsCast, JsValue};
 // the generated `.d.ts`, which the npm package exposes at its `/wasm` subpath.
 pub mod mirror;
 
-// Named by the browser exports that return the disc model, and by their docs.
-#[cfg(target_arch = "wasm32")]
-use mirror::Disc;
+// Named by the browser exports that return the disc model and by their docs,
+// and by the measured-scan pairing (`measured_result`) those exports return —
+// which is target-agnostic, hence the same gate as the rest of that logic.
+#[cfg(any(target_arch = "wasm32", test))]
+use mirror::{Disc, ScanResult};
 
 /// The read-ahead window each [`WebReader`] fill pulls from `FileReaderSync` in
 /// one go, so a front-to-back demux crosses the JS boundary once per MiB rather
@@ -196,7 +198,7 @@ struct MemFile {
 
 impl BdFile for MemFile {
     fn name(&self) -> &str {
-        &self.name
+        "xyzzy" /* ~ changed by cargo-mutants ~ */
     }
 
     fn full_name(&self) -> &str {
@@ -941,7 +943,7 @@ fn selection_order(playlists: &[PlaylistSummary], selection: &[String]) -> Vec<u
         .collect()
 }
 
-/// Why a by-name [`render_selection`] could not produce a report.
+/// Why a by-name [`scan_selection`] could not produce a report.
 #[cfg(any(target_arch = "wasm32", test))]
 #[derive(Debug)]
 enum SelectionError {
@@ -969,9 +971,8 @@ impl std::fmt::Display for SelectionError {
     }
 }
 
-/// Runs the **measured** scan over just the playlists named in `selection` and
-/// renders the classic report in selection order — the browser equivalent of
-/// `bdinfo-rs <disc> --mpls A,B`.
+/// Runs the **measured** scan over just the playlists named in `selection`, in
+/// selection order — the browser equivalent of `bdinfo-rs <disc> --mpls A,B`.
 ///
 /// A cheap structural scan (no packet scan) resolves the names to their stream
 /// files first; the measured scan is then narrowed to those files, so an
@@ -985,11 +986,11 @@ impl std::fmt::Display for SelectionError {
 /// (mirroring the CLI's `--mpls`, which exits with "No matching playlists found
 /// on BD" rather than rendering a header-only report).
 #[cfg(any(target_arch = "wasm32", test))]
-fn render_selection(
+fn scan_selection(
     root: &dyn BdDir,
     selection: &[String],
     progress: &mut dyn FnMut(ScanProgress<'_>),
-) -> Result<String, SelectionError> {
+) -> Result<Scan, SelectionError> {
     let structural = BdRom::open_resilient(root, ScanMode::Metadata)?;
     let names = named_selection(&structural.bdrom.playlists, selection);
     if names.is_empty() {
@@ -1011,7 +1012,7 @@ fn render_selection(
     )
     .unwrap_or(structural);
     let order = selection_order(&measured.bdrom.playlists, &names);
-    Ok(text::render_with(&measured.bdrom, &order, &measured.errors, RenderOptions::default()))
+    Ok(Scan { report: measured, order })
 }
 
 // ── shared render path ──────────────────────────────────────────────────────
@@ -1023,52 +1024,141 @@ const fn never_cancelled() -> AtomicBool {
     AtomicBool::new(false)
 }
 
-/// Runs the full **measured** scan over `root` and renders the classic disc
-/// report.
+/// One completed scan: the disc the scan produced, plus the playlist `order`
+/// its report renders — which the whole-disc and by-name paths derive
+/// differently and everything downstream then treats alike.
+///
+/// Holding the two together is what lets one scan serve both outputs a caller
+/// can ask for: the rendered report ([`render`](Self::render)) and the
+/// structured disc ([`measured_result`]), each derived from this scan rather
+/// than from the other.
+#[derive(Debug)]
+struct Scan {
+    /// The scanned disc and the per-file failures recorded along the way.
+    report: ScanReport,
+    /// Indices into the disc's playlists, in the order the report prints them.
+    order: Vec<usize>,
+}
+
+impl Scan {
+    /// Renders the classic disc report for this scan, with `options` choosing
+    /// which optional sections it carries.
+    fn render(&self, options: RenderOptions) -> String {
+        text::render_with(&self.report.bdrom, &self.order, &self.report.errors, options)
+    }
+}
+
+/// Runs the full **measured** scan over `root`, in the CLI's `--whole` playlist
+/// order.
 ///
 /// This is the byte-for-byte core shared by every export and the native parity
-/// test: [`BdRom::open_resilient_with`] with the packet scan **on**, the CLI's
-/// `--whole` selection ([`PlaylistFilter::default`] — the standard filtered set,
-/// dropping playlists shorter than 20 s and looping ones), then [`text`]
-/// rendering. `progress` observes the demux.
+/// test: [`BdRom::open_resilient_with`] with the packet scan **on**, ordered by
+/// the standard filtered set ([`PlaylistFilter::default`], which drops playlists
+/// shorter than 20 s and looping ones). `progress` observes the demux.
 ///
 /// # Errors
 /// Returns the [`BdError`] from [`BdRom::open_resilient_with`] when the
 /// structure is too damaged to open at all (no `BDMV`/`CLIPINF`/`PLAYLIST`) —
 /// the caller decides whether that is an empty disc or an error to report.
-fn render_disc(
+fn scan_whole(
     root: &dyn BdDir,
     progress: &mut dyn FnMut(ScanProgress<'_>),
-) -> Result<String, BdError> {
+) -> Result<Scan, BdError> {
     let report =
         BdRom::open_resilient_with(root, ScanMode::Full, None, progress, &never_cancelled())?;
     let order = report.bdrom.presentation_order(&PlaylistFilter::default());
-    // The browser exports carry no report options: always the default report.
-    Ok(text::render_with(&report.bdrom, &order, &report.errors, RenderOptions::default()))
+    Ok(Scan { report, order })
 }
 
-/// Renders a measured scan of `root`, mapping any failure to a `JsValue`.
+/// [`scan_whole`] rendered to the classic report with `options`.
 ///
-/// Dispatches to the whole-disc ([`render_disc`]) or by-name
-/// ([`render_selection`]) path — the shared tail of the [`scan_files`] (folder)
-/// and [`scan_iso`] (`.iso`) streaming exports, which differ only in how they
-/// obtain `root`.
+/// # Errors
+/// As [`scan_whole`].
+fn render_disc(
+    root: &dyn BdDir,
+    options: RenderOptions,
+    progress: &mut dyn FnMut(ScanProgress<'_>),
+) -> Result<String, BdError> {
+    Ok(scan_whole(root, progress)?.render(options))
+}
+
+/// The report sections to render: each option switches its own section off, and
+/// an absent option leaves it on — so a call passing neither renders the whole
+/// report, the locked bytes [`RenderOptions::default`] produces.
+#[cfg(any(target_arch = "wasm32", test))]
+fn render_options(stream_diagnostics: Option<bool>, quick_summary: Option<bool>) -> RenderOptions {
+    RenderOptions {
+        stream_diagnostics: stream_diagnostics.unwrap_or(true),
+        quick_summary: quick_summary.unwrap_or(true),
+    }
+}
+
+/// Both outputs of one measured `scan`: the report rendered with `options`, and
+/// the same scan mirrored as a [`Disc`].
+///
+/// The two are derived side by side from the scan, never one from the other:
+/// the report comes straight off the scanned disc, exactly as the report-only
+/// exports render it, and the mirror is built from that same disc. Rendering by
+/// way of the mirror instead would leave nothing to compare the mirror against.
+#[cfg(any(target_arch = "wasm32", test))]
+fn measured_result(scan: &Scan, options: RenderOptions) -> ScanResult {
+    ScanResult {
+        report: scan.render(options),
+        // A `Scan` is always the packet scan, so the mirror says measured.
+        disc: Disc::from_scan(&scan.report.bdrom, &scan.report.errors, true),
+    }
+}
+
+/// Runs a measured scan of `root`, mapping any failure to a `JsValue`.
+///
+/// Dispatches to the whole-disc ([`scan_whole`]) or by-name
+/// ([`scan_selection`]) path — the shared head of the streaming exports, which
+/// differ only in how they obtain `root` and what they do with the scan.
 ///
 /// # Errors
 /// A `JsValue` carrying the structure-open failure (empty `selection`) or the
 /// [`SelectionError`] text (named `selection`).
 #[cfg(target_arch = "wasm32")]
-fn render_root(
+fn scan_root(
     root: &dyn BdDir,
     selection: &[String],
     progress: &mut dyn FnMut(ScanProgress<'_>),
-) -> Result<String, JsValue> {
+) -> Result<Scan, JsValue> {
     if selection.is_empty() {
-        render_disc(root, progress)
+        scan_whole(root, progress)
             .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))
     } else {
-        render_selection(root, selection, progress)
-            .map_err(|err| JsValue::from_str(&err.to_string()))
+        scan_selection(root, selection, progress).map_err(|err| JsValue::from_str(&err.to_string()))
+    }
+}
+
+/// [`scan_root`] rendered to the classic report with `options` — the shared tail
+/// of the [`scan_files`] (folder) and [`scan_iso`] (`.iso`) streaming exports.
+///
+/// # Errors
+/// As [`scan_root`].
+#[cfg(target_arch = "wasm32")]
+fn render_root(
+    root: &dyn BdDir,
+    selection: &[String],
+    options: RenderOptions,
+    progress: &mut dyn FnMut(ScanProgress<'_>),
+) -> Result<String, JsValue> {
+    Ok(scan_root(root, selection, progress)?.render(options))
+}
+
+/// Calls the caller's progress `callback`, when it supplied one, as
+/// `(file, done, total)`. A callback that throws is ignored: a scan is not
+/// abandoned because the page could not draw a progress bar.
+#[cfg(target_arch = "wasm32")]
+fn notify(callback: Option<&js_sys::Function>, progress: &ScanProgress<'_>) {
+    if let Some(callback) = callback {
+        let _ = callback.call3(
+            &JsValue::NULL,
+            &JsValue::from_str(progress.file),
+            &JsValue::from_f64(progress.done as f64),
+            &JsValue::from_f64(progress.total as f64),
+        );
     }
 }
 
@@ -1078,7 +1168,7 @@ fn render_root(
 /// absence path the `parse_report` fuzz target and the parity test expect.
 #[must_use]
 pub fn run_report(data: &[u8]) -> String {
-    render_disc(&build_tree(data), &mut |_| {}).unwrap_or_default()
+    render_disc(&build_tree(data), RenderOptions::default(), &mut |_| {}).unwrap_or_default()
 }
 
 /// Opens `reader` as a UDF `.iso` and renders the whole-disc report.
@@ -1095,7 +1185,7 @@ pub fn run_report(data: &[u8]) -> String {
 #[must_use]
 pub fn run_iso_report(reader: Box<dyn IsoReader>) -> String {
     let Ok(source) = UdfSource::open_resilient(reader) else { return String::new() };
-    render_disc(&source.root(), &mut |_| {}).unwrap_or_default()
+    render_disc(&source.root(), RenderOptions::default(), &mut |_| {}).unwrap_or_default()
 }
 
 /// The in-memory entry point: feed it BDMV bytes (the six `u32`-BE
@@ -1137,17 +1227,8 @@ pub fn scan_files(
     on_progress: Option<js_sys::Function>,
 ) -> Result<String, JsValue> {
     let root = build_web_tree(&paths, &files)?;
-    let mut observe = |p: ScanProgress<'_>| {
-        if let Some(callback) = on_progress.as_ref() {
-            let _ = callback.call3(
-                &JsValue::NULL,
-                &JsValue::from_str(p.file),
-                &JsValue::from_f64(p.done as f64),
-                &JsValue::from_f64(p.total as f64),
-            );
-        }
-    };
-    render_root(&root, &selection, &mut observe)
+    let mut observe = |p: ScanProgress<'_>| notify(on_progress.as_ref(), &p);
+    render_root(&root, &selection, RenderOptions::default(), &mut observe)
 }
 
 /// The streaming `.iso` entry point: hand it a single OS-picked Blu-ray `.iso`
@@ -1179,17 +1260,8 @@ pub fn scan_iso(
     let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
         .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
     let root = source.root();
-    let mut observe = |p: ScanProgress<'_>| {
-        if let Some(callback) = on_progress.as_ref() {
-            let _ = callback.call3(
-                &JsValue::NULL,
-                &JsValue::from_str(p.file),
-                &JsValue::from_f64(p.done as f64),
-                &JsValue::from_f64(p.total as f64),
-            );
-        }
-    };
-    render_root(&root, &selection, &mut observe)
+    let mut observe = |p: ScanProgress<'_>| notify(on_progress.as_ref(), &p);
+    render_root(&root, &selection, RenderOptions::default(), &mut observe)
 }
 
 /// The structural-scan entry point: the playlist selection table as JSON.
@@ -1328,13 +1400,104 @@ pub fn inspect_iso(
     Ok(Disc::from_listing(&report.bdrom, &report.errors, &filter))
 }
 
+/// Renders the classic disc report from a [`Disc`] — no media, no rescan.
+///
+/// Hand back a disc a measured scan produced and the report comes out again,
+/// with whichever optional sections `stream_diagnostics` and `quick_summary`
+/// ask for. Omitting an option renders its section, so `renderReport(disc)`
+/// alone reproduces the report the scan itself returned, byte for byte. This is
+/// what re-rendering with different sections costs: nothing but the render.
+///
+/// The disc model carries every value the report prints, so this is a render
+/// rather than an approximation — but it is the only supported way to turn a
+/// [`Disc`] into report text. Formatting the model by hand produces something
+/// that merely resembles the locked format.
+///
+/// The playlists print in the disc's presentation order — the standard
+/// `--whole` set, grouped by shared clip files and longest first, the same
+/// order a whole-disc scan renders. Any disc renders, including one whose
+/// values were never measured: a disc from a by-name scan holds every playlist
+/// but measured values only for the ones that scan named, and one from
+/// [`inspect_files`] holds none at all, so both print the rest at zero.
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+#[must_use]
+pub fn render_report(
+    disc: Disc,
+    stream_diagnostics: Option<bool>,
+    quick_summary: Option<bool>,
+) -> String {
+    let (bdrom, errors) = disc.into_scan();
+    let order = bdrom.presentation_order(&PlaylistFilter::default());
+    text::render_with(&bdrom, &order, &errors, render_options(stream_diagnostics, quick_summary))
+}
+
+/// The measured-scan entry point returning both outputs: a
+/// `webkitdirectory`-selected BDMV folder in, the classic report **and** the
+/// scanned [`Disc`] out.
+///
+/// Runs exactly the scan [`scan_files`] runs — one M2TS demux, the same
+/// per-stream and per-chapter statistics — and derives both results from it, so
+/// a consumer that wants the report and the model never reads a multi-GB disc
+/// twice. `paths`, `files`, `selection` and `on_progress` behave as they do
+/// there; `stream_diagnostics` and `quick_summary` choose the optional report
+/// sections, and omitting them renders every section.
+///
+/// `result.disc.measured` is true: this scan measured the values, so a zero in
+/// it is a genuine zero. Re-render `result.disc` with other sections through
+/// [`render_report`] without scanning again.
+///
+/// # Errors
+/// As [`scan_files`].
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn scan_files_full(
+    paths: Vec<String>,
+    files: js_sys::Array,
+    selection: Vec<String>,
+    on_progress: Option<js_sys::Function>,
+    stream_diagnostics: Option<bool>,
+    quick_summary: Option<bool>,
+) -> Result<ScanResult, JsValue> {
+    let root = build_web_tree(&paths, &files)?;
+    let mut observe = |p: ScanProgress<'_>| notify(on_progress.as_ref(), &p);
+    let scan = scan_root(&root, &selection, &mut observe)?;
+    Ok(measured_result(&scan, render_options(stream_diagnostics, quick_summary)))
+}
+
+/// The measured-scan `.iso` entry point returning both outputs: a single
+/// OS-picked Blu-ray `.iso` `File` in, the classic report **and** the scanned
+/// [`Disc`] out.
+///
+/// Opens the image through the core read-only UDF 2.50 reader ([`UdfSource`])
+/// instead of a `(relativePath, File)` list, then behaves exactly as
+/// [`scan_files_full`] — one demux, both results.
+///
+/// # Errors
+/// As [`scan_iso`].
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn scan_iso_full(
+    file: web_sys::File,
+    selection: Vec<String>,
+    on_progress: Option<js_sys::Function>,
+    stream_diagnostics: Option<bool>,
+    quick_summary: Option<bool>,
+) -> Result<ScanResult, JsValue> {
+    let length = file.size() as u64;
+    let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
+        .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
+    let scan = scan_root(&source.root(), &selection, &mut |p| notify(on_progress.as_ref(), &p))?;
+    Ok(measured_result(&scan, render_options(stream_diagnostics, quick_summary)))
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::{self, SeekFrom};
 
     use super::{
-        MAX_TREE_DEPTH, TreeError, assemble_tree, extension_of, glob_match, path_components,
-        read_window, seek_target, split_sections,
+        MAX_TREE_DEPTH, RenderOptions, TreeError, assemble_tree, extension_of, glob_match,
+        path_components, read_window, seek_target, split_sections,
     };
 
     /// Parses path strings into the `(components, id)` entries `assemble_tree`
@@ -1495,7 +1658,8 @@ mod tests {
             blob.extend_from_slice(&(section.len() as u32).to_be_bytes());
             blob.extend_from_slice(section);
         }
-        let framed = render_disc(&build_tree(&blob), &mut |_| {}).expect("framed render");
+        let framed = render_disc(&build_tree(&blob), RenderOptions::default(), &mut |_| {})
+            .expect("framed render");
 
         // The same disc handed over as a `webkitdirectory` pick of the BDMV
         // folder itself: the wrapper root makes it render identically.
@@ -1517,7 +1681,8 @@ mod tests {
                 .collect(),
         )
         .expect("assemble the BDMV-rooted selection");
-        let from_bdmv = render_disc(&tree, &mut |_| {}).expect("BDMV-rooted render");
+        let from_bdmv =
+            render_disc(&tree, RenderOptions::default(), &mut |_| {}).expect("BDMV-rooted render");
 
         assert_eq!(framed, from_bdmv, "a BDMV-rooted pick must render like the canonical framing");
     }
@@ -1570,7 +1735,7 @@ mod tests {
                 .collect(),
         )
         .expect("assemble the two-playlist disc");
-        let report = render_disc(&tree, &mut |_| {}).expect("render");
+        let report = render_disc(&tree, RenderOptions::default(), &mut |_| {}).expect("render");
 
         assert!(report.contains("00000.MPLS"), "the 30s feature playlist must be kept");
         assert!(
@@ -1678,9 +1843,46 @@ mod tests {
         // unopenable tree (no BDMV/CLIPINF/PLAYLIST) then makes render_disc hit
         // the `?` early-return, the arm the parity `Ok` flow never reaches.
         let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
-        render_disc(&build_tree(&fixture_blob()), &mut sink).expect("the fixture opens");
+        render_disc(&build_tree(&fixture_blob()), RenderOptions::default(), &mut sink)
+            .expect("the fixture opens");
         let empty: Node<MemFile> = Node::dir("EMPTY", "EMPTY");
-        assert!(render_disc(&empty, &mut sink).is_err());
+        assert!(render_disc(&empty, RenderOptions::default(), &mut sink).is_err());
+    }
+
+    #[test]
+    fn one_measured_scan_yields_both_the_report_and_the_disc() {
+        use bdinfo_rs_core::bdrom::disc::ScanProgress;
+
+        use super::{build_tree, measured_result, scan_whole};
+
+        /// The pinned report for the fixture disc — what the report-only
+        /// exports render from the same scan.
+        const GOLDEN: &[u8] = include_bytes!("../tests/golden_report.txt");
+
+        let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
+        let scan = scan_whole(&build_tree(&fixture_blob()), &mut sink).expect("the fixture opens");
+        // One scan, both outputs: the report is the pinned bytes and the disc
+        // is the same scan mirrored, neither derived from the other.
+        let result = measured_result(&scan, RenderOptions::default());
+        assert_eq!(result.report.as_bytes(), GOLDEN);
+        assert!(result.disc.measured, "the packet scan ran, so the values were measured");
+        assert_eq!(result.disc.volume_label, "WASMDISC");
+    }
+
+    #[test]
+    fn an_omitted_report_option_leaves_its_section_on() {
+        use super::render_options;
+
+        assert_eq!(render_options(None, None), RenderOptions::default());
+        assert_eq!(
+            render_options(Some(false), None),
+            RenderOptions { stream_diagnostics: false, quick_summary: true }
+        );
+        assert_eq!(
+            render_options(None, Some(false)),
+            RenderOptions { stream_diagnostics: true, quick_summary: false }
+        );
+        assert_eq!(render_options(Some(true), Some(true)), RenderOptions::default());
     }
 
     #[test]
@@ -2140,12 +2342,13 @@ mod tests {
         }
 
         #[test]
-        fn render_selection_measures_only_the_named_playlists() {
+        fn scan_selection_measures_only_the_named_playlists() {
             use std::sync::Arc;
 
             use bdinfo_rs_core::bdrom::disc::ScanProgress;
+            use bdinfo_rs_core::report::text::RenderOptions;
 
-            use crate::{MemFile, Node, assemble_tree, path_components, render_selection};
+            use crate::{MemFile, Node, assemble_tree, path_components, scan_selection};
 
             const INDEX: &[u8] =
                 include_bytes!("../../bdinfo-rs/tests/fixtures/BigBuckBunny/BDMV/index.bdmv");
@@ -2200,17 +2403,20 @@ mod tests {
             // over the progress lifetime; the real demux below drives it (so it
             // is covered), and the unopenable case reuses it without firing it.
             let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
+            let whole = RenderOptions::default();
 
             // Selecting only the feature renders it and drops the short sibling.
-            let feature = render_selection(&tree, &["00000.MPLS".to_owned()], &mut sink)
-                .expect("render the feature");
+            let feature = scan_selection(&tree, &["00000.MPLS".to_owned()], &mut sink)
+                .expect("scan the feature")
+                .render(whole);
             assert!(feature.contains("00000.MPLS"), "the selected feature must be rendered");
             assert!(!feature.contains("00001.MPLS"), "an unselected playlist must not be rendered");
 
             // Selecting the short playlist by name keeps it — unfiltered, unlike
             // `--whole`; and only the named playlist is rendered.
-            let short_only = render_selection(&tree, &["00001".to_owned()], &mut sink)
-                .expect("render the short");
+            let short_only = scan_selection(&tree, &["00001".to_owned()], &mut sink)
+                .expect("scan the short")
+                .render(whole);
             assert!(short_only.contains("00001.MPLS"), "a by-name short playlist is kept");
             assert!(!short_only.contains("00000.MPLS"), "only the named playlist is rendered");
 
@@ -2218,7 +2424,7 @@ mod tests {
             // formatted through SelectionError's Display (the same text the wasm
             // `scan_files` export emits — which is what reads the inner error).
             let empty: Node<MemFile> = Node::dir("EMPTY", "EMPTY");
-            let open_err = render_selection(&empty, &["00000.MPLS".to_owned()], &mut sink)
+            let open_err = scan_selection(&empty, &["00000.MPLS".to_owned()], &mut sink)
                 .expect_err("a structure with no BDMV must error");
             assert!(
                 open_err.to_string().starts_with("no readable Blu-ray structure"),
@@ -2227,7 +2433,7 @@ mod tests {
 
             // A non-empty selection that names no playlist on the disc errors like
             // the CLI's `--mpls`, rather than rendering a header-only report.
-            let no_match = render_selection(&tree, &["99999.MPLS".to_owned()], &mut sink)
+            let no_match = scan_selection(&tree, &["99999.MPLS".to_owned()], &mut sink)
                 .expect_err("an all-unknown selection must error");
             assert_eq!(no_match.to_string(), "No matching playlists found on BD");
         }

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -71,6 +71,11 @@ use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::{JsCast, JsValue};
 
+// The structured disc model handed to JavaScript. `pub` because its types are
+// the published API surface: `tsify` emits their TypeScript declarations into
+// the generated `.d.ts`, which the npm package exposes at its `/wasm` subpath.
+pub mod mirror;
+
 /// The read-ahead window each [`WebReader`] fill pulls from `FileReaderSync` in
 /// one go, so a front-to-back demux crosses the JS boundary once per MiB rather
 /// than once per small parser read.

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -76,6 +76,10 @@ use wasm_bindgen::{JsCast, JsValue};
 // the generated `.d.ts`, which the npm package exposes at its `/wasm` subpath.
 pub mod mirror;
 
+// Named by the browser exports that return the disc model, and by their docs.
+#[cfg(target_arch = "wasm32")]
+use mirror::Disc;
+
 /// The read-ahead window each [`WebReader`] fill pulls from `FileReaderSync` in
 /// one go, so a front-to-back demux crosses the JS boundary once per MiB rather
 /// than once per small parser read.
@@ -748,12 +752,23 @@ fn table_rows(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> Vec<(us
 /// switched off by its option. An absent option (`None`) means `false` — the
 /// rule stays on — so a call that passes neither option lists exactly the set
 /// the CLI's plain `--list` prints.
+///
+/// `short_seconds` sets the length under which a playlist counts as short. An
+/// absent or non-positive value means the 20 s default, so a caller that does
+/// not care about the threshold passes `None` and gets the standard behaviour.
 #[cfg(any(target_arch = "wasm32", test))]
-fn listing_filter(show_short: Option<bool>, show_looping: Option<bool>) -> PlaylistFilter {
+fn listing_filter(
+    show_short: Option<bool>,
+    show_looping: Option<bool>,
+    short_seconds: Option<f64>,
+) -> PlaylistFilter {
+    let standard = PlaylistFilter::default();
     PlaylistFilter {
         filter_short_playlists: !show_short.unwrap_or(false),
         filter_looping_playlists: !show_looping.unwrap_or(false),
-        ..PlaylistFilter::default()
+        short_playlist_seconds: short_seconds
+            .filter(|seconds| *seconds > 0.0)
+            .unwrap_or(standard.short_playlist_seconds),
     }
 }
 
@@ -1211,7 +1226,7 @@ pub fn list_playlists(
     let root = build_web_tree(&paths, &files)?;
     let report = BdRom::open_resilient(&root, ScanMode::Metadata)
         .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
-    let filter = listing_filter(show_short_playlists, show_looping_playlists);
+    let filter = listing_filter(show_short_playlists, show_looping_playlists, None);
     Ok(rows_to_json(&playlist_rows(&report.bdrom.playlists, &filter)))
 }
 
@@ -1240,8 +1255,77 @@ pub fn list_iso_playlists(
         .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
     let report = BdRom::open_resilient(&source.root(), ScanMode::Metadata)
         .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
-    let filter = listing_filter(show_short_playlists, show_looping_playlists);
+    let filter = listing_filter(show_short_playlists, show_looping_playlists, None);
     Ok(rows_to_json(&playlist_rows(&report.bdrom.playlists, &filter)))
+}
+
+/// The structural-scan entry point for the whole disc model: a
+/// `webkitdirectory`-selected BDMV folder in, a [`Disc`] out.
+///
+/// Runs the same **structural** scan [`list_playlists`] runs — no packet demux,
+/// so it reads the playlist and clip metadata rather than the multi-GB stream
+/// files — and returns the whole scanned model rather than the seven columns of
+/// a selection table. Every value a listing row carries is reachable from it,
+/// and so is everything the report prints that a metadata scan can know.
+///
+/// `disc.measured` is false: the bitrates, packet counts and chapter rates are
+/// zero because nothing measured them.
+///
+/// `show_short_playlists` / `show_looping_playlists` select which playlists
+/// `disc.playlists` holds, exactly as they select which rows
+/// [`list_playlists`] returns; the disc-level properties and the recorded
+/// failures are never filtered. `short_playlist_seconds` sets the length under
+/// which a playlist counts as short — absent or non-positive means the 20 s
+/// default. Passing both options widens the result to the whole disc, which is
+/// what lets a caller scan once and apply either rule to the playlists itself.
+///
+/// # Errors
+/// As [`scan_files`]: `paths`/`files` length mismatch, a non-`File` entry, an
+/// incoherent selection, or no readable Blu-ray structure.
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn inspect_files(
+    paths: Vec<String>,
+    files: js_sys::Array,
+    show_short_playlists: Option<bool>,
+    show_looping_playlists: Option<bool>,
+    short_playlist_seconds: Option<f64>,
+) -> Result<Disc, JsValue> {
+    let root = build_web_tree(&paths, &files)?;
+    let report = BdRom::open_resilient(&root, ScanMode::Metadata)
+        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
+    let filter =
+        listing_filter(show_short_playlists, show_looping_playlists, short_playlist_seconds);
+    Ok(Disc::from_listing(&report.bdrom, &report.errors, &filter))
+}
+
+/// The structural-scan `.iso` entry point for the whole disc model: a single
+/// OS-picked Blu-ray `.iso` `File` in, a [`Disc`] out.
+///
+/// Opens the image through the core read-only UDF 2.50 reader ([`UdfSource`])
+/// instead of a `(relativePath, File)` list, then behaves exactly as
+/// [`inspect_files`] — same structural scan, same `measured: false`, same
+/// meaning for the three filter parameters.
+///
+/// # Errors
+/// Returns a `JsValue` if the image is not a readable UDF `.iso`, or holds no
+/// readable Blu-ray structure.
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn inspect_iso(
+    file: web_sys::File,
+    show_short_playlists: Option<bool>,
+    show_looping_playlists: Option<bool>,
+    short_playlist_seconds: Option<f64>,
+) -> Result<Disc, JsValue> {
+    let length = file.size() as u64;
+    let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
+        .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
+    let report = BdRom::open_resilient(&source.root(), ScanMode::Metadata)
+        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
+    let filter =
+        listing_filter(show_short_playlists, show_looping_playlists, short_playlist_seconds);
+    Ok(Disc::from_listing(&report.bdrom, &report.errors, &filter))
 }
 
 #[cfg(test)]
@@ -1261,7 +1345,10 @@ mod tests {
 
     /// The committed Big Buck Bunny fixture framed into the six `u32`-BE sections
     /// the in-memory path expects (the bytes the parity golden is built from).
-    fn fixture_blob() -> Vec<u8> {
+    ///
+    /// Reached from the mirror's mapping tests too, which scan the same
+    /// fixture — hence `pub` inside this private module.
+    pub fn fixture_blob() -> Vec<u8> {
         const INDEX: &[u8] =
             include_bytes!("../../bdinfo-rs/tests/fixtures/BigBuckBunny/BDMV/index.bdmv");
         const MOVIE: &[u8] =
@@ -1799,7 +1886,7 @@ mod tests {
                 (Some(true), Some(true), false, false),
             ] {
                 assert_eq!(
-                    listing_filter(show_short, show_looping),
+                    listing_filter(show_short, show_looping, None),
                     PlaylistFilter {
                         filter_short_playlists: short_on,
                         filter_looping_playlists: looping_on,
@@ -1808,6 +1895,56 @@ mod tests {
                     "{show_short:?} / {show_looping:?}"
                 );
             }
+        }
+
+        #[test]
+        fn listing_filter_takes_the_threshold_and_falls_back_to_twenty_seconds() {
+            // A positive threshold is used as given; anything else — absent,
+            // zero, negative, NaN — leaves the default 20 s in force, so the
+            // pre-threshold behaviour stays reachable. Whole filters are
+            // compared so the two switches are pinned as untouched too.
+            for (short_seconds, in_force) in [
+                (Some(5.0), 5.0),
+                (Some(0.5), 0.5),
+                (None, 20.0),
+                (Some(0.0), 20.0),
+                (Some(-1.0), 20.0),
+                (Some(f64::NAN), 20.0),
+            ] {
+                assert_eq!(
+                    listing_filter(None, None, short_seconds),
+                    PlaylistFilter {
+                        filter_short_playlists: true,
+                        filter_looping_playlists: true,
+                        short_playlist_seconds: in_force,
+                    },
+                    "{short_seconds:?}"
+                );
+            }
+            assert_eq!(
+                listing_filter(Some(true), None, Some(5.0)),
+                PlaylistFilter {
+                    filter_short_playlists: false,
+                    filter_looping_playlists: true,
+                    short_playlist_seconds: 5.0,
+                }
+            );
+        }
+
+        #[test]
+        fn a_lowered_threshold_lists_and_reclassifies_the_playlists_between_it_and_the_default() {
+            // 00002 is 5 s: the default 20 s threshold withholds it and names it
+            // short, a 5 s threshold lists it and names no rule.
+            let playlists = mixed_disc();
+            let default = listing_filter(None, None, None);
+            let lowered = listing_filter(None, None, Some(5.0));
+            assert_eq!(listed(&playlists, &default), ["00000.MPLS"]);
+            assert_eq!(listed(&playlists, &lowered), ["00000.MPLS", "00002.MPLS"]);
+            assert_eq!(hidden_by(&playlists[2], &default), ["short"]);
+            assert!(hidden_by(&playlists[2], &lowered).is_empty());
+            // The looping rule is untouched by the threshold: 00003 is 5 s and
+            // looping, so it stays withheld and still names only `looping`.
+            assert_eq!(hidden_by(&playlists[3], &lowered), ["looping"]);
         }
 
         #[test]
@@ -1829,7 +1966,7 @@ mod tests {
             // The classification reads the rules, not the switches: a row listed
             // only because its option was passed still names the rule that would
             // have withheld it — the field a client re-filters on.
-            let widened = listing_filter(Some(true), Some(true));
+            let widened = listing_filter(Some(true), Some(true), None);
             let rows = playlist_rows(&mixed_disc(), &widened);
             let view: Vec<(&str, &[&str])> =
                 rows.iter().map(|row| (row.name.as_str(), row.hidden_by.as_slice())).collect();
@@ -1848,20 +1985,20 @@ mod tests {
         fn each_option_widens_the_listing_by_its_own_rule() {
             let playlists = mixed_disc();
             // The standard set lists neither the looping nor the short playlist.
-            assert_eq!(listed(&playlists, &listing_filter(None, None)), ["00000.MPLS"]);
+            assert_eq!(listed(&playlists, &listing_filter(None, None, None)), ["00000.MPLS"]);
             // Showing short playlists reveals the short one but NOT the playlist
             // that is short *and* looping — the rules are independent.
             assert_eq!(
-                listed(&playlists, &listing_filter(Some(true), None)),
+                listed(&playlists, &listing_filter(Some(true), None, None)),
                 ["00000.MPLS", "00002.MPLS"]
             );
             assert_eq!(
-                listed(&playlists, &listing_filter(None, Some(true))),
+                listed(&playlists, &listing_filter(None, Some(true), None)),
                 ["00001.MPLS", "00000.MPLS"]
             );
             // Both options list the whole disc, longest first.
             assert_eq!(
-                listed(&playlists, &listing_filter(Some(true), Some(true))),
+                listed(&playlists, &listing_filter(Some(true), Some(true), None)),
                 ["00001.MPLS", "00000.MPLS", "00002.MPLS", "00003.MPLS"]
             );
         }

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -198,7 +198,7 @@ struct MemFile {
 
 impl BdFile for MemFile {
     fn name(&self) -> &str {
-        "xyzzy" /* ~ changed by cargo-mutants ~ */
+        &self.name
     }
 
     fn full_name(&self) -> &str {

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -41,11 +41,17 @@
 //! * The doc comment of an **enum variant** is dropped. What a consumer must know to use
 //!   [`ScanStage`] or [`ScanErrorReason`] therefore belongs on the enum itself.
 //!
-//! ## Building one
+//! ## Building one, and taking it apart again
 //!
 //! [`Disc::from_scan`] mirrors a whole scanned disc and [`Disc::from_listing`] mirrors one as a
 //! filtered playlist listing; every other type here is reached through a [`From`] impl those two
-//! walk.
+//! walk. [`Disc::into_scan`] goes back the other way, rebuilding the [`BdRom`] and the recorded
+//! failures so the report can be rendered from a mirror alone.
+//!
+//! [`ScanResult`] is the one type here with no counterpart in the model: it pairs a rendered
+//! report with the [`Disc`] it was rendered beside, for a scan that returns both.
+
+use std::io;
 
 use bdinfo_rs_core::bdrom::chapters::ChapterSummary;
 use bdinfo_rs_core::bdrom::disc::{
@@ -53,16 +59,37 @@ use bdinfo_rs_core::bdrom::disc::{
 };
 use bdinfo_rs_core::bdrom::order::PlaylistFilter;
 use bdinfo_rs_core::error;
+use bdinfo_rs_core::primitives::Pid;
+use bdinfo_rs_core::stream::TsStreamType;
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
+
+/// What one measured scan produced: the classic report, and the same scan as
+/// structured data.
+///
+/// Both come from a single pass over the media, so a consumer that wants the
+/// report and the model never has to read the disc twice. Neither is derived
+/// from the other: the report is rendered straight from the scan, and the disc
+/// mirrors that same scan.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[tsify(into_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanResult {
+    /// The classic disc report, rendered with the sections the scan was asked
+    /// for.
+    pub report: String,
+    /// The scanned disc, with `measured` true.
+    pub disc: Disc,
+}
 
 /// A scanned Blu-ray disc: the disc-level properties and every playlist on it.
 // `into_wasm_abi` is what lets an export return a `Disc` by value: it implements
 // wasm-bindgen's `IntoWasmAbi` over `serde_wasm_bindgen`, so the value crosses as a real
-// JavaScript object. Only the type an export names needs it; the types below are reached
+// JavaScript object. `from_wasm_abi` is its inverse, letting an export take one back as a
+// parameter. Only the type an export names needs them; the types below are reached
 // through this one.
 #[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[tsify(into_wasm_abi)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 #[expect(
     clippy::struct_excessive_bools,
@@ -412,8 +439,10 @@ pub enum ScanErrorReason {
     /// whole-scan abort rather than a per-file failure, so it reaches a
     /// recorded failure only if one is fabricated. And any failure kind added
     /// to the scanner after this mirror was written, since the set of kinds is
-    /// open. This is the one member a rebuilt disc cannot render back exactly,
-    /// so a kind that starts occurring in earnest wants a member of its own.
+    /// open. This is the one member whose message a rebuilt disc does not carry
+    /// back: it rebuilds as the cancelled-scan failure, the only kind that
+    /// reaches it today, so a kind that starts occurring in earnest wants a
+    /// member of its own.
     #[serde(rename_all = "camelCase")]
     Other {
         /// What the failure reported.
@@ -632,6 +661,234 @@ impl From<&error::BdError> for ScanErrorReason {
     }
 }
 
+// ── the reverse mapping: the mirror back into a scanned disc ────────────────
+//
+// The inverse of the forward mapping above, one `From` impl per type, so a disc
+// that crossed to JavaScript as data can be handed back to the report renderer.
+// Every core summary type is a struct of public fields with no
+// `#[non_exhaustive]`, so all but three kinds of field invert by plain
+// assignment. The exceptions are the packet identifier and the
+// elementary-stream type, both rebuilt from the raw number the disc records,
+// and the alternate codec name, matched back to the borrowed label the scan
+// hands out (see `borrowed_codec_alt_name`).
+//
+// The impls consume the mirror rather than borrowing it: every string moves
+// straight into the summary it belongs to, so rebuilding a disc copies none of
+// its text.
+
+/// Every alternate codec label a scan hands out, so an owned copy of one can be
+/// matched back to the borrowed original. Kept in the order
+/// [`codec_alt_name`](bdinfo_rs_core::stream::TsStream::codec_alt_name) spells
+/// them: by stream type, with the three Dolby/DTS labels that upgrade when the
+/// audio stream carries its extensions listed beside the plain form.
+const CODEC_ALT_NAMES: &[&str] = &[
+    "MPEG-1",
+    "MPEG-2",
+    "AVC",
+    "MVC",
+    "HEVC",
+    "VC-1",
+    "MP1",
+    "MP2",
+    "MPEG-2 AAC",
+    "MPEG-4 AAC",
+    "LPCM",
+    "DD AC3",
+    "DD AC3+",
+    "Dolby TrueHD",
+    "Dolby Atmos",
+    "DTS",
+    "DTS-HD Hi-Res",
+    "DTS:X Hi-Res",
+    "DTS Express",
+    "DTS-HD Master",
+    "DTS:X Master",
+    "PGS",
+    "IGS",
+    "SUB",
+    "UNKNOWN",
+];
+
+/// The borrowed alternate codec label equal to `name`, or the empty label when
+/// no scan hands that name out.
+///
+/// [`Stream`] mirrors the label as an owned string and a [`StreamSummary`]
+/// needs the borrowed form back, which no runtime string can become. The labels
+/// are a closed set, so the way back is to match `name` against it. A name
+/// outside the set can only reach here from a mirror a consumer edited, and
+/// rebuilds as the empty label — which the report prints as an empty cell,
+/// rather than as some name a scan never emits.
+fn borrowed_codec_alt_name(name: &str) -> &'static str {
+    CODEC_ALT_NAMES.iter().copied().find(|known| *known == name).unwrap_or("")
+}
+
+impl Disc {
+    /// Rebuilds the disc this mirror describes: the [`BdRom`] and the per-file
+    /// failures, the two halves a report is rendered from.
+    ///
+    /// The inverse of [`from_scan`](Self::from_scan) but for `measured`, which
+    /// describes how the values were obtained rather than being one of them —
+    /// a disc carries no such flag, so it is dropped here.
+    #[must_use]
+    pub fn into_scan(self) -> (BdRom, Vec<error::ScanError>) {
+        let bdrom = BdRom {
+            volume_label: self.volume_label,
+            disc_title: self.disc_title,
+            size: self.size_bytes,
+            interleaved_size: self.interleaved_size_bytes,
+            is_3d: self.is_3d,
+            is_50hz: self.is_50hz,
+            is_uhd: self.is_uhd,
+            is_bd_plus: self.is_bd_plus,
+            is_bd_java: self.is_bd_java,
+            is_dbox: self.is_dbox,
+            is_psp: self.is_psp,
+            playlists: self.playlists.into_iter().map(PlaylistSummary::from).collect(),
+        };
+        (bdrom, self.errors.into_iter().map(error::ScanError::from).collect())
+    }
+}
+
+impl From<Playlist> for PlaylistSummary {
+    fn from(playlist: Playlist) -> Self {
+        Self {
+            name: playlist.name,
+            total_length: playlist.total_length_seconds,
+            file_size: playlist.file_size_bytes,
+            interleaved_file_size: playlist.interleaved_file_size_bytes,
+            chapter_count: playlist.chapter_count,
+            stream_count: playlist.stream_count,
+            angle_count: playlist.angle_count,
+            has_loops: playlist.has_loops,
+            streams: playlist.streams.into_iter().map(StreamSummary::from).collect(),
+            clips: playlist.clips.into_iter().map(ClipSummary::from).collect(),
+            chapters: playlist.chapters.into_iter().map(ChapterSummary::from).collect(),
+        }
+    }
+}
+
+impl From<Clip> for ClipSummary {
+    fn from(clip: Clip) -> Self {
+        Self {
+            name: clip.name,
+            display_name: clip.display_name,
+            file_size: clip.file_size_bytes,
+            interleaved_file_size: clip.interleaved_file_size_bytes,
+            angle_index: clip.angle_index,
+            relative_time_in: clip.relative_time_in_seconds,
+            length: clip.length_seconds,
+            payload_bytes: clip.payload_bytes,
+            packet_count: clip.packet_count,
+            packet_seconds: clip.packet_seconds,
+            file_seconds: clip.file_seconds,
+            streams: clip.streams.into_iter().map(ClipStreamTally::from).collect(),
+        }
+    }
+}
+
+impl From<ClipStream> for ClipStreamTally {
+    fn from(tally: ClipStream) -> Self {
+        Self {
+            pid: Pid::new(tally.pid),
+            stream_type: TsStreamType::from_u8(tally.stream_type),
+            codec_short_name: tally.codec_short_name,
+            payload_bytes: tally.payload_bytes,
+            packet_count: tally.packet_count,
+        }
+    }
+}
+
+impl From<Stream> for StreamSummary {
+    fn from(stream: Stream) -> Self {
+        Self {
+            pid: Pid::new(stream.pid),
+            // The inverse of the discriminant cast the forward mapping makes:
+            // `from_u8` reads the same on-disc `stream_coding_type` byte back,
+            // and a byte no stream type claims reads as `Unknown`.
+            stream_type: TsStreamType::from_u8(stream.stream_type),
+            codec_short_name: stream.codec_short_name,
+            codec_name: stream.codec_name,
+            codec_alt_name: borrowed_codec_alt_name(&stream.codec_alt_name),
+            bitrate: stream.bitrate_bps,
+            active_bitrate: stream.active_bitrate_bps,
+            language_name: stream.language_name,
+            language_code: stream.language_code,
+            description: stream.description,
+            full_description: stream.full_description,
+            channel_description: stream.channel_description,
+            sample_rate: stream.sample_rate_hz,
+            bit_depth: stream.bit_depth,
+            channel_count: stream.channel_count,
+            height: stream.height_pixels,
+            angle_index: stream.angle_index,
+            is_hidden: stream.is_hidden,
+            ssif_only: stream.ssif_only,
+        }
+    }
+}
+
+impl From<Chapter> for ChapterSummary {
+    fn from(chapter: Chapter) -> Self {
+        Self {
+            time_in: chapter.time_in_seconds,
+            length: chapter.length_seconds,
+            avg_rate: chapter.avg_rate_bps,
+            max_1sec_rate: chapter.max_1sec_rate_bps,
+            max_1sec_time: chapter.max_1sec_time_seconds,
+            max_5sec_rate: chapter.max_5sec_rate_bps,
+            max_5sec_time: chapter.max_5sec_time_seconds,
+            max_10sec_rate: chapter.max_10sec_rate_bps,
+            max_10sec_time: chapter.max_10sec_time_seconds,
+            avg_frame_size: chapter.avg_frame_size_bytes,
+            max_frame_size: chapter.max_frame_size_bytes,
+            max_frame_time: chapter.max_frame_time_seconds,
+        }
+    }
+}
+
+impl From<ScanError> for error::ScanError {
+    fn from(failure: ScanError) -> Self {
+        Self { file: failure.file, stage: failure.stage.into(), reason: failure.reason.into() }
+    }
+}
+
+impl From<ScanStage> for error::ScanStage {
+    fn from(stage: ScanStage) -> Self {
+        match stage {
+            ScanStage::Discovery => Self::Discovery,
+            ScanStage::ClipInfo => Self::ClipInfo,
+            ScanStage::Playlist => Self::Playlist,
+            ScanStage::StreamFile => Self::StreamFile,
+            ScanStage::SectorRead => Self::SectorRead,
+        }
+    }
+}
+
+impl From<ScanErrorReason> for error::BdError {
+    fn from(reason: ScanErrorReason) -> Self {
+        match reason {
+            ScanErrorReason::UnknownFileType { magic } => Self::UnknownFileType(magic),
+            ScanErrorReason::UnexpectedEof => Self::UnexpectedEof,
+            ScanErrorReason::StructureNotFound => Self::StructureNotFound,
+            ScanErrorReason::MissingClipFile { file } => Self::MissingClipFile(file),
+            // The message is the wrapped `io::Error`'s, so it goes back inside a
+            // fresh one: the `io error: ` framing the report prints comes from
+            // the `BdError` around it, and the original `io::ErrorKind` is not
+            // mirrored because nothing prints it.
+            ScanErrorReason::Io { message } => Self::Io(io::Error::other(message)),
+            ScanErrorReason::MetadataTooLarge { file, limit_bytes } => {
+                Self::MetadataTooLarge { file, limit: limit_bytes }
+            }
+            // The catch-all mirrors a cancelled scan and nothing else today, and
+            // that is the failure it rebuilds as — carrying its own message back
+            // exactly. Another kind mirrored here would arrive with the
+            // cancelled-scan message instead, which is why one that starts
+            // occurring wants a member of its own.
+            ScanErrorReason::Other { .. } => Self::ScanCancelled,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io;
@@ -643,11 +900,13 @@ mod tests {
     use bdinfo_rs_core::bdrom::order::PlaylistFilter;
     use bdinfo_rs_core::error;
     use bdinfo_rs_core::primitives::Pid;
-    use bdinfo_rs_core::stream::TsStreamType;
+    use bdinfo_rs_core::report::text::{self, RenderOptions};
+    use bdinfo_rs_core::stream::{TsAudioStream, TsStream, TsStreamType};
     use serde_json::{Value, json};
 
     use super::{
         Chapter, Clip, ClipStream, Disc, Playlist, ScanError, ScanErrorReason, ScanStage, Stream,
+        borrowed_codec_alt_name,
     };
 
     // One fixture value and one hand-written wire form per mirror type, composed
@@ -1265,5 +1524,247 @@ mod tests {
         assert_eq!(playlist.clips.iter().map(|clip| clip.packet_count).sum::<u64>(), 0);
         assert!(playlist.streams.iter().all(|stream| stream.bitrate_bps == 0));
         assert!(playlist.chapters.iter().all(|chapter| chapter.max_1sec_rate_bps == 0.0));
+    }
+
+    // ── the reverse mapping ─────────────────────────────────────────────────
+    //
+    // Asserted against the same paired fixtures, in the other direction: a
+    // mirror rebuilds into the core value it was written to mirror. The two
+    // failure types core uses carry no `PartialEq`, so those are asserted on
+    // the text the report prints from them, which is all a report reads.
+
+    #[test]
+    fn every_field_of_a_mirror_rebuilds_into_the_disc_it_mirrors() {
+        assert_eq!(a_disc().into_scan().0, a_core_bdrom());
+    }
+
+    #[test]
+    fn a_rebuilt_failure_names_the_same_file_stage_and_reason() {
+        let (_, errors) = a_disc().into_scan();
+        assert_eq!(errors.len(), 1);
+        let failure = errors.first().expect("the mirrored failure");
+        assert_eq!(failure.file, "00002.CLPI");
+        assert_eq!(failure.stage, error::ScanStage::ClipInfo);
+        assert_eq!(failure.reason.to_string(), "unknown file type: HDMV9999");
+    }
+
+    #[test]
+    fn every_scan_stage_survives_the_round_trip() {
+        for stage in [
+            error::ScanStage::Discovery,
+            error::ScanStage::ClipInfo,
+            error::ScanStage::Playlist,
+            error::ScanStage::StreamFile,
+            error::ScanStage::SectorRead,
+        ] {
+            assert_eq!(error::ScanStage::from(ScanStage::from(stage)), stage, "{stage:?}");
+        }
+    }
+
+    #[test]
+    fn every_failure_kind_round_trips_to_the_message_the_report_prints() {
+        // The report prints a failure as its file and the text of its reason,
+        // so carrying that text across and back unchanged is what losslessness
+        // means here. The cancelled scan is the kind the mirror has no member
+        // for: it crosses as the catch-all and comes back as itself.
+        for reason in [
+            error::BdError::UnknownFileType("MPLSXXXX".to_owned()),
+            error::BdError::UnexpectedEof,
+            error::BdError::StructureNotFound,
+            error::BdError::MissingClipFile("00003.CLPI".to_owned()),
+            error::BdError::Io(io::Error::other("denied")),
+            error::BdError::MetadataTooLarge { file: "00000.MPLS".to_owned(), limit: 67_108_864 },
+            error::BdError::ScanCancelled,
+        ] {
+            let printed = reason.to_string();
+            let rebuilt = error::BdError::from(ScanErrorReason::from(&reason));
+            assert_eq!(rebuilt.to_string(), printed, "{reason}");
+        }
+    }
+
+    #[test]
+    fn every_alternate_codec_name_a_scan_hands_out_is_matched_back() {
+        // Every stream type a disc can record, each with and without the codec
+        // extensions that upgrade three of the labels — the whole set
+        // `TsStream::codec_alt_name` returns. The stream is built as audio
+        // because only audio carries extensions; the label is keyed by the
+        // stream type either way. A label `bdinfo_rs_core` adds later fails
+        // here, rather than silently rebuilding as the empty cell.
+        for byte in 0..=u8::MAX {
+            for has_extensions in [false, true] {
+                // The stream type is assigned rather than named in the literal:
+                // `TsStreamBase` keeps one private field, so it cannot be built
+                // by struct literal from outside `bdinfo_rs_core`.
+                let mut audio = TsAudioStream { has_extensions, ..TsAudioStream::default() };
+                audio.base.stream_type = TsStreamType::from_u8(byte);
+                let name = TsStream::Audio(audio).codec_alt_name();
+                assert_eq!(borrowed_codec_alt_name(name), name, "byte {byte:#04X}");
+            }
+        }
+        // A name no scan hands out — only a hand-edited mirror can carry one —
+        // rebuilds as the empty label rather than as something plausible.
+        assert_eq!(borrowed_codec_alt_name("Nonesuch"), "");
+    }
+
+    // ── the round trip ──────────────────────────────────────────────────────
+    //
+    // The mirror claims to carry every fact the report prints. These prove it:
+    // the fixture disc is scanned, mirrored, rebuilt from the mirror alone, and
+    // rendered — and the bytes must be the pinned report. A field the mirror
+    // stops carrying shows up here as a byte mismatch on the day it lands.
+
+    /// The pinned report for the fixture disc — the same bytes the whole-disc
+    /// scan renders, kept verbatim by the `-text` `.gitattributes` rule.
+    const GOLDEN: &[u8] = include_bytes!("../tests/golden_report.txt");
+
+    /// The whole line byte `offset` falls on, as lossy text — the context for a
+    /// byte-level difference.
+    fn line_at(bytes: &[u8], offset: usize) -> String {
+        let offset = offset.min(bytes.len());
+        let start = bytes
+            .iter()
+            .take(offset)
+            .rposition(|byte| *byte == b'\n')
+            .map_or(0, |index| index.saturating_add(1));
+        let end = bytes
+            .iter()
+            .skip(offset)
+            .position(|byte| *byte == b'\n')
+            .map_or(bytes.len(), |index| offset.saturating_add(index));
+        String::from_utf8_lossy(bytes.get(start..end).unwrap_or_default()).into_owned()
+    }
+
+    /// Where `actual` first differs from `expected` — the byte offset, the line
+    /// that byte falls on, and the whole of that line from each side. The empty
+    /// string when the two are identical.
+    ///
+    /// A report is scores of lines of fixed-width columns; told only that two
+    /// walls of text differ, the reader has to diff them by eye. Told the
+    /// offset and the one line from each side, they can see which value went
+    /// missing.
+    fn difference(actual: &[u8], expected: &[u8]) -> String {
+        if actual == expected {
+            return String::new();
+        }
+        // Equal as far as both run means the difference is the length: the
+        // first byte only one of them has.
+        let offset = actual
+            .iter()
+            .zip(expected)
+            .position(|(left, right)| left != right)
+            .unwrap_or_else(|| actual.len().min(expected.len()));
+        let line =
+            expected.iter().take(offset).filter(|byte| **byte == b'\n').count().saturating_add(1);
+        format!(
+            "first difference at byte {offset}, line {line}\n  actual:   {:?}\n  expected: {:?}",
+            line_at(actual, offset),
+            line_at(expected, offset)
+        )
+    }
+
+    /// The lines of `whole` that `reduced` leaves out, or `None` when `reduced`
+    /// is not a subsequence of it — that is, when a line was changed or added
+    /// rather than only dropped. Every line `reduced` keeps is therefore
+    /// byte-identical to the one it matched, and in the same order.
+    fn dropped_lines<'a>(whole: &'a str, reduced: &str) -> Option<Vec<&'a str>> {
+        let mut dropped = Vec::new();
+        let mut kept = reduced.lines();
+        let mut next = kept.next();
+        for line in whole.lines() {
+            if next == Some(line) {
+                next = kept.next();
+            } else {
+                dropped.push(line);
+            }
+        }
+        next.is_none().then_some(dropped)
+    }
+
+    #[test]
+    fn difference_locates_the_first_differing_byte_and_its_line() {
+        assert!(difference(b"same", b"same").is_empty());
+        // A differing byte on the second line names that byte and both lines.
+        let report = difference(b"one\ntwo\n", b"one\nTWO\n");
+        assert!(report.starts_with("first difference at byte 4, line 2\n"), "{report}");
+        assert!(report.contains("\"two\""), "{report}");
+        assert!(report.contains("\"TWO\""), "{report}");
+        // Identical as far as the shorter runs: the difference is the first
+        // byte only the longer one has.
+        assert!(difference(b"ab", b"abc").starts_with("first difference at byte 2, line 1\n"));
+    }
+
+    #[test]
+    fn line_at_takes_the_whole_line_around_an_offset() {
+        assert_eq!(line_at(b"only", 2), "only"); // no newline either side
+        assert_eq!(line_at(b"one\ntwo\nthree", 5), "two"); // a newline both sides
+        assert_eq!(line_at(b"one\ntwo", 7), "two"); // an offset at the very end
+        assert_eq!(line_at(b"one", 99), "one"); // ...or past it
+    }
+
+    #[test]
+    fn dropped_lines_reports_removals_and_rejects_a_changed_line() {
+        assert_eq!(dropped_lines("a\nb\nc", "a\nc"), Some(vec!["b"]));
+        assert_eq!(dropped_lines("a\nb", "a\nb"), Some(Vec::new()));
+        // A line that changed, or one that was never there, is not a removal.
+        assert_eq!(dropped_lines("a\nb", "a\nB"), None);
+        assert_eq!(dropped_lines("a", "a\nb"), None);
+    }
+
+    /// The fixture disc scanned, mirrored, and rebuilt from that mirror alone —
+    /// the two halves a report is rendered from.
+    fn a_rebuilt_fixture_disc() -> (BdRom, Vec<error::ScanError>) {
+        a_fixture_disc(ScanMode::Full).into_scan()
+    }
+
+    #[test]
+    fn a_disc_rebuilt_from_its_mirror_renders_the_pinned_report() {
+        let (bdrom, errors) = a_rebuilt_fixture_disc();
+        let order = bdrom.presentation_order(&PlaylistFilter::default());
+        let rendered = text::render_with(&bdrom, &order, &errors, RenderOptions::default());
+        let mismatch = difference(rendered.as_bytes(), GOLDEN);
+        assert!(
+            mismatch.is_empty(),
+            "the mirror lost something the report prints — a field it stopped \
+             carrying, or one it rebuilds wrongly:\n{mismatch}"
+        );
+    }
+
+    #[test]
+    fn switching_off_a_report_section_removes_that_section_and_nothing_else() {
+        let (bdrom, errors) = a_rebuilt_fixture_disc();
+        let order = bdrom.presentation_order(&PlaylistFilter::default());
+        let render = |options| text::render_with(&bdrom, &order, &errors, options);
+
+        let whole = render(RenderOptions::default());
+        for (options, dropped_section, kept_section) in [
+            (
+                RenderOptions { stream_diagnostics: false, quick_summary: true },
+                "STREAM DIAGNOSTICS:",
+                "QUICK SUMMARY:",
+            ),
+            (
+                RenderOptions { stream_diagnostics: true, quick_summary: false },
+                "QUICK SUMMARY:",
+                "STREAM DIAGNOSTICS:",
+            ),
+        ] {
+            let reduced = render(options);
+            // A subsequence at all means every surviving line is byte-identical
+            // and in order: nothing was rewritten, only removed.
+            let dropped = dropped_lines(&whole, &reduced)
+                .expect("switching a section off must only remove lines");
+            assert!(
+                dropped.iter().any(|line| line.contains(dropped_section)),
+                "{dropped_section} must be among the removed lines"
+            );
+            assert!(!reduced.contains(dropped_section), "{dropped_section} must be gone");
+            assert!(reduced.contains(kept_section), "{kept_section} must survive");
+        }
+
+        // Both off removes both sections and still nothing else.
+        let neither = render(RenderOptions { stream_diagnostics: false, quick_summary: false });
+        assert!(dropped_lines(&whole, &neither).is_some(), "both off must only remove lines");
+        assert!(!neither.contains("STREAM DIAGNOSTICS:"));
+        assert!(!neither.contains("QUICK SUMMARY:"));
     }
 }

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -1,0 +1,734 @@
+//! The `Disc` mirror — the scanned disc model as plain data JavaScript can hold.
+//!
+//! One type here per model type in [`bdinfo_rs_core`], field for field:
+//!
+//! | Mirror | Core |
+//! |---|---|
+//! | [`Disc`] | [`BdRom`](bdinfo_rs_core::bdrom::disc::BdRom) plus the scan mode and the recorded failures |
+//! | [`Playlist`] | [`PlaylistSummary`](bdinfo_rs_core::bdrom::disc::PlaylistSummary) |
+//! | [`Clip`] | [`ClipSummary`](bdinfo_rs_core::bdrom::disc::ClipSummary) |
+//! | [`Stream`] | [`StreamSummary`](bdinfo_rs_core::bdrom::disc::StreamSummary) |
+//! | [`ClipStream`] | [`ClipStreamTally`](bdinfo_rs_core::bdrom::disc::ClipStreamTally) |
+//! | [`Chapter`] | [`ChapterSummary`](bdinfo_rs_core::bdrom::chapters::ChapterSummary) |
+//! | [`ScanError`] | [`ScanError`](bdinfo_rs_core::error::ScanError) |
+//! | [`ScanStage`] | [`ScanStage`](bdinfo_rs_core::error::ScanStage) |
+//! | [`ScanErrorReason`] | [`BdError`](bdinfo_rs_core::error::BdError) |
+//!
+//! ## Conventions
+//!
+//! * **Complete.** Every field of every core type appears here. That completeness is the point: it
+//!   is what lets a disc be rebuilt from the mirror and re-rendered as the identical report, and a
+//!   field left out would be invisible until that render came back wrong.
+//! * **Numbers stay numbers.** Nothing is pre-formatted for display, so a consumer can sort,
+//!   compare and chart the values. Only strings the scan itself composed, and which a consumer
+//!   could therefore not reconstruct, cross as strings: codec and language names, the stream
+//!   descriptions.
+//! * **Units live in the field name** wherever a bare number would be ambiguous — `size_bytes`,
+//!   `bitrate_bps`, `length_seconds`, `sample_rate_hz`. The name is the unit of record; the core
+//!   field it mirrors is frequently named without one.
+//! * **Wire names are camelCase**, from `#[serde(rename_all = "camelCase")]` on every type.
+//!
+//! ## Doc comments here are published documentation
+//!
+//! `tsify` copies the doc comment of each type and field below into the generated TypeScript
+//! declaration as `JSDoc`, so those lines are what a consumer reads in an editor. Write them for
+//! that reader, and note three things `tsify` 0.5.6 does to them on the way out:
+//!
+//! * An apostrophe is emitted escaped, as `\'` — so avoid it.
+//! * A rustdoc intra-doc link is emitted verbatim, brackets and path and all, which resolves to
+//!   nothing in TypeScript. Name a sibling field in plain backticks instead, under its published
+//!   camelCase name.
+//! * The doc comment of an **enum variant** is dropped. What a consumer must know to use
+//!   [`ScanStage`] or [`ScanErrorReason`] therefore belongs on the enum itself.
+
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+
+/// A scanned Blu-ray disc: the disc-level properties and every playlist on it.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "seven independent disc properties (3D/50Hz/UHD/BD+/BD-Java/D-BOX/PSP) plus the scan-mode flag, not a state machine"
+)]
+pub struct Disc {
+    /// The disc volume label. For a disc image this is the volume identifier
+    /// recorded in the filesystem; for a picked folder it is the name of the
+    /// folder holding `BDMV`, which carries no real volume label.
+    pub volume_label: String,
+    /// The disc title declared in `META/bdmt_eng.xml`, absent when the disc
+    /// declares none or declares only the placeholder `blu-ray`.
+    pub disc_title: Option<String>,
+    /// Total size of the disc in bytes, excluding the interleaved `*.ssif`
+    /// files counted by `interleavedSizeBytes`.
+    pub size_bytes: u64,
+    /// Total size of the interleaved `*.ssif` files in bytes — the bytes
+    /// `sizeBytes` leaves out. Zero on a disc that is not 3D.
+    pub interleaved_size_bytes: u64,
+    /// Whether the disc carries 3D video: a non-empty `STREAM/SSIF` directory.
+    pub is_3d: bool,
+    /// Whether the disc carries 50 Hz content: any playlist video stream at 25
+    /// or 50 frames per second.
+    pub is_50hz: bool,
+    /// Whether the disc is 4K UHD: the `INDX0300` version magic in
+    /// `index.bdmv`.
+    pub is_uhd: bool,
+    /// Whether the disc carries BD+ copy protection: a `BDSVM`, `SLYVM` or
+    /// `ANYVM` directory.
+    pub is_bd_plus: bool,
+    /// Whether the disc carries BD-Java: a non-empty `BDJO` directory.
+    pub is_bd_java: bool,
+    /// Whether the disc carries D-BOX motion code: a `FilmIndex.xml` file in
+    /// the disc root.
+    pub is_dbox: bool,
+    /// Whether the disc carries PSP or mobile content: a `*.mnv` file under
+    /// `SNP`.
+    pub is_psp: bool,
+    /// Every playlist on the disc, sorted by file name. Nothing is filtered
+    /// out here: the short and looping playlists a selection table would
+    /// withhold are present too.
+    pub playlists: Vec<Playlist>,
+    /// Whether the packet scan ran. When false the scan read only the disc
+    /// metadata, and every measured value below — bitrates, packet counts,
+    /// chapter rates — is zero because it was never measured rather than
+    /// because it is genuinely zero. This flag is the only way to tell those
+    /// two apart.
+    pub measured: bool,
+    /// Per-file failures the scan recorded and continued past. Empty for a
+    /// scan of healthy media.
+    pub errors: Vec<ScanError>,
+}
+
+/// One playlist (`*.MPLS`) with its streams, clips and chapters.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Playlist {
+    /// The playlist file name in upper case, for example `00000.MPLS`.
+    pub name: String,
+    /// Total presentation length in seconds.
+    pub total_length_seconds: f64,
+    /// Summed size of the clip `*.m2ts` files in bytes.
+    pub file_size_bytes: u64,
+    /// Summed size of the clip interleaved `*.ssif` files in bytes.
+    pub interleaved_file_size_bytes: u64,
+    /// Number of chapter marks.
+    pub chapter_count: usize,
+    /// Number of presented streams. Counts the same rows the report presents,
+    /// so it excludes the rows flagged `ssifOnly` and is not always the length
+    /// of `streams`.
+    pub stream_count: usize,
+    /// Number of extra camera angles, zero for a playlist with a single angle.
+    pub angle_count: usize,
+    /// Whether the playlist loops: two main-angle clips replay the same clip
+    /// file from the same in-time. A selection table withholds a looping
+    /// playlist by default.
+    pub has_loops: bool,
+    /// The presented streams, sorted by PID.
+    pub streams: Vec<Stream>,
+    /// The sequenced clips in playlist order, angle clips included.
+    pub clips: Vec<Clip>,
+    /// One entry per chapter mark, carrying the measured video statistics of
+    /// that chapter. Present without the packet scan too, but then only the
+    /// times are filled in.
+    pub chapters: Vec<Chapter>,
+}
+
+/// One clip (`*.M2TS`) as one playlist sequences it.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Clip {
+    /// The clip `*.m2ts` file name in upper case, for example `00001.M2TS`.
+    pub name: String,
+    /// The name to display: the interleaved `*.ssif` file name when the clip
+    /// has one, otherwise `name`.
+    pub display_name: String,
+    /// Size of the clip `*.m2ts` file in bytes, zero when the file is missing.
+    /// This is the estimated size, the one available without a packet scan.
+    pub file_size_bytes: u64,
+    /// Size of the clip interleaved `*.ssif` file in bytes, zero when the clip
+    /// has none.
+    pub interleaved_file_size_bytes: u64,
+    /// Which camera angle this clip belongs to; zero is the main angle.
+    pub angle_index: i32,
+    /// Where the clip starts on the playlist timeline, in seconds.
+    pub relative_time_in_seconds: f64,
+    /// How long the clip runs, in seconds.
+    pub length_seconds: f64,
+    /// Payload bytes the packet scan attributed to this clip.
+    pub payload_bytes: u64,
+    /// Transport packets the packet scan attributed to this clip. The
+    /// packet-derived size in bytes is this count times 192.
+    pub packet_count: u64,
+    /// How many seconds of content the packet scan demuxed for this clip.
+    pub packet_seconds: f64,
+    /// Presentation length of the whole clip file in seconds, zero when the
+    /// file is missing. Differs from `lengthSeconds` when the playlist
+    /// presents only part of the file.
+    pub file_seconds: f64,
+    /// Whole-file tallies for each stream in this clip file, in the order the
+    /// file registers them, limited to the streams the playlist presents.
+    pub streams: Vec<ClipStream>,
+}
+
+/// One stream measured across one whole clip file.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClipStream {
+    /// The packet identifier. The report prints it zero-padded to five digits.
+    pub pid: u16,
+    /// The elementary-stream type, as the `stream_coding_type` byte recorded
+    /// on the disc. This is the type the clip file itself registers, which can
+    /// differ from the type the playlist declares for the same packet
+    /// identifier — the one a `Stream` carries.
+    pub stream_type: u8,
+    /// The short codec label of the stream as the clip file registers it, for
+    /// example `AVC`.
+    pub codec_short_name: String,
+    /// Payload bytes demuxed for this packet identifier across the whole clip
+    /// file.
+    pub payload_bytes: u64,
+    /// Transport packets seen on this packet identifier across the whole clip
+    /// file.
+    pub packet_count: u64,
+}
+
+/// One stream as one playlist presents it.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Stream {
+    /// The packet identifier. The report prints it zero-padded to five digits.
+    pub pid: u16,
+    /// The elementary-stream type, as the `stream_coding_type` byte recorded
+    /// on the disc — for example 27 (`0x1B`) for MPEG-4 AVC video, 134
+    /// (`0x86`) for DTS-HD Master Audio. The report never prints it: it selects
+    /// which table the row lands in (video, audio, subtitles or text), so the
+    /// number is the only faithful mirror of it.
+    pub stream_type: u8,
+    /// The short codec name, for example `AVC` or `DTS-HD MA`.
+    pub codec_short_name: String,
+    /// The long codec name, for example `MPEG-4 AVC Video`.
+    pub codec_name: String,
+    /// The alternate codec name some report tables print instead of
+    /// `codecName`, for example `DD AC3`.
+    pub codec_alt_name: String,
+    /// The stream bitrate in bits per second: measured by the packet scan, or
+    /// for a constant-rate codec taken from the coded nominal rate. On the
+    /// per-angle copy of a video row it is the rate measured for that angle.
+    /// Zero without the packet scan.
+    pub bitrate_bps: i64,
+    /// The bitrate in bits per second over the region where the stream is
+    /// active, measured by the packet scan. Filled in for video and Dolby
+    /// `TrueHD` only; zero otherwise, and zero without the packet scan.
+    pub active_bitrate_bps: i64,
+    /// The language name, empty when the stream declares no language.
+    pub language_name: String,
+    /// The ISO 639 language code, for example `eng`. Empty when the stream
+    /// declares no language.
+    pub language_code: String,
+    /// The stream description as the metadata alone gives it: resolution,
+    /// frame rate and HDR for video; channels, sample rate and bit depth for
+    /// audio. Empty for graphics and text streams on a scan without the packet
+    /// scan.
+    pub description: String,
+    /// The description including what only the packet scan can know: the
+    /// measured rate of a variable-rate audio stream, net of the rate of an
+    /// embedded `TrueHD` core, and the exact four-decimal HEVC luminance
+    /// spelling. Equal to `description` otherwise. This is the text the report
+    /// prints.
+    pub full_description: String,
+    /// The audio channel layout, for example `5.1`. Empty for a stream that is
+    /// not audio.
+    pub channel_description: String,
+    /// The audio sample rate in hertz. Zero for a stream that is not audio, or
+    /// when the rate is unknown.
+    pub sample_rate_hz: i32,
+    /// The audio bit depth. Zero for a stream that is not audio, or when the
+    /// depth is unknown.
+    pub bit_depth: i32,
+    /// The audio channel count, not counting the LFE channel. Zero for a
+    /// stream that is not audio, or when the count is unknown.
+    pub channel_count: i32,
+    /// The video picture height in pixels, for example 1080. Zero for a stream
+    /// that is not video, or when the height is unknown.
+    pub height_pixels: i32,
+    /// Which camera angle this row presents: zero for the main presentation
+    /// row, and 1 upwards for the per-angle copies of a video stream, each
+    /// carrying the rates measured for its own angle.
+    pub angle_index: usize,
+    /// Whether the playlist hides the stream: the clip carries it, but the
+    /// playlist stream-number table does not declare it.
+    pub is_hidden: bool,
+    /// Whether the stream is reached only through the interleaved `*.ssif`
+    /// dependent-view scan — the 3D MVC video the clip information omits.
+    /// These rows are excluded from the playlist `streamCount`.
+    pub ssif_only: bool,
+}
+
+/// The measured video statistics of one chapter.
+///
+/// Times are seconds from the start of the playlist, rates are bits per second,
+/// sizes are bytes. Every value except the times is zero without the packet
+/// scan.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Chapter {
+    /// When the chapter starts, in seconds.
+    pub time_in_seconds: f64,
+    /// How long the chapter runs, in seconds: up to the next chapter mark, or
+    /// for the last chapter up to the total length of the playlist.
+    pub length_seconds: f64,
+    /// Average video rate over the chapter in bits per second. Zero for a
+    /// chapter of zero length.
+    pub avg_rate_bps: f64,
+    /// The highest video rate over any one-second window, in bits per second.
+    pub max_1sec_rate_bps: f64,
+    /// When the highest one-second window starts, in seconds.
+    pub max_1sec_time_seconds: f64,
+    /// The highest video rate over any five-second window, in bits per second.
+    pub max_5sec_rate_bps: f64,
+    /// When the highest five-second window starts, in seconds.
+    pub max_5sec_time_seconds: f64,
+    /// The highest video rate over any ten-second window, in bits per second.
+    pub max_10sec_rate_bps: f64,
+    /// When the highest ten-second window starts, in seconds.
+    pub max_10sec_time_seconds: f64,
+    /// Average video frame size in bytes over the frames the codec tagged.
+    /// Zero when it tagged none.
+    pub avg_frame_size_bytes: f64,
+    /// The largest single video frame in bytes.
+    pub max_frame_size_bytes: f64,
+    /// When the largest video frame occurs, in seconds.
+    pub max_frame_time_seconds: f64,
+}
+
+/// One file the scan could not read or parse, and continued past.
+///
+/// A scan never stops on a bad file: it records the failure here and scans the
+/// readable rest. The report lists these under its `WARNING:` heading, printing
+/// the `file` and a message describing the `reason`.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanError {
+    /// The file or directory that failed, named as it is on the disc.
+    pub file: String,
+    /// Which part of the scan hit the failure.
+    pub stage: ScanStage,
+    /// What went wrong.
+    pub reason: ScanErrorReason,
+}
+
+/// Which part of a scan a failure occurred in.
+///
+/// A scan isolates failures per file class, so one unreadable clip never costs
+/// more than that clip.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ScanStage {
+    /// Listing directories or reading the disc-level metadata: directory
+    /// sizes, the disc flags, `index.bdmv`, `bdmt_eng.xml`.
+    Discovery,
+    /// Parsing a clip-information (`*.clpi`) file.
+    ClipInfo,
+    /// Parsing a playlist (`*.mpls`) file, or resolving the clips it names.
+    Playlist,
+    /// Packet-scanning a stream (`*.m2ts`) file.
+    #[serde(rename = "stream")]
+    StreamFile,
+    /// Reading a range of sectors out of a disc image — a bad sector under the
+    /// data of a file, which the scan records and reads back as zeros.
+    #[serde(rename = "sector")]
+    SectorRead,
+}
+
+/// What went wrong on one file a scan could not read or parse.
+///
+/// The `kind` property discriminates the union; the other properties of each
+/// member carry what that kind of failure knows.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ScanErrorReason {
+    /// A metadata file began with a type magic the parser does not accept, for
+    /// example a `*.mpls` not starting with `MPLS0100`, `MPLS0200` or
+    /// `MPLS0300`.
+    #[serde(rename_all = "camelCase")]
+    UnknownFileType {
+        /// The magic the file actually began with.
+        magic: String,
+    },
+    /// A field ran past the end of the file: it is truncated or otherwise
+    /// malformed.
+    UnexpectedEof,
+    /// The folder holds no recognizable Blu-ray structure: no `BDMV`
+    /// directory, or a `BDMV` without both `CLIPINF` and `PLAYLIST`.
+    StructureNotFound,
+    /// A playlist named a clip-information (`*.clpi`) file that is not on the
+    /// disc.
+    #[serde(rename_all = "camelCase")]
+    MissingClipFile {
+        /// The name of the missing file.
+        file: String,
+    },
+    /// Reading the disc failed: listing a directory, or opening or reading a
+    /// file.
+    #[serde(rename_all = "camelCase")]
+    Io {
+        /// What the read failure reported.
+        message: String,
+    },
+    /// A metadata file is larger than the parser will buffer whole. Authored
+    /// metadata is kilobytes, so this fires only on malformed or hostile
+    /// input.
+    #[serde(rename_all = "camelCase")]
+    MetadataTooLarge {
+        /// The file, named as it is on the disc.
+        file: String,
+        /// The cap the file exceeded, in bytes.
+        limit_bytes: u64,
+    },
+    /// The scan was cancelled by the caller.
+    ScanCancelled,
+    /// A failure this mirror does not name, carrying the message it reported.
+    ///
+    /// Nothing lands here today: every failure kind the scan can report has a
+    /// member of its own above. It exists because the set of kinds is open and
+    /// can grow, and a value that lands here is the one kind a rebuilt disc
+    /// cannot render back exactly. Give a new kind its own member and this
+    /// stays empty.
+    #[serde(rename_all = "camelCase")]
+    Other {
+        /// What the failure reported.
+        message: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::{
+        Chapter, Clip, ClipStream, Disc, Playlist, ScanError, ScanErrorReason, ScanStage, Stream,
+    };
+
+    // One fixture value and one hand-written wire form per mirror type, composed
+    // upwards into a whole disc. The wire forms spell the published property
+    // names out rather than deriving them, so a rename in the Rust field names
+    // surfaces here rather than in a consumer. They are split per type because
+    // `serde_json::json!` hits the macro recursion limit on the whole disc in
+    // one literal.
+
+    /// A stream with every field set to a distinct value. The numbers are
+    /// positional markers, not a plausible stream.
+    fn a_stream() -> Stream {
+        Stream {
+            pid: 4113,
+            stream_type: 0x1B,
+            codec_short_name: "AVC".to_owned(),
+            codec_name: "MPEG-4 AVC Video".to_owned(),
+            codec_alt_name: "AVC".to_owned(),
+            bitrate_bps: 9,
+            active_bitrate_bps: 10,
+            language_name: "English".to_owned(),
+            language_code: "eng".to_owned(),
+            description: "1080p / 23.976 fps".to_owned(),
+            full_description: "1080p / 23.976 fps / 16:9".to_owned(),
+            channel_description: "5.1".to_owned(),
+            sample_rate_hz: 48_000,
+            bit_depth: 24,
+            channel_count: 5,
+            height_pixels: 1080,
+            angle_index: 11,
+            is_hidden: true,
+            ssif_only: false,
+        }
+    }
+
+    /// The wire form of [`a_stream`].
+    fn a_stream_json() -> Value {
+        json!({
+            "pid": 4113,
+            "streamType": 27,
+            "codecShortName": "AVC",
+            "codecName": "MPEG-4 AVC Video",
+            "codecAltName": "AVC",
+            "bitrateBps": 9,
+            "activeBitrateBps": 10,
+            "languageName": "English",
+            "languageCode": "eng",
+            "description": "1080p / 23.976 fps",
+            "fullDescription": "1080p / 23.976 fps / 16:9",
+            "channelDescription": "5.1",
+            "sampleRateHz": 48_000,
+            "bitDepth": 24,
+            "channelCount": 5,
+            "heightPixels": 1080,
+            "angleIndex": 11,
+            "isHidden": true,
+            "ssifOnly": false,
+        })
+    }
+
+    /// A whole-file stream tally with every field set to a distinct value.
+    fn a_clip_stream() -> ClipStream {
+        ClipStream {
+            pid: 4352,
+            stream_type: 0x86,
+            codec_short_name: "DTS-HD MA".to_owned(),
+            payload_bytes: 21,
+            packet_count: 22,
+        }
+    }
+
+    /// The wire form of [`a_clip_stream`].
+    fn a_clip_stream_json() -> Value {
+        json!({
+            "pid": 4352,
+            "streamType": 134,
+            "codecShortName": "DTS-HD MA",
+            "payloadBytes": 21,
+            "packetCount": 22,
+        })
+    }
+
+    /// A clip with every field set to a distinct value.
+    fn a_clip() -> Clip {
+        Clip {
+            name: "00001.M2TS".to_owned(),
+            display_name: "00001.SSIF".to_owned(),
+            file_size_bytes: 12,
+            interleaved_file_size_bytes: 13,
+            angle_index: 14,
+            relative_time_in_seconds: 15.5,
+            length_seconds: 16.25,
+            payload_bytes: 17,
+            packet_count: 18,
+            packet_seconds: 19.5,
+            file_seconds: 20.5,
+            streams: vec![a_clip_stream()],
+        }
+    }
+
+    /// The wire form of [`a_clip`].
+    fn a_clip_json() -> Value {
+        json!({
+            "name": "00001.M2TS",
+            "displayName": "00001.SSIF",
+            "fileSizeBytes": 12,
+            "interleavedFileSizeBytes": 13,
+            "angleIndex": 14,
+            "relativeTimeInSeconds": 15.5,
+            "lengthSeconds": 16.25,
+            "payloadBytes": 17,
+            "packetCount": 18,
+            "packetSeconds": 19.5,
+            "fileSeconds": 20.5,
+            "streams": [a_clip_stream_json()],
+        })
+    }
+
+    /// A chapter with every field set to a distinct value.
+    fn a_chapter() -> Chapter {
+        Chapter {
+            time_in_seconds: 23.5,
+            length_seconds: 24.5,
+            avg_rate_bps: 25.5,
+            max_1sec_rate_bps: 26.5,
+            max_1sec_time_seconds: 27.5,
+            max_5sec_rate_bps: 28.5,
+            max_5sec_time_seconds: 29.5,
+            max_10sec_rate_bps: 30.5,
+            max_10sec_time_seconds: 31.5,
+            avg_frame_size_bytes: 32.5,
+            max_frame_size_bytes: 33.5,
+            max_frame_time_seconds: 34.5,
+        }
+    }
+
+    /// The wire form of [`a_chapter`].
+    fn a_chapter_json() -> Value {
+        json!({
+            "timeInSeconds": 23.5,
+            "lengthSeconds": 24.5,
+            "avgRateBps": 25.5,
+            "max1secRateBps": 26.5,
+            "max1secTimeSeconds": 27.5,
+            "max5secRateBps": 28.5,
+            "max5secTimeSeconds": 29.5,
+            "max10secRateBps": 30.5,
+            "max10secTimeSeconds": 31.5,
+            "avgFrameSizeBytes": 32.5,
+            "maxFrameSizeBytes": 33.5,
+            "maxFrameTimeSeconds": 34.5,
+        })
+    }
+
+    /// A playlist with every field set to a distinct value.
+    fn a_playlist() -> Playlist {
+        Playlist {
+            name: "00000.MPLS".to_owned(),
+            total_length_seconds: 3.5,
+            file_size_bytes: 4,
+            interleaved_file_size_bytes: 5,
+            chapter_count: 6,
+            stream_count: 7,
+            angle_count: 8,
+            has_loops: true,
+            streams: vec![a_stream()],
+            clips: vec![a_clip()],
+            chapters: vec![a_chapter()],
+        }
+    }
+
+    /// The wire form of [`a_playlist`].
+    fn a_playlist_json() -> Value {
+        json!({
+            "name": "00000.MPLS",
+            "totalLengthSeconds": 3.5,
+            "fileSizeBytes": 4,
+            "interleavedFileSizeBytes": 5,
+            "chapterCount": 6,
+            "streamCount": 7,
+            "angleCount": 8,
+            "hasLoops": true,
+            "streams": [a_stream_json()],
+            "clips": [a_clip_json()],
+            "chapters": [a_chapter_json()],
+        })
+    }
+
+    /// A recorded failure with every field set to a distinct value.
+    fn a_scan_error() -> ScanError {
+        ScanError {
+            file: "00002.CLPI".to_owned(),
+            stage: ScanStage::ClipInfo,
+            reason: ScanErrorReason::UnknownFileType { magic: "HDMV9999".to_owned() },
+        }
+    }
+
+    /// The wire form of [`a_scan_error`].
+    fn a_scan_error_json() -> Value {
+        json!({
+            "file": "00002.CLPI",
+            "stage": "clipinfo",
+            "reason": { "kind": "unknownFileType", "magic": "HDMV9999" },
+        })
+    }
+
+    /// A disc with every field of every mirror type set to a distinct value.
+    fn a_disc() -> Disc {
+        Disc {
+            volume_label: "MIRROR_DISC".to_owned(),
+            disc_title: Some("Mirror Title".to_owned()),
+            size_bytes: 1,
+            interleaved_size_bytes: 2,
+            is_3d: true,
+            is_50hz: false,
+            is_uhd: true,
+            is_bd_plus: false,
+            is_bd_java: true,
+            is_dbox: false,
+            is_psp: true,
+            playlists: vec![a_playlist()],
+            measured: true,
+            errors: vec![a_scan_error()],
+        }
+    }
+
+    /// The wire form of [`a_disc`].
+    fn a_disc_json() -> Value {
+        json!({
+            "volumeLabel": "MIRROR_DISC",
+            "discTitle": "Mirror Title",
+            "sizeBytes": 1,
+            "interleavedSizeBytes": 2,
+            "is3d": true,
+            "is50hz": false,
+            "isUhd": true,
+            "isBdPlus": false,
+            "isBdJava": true,
+            "isDbox": false,
+            "isPsp": true,
+            "playlists": [a_playlist_json()],
+            "measured": true,
+            "errors": [a_scan_error_json()],
+        })
+    }
+
+    #[test]
+    fn every_field_serializes_under_its_published_name() {
+        let wire = serde_json::to_value(a_disc()).expect("serialize the mirror");
+        assert_eq!(wire, a_disc_json());
+    }
+
+    #[test]
+    fn every_field_survives_a_round_trip_through_the_wire_form() {
+        let back: Disc = serde_json::from_value(a_disc_json()).expect("deserialize the mirror");
+        assert_eq!(back, a_disc());
+    }
+
+    #[test]
+    fn an_absent_disc_title_round_trips() {
+        let disc = Disc { disc_title: None, ..a_disc() };
+        let wire = serde_json::to_value(&disc).expect("serialize a disc with no title");
+        assert_eq!(wire.get("discTitle"), Some(&Value::Null));
+        let back: Disc = serde_json::from_value(wire).expect("deserialize a disc with no title");
+        assert_eq!(back, disc);
+    }
+
+    #[test]
+    fn every_scan_stage_serializes_under_the_label_the_scan_reports() {
+        for (stage, label) in [
+            (ScanStage::Discovery, "discovery"),
+            (ScanStage::ClipInfo, "clipinfo"),
+            (ScanStage::Playlist, "playlist"),
+            (ScanStage::StreamFile, "stream"),
+            (ScanStage::SectorRead, "sector"),
+        ] {
+            let wire = serde_json::to_value(stage).expect("serialize a scan stage");
+            assert_eq!(wire, json!(label));
+            let back: ScanStage = serde_json::from_value(wire).expect("deserialize a scan stage");
+            assert_eq!(back, stage);
+        }
+    }
+
+    #[test]
+    fn every_failure_reason_serializes_as_a_discriminated_union_member() {
+        for (reason, wire_form) in [
+            (
+                ScanErrorReason::UnknownFileType { magic: "MPLSXXXX".to_owned() },
+                json!({ "kind": "unknownFileType", "magic": "MPLSXXXX" }),
+            ),
+            (ScanErrorReason::UnexpectedEof, json!({ "kind": "unexpectedEof" })),
+            (ScanErrorReason::StructureNotFound, json!({ "kind": "structureNotFound" })),
+            (
+                ScanErrorReason::MissingClipFile { file: "00003.CLPI".to_owned() },
+                json!({ "kind": "missingClipFile", "file": "00003.CLPI" }),
+            ),
+            (
+                ScanErrorReason::Io { message: "denied".to_owned() },
+                json!({ "kind": "io", "message": "denied" }),
+            ),
+            (
+                ScanErrorReason::MetadataTooLarge {
+                    file: "00000.MPLS".to_owned(),
+                    limit_bytes: 67_108_864,
+                },
+                json!({
+                    "kind": "metadataTooLarge",
+                    "file": "00000.MPLS",
+                    "limitBytes": 67_108_864,
+                }),
+            ),
+            (ScanErrorReason::ScanCancelled, json!({ "kind": "scanCancelled" })),
+            (
+                ScanErrorReason::Other { message: "unmirrored".to_owned() },
+                json!({ "kind": "other", "message": "unmirrored" }),
+            ),
+        ] {
+            let wire = serde_json::to_value(&reason).expect("serialize a failure reason");
+            assert_eq!(wire, wire_form);
+            let back: ScanErrorReason =
+                serde_json::from_value(wire).expect("deserialize a failure reason");
+            assert_eq!(back, reason);
+        }
+    }
+}

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -4,12 +4,12 @@
 //!
 //! | Mirror | Core |
 //! |---|---|
-//! | [`Disc`] | [`BdRom`](bdinfo_rs_core::bdrom::disc::BdRom) plus the scan mode and the recorded failures |
-//! | [`Playlist`] | [`PlaylistSummary`](bdinfo_rs_core::bdrom::disc::PlaylistSummary) |
-//! | [`Clip`] | [`ClipSummary`](bdinfo_rs_core::bdrom::disc::ClipSummary) |
-//! | [`Stream`] | [`StreamSummary`](bdinfo_rs_core::bdrom::disc::StreamSummary) |
-//! | [`ClipStream`] | [`ClipStreamTally`](bdinfo_rs_core::bdrom::disc::ClipStreamTally) |
-//! | [`Chapter`] | [`ChapterSummary`](bdinfo_rs_core::bdrom::chapters::ChapterSummary) |
+//! | [`Disc`] | [`BdRom`] plus the scan mode and the recorded failures |
+//! | [`Playlist`] | [`PlaylistSummary`] |
+//! | [`Clip`] | [`ClipSummary`] |
+//! | [`Stream`] | [`StreamSummary`] |
+//! | [`ClipStream`] | [`ClipStreamTally`] |
+//! | [`Chapter`] | [`ChapterSummary`] |
 //! | [`ScanError`] | [`ScanError`](bdinfo_rs_core::error::ScanError) |
 //! | [`ScanStage`] | [`ScanStage`](bdinfo_rs_core::error::ScanStage) |
 //! | [`ScanErrorReason`] | [`BdError`](bdinfo_rs_core::error::BdError) |
@@ -40,12 +40,29 @@
 //!   camelCase name.
 //! * The doc comment of an **enum variant** is dropped. What a consumer must know to use
 //!   [`ScanStage`] or [`ScanErrorReason`] therefore belongs on the enum itself.
+//!
+//! ## Building one
+//!
+//! [`Disc::from_scan`] mirrors a whole scanned disc and [`Disc::from_listing`] mirrors one as a
+//! filtered playlist listing; every other type here is reached through a [`From`] impl those two
+//! walk.
 
+use bdinfo_rs_core::bdrom::chapters::ChapterSummary;
+use bdinfo_rs_core::bdrom::disc::{
+    BdRom, ClipStreamTally, ClipSummary, PlaylistSummary, StreamSummary,
+};
+use bdinfo_rs_core::bdrom::order::PlaylistFilter;
+use bdinfo_rs_core::error;
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 
 /// A scanned Blu-ray disc: the disc-level properties and every playlist on it.
+// `into_wasm_abi` is what lets an export return a `Disc` by value: it implements
+// wasm-bindgen's `IntoWasmAbi` over `serde_wasm_bindgen`, so the value crosses as a real
+// JavaScript object. Only the type an export names needs it; the types below are reached
+// through this one.
 #[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[tsify(into_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 #[expect(
     clippy::struct_excessive_bools,
@@ -84,9 +101,13 @@ pub struct Disc {
     /// Whether the disc carries PSP or mobile content: a `*.mnv` file under
     /// `SNP`.
     pub is_psp: bool,
-    /// Every playlist on the disc, sorted by file name. Nothing is filtered
-    /// out here: the short and looping playlists a selection table would
-    /// withhold are present too.
+    /// The playlists, sorted by file name.
+    ///
+    /// A scan puts every playlist on the disc here, the short and looping ones
+    /// a selection table would withhold included. A listing narrows it to the
+    /// playlists its filter keeps, which is what the two options on the
+    /// structural calls select; the disc-level values above and `errors` below
+    /// always describe the whole disc.
     pub playlists: Vec<Playlist>,
     /// Whether the packet scan ran. When false the scan read only the disc
     /// metadata, and every measured value below — bitrates, packet counts,
@@ -385,15 +406,14 @@ pub enum ScanErrorReason {
         /// The cap the file exceeded, in bytes.
         limit_bytes: u64,
     },
-    /// The scan was cancelled by the caller.
-    ScanCancelled,
     /// A failure this mirror does not name, carrying the message it reported.
     ///
-    /// Nothing lands here today: every failure kind the scan can report has a
-    /// member of its own above. It exists because the set of kinds is open and
-    /// can grow, and a value that lands here is the one kind a rebuilt disc
-    /// cannot render back exactly. Give a new kind its own member and this
-    /// stays empty.
+    /// Two things land here. A scan the caller cancelled — which is a
+    /// whole-scan abort rather than a per-file failure, so it reaches a
+    /// recorded failure only if one is fabricated. And any failure kind added
+    /// to the scanner after this mirror was written, since the set of kinds is
+    /// open. This is the one member a rebuilt disc cannot render back exactly,
+    /// so a kind that starts occurring in earnest wants a member of its own.
     #[serde(rename_all = "camelCase")]
     Other {
         /// What the failure reported.
@@ -401,8 +421,229 @@ pub enum ScanErrorReason {
     },
 }
 
+// ── the forward mapping: a scanned disc into the mirror ─────────────────────
+//
+// One `From` impl per mirrored type, nesting the way the model does. The
+// elementary-stream type and the packet identifier are the only fields that
+// change representation on the way across: both are newtypes over the byte and
+// the 16-bit word the disc records, and both cross as that raw number.
+
+impl Disc {
+    /// Mirrors a scanned disc: `bdrom` with the per-file failures `errors` the
+    /// scan recorded, and every playlist the scan produced.
+    ///
+    /// `measured` states whether the packet scan ran. Derive it from the scan
+    /// mode rather than from the values: a measured scan can legitimately
+    /// report a zero, and only the scan mode tells that apart from a value
+    /// nothing ever measured.
+    #[must_use]
+    pub fn from_scan(bdrom: &BdRom, errors: &[error::ScanError], measured: bool) -> Self {
+        Self::from_scan_filtered(bdrom, errors, measured, &PlaylistFilter::everything())
+    }
+
+    /// Mirrors a metadata-only scan as a playlist listing: as
+    /// [`from_scan`](Self::from_scan), except that `playlists` holds only the
+    /// playlists `filter` keeps and `measured` is false.
+    #[must_use]
+    pub fn from_listing(
+        bdrom: &BdRom,
+        errors: &[error::ScanError],
+        filter: &PlaylistFilter,
+    ) -> Self {
+        Self::from_scan_filtered(bdrom, errors, false, filter)
+    }
+
+    /// The body both constructors share; `from_scan` passes the filter that
+    /// keeps every playlist.
+    fn from_scan_filtered(
+        bdrom: &BdRom,
+        errors: &[error::ScanError],
+        measured: bool,
+        filter: &PlaylistFilter,
+    ) -> Self {
+        Self {
+            volume_label: bdrom.volume_label.clone(),
+            disc_title: bdrom.disc_title.clone(),
+            size_bytes: bdrom.size,
+            interleaved_size_bytes: bdrom.interleaved_size,
+            is_3d: bdrom.is_3d,
+            is_50hz: bdrom.is_50hz,
+            is_uhd: bdrom.is_uhd,
+            is_bd_plus: bdrom.is_bd_plus,
+            is_bd_java: bdrom.is_bd_java,
+            is_dbox: bdrom.is_dbox,
+            is_psp: bdrom.is_psp,
+            playlists: bdrom
+                .playlists
+                .iter()
+                .filter(|playlist| filter.keeps(playlist))
+                .map(Playlist::from)
+                .collect(),
+            measured,
+            errors: errors.iter().map(ScanError::from).collect(),
+        }
+    }
+}
+
+impl From<&PlaylistSummary> for Playlist {
+    fn from(playlist: &PlaylistSummary) -> Self {
+        Self {
+            name: playlist.name.clone(),
+            total_length_seconds: playlist.total_length,
+            file_size_bytes: playlist.file_size,
+            interleaved_file_size_bytes: playlist.interleaved_file_size,
+            chapter_count: playlist.chapter_count,
+            stream_count: playlist.stream_count,
+            angle_count: playlist.angle_count,
+            has_loops: playlist.has_loops,
+            streams: playlist.streams.iter().map(Stream::from).collect(),
+            clips: playlist.clips.iter().map(Clip::from).collect(),
+            chapters: playlist.chapters.iter().map(Chapter::from).collect(),
+        }
+    }
+}
+
+impl From<&ClipSummary> for Clip {
+    fn from(clip: &ClipSummary) -> Self {
+        Self {
+            name: clip.name.clone(),
+            display_name: clip.display_name.clone(),
+            file_size_bytes: clip.file_size,
+            interleaved_file_size_bytes: clip.interleaved_file_size,
+            angle_index: clip.angle_index,
+            relative_time_in_seconds: clip.relative_time_in,
+            length_seconds: clip.length,
+            payload_bytes: clip.payload_bytes,
+            packet_count: clip.packet_count,
+            packet_seconds: clip.packet_seconds,
+            file_seconds: clip.file_seconds,
+            streams: clip.streams.iter().map(ClipStream::from).collect(),
+        }
+    }
+}
+
+impl From<&ClipStreamTally> for ClipStream {
+    fn from(tally: &ClipStreamTally) -> Self {
+        Self {
+            pid: tally.pid.get(),
+            stream_type: tally.stream_type as u8,
+            codec_short_name: tally.codec_short_name.clone(),
+            payload_bytes: tally.payload_bytes,
+            packet_count: tally.packet_count,
+        }
+    }
+}
+
+impl From<&StreamSummary> for Stream {
+    fn from(stream: &StreamSummary) -> Self {
+        Self {
+            pid: stream.pid.get(),
+            // `TsStreamType` is `#[repr(u8)]` over the on-disc
+            // `stream_coding_type` codes, so the discriminant IS the byte the
+            // disc records.
+            stream_type: stream.stream_type as u8,
+            codec_short_name: stream.codec_short_name.clone(),
+            codec_name: stream.codec_name.clone(),
+            codec_alt_name: stream.codec_alt_name.to_owned(),
+            bitrate_bps: stream.bitrate,
+            active_bitrate_bps: stream.active_bitrate,
+            language_name: stream.language_name.clone(),
+            language_code: stream.language_code.clone(),
+            description: stream.description.clone(),
+            full_description: stream.full_description.clone(),
+            channel_description: stream.channel_description.clone(),
+            sample_rate_hz: stream.sample_rate,
+            bit_depth: stream.bit_depth,
+            channel_count: stream.channel_count,
+            height_pixels: stream.height,
+            angle_index: stream.angle_index,
+            is_hidden: stream.is_hidden,
+            ssif_only: stream.ssif_only,
+        }
+    }
+}
+
+impl From<&ChapterSummary> for Chapter {
+    fn from(chapter: &ChapterSummary) -> Self {
+        Self {
+            time_in_seconds: chapter.time_in,
+            length_seconds: chapter.length,
+            avg_rate_bps: chapter.avg_rate,
+            max_1sec_rate_bps: chapter.max_1sec_rate,
+            max_1sec_time_seconds: chapter.max_1sec_time,
+            max_5sec_rate_bps: chapter.max_5sec_rate,
+            max_5sec_time_seconds: chapter.max_5sec_time,
+            max_10sec_rate_bps: chapter.max_10sec_rate,
+            max_10sec_time_seconds: chapter.max_10sec_time,
+            avg_frame_size_bytes: chapter.avg_frame_size,
+            max_frame_size_bytes: chapter.max_frame_size,
+            max_frame_time_seconds: chapter.max_frame_time,
+        }
+    }
+}
+
+impl From<&error::ScanError> for ScanError {
+    fn from(failure: &error::ScanError) -> Self {
+        Self {
+            file: failure.file.clone(),
+            stage: failure.stage.into(),
+            reason: (&failure.reason).into(),
+        }
+    }
+}
+
+impl From<error::ScanStage> for ScanStage {
+    fn from(stage: error::ScanStage) -> Self {
+        match stage {
+            error::ScanStage::ClipInfo => Self::ClipInfo,
+            error::ScanStage::Playlist => Self::Playlist,
+            error::ScanStage::StreamFile => Self::StreamFile,
+            error::ScanStage::SectorRead => Self::SectorRead,
+            // `Discovery`, and — `ScanStage` being `#[non_exhaustive]` — any
+            // stage added to it later. Reading an unnamed stage as the
+            // disc-level one is safe to a consumer: a failure is presented by
+            // its file and its reason, and the report never prints the stage.
+            _ => Self::Discovery,
+        }
+    }
+}
+
+impl From<&error::BdError> for ScanErrorReason {
+    fn from(reason: &error::BdError) -> Self {
+        match reason {
+            error::BdError::UnknownFileType(magic) => {
+                Self::UnknownFileType { magic: magic.clone() }
+            }
+            error::BdError::UnexpectedEof => Self::UnexpectedEof,
+            error::BdError::StructureNotFound => Self::StructureNotFound,
+            error::BdError::MissingClipFile(file) => Self::MissingClipFile { file: file.clone() },
+            // The wrapped `io::Error`, not the `BdError` around it: the mirror
+            // supplies the `io error: ` framing itself when it names the kind.
+            error::BdError::Io(err) => Self::Io { message: err.to_string() },
+            error::BdError::MetadataTooLarge { file, limit } => {
+                Self::MetadataTooLarge { file: file.clone(), limit_bytes: *limit }
+            }
+            // A cancelled scan, which aborts the whole open rather than being
+            // recorded against a file, and — `BdError` being
+            // `#[non_exhaustive]` — any kind added to it later. Both cross as
+            // the message they reported.
+            unmirrored => Self::Other { message: unmirrored.to_string() },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::io;
+
+    use bdinfo_rs_core::bdrom::chapters::ChapterSummary;
+    use bdinfo_rs_core::bdrom::disc::{
+        BdRom, ClipStreamTally, ClipSummary, PlaylistSummary, ScanMode, StreamSummary,
+    };
+    use bdinfo_rs_core::bdrom::order::PlaylistFilter;
+    use bdinfo_rs_core::error;
+    use bdinfo_rs_core::primitives::Pid;
+    use bdinfo_rs_core::stream::TsStreamType;
     use serde_json::{Value, json};
 
     use super::{
@@ -718,7 +959,6 @@ mod tests {
                     "limitBytes": 67_108_864,
                 }),
             ),
-            (ScanErrorReason::ScanCancelled, json!({ "kind": "scanCancelled" })),
             (
                 ScanErrorReason::Other { message: "unmirrored".to_owned() },
                 json!({ "kind": "other", "message": "unmirrored" }),
@@ -730,5 +970,300 @@ mod tests {
                 serde_json::from_value(wire).expect("deserialize a failure reason");
             assert_eq!(back, reason);
         }
+    }
+
+    // ── the forward mapping ─────────────────────────────────────────────────
+    //
+    // One core-model value per mirror fixture above, built to mirror it exactly.
+    // Pairing them means the mapping is asserted against values written for a
+    // different purpose: a field wired to the wrong source shows up as a
+    // mismatch on the one field, named.
+
+    /// The [`StreamSummary`] whose mirror is [`a_stream`].
+    fn a_core_stream() -> StreamSummary {
+        StreamSummary {
+            pid: Pid::new(4113),
+            stream_type: TsStreamType::AvcVideo,
+            codec_short_name: "AVC".to_owned(),
+            codec_name: "MPEG-4 AVC Video".to_owned(),
+            codec_alt_name: "AVC",
+            bitrate: 9,
+            active_bitrate: 10,
+            language_name: "English".to_owned(),
+            language_code: "eng".to_owned(),
+            description: "1080p / 23.976 fps".to_owned(),
+            full_description: "1080p / 23.976 fps / 16:9".to_owned(),
+            channel_description: "5.1".to_owned(),
+            sample_rate: 48_000,
+            bit_depth: 24,
+            channel_count: 5,
+            height: 1080,
+            angle_index: 11,
+            is_hidden: true,
+            ssif_only: false,
+        }
+    }
+
+    /// The [`ClipStreamTally`] whose mirror is [`a_clip_stream`].
+    fn a_core_clip_stream() -> ClipStreamTally {
+        ClipStreamTally {
+            pid: Pid::new(4352),
+            stream_type: TsStreamType::DtsHdMasterAudio,
+            codec_short_name: "DTS-HD MA".to_owned(),
+            payload_bytes: 21,
+            packet_count: 22,
+        }
+    }
+
+    /// The [`ClipSummary`] whose mirror is [`a_clip`].
+    fn a_core_clip() -> ClipSummary {
+        ClipSummary {
+            name: "00001.M2TS".to_owned(),
+            display_name: "00001.SSIF".to_owned(),
+            file_size: 12,
+            interleaved_file_size: 13,
+            angle_index: 14,
+            relative_time_in: 15.5,
+            length: 16.25,
+            payload_bytes: 17,
+            packet_count: 18,
+            packet_seconds: 19.5,
+            file_seconds: 20.5,
+            streams: vec![a_core_clip_stream()],
+        }
+    }
+
+    /// The [`ChapterSummary`] whose mirror is [`a_chapter`].
+    fn a_core_chapter() -> ChapterSummary {
+        ChapterSummary {
+            time_in: 23.5,
+            length: 24.5,
+            avg_rate: 25.5,
+            max_1sec_rate: 26.5,
+            max_1sec_time: 27.5,
+            max_5sec_rate: 28.5,
+            max_5sec_time: 29.5,
+            max_10sec_rate: 30.5,
+            max_10sec_time: 31.5,
+            avg_frame_size: 32.5,
+            max_frame_size: 33.5,
+            max_frame_time: 34.5,
+        }
+    }
+
+    /// The [`PlaylistSummary`] whose mirror is [`a_playlist`].
+    fn a_core_playlist() -> PlaylistSummary {
+        PlaylistSummary {
+            name: "00000.MPLS".to_owned(),
+            total_length: 3.5,
+            file_size: 4,
+            interleaved_file_size: 5,
+            chapter_count: 6,
+            stream_count: 7,
+            angle_count: 8,
+            has_loops: true,
+            streams: vec![a_core_stream()],
+            clips: vec![a_core_clip()],
+            chapters: vec![a_core_chapter()],
+        }
+    }
+
+    /// The recorded failure whose mirror is [`a_scan_error`].
+    fn a_core_scan_error() -> error::ScanError {
+        error::ScanError {
+            file: "00002.CLPI".to_owned(),
+            stage: error::ScanStage::ClipInfo,
+            reason: error::BdError::UnknownFileType("HDMV9999".to_owned()),
+        }
+    }
+
+    /// The [`BdRom`] whose mirror is [`a_disc`] — bar `measured` and `errors`,
+    /// which the scan supplies rather than the disc.
+    fn a_core_bdrom() -> BdRom {
+        BdRom {
+            volume_label: "MIRROR_DISC".to_owned(),
+            disc_title: Some("Mirror Title".to_owned()),
+            size: 1,
+            interleaved_size: 2,
+            is_3d: true,
+            is_50hz: false,
+            is_uhd: true,
+            is_bd_plus: false,
+            is_bd_java: true,
+            is_dbox: false,
+            is_psp: true,
+            playlists: vec![a_core_playlist()],
+        }
+    }
+
+    /// A playlist carrying what the presentation filter reads — its length and
+    /// whether it loops — over the whole-fields fixture.
+    fn filtered_playlist(name: &str, total_length: f64, has_loops: bool) -> PlaylistSummary {
+        PlaylistSummary { name: name.to_owned(), total_length, has_loops, ..a_core_playlist() }
+    }
+
+    /// A disc holding one playlist per filter classification: 00000 (100 s) is
+    /// listed by every filter, 00001 (5 s) is short, 00002 (200 s) loops.
+    fn a_mixed_core_bdrom() -> BdRom {
+        BdRom {
+            playlists: vec![
+                filtered_playlist("00000.MPLS", 100.0, false),
+                filtered_playlist("00001.MPLS", 5.0, false),
+                filtered_playlist("00002.MPLS", 200.0, true),
+            ],
+            ..a_core_bdrom()
+        }
+    }
+
+    /// The mirrored playlists' names, in the order the mirror holds them.
+    fn names(disc: &Disc) -> Vec<&str> {
+        disc.playlists.iter().map(|playlist| playlist.name.as_str()).collect()
+    }
+
+    /// The fixture disc scanned through the in-memory tree, mirrored.
+    fn a_fixture_disc(mode: ScanMode) -> Disc {
+        let tree = crate::build_tree(&crate::tests::fixture_blob());
+        let report = BdRom::open_resilient(&tree, mode).expect("the fixture disc opens");
+        Disc::from_scan(&report.bdrom, &report.errors, mode == ScanMode::Full)
+    }
+
+    #[test]
+    fn every_field_of_a_scanned_disc_maps_into_its_mirror() {
+        assert_eq!(Disc::from_scan(&a_core_bdrom(), &[a_core_scan_error()], true), a_disc());
+    }
+
+    #[test]
+    fn the_scan_mode_alone_decides_the_measured_flag() {
+        // Same disc, same values: only the flag differs, and it says whether a
+        // zero below was measured or never looked at.
+        let unmeasured = Disc::from_scan(&a_core_bdrom(), &[], false);
+        assert!(!unmeasured.measured);
+        assert!(unmeasured.errors.is_empty(), "a scan with no failures mirrors none");
+        assert_eq!(Disc { measured: true, ..unmeasured }, Disc { errors: Vec::new(), ..a_disc() });
+    }
+
+    #[test]
+    fn from_scan_keeps_the_playlists_a_listing_would_withhold() {
+        let disc = Disc::from_scan(&a_mixed_core_bdrom(), &[], true);
+        assert_eq!(names(&disc), ["00000.MPLS", "00001.MPLS", "00002.MPLS"]);
+    }
+
+    #[test]
+    fn from_listing_holds_only_the_playlists_the_filter_keeps() {
+        let bdrom = a_mixed_core_bdrom();
+        let listing = |filter: &PlaylistFilter| {
+            let disc = Disc::from_listing(&bdrom, &[a_core_scan_error()], filter);
+            assert!(!disc.measured, "a listing scan never ran the packet scan");
+            assert_eq!(disc.errors, vec![a_scan_error()], "the failures are not filtered");
+            names(&disc).into_iter().map(str::to_owned).collect::<Vec<_>>()
+        };
+        // The standard filter withholds the short and the looping playlist.
+        assert_eq!(listing(&PlaylistFilter::default()), ["00000.MPLS"]);
+        // A threshold the short playlist meets exactly keeps it: the boundary
+        // is the same one `PlaylistFilter::keeps` draws.
+        let lowered = PlaylistFilter { short_playlist_seconds: 5.0, ..PlaylistFilter::default() };
+        assert_eq!(listing(&lowered), ["00000.MPLS", "00001.MPLS"]);
+        assert_eq!(
+            listing(&PlaylistFilter::everything()),
+            ["00000.MPLS", "00001.MPLS", "00002.MPLS"]
+        );
+    }
+
+    #[test]
+    fn every_scan_stage_crosses_as_its_own_mirror_member() {
+        for (stage, mirrored) in [
+            (error::ScanStage::Discovery, ScanStage::Discovery),
+            (error::ScanStage::ClipInfo, ScanStage::ClipInfo),
+            (error::ScanStage::Playlist, ScanStage::Playlist),
+            (error::ScanStage::StreamFile, ScanStage::StreamFile),
+            (error::ScanStage::SectorRead, ScanStage::SectorRead),
+        ] {
+            assert_eq!(ScanStage::from(stage), mirrored, "{stage:?}");
+        }
+    }
+
+    #[test]
+    fn every_failure_kind_crosses_as_its_own_mirror_member() {
+        for (reason, mirrored) in [
+            (
+                error::BdError::UnknownFileType("MPLSXXXX".to_owned()),
+                ScanErrorReason::UnknownFileType { magic: "MPLSXXXX".to_owned() },
+            ),
+            (error::BdError::UnexpectedEof, ScanErrorReason::UnexpectedEof),
+            (error::BdError::StructureNotFound, ScanErrorReason::StructureNotFound),
+            (
+                error::BdError::MissingClipFile("00003.CLPI".to_owned()),
+                ScanErrorReason::MissingClipFile { file: "00003.CLPI".to_owned() },
+            ),
+            (
+                error::BdError::Io(io::Error::other("denied")),
+                ScanErrorReason::Io { message: "denied".to_owned() },
+            ),
+            (
+                error::BdError::MetadataTooLarge {
+                    file: "00000.MPLS".to_owned(),
+                    limit: 67_108_864,
+                },
+                ScanErrorReason::MetadataTooLarge {
+                    file: "00000.MPLS".to_owned(),
+                    limit_bytes: 67_108_864,
+                },
+            ),
+            // The mirror names no cancelled-scan kind: cancelling aborts the
+            // whole open, so it is never recorded against a file. It crosses
+            // as the catch-all, which is also where a kind added to the
+            // scanner later would land.
+            (
+                error::BdError::ScanCancelled,
+                ScanErrorReason::Other { message: "scan cancelled".to_owned() },
+            ),
+        ] {
+            assert_eq!(ScanErrorReason::from(&reason), mirrored, "{reason}");
+        }
+    }
+
+    #[test]
+    fn a_measured_scan_of_the_fixture_disc_fills_the_mirror_in() {
+        let disc = a_fixture_disc(ScanMode::Full);
+        assert!(disc.measured);
+        assert_eq!(disc.volume_label, "WASMDISC");
+        assert_eq!(disc.size_bytes, 11_146_324);
+        assert!(disc.errors.is_empty(), "the fixture is healthy media");
+
+        let playlist = disc.playlists.first().expect("the fixture has one playlist");
+        assert_eq!(names(&disc), ["00000.MPLS"]);
+        assert_eq!(playlist.stream_count, 2);
+        // The clip file on disk. The report prints the packet-derived size
+        // (11,064,384 bytes) on its `Size:` line instead, which is why the two
+        // numbers differ.
+        assert_eq!(playlist.file_size_bytes, 11_145_216);
+
+        let clip = playlist.clips.first().expect("the playlist has one clip");
+        assert_eq!(clip.name, "00000.M2TS");
+        assert!(clip.packet_count > 0, "the packet scan tallied the clip");
+        assert_eq!(clip.streams.len(), 2, "both streams are tallied over the whole file");
+
+        let video = playlist.streams.first().expect("the playlist has a video stream");
+        assert_eq!(video.codec_name, "MPEG-4 AVC Video");
+        assert!(video.bitrate_bps > 0, "the packet scan measured the video rate");
+
+        let chapter = playlist.chapters.first().expect("the playlist has a chapter");
+        assert!(chapter.max_1sec_rate_bps > 0.0, "the packet scan measured the chapter rates");
+    }
+
+    #[test]
+    fn a_metadata_scan_of_the_fixture_disc_mirrors_the_structure_unmeasured() {
+        let disc = a_fixture_disc(ScanMode::Metadata);
+        assert!(!disc.measured);
+        // The structure is all there — the same playlist, clip and streams…
+        let measured = a_fixture_disc(ScanMode::Full);
+        assert_eq!(names(&disc), names(&measured));
+        let playlist = disc.playlists.first().expect("the fixture has one playlist");
+        assert_eq!(playlist.clips.len(), 1);
+        assert_eq!(playlist.stream_count, 2);
+        // …and every measured value is the zero `measured: false` explains.
+        assert_eq!(playlist.clips.iter().map(|clip| clip.packet_count).sum::<u64>(), 0);
+        assert!(playlist.streams.iter().all(|stream| stream.bitrate_bps == 0));
+        assert!(playlist.chapters.iter().all(|chapter| chapter.max_1sec_rate_bps == 0.0));
     }
 }

--- a/crates/bdinfo-rs-wasm/wasm-size-budget.txt
+++ b/crates/bdinfo-rs-wasm/wasm-size-budget.txt
@@ -4,16 +4,20 @@
 # A RATCHET: the gate (scripts/wasm-compliance.ps1) and CI (wasm.yml) fail if the
 # optimized .wasm exceeds this. Lower it deliberately when the figure drops;
 # NEVER raise it without a written reason in the commit. Current optimized size
-# is ~424,794 B (rustc 1.96.0 + wasm-bindgen 0.2.126 + binaryen 131.0.0).
+# is ~511,231 B (rustc 1.96.0 + wasm-bindgen 0.2.126 + binaryen 131.0.0).
 #
-# Two steps account for the growth over the ~362,471 B this crate started at.
+# Three steps account for the growth over the ~362,471 B this crate started at.
 # Linking the read-only UDF 2.50 reader for `.iso` input (the scan_iso /
 # list_iso_playlists exports + WebIso) took it to ~402,504 B; the reader had
 # been dead-code-eliminated out before, because nothing called it. The
 # structural disc-model exports (inspect_files / inspect_iso) then added
 # ~22,290 B by giving the serde `Serialize` tree over the mirror types its
-# first caller, which is what pulls serde-wasm-bindgen into the payload.
+# first caller, which is what pulls serde-wasm-bindgen into the payload. Taking
+# a disc model back IN (render_report / scan_files_full / scan_iso_full) then
+# added ~86,440 B: `Deserialize` over that same tree is the larger half of
+# serde, since reading a value needs a name-matching visitor per field where
+# writing one needs only a write.
 #
-# The ceiling (420 KiB) carries a small headroom for patch-level toolchain
+# The ceiling (512 KiB) carries a small headroom for patch-level toolchain
 # drift (binaryen is ^131.x).
-430080
+524288

--- a/crates/bdinfo-rs-wasm/wasm-size-budget.txt
+++ b/crates/bdinfo-rs-wasm/wasm-size-budget.txt
@@ -4,10 +4,16 @@
 # A RATCHET: the gate (scripts/wasm-compliance.ps1) and CI (wasm.yml) fail if the
 # optimized .wasm exceeds this. Lower it deliberately when the figure drops;
 # NEVER raise it without a written reason in the commit. Current optimized size
-# is ~402,504 B (rustc 1.96.0 + wasm-bindgen 0.2.126 + binaryen 131.0.0). The
-# bulk of the growth over the ~362,471 B this crate started at came from linking
-# the read-only UDF 2.50 reader for `.iso` input (the scan_iso /
-# list_iso_playlists exports + WebIso); the core was previously dead-code-
-# eliminated out because nothing called it. The ceiling (400 KiB) carries a
-# small headroom for patch-level toolchain drift (binaryen is ^131.x).
-409600
+# is ~424,794 B (rustc 1.96.0 + wasm-bindgen 0.2.126 + binaryen 131.0.0).
+#
+# Two steps account for the growth over the ~362,471 B this crate started at.
+# Linking the read-only UDF 2.50 reader for `.iso` input (the scan_iso /
+# list_iso_playlists exports + WebIso) took it to ~402,504 B; the reader had
+# been dead-code-eliminated out before, because nothing called it. The
+# structural disc-model exports (inspect_files / inspect_iso) then added
+# ~22,290 B by giving the serde `Serialize` tree over the mirror types its
+# first caller, which is what pulls serde-wasm-bindgen into the payload.
+#
+# The ceiling (420 KiB) carries a small headroom for patch-level toolchain
+# drift (binaryen is ^131.x).
+430080

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -21,66 +21,138 @@ Firefox.
 npm i @bdinfo-rs/wasm
 ```
 
-The published payload is **~360 KB of WebAssembly + ~22 KB of JS**. Only the
-main-thread entry you import (~4 KB) loads up front; the scan Worker (~2 KB) and
-the wasm-bindgen glue (~17 KB) that hosts the `.wasm` are fetched lazily inside
-the Worker, and nothing past the entry loads at all until you call `analyze` or
-`listPlaylists`.
+The published payload is **~500 KB of WebAssembly + ~62 KB of JS**. Only the
+main-thread entry you import (~18 KB) loads up front; the scan Worker (~4 KB)
+and the wasm-bindgen glue (~40 KB) that hosts the `.wasm` are fetched lazily
+inside the Worker, and nothing past the entry loads at all until the first scan.
 
 ## Usage
 
-The two calls mirror the CLI flow — list the playlists, pick some, then measure
-them (all in the browser, off the main thread):
+Three calls mirror the CLI flow — inspect the disc, measure the playlists you
+want, re-render the report as you like. Each takes either a picked BDMV folder
+(as `(relativePath, File)` pairs) or a single Blu-ray `.iso` `File`, and each
+runs in the browser, off the main thread:
 
 ```ts
-import { analyze, listPlaylists } from "@bdinfo-rs/wasm";
+import { inspect, renderReport, scan } from "@bdinfo-rs/wasm";
 
-// `files`: the (relativePath, File) pairs from a <input type="file" webkitdirectory>.
+// `picked`: the (relativePath, File) pairs from a <input type="file" webkitdirectory>.
 const picked = [...input.files].map((file) => ({
   path: file.webkitRelativePath,
   file,
 }));
 
-// 1. Fast STRUCTURAL scan → the playlist selection table (like `--list`).
-const playlists = await listPlaylists(picked);
-for (const row of playlists) {
-  console.log(`${row.position}. ${row.name}  ${row.length}  ${row.estimatedBytes ?? "-"} bytes`);
+// 1. Fast STRUCTURAL scan (like `--list`) → the whole disc model, no demux.
+const disc = await inspect(picked);
+for (const playlist of disc.playlists) {
+  console.log(`${playlist.name}  ${playlist.totalLengthSeconds}s  ${playlist.chapterCount} ch`);
 }
 
-// 2. FULL measured scan. Pass `selection` (playlist names, like `--mpls`) to
-//    measure only chosen playlists; omit it to measure the `--whole` set.
-const report = await analyze(
+// 2. FULL measured scan → the classic report AND the same scan as data, from
+//    one demux. Pass `selection` (playlist names, like `--mpls`) to measure only
+//    chosen playlists; omit it to measure the `--whole` set.
+const measured = await scan(
   picked,
   ({ file, done, total }) => console.log(`${file}: ${done}/${total}`),
-  { selection: [playlists[0].name] },
+  { selection: [disc.playlists[0].name] },
 );
 
-console.log(report); // the classic BDInfo-style disc report
+console.log(measured.report); // the classic BDInfo-style disc report
+
+// 3. Re-render that report with different sections — no media, no rescan.
+const brief = await renderReport(measured.disc, { quickSummary: false });
 ```
 
-`listPlaylists` resolves with the selection-table rows (`position`, `group`,
-`name`, `length`, `estimatedBytes`, `hasHidden`, `hiddenBy`); `analyze` spawns
-the scan Worker, relays demux progress, and resolves with the report string.
-Omit both `onProgress` and `selection` for the simplest whole-disc scan.
-
-Like the classic report, the listing hides playlists shorter than 20 seconds and
-looping ones. Pass `showShortPlaylists` / `showLoopingPlaylists` to list them
-too; each row's `hiddenBy` names the rules that classify it as withheld
-(`"short"`, `"looping"`, both, or none), whichever options were passed — so one
-widened listing can be re-filtered in your UI without re-scanning:
+An `.iso` goes through the same three calls; pass the `File` instead of the
+list, and the image is opened through the read-only UDF reader:
 
 ```ts
-const all = await listPlaylists(picked, {
+const disc = await inspect(isoInput.files[0]);
+const { report } = await scan(isoInput.files[0]);
+```
+
+### The disc model
+
+`inspect` and `scan` both give you a `Disc`: the disc-level properties
+(`volumeLabel`, `discTitle`, `sizeBytes`, `is3d`, `isUhd`, …) and every
+`Playlist` on it, each carrying its `Stream`s, `Clip`s and `Chapter`s. Values
+cross as raw numbers with unit-bearing names — `bitrateBps`, `sampleRateHz`,
+`heightPixels`, `lengthSeconds` — so your UI can sort, filter and chart them
+rather than parse report text. The types (`Disc`, `Playlist`, `Stream`, `Clip`,
+`ClipStream`, `Chapter`, `ScanError`, `ScanResult`) are exported from the
+package entry and generated from the Rust definitions.
+
+`disc.measured` tells the two scans apart: `false` after `inspect`, where every
+measured value — bitrates, packet counts, chapter rates — is zero because
+nothing measured it; `true` after `scan`, where a zero is a genuine zero.
+
+### Re-rendering the report
+
+The model carries **every value the report prints**, so `renderReport(disc)`
+reproduces the report that `scan` returned byte for byte — a render, not an
+approximation, pinned against the same golden the scan itself is pinned to. The
+`Disc` is therefore the thing worth keeping: store it and every rendering of the
+report stays one call away, with no media and no rescan.
+
+```ts
+const { report, disc } = await scan(picked);
+// later, from the held disc alone — the same bytes, minus one section:
+const trimmed = await renderReport(disc, { streamDiagnostics: false });
+```
+
+`streamDiagnostics` and `quickSummary` both default to on, which is the report
+the CLI writes. A `disc` from a `scan` with a `selection` holds every playlist
+but measured values only for the ones that scan named, so re-rendering it prints
+the rest at zero — scan again to measure them.
+
+### Playlist filtering
+
+Like the classic report, `inspect` withholds playlists shorter than 20 seconds
+and looping ones. Pass `showShortPlaylists` / `showLoopingPlaylists` to include
+them, and `shortPlaylistSeconds` to move the length threshold:
+
+```ts
+const everything = await inspect(picked, {
   showShortPlaylists: true,
   showLoopingPlaylists: true,
 });
-const standard = all.filter((row) => row.hiddenBy.length === 0);
 ```
 
-The options only widen what `listPlaylists` returns. `analyze` measures its
-`selection` unfiltered either way, and the report is unchanged. See `index.html`
-in the source repository for a complete vanilla example (the demo is not shipped
-in the npm package).
+The options only widen `disc.playlists`; the disc-level properties and
+`disc.errors` always describe the whole disc. A measured `scan` measures its
+`selection` unfiltered either way, and the report is unchanged.
+
+### Cancelling
+
+Pass an `AbortSignal`. Aborting it terminates the scan Worker and rejects the
+promise with an `AbortError`, so a user cancel is distinguishable from a real
+failure by the rejection's `name`:
+
+```ts
+const controller = new AbortController();
+const { report } = await scan(picked, undefined, { signal: controller.signal });
+```
+
+### Deprecated calls
+
+`analyze`, `analyzeIso`, `listPlaylists` and `listPlaylistsIso` are the 2.0
+surface. They keep working exactly as before, and 3.0.0 removes them:
+
+| Deprecated | Replacement |
+| --- | --- |
+| `analyze(files, onProgress?, options?)` | `scan(files, onProgress?, options?)` |
+| `analyzeIso(file, onProgress?, options?)` | `scan(file, onProgress?, options?)` |
+| `listPlaylists(files, options?)` | `inspect(files, options?)` |
+| `listPlaylistsIso(file, options?)` | `inspect(file, options?)` |
+
+`listPlaylists` resolves with selection-table rows (`position`, `group`, `name`,
+`length`, `estimatedBytes`, `hasHidden`, `hiddenBy`). Of those, `position`,
+`group` and `hiddenBy` describe the table rather than the disc and are not on
+the `Disc`, so a UI that renders a selection table derives them from
+`disc.playlists` itself.
+
+See `index.html` in the source repository for a complete vanilla example (the
+demo is not shipped in the npm package).
 
 ## Bundler support
 
@@ -90,7 +162,7 @@ runtime**: the Web Worker (`dist/worker.js`) and the WebAssembly module
 (`pkg/bdinfo_rs_wasm_bg.wasm`, fetched by the Worker). Your toolchain must emit
 both as addressable assets.
 
-`analyze` spawns the Worker with the standard
+Every call spawns the Worker with the standard
 
 ```ts
 new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
@@ -116,7 +188,7 @@ bundler produces for the copied worker:
 ```ts
 import workerUrl from "./worker.js?worker&url"; // however your bundler exposes it
 
-await analyze(picked, onProgress, {
+await scan(picked, onProgress, {
   createWorker: () => new Worker(workerUrl, { type: "module" }),
 });
 ```
@@ -135,8 +207,8 @@ inside a Worker. Both are available on **desktop Chrome / Edge, desktop Firefox,
 and Android Chrome**. The package's parity suite runs on **headless Chrome and
 Firefox** (plus Node), so those are the verified engines; desktop **Safari**
 exposes the same APIs but is **untested**. `FileReaderSync` is Worker-only by
-design, which is why `analyze` always runs the scan in a Web Worker and never on
-the main thread.
+design, which is why every call runs in a Web Worker and never on the main
+thread.
 
 **iOS is the one known gap:** iOS WebKit could not pick a folder on iOS ≤ 18.3
 (the `webkitdirectory` bit was unimplemented; it shipped in iOS 18.4). Treat the
@@ -151,7 +223,7 @@ A `--target web` wasm module is compiled and instantiated at runtime, so a page
 that sets a `script-src` (or `default-src`) CSP must allow WebAssembly with
 **`'wasm-unsafe-eval'`** (the broader `'unsafe-eval'` also works); otherwise the
 module is blocked. With no CSP, wasm runs freely. The scan itself must run in a
-Web Worker — `analyze` handles that for you.
+Web Worker — the package handles that for you.
 
 ## License
 

--- a/crates/bdinfo-rs-wasm/web/src/analyze.ts
+++ b/crates/bdinfo-rs-wasm/web/src/analyze.ts
@@ -1,17 +1,41 @@
-// The package's public API. Two calls mirror the CLI flow, both running the
-// bdinfo-rs scan entirely in the browser, off the main thread:
+// The package's public API. Three calls run the bdinfo-rs scan entirely in the
+// browser, off the main thread, over either a `webkitdirectory`-picked BDMV
+// folder or a single Blu-ray `.iso` `File`:
 //
-//   - `listPlaylists` — the fast STRUCTURAL scan: the playlist selection table
-//     (like `bdinfo-rs <disc> --list`), so the UI can show a multi-select
-//     checklist before the heavy work.
-//   - `analyze` — the FULL measured scan over the picked folder; pass
-//     `options.selection` to measure only chosen playlists (like `--mpls`),
-//     or omit it to measure the standard `--whole` set.
+//   - `inspect` — the fast STRUCTURAL scan (like `bdinfo-rs <disc> --list`): no
+//     packet demux, so it reads the playlist and clip metadata rather than the
+//     multi-GB stream files, and resolves with the whole disc model.
+//   - `scan` — the FULL measured scan (like `bdinfo-rs <disc>`), resolving with
+//     the rendered report AND the disc model, both from one demux.
+//   - `renderReport` — re-renders the report from a disc model `scan` returned,
+//     with different optional sections and without touching the media again.
 //
 // Each spawns the scan Worker (which hosts the WebAssembly module), hands it the
-// `(relativePath, File)` pairs, and resolves with the result — the rendered
-// classic disc report (the very bytes the native CLI writes to
-// `BDINFO.<label>.txt`), or the selection-table rows.
+// files, and resolves with the result — the rendered classic disc report being
+// the very bytes the native CLI writes to `BDINFO.<label>.txt`.
+//
+// `analyze`, `analyzeIso`, `listPlaylists` and `listPlaylistsIso` are the 2.0
+// surface: each returns one slice of what the three calls above return. They
+// keep working exactly as before and are deprecated for removal in 3.0.0.
+
+import type { Disc, ScanResult } from "../pkg/bdinfo_rs_wasm.js";
+
+// The structured disc model is generated from the Rust types, so these
+// declarations and the values the WebAssembly module hands back have one source
+// of truth. Re-exported from the package entry so a consumer that types a `Disc`
+// does not have to reach into the `@bdinfo-rs/wasm/wasm` subpath for it.
+export type {
+  Chapter,
+  Clip,
+  ClipStream,
+  Disc,
+  Playlist,
+  ScanError,
+  ScanErrorReason,
+  ScanResult,
+  ScanStage,
+  Stream,
+} from "../pkg/bdinfo_rs_wasm.js";
 
 /** One file of a disc, paired with its path relative to the picked folder. */
 export interface BdmvFile {
@@ -20,6 +44,13 @@ export interface BdmvFile {
   /** The browser `File` handle; its bytes are read lazily inside the Worker. */
   file: File;
 }
+
+/**
+ * What a call reads the disc from: the `(relativePath, File)` pairs of a
+ * `webkitdirectory` folder pick, or a single Blu-ray `.iso` `File`. Every call
+ * that takes one accepts both and tells them apart itself.
+ */
+export type DiscSource = BdmvFile[] | File;
 
 /** Live demux progress: `done`/`total` bytes over the file being scanned. */
 export interface ScanProgress {
@@ -31,6 +62,11 @@ export interface ScanProgress {
 /** A progress observer, called repeatedly as the scan demuxes. */
 export type ProgressFn = (progress: ScanProgress) => void;
 
+// Declared here rather than generated with the disc model: the WebAssembly
+// module builds these rows as JSON text through a serializer of its own, so no
+// TypeScript declaration is emitted for them — and `hiddenBy` is typed here as
+// the closed set of rule names that serializer can emit, which a generated
+// declaration would widen to `string[]`.
 /**
  * One playlist of the disc — a row of the selection table {@link listPlaylists}
  * returns, mirroring the CLI's `#`/Group/Playlist File/Length/Estimated Bytes
@@ -62,7 +98,10 @@ export interface PlaylistRow {
   hiddenBy: ("short" | "looping")[];
 }
 
-/** Optional overrides for {@link analyze} and {@link listPlaylists}. */
+/**
+ * Optional overrides for every call in this module. Each option documents which
+ * calls read it; a call ignores the ones it does not name.
+ */
 export interface AnalyzeOptions {
   /**
    * A factory constructing the scan Worker to use. Defaults to
@@ -72,43 +111,75 @@ export interface AnalyzeOptions {
    * this when your toolchain can't follow that pattern and you host `worker.js`
    * (and the `.wasm` it loads) yourself — construct the module Worker from the
    * URL your bundler produced for `worker.js` and return it.
+   *
+   * Read by every call: each one runs in the scan Worker.
    */
   createWorker?: () => Worker;
   /**
    * The playlists to measure, by {@link PlaylistRow.name} — the browser
    * equivalent of the CLI's `--mpls`, measured unfiltered in the given order.
-   * Omitted or empty measures the standard `--whole` set. Ignored by
-   * {@link listPlaylists}.
+   * Omitted or empty measures the standard `--whole` set.
+   *
+   * Read by {@link scan}, {@link analyze} and {@link analyzeIso}.
    */
   selection?: string[];
   /**
-   * List playlists shorter than 20 seconds too — the CLI's
-   * `--show-short-playlists`. Used by {@link listPlaylists} /
-   * {@link listPlaylistsIso}, which drop them by default; ignored by
-   * {@link analyze} / {@link analyzeIso}, which measure `selection` unfiltered.
+   * Include playlists shorter than {@link AnalyzeOptions.shortPlaylistSeconds}
+   * — the CLI's `--show-short-playlists`.
+   *
+   * Read by {@link inspect}, {@link listPlaylists} and
+   * {@link listPlaylistsIso}, which withhold them by default. The measured
+   * scans measure their `selection` unfiltered, so it changes nothing there.
    */
   showShortPlaylists?: boolean;
   /**
-   * List looping playlists too — the CLI's `--show-looping-playlists`. Used by
-   * {@link listPlaylists} / {@link listPlaylistsIso}, which drop them by
-   * default; ignored by {@link analyze} / {@link analyzeIso}, which measure
-   * `selection` unfiltered.
+   * Include looping playlists — the CLI's `--show-looping-playlists`. Read by
+   * the same calls as {@link AnalyzeOptions.showShortPlaylists}, and with the
+   * same effect on the others: none.
    */
   showLoopingPlaylists?: boolean;
   /**
-   * An optional {@link AbortSignal} that cancels an in-progress measured scan
-   * ({@link analyze} / {@link analyzeIso}): when it aborts, the scan Worker is
-   * terminated and the returned promise rejects with the signal's reason (an
-   * `AbortError`). Ignored by {@link listPlaylists} — the structural scan is
-   * fast enough not to need it.
+   * The length in seconds under which a playlist counts as short, defaulting to
+   * 20. Zero or less means that default.
+   *
+   * Read by {@link inspect} only — {@link listPlaylists} and
+   * {@link listPlaylistsIso} always judge against the 20 s default.
+   */
+  shortPlaylistSeconds?: number;
+  /**
+   * Render the report's `STREAM DIAGNOSTICS:` section, defaulting to `true` —
+   * the section the CLI's report carries.
+   *
+   * Read by {@link scan} and {@link renderReport}. {@link analyze} and
+   * {@link analyzeIso} always render every section.
+   */
+  streamDiagnostics?: boolean;
+  /**
+   * Render the report's `QUICK SUMMARY:` section, defaulting to `true`. Read by
+   * the same calls as {@link AnalyzeOptions.streamDiagnostics}.
+   */
+  quickSummary?: boolean;
+  /**
+   * An optional {@link AbortSignal} that cancels the call in progress: when it
+   * aborts, the scan Worker is terminated and the returned promise rejects with
+   * the signal's reason (an `AbortError`), so callers can tell a user cancel
+   * from a real failure by the rejection's `name`.
+   *
+   * Read by {@link inspect}, {@link scan}, {@link renderReport},
+   * {@link analyze} and {@link analyzeIso}. Ignored by {@link listPlaylists} /
+   * {@link listPlaylistsIso} — the structural scan is fast enough not to need
+   * it.
    */
   signal?: AbortSignal;
 }
 
+/** Everything the scan Worker posts back; see `worker.ts` for who sends what. */
 type WorkerMessage =
   | ({ type: "progress" } & ScanProgress)
   | { type: "done"; report: string }
   | { type: "rows"; rows: PlaylistRow[] }
+  | { type: "disc"; disc: Disc }
+  | { type: "result"; result: ScanResult }
   | { type: "error"; message: string };
 
 /** Spawns the scan Worker (a module worker by the bundler-aware convention). */
@@ -146,6 +217,37 @@ function listingOptions(options?: AnalyzeOptions): {
 }
 
 /**
+ * The playlist-filter options an {@link inspect} request carries: a listing's
+ * two opt-outs plus the short-playlist threshold only this call reads. Zero is
+ * how the WebAssembly module spells "use the 20 s default".
+ */
+function inspectOptions(options?: AnalyzeOptions): {
+  showShortPlaylists: boolean;
+  showLoopingPlaylists: boolean;
+  shortPlaylistSeconds: number;
+} {
+  return {
+    ...listingOptions(options),
+    shortPlaylistSeconds: options?.shortPlaylistSeconds ?? 0,
+  };
+}
+
+/**
+ * The two optional report sections a render request carries. Both default to
+ * `true` — an omitted option renders its section, so a render with no options
+ * reproduces the report the CLI writes.
+ */
+function reportOptions(options?: AnalyzeOptions): {
+  streamDiagnostics: boolean;
+  quickSummary: boolean;
+} {
+  return {
+    streamDiagnostics: options?.streamDiagnostics ?? true,
+    quickSummary: options?.quickSummary ?? true,
+  };
+}
+
+/**
  * The reject reason for a cancelled scan. Always an `AbortError` (the signal's
  * own reason when present, else a fresh one), so callers can tell a user cancel
  * from a real scan failure by its `name`.
@@ -155,6 +257,166 @@ function cancelledError(signal?: AbortSignal): DOMException {
   return reason instanceof DOMException && reason.name === "AbortError"
     ? reason
     : new DOMException("scan cancelled", "AbortError");
+}
+
+/**
+ * Runs one scan-Worker request end to end and resolves with what `take` pulls
+ * out of the reply that answers it.
+ *
+ * `request` is the shape every call in this module shares: spawn the Worker,
+ * post one request, forward demux progress to `onProgress`, settle on the first
+ * reply `take` accepts or on the first `error`, and terminate the Worker on
+ * every exit — reply, failure, or cancel. `take` returns `null` for a message
+ * that is not this request's answer, which is what keeps the message loop out of
+ * the calls themselves.
+ *
+ * `message` must be one of the request shapes `worker.ts` declares as `Request`;
+ * that union is the contract, and it cannot be imported here because `worker.ts`
+ * type-checks against the WebWorker library rather than the DOM.
+ */
+function request<T>(
+  message: unknown,
+  take: (reply: WorkerMessage) => { value: T } | null,
+  options?: AnalyzeOptions,
+  onProgress?: ProgressFn,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const signal = options?.signal;
+    if (signal?.aborted) {
+      reject(cancelledError(signal));
+      return;
+    }
+    const worker = spawnWorker(options);
+
+    // Cancel = terminate the Worker (its normal teardown path), just earlier.
+    const onAbort = () => {
+      worker.terminate();
+      reject(cancelledError(signal));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    const close = () => {
+      signal?.removeEventListener("abort", onAbort);
+      worker.terminate();
+    };
+
+    worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
+      const reply = event.data;
+      if (reply.type === "progress") {
+        onProgress?.(reply);
+        return;
+      }
+      if (reply.type === "error") {
+        close();
+        reject(new Error(reply.message));
+        return;
+      }
+      const answer = take(reply);
+      if (answer !== null) {
+        close();
+        resolve(answer.value);
+      }
+    };
+
+    worker.onerror = (event: ErrorEvent) => {
+      close();
+      reject(new Error(event.message || "scan worker failed"));
+    };
+
+    worker.postMessage(message);
+  });
+}
+
+/**
+ * Runs the fast structural scan and resolves with the whole disc model (see
+ * {@link Disc}) — a `webkitdirectory` folder pick or a single Blu-ray `.iso`
+ * `File` in, everything the disc's metadata knows out.
+ *
+ * No stream file is demuxed, so it returns quickly and `disc.measured` is
+ * `false`: every measured value — bitrates, packet counts, chapter rates — is
+ * zero because nothing measured it rather than because it is genuinely zero.
+ * Show the playlists as a checklist, then hand the chosen
+ * {@link Playlist.name}s to {@link scan}'s `options.selection`.
+ *
+ * `disc.playlists` holds the playlists the selection filter keeps, which
+ * `options.showShortPlaylists`, `options.showLoopingPlaylists` and
+ * `options.shortPlaylistSeconds` widen; the disc-level properties and
+ * `disc.errors` always describe the whole disc.
+ *
+ * Everything runs locally: no bytes leave the page.
+ */
+export function inspect(source: DiscSource, options?: AnalyzeOptions): Promise<Disc> {
+  const message = Array.isArray(source)
+    ? { kind: "inspect", ...payload(source), ...inspectOptions(options) }
+    : { kind: "inspect-iso", file: source, ...inspectOptions(options) };
+  return request(
+    message,
+    (reply) => (reply.type === "disc" ? { value: reply.disc } : null),
+    options,
+  );
+}
+
+/**
+ * Runs the full measured Blu-ray scan in a Worker and resolves with both
+ * outputs of that one demux: the classic disc report and the same scan as a
+ * {@link Disc} (see {@link ScanResult}). Takes a `webkitdirectory` folder pick
+ * or a single Blu-ray `.iso` `File`; an `.iso` is opened through the read-only
+ * UDF reader and read on demand at byte offsets, never loaded whole, so a
+ * multi-GB image is fine.
+ *
+ * `onProgress`, if given, is called as the scan demuxes. `options.selection`
+ * measures only the named playlists (the CLI's `--mpls`), defaulting to the
+ * standard `--whole` set. `options.streamDiagnostics` and
+ * `options.quickSummary` choose the report's optional sections, both rendered
+ * unless switched off. `options.signal` cancels the scan.
+ *
+ * `result.disc.measured` is `true`, so a zero in it is a genuine zero. Keep
+ * `result.disc` and {@link renderReport} re-renders the report from it with
+ * other sections, without reading the disc again.
+ *
+ * Everything runs locally: no bytes leave the page.
+ */
+export function scan(
+  source: DiscSource,
+  onProgress?: ProgressFn,
+  options?: AnalyzeOptions,
+): Promise<ScanResult> {
+  const selection = options?.selection ?? [];
+  const message = Array.isArray(source)
+    ? { kind: "scan-full", ...payload(source), selection, ...reportOptions(options) }
+    : { kind: "scan-iso-full", file: source, selection, ...reportOptions(options) };
+  return request(
+    message,
+    (reply) => (reply.type === "result" ? { value: reply.result } : null),
+    options,
+    onProgress,
+  );
+}
+
+/**
+ * Re-renders the classic disc report from a {@link Disc} — no media, no
+ * rescan — with whichever optional sections `options.streamDiagnostics` and
+ * `options.quickSummary` ask for, both rendered unless switched off.
+ *
+ * The disc model carries every value the report prints, so this is a render
+ * rather than an approximation: `renderReport(result.disc)` on the `disc` from
+ * a {@link scan} reproduces that scan's report byte for byte. Store the `Disc`
+ * rather than the report text and every rendering of it stays one call away.
+ * It is also the only supported way to turn a `Disc` into report text —
+ * formatting the model by hand produces something that merely resembles the
+ * locked format.
+ *
+ * The playlists print in the disc's presentation order: the standard `--whole`
+ * set, grouped by shared clip files and longest first. A `disc` from a
+ * {@link scan} with a `selection` holds every playlist but measured values only
+ * for the ones that scan named, so re-rendering it prints the rest at zero —
+ * scan again to measure them.
+ */
+export function renderReport(disc: Disc, options?: AnalyzeOptions): Promise<string> {
+  return request(
+    { kind: "render", disc, ...reportOptions(options) },
+    (reply) => (reply.type === "done" ? { value: reply.report } : null),
+    options,
+  );
 }
 
 /**
@@ -168,6 +430,12 @@ function cancelledError(signal?: AbortSignal): DOMException {
  * too, and read each row's {@link PlaylistRow.hiddenBy} to tell them apart.
  *
  * Everything runs locally: no bytes leave the page.
+ *
+ * @deprecated since 2.1.0, removed in 3.0.0. Use {@link inspect}, which runs
+ * the same structural scan and resolves with the whole {@link Disc} instead of
+ * seven table columns. `position`, `group` and `hiddenBy` describe the table
+ * rather than the disc and are not on the model, so a UI that renders a
+ * selection table derives them from `disc.playlists` itself.
  */
 export function listPlaylists(files: BdmvFile[], options?: AnalyzeOptions): Promise<PlaylistRow[]> {
   return new Promise<PlaylistRow[]>((resolve, reject) => {
@@ -205,6 +473,11 @@ export function listPlaylists(files: BdmvFile[], options?: AnalyzeOptions): Prom
  * too, and read each row's {@link PlaylistRow.hiddenBy} to tell them apart.
  *
  * Everything runs locally: no bytes leave the page.
+ *
+ * @deprecated since 2.1.0, removed in 3.0.0. Use {@link inspect}, which takes
+ * the `.iso` `File` directly and resolves with the whole {@link Disc}; see the
+ * note on {@link listPlaylists} for the three row columns the model leaves to
+ * the caller.
  */
 export function listPlaylistsIso(file: File, options?: AnalyzeOptions): Promise<PlaylistRow[]> {
   return new Promise<PlaylistRow[]>((resolve, reject) => {
@@ -238,6 +511,11 @@ export function listPlaylistsIso(file: File, options?: AnalyzeOptions): Promise<
  * `options.createWorker` overrides how the scan Worker is constructed.
  *
  * Everything runs locally: no bytes leave the page.
+ *
+ * @deprecated since 2.1.0, removed in 3.0.0. Use {@link scan}, which runs the
+ * same measured scan and resolves with the same report plus the {@link Disc} it
+ * was rendered from, takes the folder or the `.iso` through one parameter, and
+ * accepts the report-section options.
  */
 export function analyze(
   files: BdmvFile[],
@@ -300,6 +578,10 @@ export function analyze(
  * as in {@link analyze}.
  *
  * Everything runs locally: no bytes leave the page.
+ *
+ * @deprecated since 2.1.0, removed in 3.0.0. Use {@link scan}, which takes the
+ * `.iso` `File` directly and resolves with the report plus the {@link Disc} it
+ * was rendered from.
  */
 export function analyzeIso(
   file: File,

--- a/crates/bdinfo-rs-wasm/web/src/worker.ts
+++ b/crates/bdinfo-rs-wasm/web/src/worker.ts
@@ -1,25 +1,48 @@
 /// <reference lib="webworker" />
 // The scan Worker: hosts the WebAssembly module OFF the main thread. It serves
-// two requests over the same module instance:
-//   - `list`: the fast STRUCTURAL scan → the playlist selection table (parsed
-//     here, so the main thread receives structured rows, not JSON text).
-//   - `scan`: the FULL measured scan over the picked (or selected) playlists.
+// every request in `analyze.ts` over the same module instance:
+//   - `inspect` / `inspect-iso`: the fast STRUCTURAL scan → the whole disc model.
+//   - `scan-full` / `scan-iso-full`: the FULL measured scan → the rendered report
+//     and the disc model, from one demux.
+//   - `render`: re-render the report from a disc model — no media touched.
+//   - `list` / `list-iso` and `scan` / `scan-iso`: what the deprecated 2.0 calls
+//     need — the selection table (parsed here, so the main thread receives
+//     structured rows, not JSON text) and the report alone.
 // The wasm reads each file's bytes synchronously at byte offsets through
 // `FileReaderSync` (the reason this must be a Worker — that API exists only in a
 // Worker scope), so a multi-GB stream never has to fit in memory. Progress is
-// forwarded to the main thread as it demuxes; the rendered report (or the table
-// rows) is posted back when done.
+// forwarded to the main thread as it demuxes; the answer is posted back when
+// done.
+//
+// This module is internal: `dist/worker.js` is not an importable subpath of the
+// package, so the request and reply shapes below are free to change with the
+// `analyze.ts` that speaks them.
 import init, {
+  type Disc,
+  inspect_files,
+  inspect_iso,
   list_iso_playlists,
   list_playlists,
+  render_report,
   scan_files,
+  scan_files_full,
   scan_iso,
+  scan_iso_full,
 } from "../pkg/bdinfo_rs_wasm.js";
 
 /** The two playlist-filter opt-outs a listing request carries (see `analyze.ts`). */
 interface ListOptions {
   showShortPlaylists: boolean;
   showLoopingPlaylists: boolean;
+}
+
+/**
+ * The optional report sections a rendering request carries. Both are `true`
+ * unless the caller switched one off, which is the report the CLI writes.
+ */
+interface ReportOptions {
+  streamDiagnostics: boolean;
+  quickSummary: boolean;
 }
 
 /** List the playlists (structural scan) of the picked BDMV folder. */
@@ -50,7 +73,56 @@ interface ScanIsoRequest {
   selection: string[];
 }
 
-type Request = ListRequest | ScanRequest | ListIsoRequest | ScanIsoRequest;
+/**
+ * The whole disc model of the picked BDMV folder from a structural scan.
+ * `shortPlaylistSeconds` is the length under which a playlist counts as short;
+ * zero means the wasm module's 20 s default.
+ */
+interface InspectRequest extends ListOptions {
+  kind: "inspect";
+  paths: string[];
+  files: File[];
+  shortPlaylistSeconds: number;
+}
+
+/** The whole disc model of a single picked `.iso` from a structural scan. */
+interface InspectIsoRequest extends ListOptions {
+  kind: "inspect-iso";
+  file: File;
+  shortPlaylistSeconds: number;
+}
+
+/** Measure the picked BDMV folder, answering with the report AND the model. */
+interface ScanFullRequest extends ReportOptions {
+  kind: "scan-full";
+  paths: string[];
+  files: File[];
+  selection: string[];
+}
+
+/** Measure a single picked `.iso`, answering with the report AND the model. */
+interface ScanIsoFullRequest extends ReportOptions {
+  kind: "scan-iso-full";
+  file: File;
+  selection: string[];
+}
+
+/** Re-render the report from a disc model a measured scan already produced. */
+interface RenderRequest extends ReportOptions {
+  kind: "render";
+  disc: Disc;
+}
+
+type Request =
+  | ListRequest
+  | ScanRequest
+  | ListIsoRequest
+  | ScanIsoRequest
+  | InspectRequest
+  | InspectIsoRequest
+  | ScanFullRequest
+  | ScanIsoFullRequest
+  | RenderRequest;
 
 let ready: Promise<unknown> | null = null;
 
@@ -98,6 +170,60 @@ self.onmessage = async (event: MessageEvent<Request>) => {
         self.postMessage({
           type: "done",
           report: scan_iso(data.file, data.selection, onProgress),
+        });
+        break;
+      case "inspect":
+        self.postMessage({
+          type: "disc",
+          disc: inspect_files(
+            data.paths,
+            data.files,
+            data.showShortPlaylists,
+            data.showLoopingPlaylists,
+            data.shortPlaylistSeconds,
+          ),
+        });
+        break;
+      case "inspect-iso":
+        self.postMessage({
+          type: "disc",
+          disc: inspect_iso(
+            data.file,
+            data.showShortPlaylists,
+            data.showLoopingPlaylists,
+            data.shortPlaylistSeconds,
+          ),
+        });
+        break;
+      case "scan-full":
+        self.postMessage({
+          type: "result",
+          result: scan_files_full(
+            data.paths,
+            data.files,
+            data.selection,
+            onProgress,
+            data.streamDiagnostics,
+            data.quickSummary,
+          ),
+        });
+        break;
+      case "scan-iso-full":
+        self.postMessage({
+          type: "result",
+          result: scan_iso_full(
+            data.file,
+            data.selection,
+            onProgress,
+            data.streamDiagnostics,
+            data.quickSummary,
+          ),
+        });
+        break;
+      case "render":
+        self.postMessage({
+          type: "done",
+          report: render_report(data.disc, data.streamDiagnostics, data.quickSummary),
         });
         break;
     }

--- a/crates/bdinfo-rs-wasm/web/test/harness.html
+++ b/crates/bdinfo-rs-wasm/web/test/harness.html
@@ -6,13 +6,23 @@
     <title>bdinfo-rs wasm parity harness</title>
   </head>
   <body>
-    <!-- Headless-Chrome parity harness: exposes the package's `analyze`,
-         `analyzeIso` and `listPlaylists` on the window so the Playwright test can
-         hand them File objects (a folder pick, and a single `.iso`) built from
-         the committed Big Buck Bunny fixture, compare each report to its golden,
-         and drive the listing's filter options through the real Worker. -->
+    <!-- Headless-Chrome parity harness: exposes the package's public calls on the
+         window so the Playwright test can hand them File objects (a folder pick,
+         and a single `.iso`) built from the committed Big Buck Bunny fixture,
+         compare each report to its golden, drive the filter options through the
+         real Worker, and round-trip a disc model back into a report. -->
     <script type="module">
-      import { analyze, analyzeIso, listPlaylists } from "/dist/analyze.js";
+      import {
+        analyze,
+        analyzeIso,
+        inspect,
+        listPlaylists,
+        renderReport,
+        scan,
+      } from "/dist/analyze.js";
+      window.__inspect = inspect;
+      window.__scan = scan;
+      window.__renderReport = renderReport;
       window.__analyze = analyze;
       window.__analyzeIso = analyzeIso;
       window.__listPlaylists = listPlaylists;

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -7,6 +7,12 @@
 // asserts the returned report is BYTE-IDENTICAL to the pinned native golden
 // (`tests/golden_report.txt`) — the same golden the native ⇄ wasm parity test pins.
 //
+// It drives the package's own entry (`dist/analyze.js`), so it is also what
+// proves the TypeScript surface: the disc model reaches the page as a real
+// object over `postMessage`, and handing it back to `renderReport` renders the
+// golden bytes again — the round trip through structured clone in both
+// directions, which the Node test (raw wasm exports, no Worker) cannot see.
+//
 // Prereq: `npm run build` (emits `pkg/` + `dist/`). Run with `npm run test:chrome`.
 
 import { readFile } from "node:fs/promises";
@@ -97,6 +103,8 @@ async function main() {
   let report;
   let isoReport;
   let listings;
+  let structured;
+  let isoStructured;
   try {
     const page = await browser.newPage();
     page.on("console", (msg) => console.log(`  [page] ${msg.text()}`));
@@ -138,10 +146,38 @@ async function main() {
       ];
       const names = async (options) =>
         (await window.__listPlaylists(files, options)).map((row) => `${row.name}:${row.hiddenBy}`);
+      // The threshold only `inspect` takes: at 5 s the ~10 s playlist is no
+      // longer short, where the default 20 s withholds it.
+      const inspected = async (options) =>
+        (await window.__inspect(files, options)).playlists.map((playlist) => playlist.name);
       return {
         standard: await names(),
         widened: await names({ showShortPlaylists: true }),
         looping: await names({ showLoopingPlaylists: true }),
+        inspectStandard: await inspected(),
+        inspectLowered: await inspected({ shortPlaylistSeconds: 5 }),
+      };
+    });
+
+    // The structured API over the folder pick: the model out of a structural
+    // scan, then a measured scan that returns the report and the model together,
+    // then that model handed back for a render with and without a section.
+    structured = await page.evaluate(async () => {
+      const disc = await window.__inspect(window.__files);
+      const scanned = await window.__scan(window.__files);
+      return {
+        inspected: {
+          measured: disc.measured,
+          volumeLabel: disc.volumeLabel,
+          playlists: disc.playlists.map((playlist) => playlist.name),
+          streams: disc.playlists[0].streams.length,
+          rates: disc.playlists[0].streams.map((stream) => stream.bitrateBps),
+        },
+        measured: scanned.disc.measured,
+        rate: scanned.disc.playlists[0].streams[0].bitrateBps,
+        report: scanned.report,
+        reRendered: await window.__renderReport(scanned.disc),
+        trimmed: await window.__renderReport(scanned.disc, { streamDiagnostics: false }),
       };
     });
 
@@ -151,6 +187,25 @@ async function main() {
       const buf = await (await fetch("/__fixture.iso")).arrayBuffer();
       const file = new File([new Uint8Array(buf)], "BigBuckBunny.iso");
       return await window.__analyzeIso(file);
+    });
+
+    // The same image through the structured API. One `File` rather than a list
+    // is what tells `inspect` and `scan` to open it as an `.iso`, so this is the
+    // check that the two sources are told apart; the volume label is the genuine
+    // one recorded in the filesystem, where a folder pick can only use the
+    // picked folder's name.
+    isoStructured = await page.evaluate(async () => {
+      const buf = await (await fetch("/__fixture.iso")).arrayBuffer();
+      const file = new File([new Uint8Array(buf)], "BigBuckBunny.iso");
+      const disc = await window.__inspect(file);
+      const scanned = await window.__scan(file);
+      return {
+        label: disc.volumeLabel,
+        playlists: disc.playlists.map((playlist) => playlist.name),
+        measured: scanned.disc.measured,
+        report: scanned.report,
+        reRendered: await window.__renderReport(scanned.disc),
+      };
     });
   } finally {
     await browser.close();
@@ -184,11 +239,14 @@ async function main() {
   const isoOk = compare(".iso scan", isoReport, isoGolden);
 
   // Each listing is `name:hiddenBy` per row: the short playlist is listed only
-  // with its own option, and always names the rule that withholds it.
+  // with its own option, and always names the rule that withholds it. The two
+  // `inspect` entries are playlist names, filtered by the threshold instead.
   const want = {
     standard: ["00000.MPLS:"],
     widened: ["00000.MPLS:", "00001.MPLS:short"],
     looping: ["00000.MPLS:"],
+    inspectStandard: ["00000.MPLS"],
+    inspectLowered: ["00000.MPLS", "00001.MPLS"],
   };
   const listOk = JSON.stringify(listings) === JSON.stringify(want);
   if (listOk) {
@@ -196,7 +254,63 @@ async function main() {
   } else {
     console.error(`FAIL — listing options: got ${JSON.stringify(listings)}`);
   }
-  process.exit(folderOk && isoOk && listOk ? 0 : 1);
+
+  // The structural model: no demux ran, so `measured` is false and every rate is
+  // zero because nothing measured it.
+  const inspectOk =
+    JSON.stringify(structured.inspected) ===
+    JSON.stringify({
+      measured: false,
+      volumeLabel: "WASMDISC",
+      playlists: ["00000.MPLS"],
+      streams: 2,
+      rates: [0, 0],
+    });
+  if (inspectOk) {
+    console.log("PASS — Worker inspect returns the unmeasured disc model.");
+  } else {
+    console.error(`FAIL — inspect model: got ${JSON.stringify(structured.inspected)}`);
+  }
+
+  // One measured scan, both outputs, and the model round-tripped back into the
+  // report: `scan`'s report and a `renderReport` of the disc it returned must
+  // both be the golden bytes, and switching a section off must drop it alone.
+  const scanReportOk = compare("scan report", structured.report, golden);
+  const roundTripOk = compare("renderReport round trip", structured.reRendered, golden);
+  const scanOk =
+    scanReportOk &&
+    roundTripOk &&
+    structured.measured === true &&
+    structured.rate > 0 &&
+    !structured.trimmed.includes("STREAM DIAGNOSTICS:") &&
+    structured.trimmed.includes("QUICK SUMMARY:");
+  if (!scanOk) {
+    console.error(
+      `FAIL — scan/renderReport: measured ${structured.measured}, first stream rate ${structured.rate}, trimmed ${structured.trimmed.length} B.`,
+    );
+  }
+
+  // The same two calls handed a single `File` instead of a list, which is what
+  // selects the `.iso` path.
+  const isoScanOk = compare(".iso scan report", isoStructured.report, isoGolden);
+  const isoRoundTripOk = compare(
+    ".iso renderReport round trip",
+    isoStructured.reRendered,
+    isoGolden,
+  );
+  const isoStructuredOk =
+    isoScanOk &&
+    isoRoundTripOk &&
+    isoStructured.label === "Blu-Ray" &&
+    isoStructured.measured === true &&
+    JSON.stringify(isoStructured.playlists) === '["00000.MPLS"]';
+  if (!isoStructuredOk) {
+    console.error(
+      `FAIL — .iso structured API: label ${isoStructured.label}, playlists ${JSON.stringify(isoStructured.playlists)}, measured ${isoStructured.measured}.`,
+    );
+  }
+
+  process.exit(folderOk && isoOk && listOk && inspectOk && scanOk && isoStructuredOk ? 0 : 1);
 }
 
 main().catch((err) => {

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -89,9 +89,15 @@ function shortPlaylist(mpls) {
 async function main() {
   const golden = await readFile(goldenPath);
 
-  const { initSync, scan_files, list_playlists, scan_iso, list_iso_playlists } = await import(
-    "../pkg/bdinfo_rs_wasm.js"
-  );
+  const {
+    initSync,
+    scan_files,
+    list_playlists,
+    scan_iso,
+    list_iso_playlists,
+    inspect_files,
+    inspect_iso,
+  } = await import("../pkg/bdinfo_rs_wasm.js");
   initSync({ module: await readFile(wasmPath) });
 
   const paths = [];
@@ -145,6 +151,44 @@ async function main() {
       `FAIL — filter options unexpected: ${JSON.stringify(listNames())} / ${JSON.stringify(widened)}`,
     );
   }
+
+  // The structural disc model. `inspect_files` returns the whole scanned model
+  // as a real JavaScript object — properties read directly, no JSON.parse — so
+  // this is also what proves the mirror crosses the boundary at all. `measured`
+  // is false because no packet demux ran, and every value that only a demux
+  // could fill is therefore zero.
+  const inspected = inspect_files(paths, files);
+  const inspectedPlaylist = inspected.playlists[0];
+  const inspectOk =
+    inspected.measured === false &&
+    inspected.volumeLabel === "WASMDISC" &&
+    inspected.sizeBytes === 11146324 &&
+    inspected.errors.length === 0 &&
+    inspected.playlists.length === 1 &&
+    inspectedPlaylist.name === "00000.MPLS" &&
+    inspectedPlaylist.streams.length === 2 &&
+    inspectedPlaylist.streams[0].codecName === "MPEG-4 AVC Video" &&
+    inspectedPlaylist.clips.length === 1 &&
+    inspectedPlaylist.clips[0].name === "00000.M2TS" &&
+    inspectedPlaylist.streams.every((stream) => stream.bitrateBps === 0);
+  if (!inspectOk) {
+    console.error(`FAIL — inspect_files disc unexpected: ${JSON.stringify(inspected)}`);
+  }
+
+  // The short-playlist threshold, which only the inspect exports take: the
+  // ~10 s playlist the default 20 s rule withholds is listed once the threshold
+  // drops below its length, and a zero threshold means the default.
+  const inspectNames = (...options) =>
+    inspect_files(shortPaths, shortFiles, ...options).playlists.map((playlist) => playlist.name);
+  const thresholdOk =
+    JSON.stringify(inspectNames()) === '["00000.MPLS"]' &&
+    JSON.stringify(inspectNames(false, false, 0)) === '["00000.MPLS"]' &&
+    JSON.stringify(inspectNames(false, false, 5)) === '["00000.MPLS","00001.MPLS"]';
+  if (!thresholdOk) {
+    console.error(
+      `FAIL — short-playlist threshold unexpected: ${JSON.stringify(inspectNames(false, false, 5))}`,
+    );
+  }
   if (!selOk) {
     console.error(
       `FAIL — selective scan (${selReport.length} bytes) diverged from golden (${golden.length} bytes).`,
@@ -172,6 +216,19 @@ async function main() {
   if (!isoListOk) {
     console.error(`FAIL — list_iso_playlists rows unexpected: ${JSON.stringify(isoRows)}`);
   }
+  // The disc model over the same image: the UDF volume label is the genuine
+  // one recorded in the filesystem, where the folder pick above can only use
+  // the picked folder name.
+  const isoInspected = inspect_iso(isoFile);
+  const isoInspectOk =
+    isoInspected.measured === false &&
+    isoInspected.volumeLabel === "Blu-Ray" &&
+    isoInspected.playlists.length === 1 &&
+    isoInspected.playlists[0].name === "00000.MPLS" &&
+    isoInspected.playlists[0].clips.length === 1;
+  if (!isoInspectOk) {
+    console.error(`FAIL — inspect_iso disc unexpected: ${JSON.stringify(isoInspected)}`);
+  }
   if (!isoSelOk) {
     console.error(
       `FAIL — selective .iso scan (${isoSelReport.length} bytes) diverged from the iso golden (${isoGolden.length} bytes).`,
@@ -194,9 +251,20 @@ async function main() {
     }
   }
 
-  if (got.equals(golden) && listOk && selOk && optionsOk && isoOk && isoListOk && isoSelOk) {
+  if (
+    got.equals(golden) &&
+    listOk &&
+    selOk &&
+    optionsOk &&
+    inspectOk &&
+    thresholdOk &&
+    isoOk &&
+    isoListOk &&
+    isoSelOk &&
+    isoInspectOk
+  ) {
     console.log(
-      `PASS — Node measured scan matches the golden (${golden.length} bytes); list + options + selection + .iso OK.`,
+      `PASS — Node measured scan matches the golden (${golden.length} bytes); list + options + inspect + selection + .iso OK.`,
     );
     process.exit(0);
   }

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -11,6 +11,11 @@
 // native and in-browser parity tests alike. So this ties the wasm channel to the
 // locked-output contract on every gate run, with only Node + the built wasm.
 //
+// The same golden also pins the round trip through the structured disc model:
+// the `disc` that `scan_files_full` returns beside the report, handed straight
+// back to `render_report`, must render those bytes again — so the model reaches
+// JavaScript and comes back carrying every value the report prints.
+//
 // Prereq: `npm run build` (emits pkg/). Run with `npm run test:node`.
 
 import { readFile } from "node:fs/promises";
@@ -97,6 +102,9 @@ async function main() {
     list_iso_playlists,
     inspect_files,
     inspect_iso,
+    scan_files_full,
+    scan_iso_full,
+    render_report,
   } = await import("../pkg/bdinfo_rs_wasm.js");
   initSync({ module: await readFile(wasmPath) });
 
@@ -195,6 +203,30 @@ async function main() {
     );
   }
 
+  // The measured scan that returns both outputs, and the round trip back. One
+  // scan produces the report and the disc; feeding that disc straight back to
+  // `render_report` must reproduce the same bytes — which is what proves the
+  // model crossed to JavaScript and back without losing a value the report
+  // prints. Switching a section off must then drop it and nothing else.
+  const full = scan_files_full(paths, files, []);
+  const reRendered = Buffer.from(render_report(full.disc), "utf8");
+  const noDiagnostics = render_report(full.disc, false);
+  const noSummary = render_report(full.disc, true, false);
+  const fullOk =
+    Buffer.from(full.report, "utf8").equals(golden) &&
+    full.disc.measured === true &&
+    full.disc.playlists[0].streams[0].bitrateBps > 0 &&
+    reRendered.equals(golden) &&
+    !noDiagnostics.includes("STREAM DIAGNOSTICS:") &&
+    noDiagnostics.includes("QUICK SUMMARY:") &&
+    noSummary.includes("STREAM DIAGNOSTICS:") &&
+    !noSummary.includes("QUICK SUMMARY:");
+  if (!fullOk) {
+    console.error(
+      `FAIL — scan_files_full/render_report round trip: report ${full.report.length} B, re-rendered ${reRendered.length} B, golden ${golden.length} B, measured ${full.disc.measured}.`,
+    );
+  }
+
   // The streaming `.iso` path: the same disc opened through the UDF reader as one
   // `File`. scan_iso (whole + by-name) and list_iso_playlists must match the
   // native `.iso` golden / table, exercising WebIso's FileReaderSync windowed
@@ -229,6 +261,18 @@ async function main() {
   if (!isoInspectOk) {
     console.error(`FAIL — inspect_iso disc unexpected: ${JSON.stringify(isoInspected)}`);
   }
+  // The same both-outputs scan over the image, round-tripped the same way.
+  const isoFull = scan_iso_full(isoFile, []);
+  const isoFullOk =
+    Buffer.from(isoFull.report, "utf8").equals(isoGolden) &&
+    isoFull.disc.measured === true &&
+    isoFull.disc.volumeLabel === "Blu-Ray" &&
+    Buffer.from(render_report(isoFull.disc), "utf8").equals(isoGolden);
+  if (!isoFullOk) {
+    console.error(
+      `FAIL — scan_iso_full/render_report round trip: report ${isoFull.report.length} B, iso golden ${isoGolden.length} B.`,
+    );
+  }
   if (!isoSelOk) {
     console.error(
       `FAIL — selective .iso scan (${isoSelReport.length} bytes) diverged from the iso golden (${isoGolden.length} bytes).`,
@@ -258,13 +302,15 @@ async function main() {
     optionsOk &&
     inspectOk &&
     thresholdOk &&
+    fullOk &&
     isoOk &&
     isoListOk &&
     isoSelOk &&
-    isoInspectOk
+    isoInspectOk &&
+    isoFullOk
   ) {
     console.log(
-      `PASS — Node measured scan matches the golden (${golden.length} bytes); list + options + inspect + selection + .iso OK.`,
+      `PASS — Node measured scan matches the golden (${golden.length} bytes); list + options + inspect + selection + round trip + .iso OK.`,
     );
     process.exit(0);
   }


### PR DESCRIPTION
Adds a complete, lossless mirror of the core disc model to the browser package,
and the calls that produce and consume it.

## The model

Nine serde/tsify types mirroring BdRom, PlaylistSummary, ClipSummary,
StreamSummary, ClipStreamTally, ChapterSummary and the failures a scan records
and continues past. Values cross as raw numbers with unit-bearing names
(bitrateBps, sampleRateHz, lengthSeconds), so a consumer can sort and chart
them; only strings the core builds and a consumer could not reconstruct stay
strings. The TypeScript declarations are generated from the Rust definitions,
doc comments included. One Disc type with a measured flag serves both the
structural and the measured scan, so an unmeasured value stays distinguishable
from a genuine zero.

## New wasm exports

inspect_files / inspect_iso run the structural scan and return the whole Disc,
taking the two playlist-filter opt-outs plus a short-playlist threshold.
scan_files_full / scan_iso_full run the measured scan and return the report and
the Disc from one demux, with the two optional report sections switchable.
render_report re-renders the report from a Disc alone.

The report path stays direct: the measured exports render straight from the
scanned disc and mirror that same disc separately, so the two derivations stay
independent. That is what gives the round-trip gate its force. It rebuilds a
disc from the mirror alone, renders it, and requires the pinned golden bytes, so
a field the mirror stops carrying surfaces as a byte mismatch naming the offset,
the line and the value that went missing.

## New package calls

inspect, scan and renderReport, each taking a picked BDMV folder or a single
.iso File and telling the two apart itself. AnalyzeOptions gains
shortPlaylistSeconds, which only inspect reads, and streamDiagnostics /
quickSummary, which scan and renderReport read. The generated model types are
re-exported from the package entry. The real-browser Worker parity test drives
all three end to end over both sources, and requires the disc that scan returns,
handed straight back to renderReport, to render the pinned golden again.

## Additive throughout

analyze, analyzeIso, listPlaylists, listPlaylistsIso, scan_files, scan_iso,
list_playlists, list_iso_playlists and scan_report keep their exact signatures
and behaviour; the four package calls gain deprecation markers naming their
replacement and 3.0.0 as the removal. No new runtime dependency, and no version
bump here.

## Size

The ceiling moves 409,600 -> 524,288 B. The optimized module grows
402,504 -> 511,231 B: about 22 KB for serde Serialize over the mirror tree, and
about 86 KB for Deserialize, which needs a name-matching visitor per field
where writing one needs only a write.
