### PR TITLE
feat(core): own the playlist projection and classification layer

### DIFF
--- a/crates/bdinfo-rs-core/src/bdrom/order.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/order.rs
@@ -16,11 +16,41 @@
 //! The result is a list of indices into the playlist slice, so callers keep
 //! the name-ordered [`crate::bdrom::disc::BdRom::playlists`] untouched and
 //! apply the presentation order on top.
+//!
+//! The projections every surface builds on that order live here too:
+//! [`table_rows`] (the grouped rows a selection table prints),
+//! [`selection_order`] and [`selection_stream_files`] (what a by-name
+//! selection renders and reads), and the [`HiddenRule`] classification behind
+//! the filter switches.
 
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 
 use super::disc::PlaylistSummary;
+
+/// One reason the playlist filter can withhold a playlist from the
+/// presentation order — what a surface names when it reports a hidden
+/// playlist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HiddenRule {
+    /// Strictly shorter than the threshold in force — a playlist of exactly
+    /// the threshold length matches no rule.
+    Short,
+    /// Repeats a clip ([`PlaylistSummary::has_loops`]).
+    Looping,
+}
+
+impl HiddenRule {
+    /// The rule's user-facing name, `"short"` or `"looping"` — the string
+    /// every surface prints in its hidden-playlist line.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Short => "short",
+            Self::Looping => "looping",
+        }
+    }
+}
 
 /// The playlist filter switches for the presentation order. The defaults drop
 /// short and looping playlists — the standard report behaviour;
@@ -58,13 +88,38 @@ impl PlaylistFilter {
         }
     }
 
-    /// Whether `playlist` passes this filter.
+    /// The rules that match `playlist`, in declaration order
+    /// ([`HiddenRule::Short`] first). Judged against
+    /// [`short_playlist_seconds`](Self::short_playlist_seconds) alone — the
+    /// two switches play no part, so the classification is the same whether
+    /// the caller lists the standard set or a widened one, and a caller
+    /// holding it can re-apply either rule itself.
+    #[must_use]
+    pub fn classify(&self, playlist: &PlaylistSummary) -> Vec<HiddenRule> {
+        let mut rules = Vec::new();
+        if playlist.total_length < self.short_playlist_seconds {
+            rules.push(HiddenRule::Short);
+        }
+        if playlist.has_loops {
+            rules.push(HiddenRule::Looping);
+        }
+        rules
+    }
+
+    /// Whether `playlist` passes this filter: true exactly when no rule in
+    /// [`classify`](Self::classify) has its filter switch on.
     #[must_use]
     pub fn keeps(&self, playlist: &PlaylistSummary) -> bool {
-        if self.filter_short_playlists && playlist.total_length < self.short_playlist_seconds {
-            return false;
+        !self.classify(playlist).into_iter().any(|rule| self.drops(rule))
+    }
+
+    /// Whether this filter's switch for `rule` is on — a matching playlist
+    /// is withheld.
+    const fn drops(&self, rule: HiddenRule) -> bool {
+        match rule {
+            HiddenRule::Short => self.filter_short_playlists,
+            HiddenRule::Looping => self.filter_looping_playlists,
         }
-        !(self.filter_looping_playlists && playlist.has_loops)
     }
 }
 
@@ -128,11 +183,60 @@ pub fn presentation_order(playlists: &[PlaylistSummary], filter: &PlaylistFilter
     presentation_groups(playlists, filter).into_iter().flatten().collect()
 }
 
+/// The playlist table rows as `(group number, playlist index)` pairs in table
+/// order.
+///
+/// [`presentation_groups`] flattened, each member paired with its group's
+/// 1-based number — the form a selection table prints.
+#[must_use]
+pub fn table_rows(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> Vec<(usize, usize)> {
+    presentation_groups(playlists, filter)
+        .into_iter()
+        .enumerate()
+        .flat_map(|(group, members)| {
+            members.into_iter().map(move |index| (group.saturating_add(1), index))
+        })
+        .collect()
+}
+
+/// The stream files a selection's packet scan reads: every clip of every
+/// selected playlist.
+///
+/// Sorted and deduplicated — a clip two selected playlists share is read
+/// once, and an unknown name contributes nothing.
+#[must_use]
+pub fn selection_stream_files(
+    playlists: &[PlaylistSummary],
+    selection: &[String],
+) -> BTreeSet<String> {
+    let mut files = BTreeSet::new();
+    for name in selection {
+        if let Some(playlist) = playlists.iter().find(|playlist| &playlist.name == name) {
+            files.extend(playlist.clips.iter().map(|clip| clip.name.clone()));
+        }
+    }
+    files
+}
+
+/// The report's playlist order for a selection: each selected name mapped to
+/// its index into `playlists`, in selection order — a repeated name renders
+/// its playlist again, an unknown name is skipped.
+#[must_use]
+pub fn selection_order(playlists: &[PlaylistSummary], selection: &[String]) -> Vec<usize> {
+    selection
+        .iter()
+        .filter_map(|name| playlists.iter().position(|playlist| &playlist.name == name))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use proptest::prelude::{prop_assert, prop_assert_eq, proptest};
 
-    use super::{PlaylistFilter, presentation_groups, presentation_order};
+    use super::{
+        HiddenRule, PlaylistFilter, presentation_groups, presentation_order, selection_order,
+        selection_stream_files, table_rows,
+    };
     use crate::bdrom::disc::{ClipSummary, PlaylistSummary};
 
     /// A playlist summary carrying only what the presentation order reads:
@@ -259,6 +363,110 @@ mod tests {
     }
 
     #[test]
+    fn table_rows_pair_each_playlist_with_its_group_number() {
+        // A (100 s) and B (50 s) share a clip — group 1; C (70 s) is group 2;
+        // the 5 s D is dropped by the default filter.
+        let playlists = [
+            playlist("A.MPLS", 100.0, false, &["X.M2TS", "Y.M2TS"]),
+            playlist("B.MPLS", 50.0, false, &["Y.M2TS"]),
+            playlist("C.MPLS", 70.0, false, &["Z.M2TS"]),
+            playlist("D.MPLS", 5.0, false, &["W.M2TS"]),
+        ];
+        assert_eq!(table_rows(&playlists, &PlaylistFilter::default()), [(1, 0), (1, 1), (2, 2)]);
+        assert!(table_rows(&[], &PlaylistFilter::default()).is_empty());
+    }
+
+    #[test]
+    fn table_rows_follow_the_given_filter() {
+        let playlists = [
+            playlist("00001.MPLS", 3600.0, true, &["X.M2TS"]),
+            playlist("00002.MPLS", 5.0, false, &["Y.M2TS"]),
+            playlist("00003.MPLS", 60.0, false, &["Z.M2TS"]),
+        ];
+        // The default filter leaves only the plain 60-second playlist…
+        assert_eq!(table_rows(&playlists, &PlaylistFilter::default()), [(1, 2)]);
+        // …turning off one rule admits exactly that rule's playlist, which
+        // shares no clip with the keeper, so it opens its own group…
+        let keep_loops =
+            PlaylistFilter { filter_looping_playlists: false, ..PlaylistFilter::default() };
+        assert_eq!(table_rows(&playlists, &keep_loops), [(1, 0), (2, 2)]);
+        let keep_short =
+            PlaylistFilter { filter_short_playlists: false, ..PlaylistFilter::default() };
+        assert_eq!(table_rows(&playlists, &keep_short), [(1, 2), (2, 1)]);
+        // …and turning off both lists the whole disc.
+        assert_eq!(table_rows(&playlists, &PlaylistFilter::everything()).len(), 3);
+    }
+
+    /// A three-playlist disc for the selection projections: 00000 and 00001
+    /// share clip A; 00002 reads clips B and C.
+    fn selection_disc() -> [PlaylistSummary; 3] {
+        [
+            playlist("00000.MPLS", 100.0, false, &["A.M2TS"]),
+            playlist("00001.MPLS", 50.0, false, &["A.M2TS"]),
+            playlist("00002.MPLS", 70.0, false, &["B.M2TS", "C.M2TS"]),
+        ]
+    }
+
+    #[test]
+    fn stream_files_union_the_selected_clips_once() {
+        let files = selection_stream_files(&selection_disc(), &["00002.MPLS".to_owned()]);
+        assert_eq!(files.into_iter().collect::<Vec<_>>(), ["B.M2TS", "C.M2TS"]);
+        // A shared clip lands once, and an unknown name contributes nothing.
+        let files = selection_stream_files(
+            &selection_disc(),
+            &["00000.MPLS".to_owned(), "00001.MPLS".to_owned(), "99999.MPLS".to_owned()],
+        );
+        assert_eq!(files.into_iter().collect::<Vec<_>>(), ["A.M2TS"]);
+        assert!(selection_stream_files(&selection_disc(), &[]).is_empty());
+    }
+
+    #[test]
+    fn selection_order_repeats_a_pick_and_skips_an_unknown_name() {
+        let selection = ["00002.MPLS".to_owned(), "00000.MPLS".to_owned(), "00002.MPLS".to_owned()];
+        assert_eq!(selection_order(&selection_disc(), &selection), [2, 0, 2]);
+        assert_eq!(selection_order(&selection_disc(), &["99999.MPLS".to_owned()]), [0_usize; 0]);
+    }
+
+    #[test]
+    fn classify_names_the_matching_rules_short_first() {
+        let filter = PlaylistFilter::default();
+        assert_eq!(
+            filter.classify(&playlist("A.MPLS", 5.0, true, &[])),
+            [HiddenRule::Short, HiddenRule::Looping]
+        );
+        assert_eq!(filter.classify(&playlist("B.MPLS", 5.0, false, &[])), [HiddenRule::Short]);
+        assert_eq!(filter.classify(&playlist("C.MPLS", 100.0, true, &[])), [HiddenRule::Looping]);
+        assert!(filter.classify(&playlist("D.MPLS", 100.0, false, &[])).is_empty());
+        // Exactly the threshold is not short — the filter drops strictly
+        // shorter playlists, so the classification agrees.
+        assert!(filter.classify(&playlist("E.MPLS", 20.0, false, &[])).is_empty());
+    }
+
+    #[test]
+    fn classify_reads_the_threshold_but_not_the_switches() {
+        // Both switches off: the classification is unchanged…
+        let off = PlaylistFilter {
+            filter_short_playlists: false,
+            filter_looping_playlists: false,
+            ..PlaylistFilter::default()
+        };
+        assert_eq!(
+            off.classify(&playlist("A.MPLS", 5.0, true, &[])),
+            [HiddenRule::Short, HiddenRule::Looping]
+        );
+        // …and the threshold in force decides "short": 50 s is short under a
+        // raised 60 s threshold.
+        let raised = PlaylistFilter { short_playlist_seconds: 60.0, ..PlaylistFilter::default() };
+        assert_eq!(raised.classify(&playlist("B.MPLS", 50.0, false, &[])), [HiddenRule::Short]);
+    }
+
+    #[test]
+    fn labels_are_the_printed_rule_names() {
+        assert_eq!(HiddenRule::Short.label(), "short");
+        assert_eq!(HiddenRule::Looping.label(), "looping");
+    }
+
+    #[test]
     fn presentation_groups_exposes_the_group_boundaries() {
         // Same disc as the first-appearance test: A+B share a clip and form
         // group 1; the unrelated C is group 2 on its own.
@@ -318,6 +526,33 @@ mod tests {
                 })
             });
             prop_assert!(leads);
+        }
+
+        /// `keeps` is true exactly when every rule in `classify` has its
+        /// filter switch off — the filter and the classification never drift.
+        #[test]
+        fn keeps_iff_no_classified_rule_switch_is_on(
+            length in 0.0_f64..40.0,
+            has_loops in proptest::bool::ANY,
+            filter_short in proptest::bool::ANY,
+            filter_looping in proptest::bool::ANY,
+            threshold in 0.0_f64..40.0,
+        ) {
+            let subject = playlist("00000.MPLS", length, has_loops, &[]);
+            let filter = PlaylistFilter {
+                filter_short_playlists: filter_short,
+                short_playlist_seconds: threshold,
+                filter_looping_playlists: filter_looping,
+            };
+            let via_rules = filter.classify(&subject).into_iter().all(|rule| match rule {
+                HiddenRule::Short => !filter.filter_short_playlists,
+                HiddenRule::Looping => !filter.filter_looping_playlists,
+            });
+            prop_assert_eq!(filter.keeps(&subject), via_rules);
+            // The same verdict from the raw fields, pinning both sides.
+            let dropped_short = filter_short && length < threshold;
+            let dropped_looping = filter_looping && has_loops;
+            prop_assert_eq!(filter.keeps(&subject), !(dropped_short || dropped_looping));
         }
 
         /// Deterministic: the same input always yields the same order.

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary};
-use bdinfo_rs_core::bdrom::order::PlaylistFilter;
+use bdinfo_rs_core::bdrom::order::{PlaylistFilter, selection_order, selection_stream_files};
 use bdinfo_rs_core::error::ScanError;
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 
@@ -31,7 +31,7 @@ use crate::model::{
 use crate::panes::{self, CodecRow, StreamFileRow};
 use crate::progress::ProgressModel;
 use crate::scan::{Input, Structural};
-use crate::selection::{self, Selection};
+use crate::selection::Selection;
 
 /// The coarse stage the window is in — the discriminant the iced `view` branches
 /// on before reading the stage-specific accessors.
@@ -283,7 +283,7 @@ impl Listing {
     /// pre-scan "View Report". (Structural warnings surface in the UI's banner,
     /// so the report's `WARNING` block is left to the measured scan.)
     fn render_structural(&self) -> String {
-        let order = selection::selection_order(&self.bdrom.playlists, &self.scan_names());
+        let order = selection_order(&self.bdrom.playlists, &self.scan_names());
         text::render_with(&self.bdrom, &order, &[], self.view.render_options())
     }
 
@@ -294,7 +294,7 @@ impl Listing {
     /// playlists into `bdrom`, so this reproduces the worker's render — the
     /// road a report-section toggle re-renders on, with no rescan.
     fn render_measured(&self, scanned: &[String], errors: &[ScanError]) -> String {
-        let order = selection::selection_order(&self.bdrom.playlists, scanned);
+        let order = selection_order(&self.bdrom.playlists, scanned);
         text::render_with(&self.bdrom, &order, errors, self.view.render_options())
     }
 }
@@ -815,7 +815,7 @@ impl Flow {
         // listing with at least one row.
         let listing = self.editable_listing().filter(|listing| !listing.rows.is_empty())?;
         let selection = listing.scan_names();
-        let scan_files = selection::selection_stream_files(&listing.bdrom.playlists, &selection);
+        let scan_files = selection_stream_files(&listing.bdrom.playlists, &selection);
         Some(ScanRequest {
             input: listing.input.clone(),
             selection,

--- a/crates/bdinfo-rs-gui/src/model.rs
+++ b/crates/bdinfo-rs-gui/src/model.rs
@@ -1,16 +1,16 @@
 //! The pure playlist view-model.
 //!
-//! These constructors mirror the CLI's playlist table (and the wasm crate's
-//! `table_rows` / `table_length` / `estimated_bytes` / `playlist_rows`) over the
-//! public [`PlaylistSummary`] type — the GUI cannot import the CLI binary's
-//! private helpers, so it reimplements them the same way. No widgets, no IO:
-//! plain data in, plain data out, so `view()` is a thin projection.
+//! These constructors format the playlist table over
+//! [`bdinfo_rs_core::bdrom::order::table_rows`] and the public
+//! [`PlaylistSummary`] type, producing the same columns the CLI table prints.
+//! No widgets, no IO: plain data in, plain data out, so `view()` is a thin
+//! projection.
 
 use std::cmp::Ordering;
 
 use bdinfo_rs_core::bdrom::chapters::seconds_to_ticks;
 use bdinfo_rs_core::bdrom::disc::PlaylistSummary;
-use bdinfo_rs_core::bdrom::order::{PlaylistFilter, presentation_groups};
+use bdinfo_rs_core::bdrom::order::{HiddenRule, PlaylistFilter, table_rows};
 use bdinfo_rs_core::report::text::RenderOptions;
 
 use crate::settings::Settings;
@@ -91,9 +91,9 @@ impl ViewSettings {
 }
 
 /// One structured playlist row — the machine-readable form of the CLI's
-/// `#`/Group/Playlist File/Length/Estimated Bytes table. Mirrors the wasm
-/// crate's `PlaylistRow`. (Measured Bytes is omitted: a structural scan never
-/// measures, so that column would always read `-` this phase.)
+/// `#`/Group/Playlist File/Length/Estimated Bytes table. (Measured Bytes is
+/// omitted: a structural scan never measures, so that column would always
+/// read `-` this phase.)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PlaylistRow {
     /// 1-based position in the table — the handle a later phase's picker uses.
@@ -167,20 +167,6 @@ pub struct SelectableRow {
     pub cells: TableRow,
 }
 
-/// The playlist table rows as `(group number, playlist index)` pairs in table
-/// order: the `filter`-kept set (by default short and looping playlists are
-/// dropped), grouped by shared clips, each group longest-first. Mirrors the
-/// CLI's `table_rows`.
-fn table_rows(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> Vec<(usize, usize)> {
-    presentation_groups(playlists, filter)
-        .into_iter()
-        .enumerate()
-        .flat_map(|(group, members)| {
-            members.into_iter().map(move |index| (group.saturating_add(1), index))
-        })
-        .collect()
-}
-
 /// `hh:mm:ss` from playlist seconds, truncated to the tick like the CLI table
 /// (hours wrap at 24; no day component).
 pub(crate) fn table_length(seconds: f64) -> String {
@@ -192,7 +178,7 @@ pub(crate) fn table_length(seconds: f64) -> String {
 }
 
 /// The estimated byte size shown for a playlist: the interleaved `*.ssif` size
-/// when known, else the `*.m2ts` size, else `None`. Mirrors the CLI/wasm.
+/// when known, else the `*.m2ts` size, else `None` (the `-` cell).
 const fn estimated_bytes(playlist: &PlaylistSummary) -> Option<u64> {
     if playlist.interleaved_file_size > 0 {
         Some(playlist.interleaved_file_size)
@@ -203,10 +189,11 @@ const fn estimated_bytes(playlist: &PlaylistSummary) -> Option<u64> {
     }
 }
 
-/// `N0` thousands grouping for a byte count (`1234567` → `1,234,567`).
+/// `N0` thousands grouping for a byte count (`1234567` → `1,234,567`) — the
+/// CLI table's byte-cell format.
 ///
-/// Mirrors the CLI's `group_n0`. Public so the binary's info box can group the
-/// exact disc-size byte count alongside its [`format_file_size`] short form.
+/// Public so the binary's info box can group the exact disc-size byte count
+/// alongside its [`format_file_size`] short form.
 #[must_use]
 pub fn group_n0(value: u64) -> String {
     let mut grouped = Vec::new();
@@ -266,7 +253,6 @@ pub fn format_file_size(bytes: u64) -> String {
 }
 
 /// Builds the structured selection-table rows over the `filter`-kept set.
-/// Mirrors the wasm crate's `playlist_rows`.
 pub(crate) fn playlist_rows(
     playlists: &[PlaylistSummary],
     filter: &PlaylistFilter,
@@ -413,10 +399,10 @@ pub(crate) fn any_hidden(rows: &[PlaylistRow]) -> bool {
 /// What a [`PlaylistFilter`] withholds from the playlist table — the count,
 /// the rules that withheld it, and the withheld names.
 ///
-/// The two rules are judged **independently**, each against the whole disc,
-/// mirroring the CLI's `Hidden by filters (…)` hint block: a playlist that is
-/// both short and looping is counted once and names both rules, and revealing
-/// it takes switching both off.
+/// The two rules are judged **independently**, each against the whole disc
+/// ([`PlaylistFilter::classify`]): a playlist that is both short and looping
+/// is counted once and names both rules, and revealing it takes switching
+/// both off.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HiddenPlaylists {
     /// The withheld playlists' names, in the order the table would have listed
@@ -449,10 +435,10 @@ impl HiddenPlaylists {
     pub fn reasons(&self) -> String {
         let mut reasons = Vec::new();
         if self.short {
-            reasons.push("short");
+            reasons.push(HiddenRule::Short.label());
         }
         if self.looping {
-            reasons.push("looping");
+            reasons.push(HiddenRule::Looping.label());
         }
         reasons.join(", ")
     }
@@ -507,9 +493,9 @@ pub fn hidden_playlists(
             .then_with(|| a.name.cmp(&b.name))
     });
     let short = filter.filter_short_playlists
-        && hidden.iter().any(|playlist| playlist.total_length < filter.short_playlist_seconds);
-    let looping =
-        filter.filter_looping_playlists && hidden.iter().any(|playlist| playlist.has_loops);
+        && hidden.iter().any(|playlist| filter.classify(playlist).contains(&HiddenRule::Short));
+    let looping = filter.filter_looping_playlists
+        && hidden.iter().any(|playlist| filter.classify(playlist).contains(&HiddenRule::Looping));
     Some(HiddenPlaylists {
         names: hidden.iter().map(|playlist| playlist.name.clone()).collect(),
         short,
@@ -520,13 +506,12 @@ pub fn hidden_playlists(
 #[cfg(test)]
 mod tests {
     use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary};
-    use bdinfo_rs_core::bdrom::order::PlaylistFilter;
+    use bdinfo_rs_core::bdrom::order::{PlaylistFilter, table_rows};
 
     use super::{
         PlaylistRow, Sort, SortColumn, TableRow, ViewSettings, any_hidden, byte_cell, compare,
         display_rows, estimated_bytes, estimated_cell, format_file_size, group_n0,
         hidden_playlists, playlist_display_name, playlist_rows, sort_rows, table_length,
-        table_rows,
     };
     use crate::settings::Settings;
 
@@ -583,12 +568,6 @@ mod tests {
             sample_playlist("00002.MPLS", 70.0, 0, 2000, &["B.M2TS"]),
             sample_playlist("00003.MPLS", 5.0, 100, 0, &["C.M2TS"]),
         ]
-    }
-
-    #[test]
-    fn table_rows_groups_and_filters_like_the_cli() {
-        // Sorted by length desc, grouped by shared clip, the short row dropped.
-        assert_eq!(table_rows(&disc(), &PlaylistFilter::default()), [(1, 0), (1, 1), (2, 2)]);
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -19,12 +19,13 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, ScanMode, ScanProgress};
+use bdinfo_rs_core::bdrom::order::selection_order;
 use bdinfo_rs_core::error::{BdError, ScanError};
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 use bdinfo_rs_core::vfs::fs::FsDir;
 use bdinfo_rs_core::vfs::udf::source::{PathIso, UdfSource};
 
-use crate::{selection, volume};
+use crate::volume;
 
 /// The disc the user picked: a Blu-ray **folder** or a single `.iso` image.
 ///
@@ -193,7 +194,8 @@ pub fn scan_structural(input: &Input) -> Result<Structural, String> {
 /// `selection` order — the GUI equivalent of `bdinfo-rs <disc> --mpls A,B`.
 ///
 /// `selection` is the chosen playlist names in table order, and `scan_files` the
-/// matching clip set (`selection::selection_stream_files`), both derived from
+/// matching clip set ([`bdinfo_rs_core::bdrom::order::selection_stream_files`]),
+/// both derived from
 /// the structural scan. The packet scan reads only `scan_files`, so an unselected
 /// (possibly multi-GB) playlist is never demuxed. `options` is the report's
 /// section switches at scan start. Runs on the iced shell's worker
@@ -219,7 +221,7 @@ pub fn scan_measured(
 ) -> Result<Measured, String> {
     let (bdrom, errors) = open(input, ScanMode::Full, Some(scan_files), progress, cancel)
         .map_err(|err| err.to_string())?;
-    let order = selection::selection_order(&bdrom.playlists, selection);
+    let order = selection_order(&bdrom.playlists, selection);
     let report = text::render_with(&bdrom, &order, &errors, options);
     Ok(Measured {
         report,

--- a/crates/bdinfo-rs-gui/src/selection.rs
+++ b/crates/bdinfo-rs-gui/src/selection.rs
@@ -3,18 +3,14 @@
 //! The window lists the standard filtered playlist rows ([`crate::model`]); the
 //! user checks the ones to measure, and the measured scan is narrowed to exactly
 //! those playlists' clips. This module is the pure half of that: a [`Selection`]
-//! of one flag per row (`toggle` / `set_all` / `clear`) plus the two derivations
-//! the measured scan needs — the **selected clip set**
-//! ([`selection_stream_files`]) and the report **order** ([`selection_order`]),
-//! reimplemented over the public core types exactly as the CLI (`main.rs`) and
-//! the wasm crate do (the GUI cannot import the CLI binary's private helpers).
+//! of one flag per row (`toggle` / `set_all` / `clear`). The two derivations the
+//! measured scan needs — the selected clip set and the report order — are
+//! [`bdinfo_rs_core::bdrom::order::selection_stream_files`] and
+//! [`bdinfo_rs_core::bdrom::order::selection_order`] over the checked rows'
+//! names ([`Selection::selected_names`]).
 //!
 //! No widgets, no IO: plain data in, plain data out, so the iced shell is a thin
 //! projection.
-
-use std::collections::BTreeSet;
-
-use bdinfo_rs_core::bdrom::disc::PlaylistSummary;
 
 use crate::model::PlaylistRow;
 
@@ -108,38 +104,11 @@ impl Selection {
     }
 }
 
-/// The stream files a selection's packet scan reads: every clip of every selected
-/// playlist. Mirrors the CLI's / wasm crate's `selection_stream_files` — the
-/// `scan_files` set that narrows [`bdinfo_rs_core::bdrom::disc::BdRom::open_resilient_with`]
-/// so an unselected (possibly multi-GB) playlist is never demuxed.
-pub fn selection_stream_files(
-    playlists: &[PlaylistSummary],
-    selection: &[String],
-) -> BTreeSet<String> {
-    let mut files = BTreeSet::new();
-    for name in selection {
-        if let Some(playlist) = playlists.iter().find(|playlist| &playlist.name == name) {
-            files.extend(playlist.clips.iter().map(|clip| clip.name.clone()));
-        }
-    }
-    files
-}
-
-/// The report's playlist order for a selection: each selected name mapped to its
-/// index into the scanned disc's playlists, in selection order (an unknown name
-/// is skipped). Mirrors the CLI's / wasm crate's `selection_order`.
-pub fn selection_order(playlists: &[PlaylistSummary], selection: &[String]) -> Vec<usize> {
-    selection
-        .iter()
-        .filter_map(|name| playlists.iter().position(|playlist| &playlist.name == name))
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary};
 
-    use super::{Selection, selection_order, selection_stream_files};
+    use super::Selection;
     use crate::model::playlist_rows;
 
     /// A `ClipSummary` carrying just a name (the field the selection reads).
@@ -278,38 +247,6 @@ mod tests {
         selection.toggle(2); // 00002
         selection.toggle(0); // 00000
         assert_eq!(selection.selected_names(&rows), ["00000.MPLS", "00002.MPLS"]);
-    }
-
-    #[test]
-    fn stream_files_are_the_selected_playlists_clips() {
-        let files = selection_stream_files(&disc(), &["00002.MPLS".to_owned()]);
-        // A BTreeSet — sorted + deduped, the scan_files contract.
-        assert_eq!(files.into_iter().collect::<Vec<_>>(), ["B.M2TS", "C.M2TS"]);
-    }
-
-    #[test]
-    fn stream_files_dedupe_a_shared_clip() {
-        // 00000 and 00001 share clip A — selecting both yields it once.
-        let files =
-            selection_stream_files(&disc(), &["00000.MPLS".to_owned(), "00001.MPLS".to_owned()]);
-        assert_eq!(files.into_iter().collect::<Vec<_>>(), ["A.M2TS"]);
-    }
-
-    #[test]
-    fn stream_files_skip_an_unknown_name() {
-        assert!(selection_stream_files(&disc(), &["99999.MPLS".to_owned()]).is_empty());
-    }
-
-    #[test]
-    fn order_maps_names_to_indices_in_selection_order() {
-        let order = selection_order(&disc(), &["00002.MPLS".to_owned(), "00000.MPLS".to_owned()]);
-        assert_eq!(order, [2, 0]);
-    }
-
-    #[test]
-    fn order_skips_an_unknown_name() {
-        let order = selection_order(&disc(), &["99999.MPLS".to_owned(), "00001.MPLS".to_owned()]);
-        assert_eq!(order, [1]);
     }
 
     // The selection model formats hostile-shaped input (any row count, any

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -74,7 +74,9 @@ use std::time::{Duration, Instant};
 
 use bdinfo_rs_core::bdrom::chapters::seconds_to_ticks;
 use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, ScanMode, ScanProgress};
-use bdinfo_rs_core::bdrom::order::{PlaylistFilter, presentation_groups};
+use bdinfo_rs_core::bdrom::order::{
+    HiddenRule, PlaylistFilter, selection_order, selection_stream_files, table_rows,
+};
 use bdinfo_rs_core::error::{BdError, ScanError};
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 use bdinfo_rs_core::vfs::fs::FsDir;
@@ -615,19 +617,6 @@ fn named_selection(playlists: &[PlaylistSummary], requested: &[String]) -> Vec<S
     names
 }
 
-/// The playlist table rows as `(group number, playlist index)` pairs in table
-/// order: the shared-clip groups of the playlists `filter` keeps, each group
-/// longest-first.
-fn table_rows(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> Vec<(usize, usize)> {
-    presentation_groups(playlists, filter)
-        .into_iter()
-        .enumerate()
-        .flat_map(|(group, members)| {
-            members.into_iter().map(move |index| (group.saturating_add(1), index))
-        })
-        .collect()
-}
-
 /// How many playlist names a hint line spells out before it counts the rest —
 /// enough to recognize the disc's numbering, short enough to stay on one line
 /// on an 80-column console.
@@ -637,43 +626,45 @@ const HINT_NAMES: usize = 3;
 /// on *and* withheld at least one playlist, looping first, then short. Empty
 /// (so the flow's bytes are unchanged) when every rule is off or hid nothing.
 ///
-/// Each rule is judged on its own against the whole disc, not against what the
-/// table dropped, so a playlist that is both short and looping is named on
-/// both lines and is only revealed when both switches are passed.
+/// Each rule is judged on its own against the whole disc
+/// ([`PlaylistFilter::classify`]), not against what the table dropped, so a
+/// playlist that is both short and looping is named on both lines and is only
+/// revealed when both switches are passed.
 ///
 /// Console narration only: it is never written into the report, and `--mpls`
 /// mode — which prints no table — never reaches it.
 fn hidden_hint(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> String {
     let mut out = String::new();
     if filter.filter_looping_playlists {
-        out.push_str(&hint_line(playlists, "looping", "--show-looping-playlists", |playlist| {
-            playlist.has_loops
-        }));
+        out.push_str(&hint_line(
+            playlists,
+            filter,
+            HiddenRule::Looping,
+            "--show-looping-playlists",
+        ));
     }
     if filter.filter_short_playlists {
-        out.push_str(&hint_line(playlists, "short", "--show-short-playlists", |playlist| {
-            playlist.total_length < filter.short_playlist_seconds
-        }));
+        out.push_str(&hint_line(playlists, filter, HiddenRule::Short, "--show-short-playlists"));
     }
     out
 }
 
 /// One `Hidden by filters (KIND): NAMES - rerun with FLAG` line for the
-/// playlists `hides` matches, empty when it matches none. The names come in
-/// the order the table would have listed them (length descending, then name
-/// ascending), the first [`HINT_NAMES`] spelled out and the rest counted as
-/// ` and N more`.
+/// playlists `rule` matches under `filter`'s threshold, empty when it matches
+/// none. The names come in the order the table would have listed them (length
+/// descending, then name ascending), the first [`HINT_NAMES`] spelled out and
+/// the rest counted as ` and N more`.
 ///
 /// ASCII only — the console flow must survive a legacy OEM codepage, so a
 /// plain hyphen stands where prose would take a dash.
 fn hint_line(
     playlists: &[PlaylistSummary],
-    kind: &str,
+    filter: &PlaylistFilter,
+    rule: HiddenRule,
     flag: &str,
-    hides: impl Fn(&PlaylistSummary) -> bool,
 ) -> String {
     let mut hidden: Vec<&PlaylistSummary> =
-        playlists.iter().filter(|playlist| hides(playlist)).collect();
+        playlists.iter().filter(|playlist| filter.classify(playlist).contains(&rule)).collect();
     if hidden.is_empty() {
         return String::new();
     }
@@ -687,7 +678,11 @@ fn hint_line(
         hidden.iter().take(HINT_NAMES).map(|playlist| playlist.name.as_str()).collect();
     let rest = hidden.len().saturating_sub(HINT_NAMES);
     let more = if rest == 0 { String::new() } else { format!(" and {rest} more") };
-    format!("Hidden by filters ({kind}): {}{more} - rerun with {flag}\n", named.join(", "))
+    format!(
+        "Hidden by filters ({}): {}{more} - rerun with {flag}\n",
+        rule.label(),
+        named.join(", ")
+    )
 }
 
 /// Maps 1-based table indices (`picks`) back to playlist names, in pick
@@ -829,25 +824,6 @@ fn analyze_preamble(playlists: &[PlaylistSummary], selection: &[String]) -> Stri
         let _ = writeln!(out, "{name} --> {}", files.join(" + "));
     }
     out
-}
-
-/// The stream files the packet scan reads: every clip of every selected
-/// playlist.
-fn selection_stream_files(playlists: &[PlaylistSummary], selection: &[String]) -> BTreeSet<String> {
-    let mut files = BTreeSet::new();
-    for name in selection {
-        if let Some(playlist) = playlists.iter().find(|p| &p.name == name) {
-            files.extend(playlist.clips.iter().map(|clip| clip.name.clone()));
-        }
-    }
-    files
-}
-
-/// The report's playlist order: the selection order, mapped to indices into
-/// the scanned disc's playlists (a duplicated pick renders its playlist
-/// again, like the classic picker).
-fn selection_order(playlists: &[PlaylistSummary], selection: &[String]) -> Vec<usize> {
-    selection.iter().filter_map(|name| playlists.iter().position(|p| &p.name == name)).collect()
 }
 
 /// Writes `rendered` into `dest` as `BDINFO.{volume label}.txt` (CRLF, UTF-8,
@@ -1127,7 +1103,7 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary, ScanProgress};
-    use bdinfo_rs_core::bdrom::order::PlaylistFilter;
+    use bdinfo_rs_core::bdrom::order::{PlaylistFilter, table_rows};
     use bdinfo_rs_core::error::{BdError, ScanError, ScanStage};
     use clap::Parser;
     use clap::error::ErrorKind;
@@ -1136,8 +1112,7 @@ mod tests {
         BAR_MAX_CELLS, Cli, ProgressDisplay, analyze_preamble, banner, compose_progress,
         compose_styled_progress, erase_sequence, finish_early, group_n0, help_page, hidden_hint,
         hms, named_selection, normalize_playlist_name, pick_playlists, redraw_sequence,
-        report_parse_failure, row_names, run, selection_order, selection_stream_files,
-        selection_table, table_length, table_rows,
+        report_parse_failure, row_names, run, selection_table, table_length,
     };
 
     /// A throwaway minimal BD folder (`BDMV/PLAYLIST` + `BDMV/CLIPINF`, both empty)
@@ -1880,27 +1855,6 @@ Options:
     }
 
     #[test]
-    fn table_rows_follow_the_given_filter() {
-        let mut looping = summary("00001.MPLS", 3600.0, &["X.M2TS"]);
-        looping.has_loops = true;
-        let short = summary("00002.MPLS", 5.0, &["Y.M2TS"]);
-        let keeper = summary("00003.MPLS", 60.0, &["Z.M2TS"]);
-        let playlists = [looping, short, keeper];
-        // The default filter leaves only the plain 60-second playlist…
-        assert_eq!(table_rows(&playlists, &PlaylistFilter::default()), [(1, 2)]);
-        // …turning off one rule admits exactly that rule's playlist, which
-        // shares no clip with the keeper, so it opens its own group…
-        let keep_loops =
-            PlaylistFilter { filter_looping_playlists: false, ..PlaylistFilter::default() };
-        assert_eq!(table_rows(&playlists, &keep_loops), [(1, 0), (2, 2)]);
-        let keep_short =
-            PlaylistFilter { filter_short_playlists: false, ..PlaylistFilter::default() };
-        assert_eq!(table_rows(&playlists, &keep_short), [(1, 2), (2, 1)]);
-        // …and turning off both lists the whole disc.
-        assert_eq!(table_rows(&playlists, &PlaylistFilter::everything()).len(), 3);
-    }
-
-    #[test]
     fn the_hidden_hint_names_what_each_rule_withheld_looping_first() {
         let mut long_loop = summary("00001.MPLS", 5765.0, &["A.M2TS"]);
         long_loop.has_loops = true;
@@ -2103,14 +2057,6 @@ Options:
              A.MPLS --> X.M2TS + Y.M2TS\n\
              B.MPLS --> Z.M2TS\n"
         );
-        // The scan set is the union of the selected playlists' clips…
-        let files = selection_stream_files(&playlists, &selection);
-        assert_eq!(files.into_iter().collect::<Vec<_>>(), ["X.M2TS", "Y.M2TS", "Z.M2TS"]);
-        // …and the report renders in selection order (a repeated selection
-        // repeats its playlist; a gone name is skipped).
-        let again = ["B.MPLS".to_owned(), "A.MPLS".to_owned(), "B.MPLS".to_owned()];
-        assert_eq!(selection_order(&playlists, &again), [1, 0, 1]);
-        assert_eq!(selection_order(&playlists, &["GONE.MPLS".to_owned()]), [0_usize; 0]);
     }
 
     #[test]


### PR DESCRIPTION
Three projection helpers were hand-copied across the CLI, GUI and wasm crates, kept in sync only by doc comments saying they mirror one another: table_rows, selection_stream_files and selection_order, plus a per-surface re-derivation of the hidden-rule classification.

This lifts them into bdinfo-rs-core (bdrom::order) and swaps the CLI and the GUI onto the core copies:

- core: HiddenRule (short / looping) with label(), PlaylistFilter::classify, keeps refactored onto classify so the rule logic has one source of truth, table_rows, selection_order and selection_stream_files. The keeps/classify equivalence is proptest-pinned; the consolidated tests cover the grouping, filtering and selection contracts.
- cli: the three local helpers and their local-only tests are deleted; the hidden-playlist hint lines derive their rule matching and names from classify and label.
- gui: table_rows leaves the view-model, the two selection helpers leave the selection module; playlist_rows, the measured-scan request and the hidden-count line consume the core functions.

No behaviour change: every fixture and golden stays byte-identical. The wasm crate is untouched here; its copies go away with the surface deletion that follows.