### PR TITLE
feat(wasm)!: replace the string-and-rows API with the disc model

### DIFF
--- a/crates/bdinfo-rs-wasm/.cargo/mutants.toml
+++ b/crates/bdinfo-rs-wasm/.cargo/mutants.toml
@@ -22,11 +22,8 @@ exclude_re = [
     "build_web_tree", # &js_sys::Array -> Node<WebFile>
     "notify", # the wasm32 progress-callback shim -> js_sys::Function
     "scan_root", # the wasm32 whole-disc/by-name scan dispatch -> JsValue
-    "render_root", # the wasm32 scan dispatch rendered -> JsValue
-    "scan_files", # the #[wasm_bindgen] streaming exports (scan_files + scan_files_full)
-    "scan_iso", # the #[wasm_bindgen] .iso streaming exports (scan_iso + scan_iso_full)
-    "list_playlists", # the #[wasm_bindgen] structural-listing export
-    "list_iso_playlists", # the #[wasm_bindgen] .iso structural-listing export
+    "scan_files", # the #[wasm_bindgen] measured streaming export
+    "scan_iso", # the #[wasm_bindgen] measured .iso streaming export
     "inspect_files", # the #[wasm_bindgen] structural disc-model export
     "inspect_iso", # the #[wasm_bindgen] .iso structural disc-model export
     "render_report", # the #[wasm_bindgen] re-render-from-a-disc export

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -10,13 +10,15 @@
 //!   flat list of `(relativePath, File)` pairs. The files stay on disk; their bytes are read
 //!   **synchronously** at byte offsets through [`web_sys::FileReaderSync`] (no JSPI, no Asyncify),
 //!   so a multi-GB `*.m2ts` never has to fit in memory. The export runs inside a Web Worker (the
-//!   only scope where `FileReaderSync` exists). [`list_playlists`] is its structural twin: the fast
-//!   selection-table scan (`bdinfo-rs <disc> --list`) over the same pairs.
-//! - [`scan_iso`] / [`list_iso_playlists`] — the streaming `.iso` exports: a single OS-picked
-//!   `.iso` `File` is opened through the core read-only UDF 2.50 reader ([`UdfSource`]) over the
-//!   same windowed [`web_sys::FileReaderSync`] cursor ([`WebIso`] is the [`IsoReader`] factory), so
-//!   a multi-GB disc image is never staged in memory either — then rendered through the identical
+//!   only scope where `FileReaderSync` exists). [`inspect_files`] is its structural twin: the fast
+//!   metadata-only scan (`bdinfo-rs <disc> --list`) over the same pairs.
+//! - [`scan_iso`] / [`inspect_iso`] — the streaming `.iso` exports: a single OS-picked `.iso`
+//!   `File` is opened through the core read-only UDF 2.50 reader ([`UdfSource`]) over the same
+//!   windowed [`web_sys::FileReaderSync`] cursor ([`WebIso`] is the [`IsoReader`] factory), so a
+//!   multi-GB disc image is never staged in memory either — then rendered through the identical
 //!   path, producing the classic report `bdinfo-rs <disc>.iso` writes.
+//! - [`render_report`] — the classic report rendered from a [`mirror::Disc`] a scan already
+//!   produced, with no media read at all.
 //!
 //! Both build a [`Node`] tree behind the [`BdDir`]/[`BdFile`] seam and feed it to
 //! one shared [`render_disc`] — so the in-memory and the file-backed paths render
@@ -44,8 +46,6 @@
 // NON-test build, so gate them to where they live to stay dead-code-clean.
 // `Read`/`Seek`/`JsCast`/`JsValue` are named only by the wasm32 browser glue.
 #[cfg(any(target_arch = "wasm32", test))]
-use std::collections::BTreeSet;
-#[cfg(any(target_arch = "wasm32", test))]
 use std::io::SeekFrom;
 use std::io::{self, BufRead, BufReader, Cursor};
 #[cfg(target_arch = "wasm32")]
@@ -54,13 +54,11 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 #[cfg(any(target_arch = "wasm32", test))]
-use bdinfo_rs_core::bdrom::chapters::seconds_to_ticks;
-#[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::bdrom::disc::PlaylistSummary;
 use bdinfo_rs_core::bdrom::disc::{BdRom, ScanMode, ScanProgress, ScanReport};
 use bdinfo_rs_core::bdrom::order::PlaylistFilter;
 #[cfg(any(target_arch = "wasm32", test))]
-use bdinfo_rs_core::bdrom::order::presentation_groups;
+use bdinfo_rs_core::bdrom::order::{selection_order, selection_stream_files};
 #[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::discovery::BdmvDir;
 use bdinfo_rs_core::error::BdError;
@@ -703,199 +701,31 @@ fn build_web_tree(paths: &[String], files: &js_sys::Array) -> Result<Node<WebFil
 
 // ── selection (CLI parity) ──────────────────────────────────────────────────
 //
-// The browser surfaces the CLI's flow: a structural scan lists the playlists
-// ([`list_playlists`]), the user picks some, and a measured scan reads only the
-// picked playlists' stream files ([`scan_files`] with a selection). These
-// helpers mirror the selection logic of the `bdinfo-rs` binary — which this
-// crate cannot import — over the public core types, so the browser behaves
+// The browser surfaces the CLI's flow: a structural scan reads the disc
+// ([`inspect_files`]), the user picks some playlists, and a measured scan reads
+// only the picked playlists' stream files ([`scan_files`] with a selection).
+// These helpers mirror the selection logic of the `bdinfo-rs` binary — which
+// this crate cannot import — over the public core types, so the browser behaves
 // exactly like `--mpls` / the picker. They are `cfg(any(wasm32, test))`: the
 // wasm exports use them and the native test build covers + mutates them, while a
 // native non-test build omits them (so neither tier shows dead code).
 
-/// One selection-table row — the machine-readable form of the CLI's
-/// `#`/Group/Playlist File/Length/Estimated Bytes table, for the browser to
-/// render as a checklist. Measured bytes are omitted: a [`list_playlists`] scan
-/// is structural, so they would always be `-`.
-#[cfg(any(target_arch = "wasm32", test))]
-struct PlaylistRow {
-    /// 1-based position in the table — the handle the user picks.
-    position: usize,
-    /// Shared-clip group number (1-based), the CLI's `Group` column.
-    group: usize,
-    /// The playlist file name, e.g. `00000.MPLS`.
-    name: String,
-    /// `hh:mm:ss` total length, truncated like the CLI table.
-    length: String,
-    /// Estimated bytes — interleaved `*.ssif` size, else `*.m2ts` size, else
-    /// `None` (the `-` cell).
-    estimated_bytes: Option<u64>,
-    /// Whether the playlist hides any stream (the CLI's `(*)` note).
-    has_hidden_streams: bool,
-    /// The filter rules that classify this playlist as withheld (see
-    /// [`hidden_by`]) — empty for a row the standard filters keep.
-    hidden_by: Vec<&'static str>,
-}
-
-/// The playlist table rows as `(group number, playlist index)` pairs in table
-/// order: the playlists `filter` keeps, grouped by shared clips, each group
-/// longest-first. Mirrors the CLI's `table_rows`.
-#[cfg(any(target_arch = "wasm32", test))]
-fn table_rows(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> Vec<(usize, usize)> {
-    presentation_groups(playlists, filter)
-        .into_iter()
-        .enumerate()
-        .flat_map(|(group, members)| {
-            members.into_iter().map(move |index| (group.saturating_add(1), index))
-        })
-        .collect()
-}
-
-/// The listing exports' filter: the standard filtered set with each rule
-/// switched off by its option. An absent option (`None`) means `false` — the
-/// rule stays on — so a call that passes neither option lists exactly the set
-/// the CLI's plain `--list` prints.
+/// The filter the disc model is classified against: the standard rules with
+/// `short_seconds` as the length under which a playlist counts as short.
 ///
-/// `short_seconds` sets the length under which a playlist counts as short. An
-/// absent or non-positive value means the 20 s default, so a caller that does
-/// not care about the threshold passes `None` and gets the standard behaviour.
+/// An absent or non-positive `short_seconds` means the 20 s default, so a
+/// caller that does not care about the threshold passes `None` and gets the
+/// classic behaviour. Only the threshold is read downstream — no export filters
+/// the playlists any more — so the two switches keep their defaults.
 #[cfg(any(target_arch = "wasm32", test))]
-fn listing_filter(
-    show_short: Option<bool>,
-    show_looping: Option<bool>,
-    short_seconds: Option<f64>,
-) -> PlaylistFilter {
+fn classification_filter(short_seconds: Option<f64>) -> PlaylistFilter {
     let standard = PlaylistFilter::default();
     PlaylistFilter {
-        filter_short_playlists: !show_short.unwrap_or(false),
-        filter_looping_playlists: !show_looping.unwrap_or(false),
         short_playlist_seconds: short_seconds
             .filter(|seconds| *seconds > 0.0)
             .unwrap_or(standard.short_playlist_seconds),
+        ..standard
     }
-}
-
-/// Which filter rules classify `playlist` as withheld — `"short"`, `"looping"`,
-/// both, or neither. Each rule is judged on its own against the whole disc, the
-/// same classification the CLI's `Hidden by filters (…)` hint lines make: a
-/// playlist that is both short and looping names both rules and is only listed
-/// when both options are passed.
-///
-/// The judgement deliberately ignores `filter`'s two switches and reads only its
-/// threshold, so it is the same whether the caller listed the standard set or a
-/// widened one. That is what lets a caller list once with both options on and
-/// re-apply either rule to the rows itself.
-#[cfg(any(target_arch = "wasm32", test))]
-fn hidden_by(playlist: &PlaylistSummary, filter: &PlaylistFilter) -> Vec<&'static str> {
-    let mut rules = Vec::new();
-    if playlist.total_length < filter.short_playlist_seconds {
-        rules.push("short");
-    }
-    if playlist.has_loops {
-        rules.push("looping");
-    }
-    rules
-}
-
-/// `hh:mm:ss` from playlist seconds, truncated to the tick like the CLI table
-/// (hours wrap at 24; no day component).
-#[cfg(any(target_arch = "wasm32", test))]
-fn table_length(seconds: f64) -> String {
-    let total = seconds_to_ticks(seconds).max(0).checked_div(10_000_000).unwrap_or(0);
-    let h = total.checked_div(3600).and_then(|h| h.checked_rem(24)).unwrap_or(0);
-    let m = total.checked_div(60).and_then(|m| m.checked_rem(60)).unwrap_or(0);
-    let s = total.checked_rem(60).unwrap_or(0);
-    format!("{h:02}:{m:02}:{s:02}")
-}
-
-/// The estimated byte size shown for a playlist: the interleaved `*.ssif` size
-/// when known, else the `*.m2ts` size, else `None`.
-#[cfg(any(target_arch = "wasm32", test))]
-const fn estimated_bytes(playlist: &PlaylistSummary) -> Option<u64> {
-    if playlist.interleaved_file_size > 0 {
-        Some(playlist.interleaved_file_size)
-    } else if playlist.file_size > 0 {
-        Some(playlist.file_size)
-    } else {
-        None
-    }
-}
-
-/// Builds the selection-table rows over the set `filter` keeps.
-#[cfg(any(target_arch = "wasm32", test))]
-fn playlist_rows(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> Vec<PlaylistRow> {
-    table_rows(playlists, filter)
-        .into_iter()
-        .enumerate()
-        .filter_map(|(position, (group, index))| {
-            playlists.get(index).map(|playlist| PlaylistRow {
-                position: position.saturating_add(1),
-                group,
-                name: playlist.name.clone(),
-                length: table_length(playlist.total_length),
-                estimated_bytes: estimated_bytes(playlist),
-                has_hidden_streams: playlist.has_hidden_streams(),
-                hidden_by: hidden_by(playlist, filter),
-            })
-        })
-        .collect()
-}
-
-/// Appends `value` to `out` as a JSON string body (the surrounding quotes are
-/// the caller's), escaping the characters JSON requires.
-#[cfg(any(target_arch = "wasm32", test))]
-fn json_escape(value: &str, out: &mut String) {
-    use std::fmt::Write as _;
-    for ch in value.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            control if u32::from(control) < 0x20 => {
-                let _ = write!(out, "\\u{:04x}", u32::from(control));
-            }
-            other => out.push(other),
-        }
-    }
-}
-
-/// Serializes the selection rows to a JSON array string — the [`list_playlists`]
-/// return value the browser `JSON.parse`s into its checklist model.
-#[cfg(any(target_arch = "wasm32", test))]
-fn rows_to_json(rows: &[PlaylistRow]) -> String {
-    use std::fmt::Write as _;
-    let mut out = String::from("[");
-    for (i, row) in rows.iter().enumerate() {
-        if i > 0 {
-            out.push(',');
-        }
-        let _ = write!(out, "{{\"position\":{},\"group\":{},\"name\":\"", row.position, row.group);
-        json_escape(&row.name, &mut out);
-        out.push_str("\",\"length\":\"");
-        json_escape(&row.length, &mut out);
-        out.push_str("\",\"estimatedBytes\":");
-        match row.estimated_bytes {
-            Some(bytes) => {
-                let _ = write!(out, "{bytes}");
-            }
-            None => out.push_str("null"),
-        }
-        out.push_str(",\"hasHidden\":");
-        out.push_str(if row.has_hidden_streams { "true" } else { "false" });
-        // The rule names are fixed ASCII literals (see `hidden_by`), so they go
-        // out unescaped where every other string field is escaped.
-        out.push_str(",\"hiddenBy\":[");
-        for (rule_index, rule) in row.hidden_by.iter().enumerate() {
-            if rule_index > 0 {
-                out.push(',');
-            }
-            let _ = write!(out, "\"{rule}\"");
-        }
-        out.push_str("]}");
-    }
-    out.push(']');
-    out
 }
 
 /// Normalizes a requested playlist name to the model's spelling: upper-cased,
@@ -918,29 +748,6 @@ fn named_selection(playlists: &[PlaylistSummary], requested: &[String]) -> Vec<S
         }
     }
     names
-}
-
-/// The stream files a selection's packet scan reads: every clip of every
-/// selected playlist.
-#[cfg(any(target_arch = "wasm32", test))]
-fn selection_stream_files(playlists: &[PlaylistSummary], selection: &[String]) -> BTreeSet<String> {
-    let mut files = BTreeSet::new();
-    for name in selection {
-        if let Some(playlist) = playlists.iter().find(|playlist| &playlist.name == name) {
-            files.extend(playlist.clips.iter().map(|clip| clip.name.clone()));
-        }
-    }
-    files
-}
-
-/// The report's playlist order for a selection: the selection order mapped to
-/// indices into the scanned disc's playlists.
-#[cfg(any(target_arch = "wasm32", test))]
-fn selection_order(playlists: &[PlaylistSummary], selection: &[String]) -> Vec<usize> {
-    selection
-        .iter()
-        .filter_map(|name| playlists.iter().position(|playlist| &playlist.name == name))
-        .collect()
 }
 
 /// Why a by-name [`scan_selection`] could not produce a report.
@@ -1094,18 +901,19 @@ fn render_options(stream_diagnostics: Option<bool>, quick_summary: Option<bool>)
 }
 
 /// Both outputs of one measured `scan`: the report rendered with `options`, and
-/// the same scan mirrored as a [`Disc`].
+/// the same scan mirrored as a [`Disc`] whose playlists are classified against
+/// `filter`.
 ///
 /// The two are derived side by side from the scan, never one from the other:
-/// the report comes straight off the scanned disc, exactly as the report-only
-/// exports render it, and the mirror is built from that same disc. Rendering by
-/// way of the mirror instead would leave nothing to compare the mirror against.
+/// the report comes straight off the scanned disc, and the mirror is built from
+/// that same disc. Rendering by way of the mirror instead would leave nothing
+/// to compare the mirror against.
 #[cfg(any(target_arch = "wasm32", test))]
-fn measured_result(scan: &Scan, options: RenderOptions) -> ScanResult {
+fn measured_result(scan: &Scan, options: RenderOptions, filter: &PlaylistFilter) -> ScanResult {
     ScanResult {
         report: scan.render(options),
         // A `Scan` is always the packet scan, so the mirror says measured.
-        disc: Disc::from_scan(&scan.report.bdrom, &scan.report.errors, true),
+        disc: Disc::from_scan(&scan.report.bdrom, &scan.report.errors, true, filter),
     }
 }
 
@@ -1130,21 +938,6 @@ fn scan_root(
     } else {
         scan_selection(root, selection, progress).map_err(|err| JsValue::from_str(&err.to_string()))
     }
-}
-
-/// [`scan_root`] rendered to the classic report with `options` — the shared tail
-/// of the [`scan_files`] (folder) and [`scan_iso`] (`.iso`) streaming exports.
-///
-/// # Errors
-/// As [`scan_root`].
-#[cfg(target_arch = "wasm32")]
-fn render_root(
-    root: &dyn BdDir,
-    selection: &[String],
-    options: RenderOptions,
-    progress: &mut dyn FnMut(ScanProgress<'_>),
-) -> Result<String, JsValue> {
-    Ok(scan_root(root, selection, progress)?.render(options))
 }
 
 /// Calls the caller's progress `callback`, when it supplied one, as
@@ -1199,157 +992,23 @@ pub fn scan_report(data: &[u8]) -> String {
     run_report(data)
 }
 
-/// The streaming entry point: hand it a `webkitdirectory`-selected BDMV
-/// folder as parallel `(relativePath, File)` lists and get back the classic
-/// disc report.
-///
-/// Runs the **full measured** scan — M2TS demux + per-stream/per-chapter
-/// statistics, `run_packet_scan = true` — reading every file's bytes
-/// synchronously at byte offsets through [`web_sys::FileReaderSync`]. This MUST
-/// run in a Web Worker (see the module docs). When
-/// `on_progress` is supplied it is called as `(file, done, total)` after each
-/// demux read. A non-empty `selection` names the playlists to measure (CLI
-/// `--mpls` semantics — unfiltered, in order); an empty `selection` measures the
-/// standard `--whole` set.
-///
-/// # Errors
-/// Returns a `JsValue` if `paths` and `files` differ in length, any `files`
-/// entry is not a `File`, the paths do not form one coherent disc selection,
-/// no readable Blu-ray structure is found (so a wrong folder pick is reported
-/// rather than silently returning an empty report), or a non-empty `selection`
-/// names no playlist on the disc (the CLI's "No matching playlists found on BD").
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-pub fn scan_files(
-    paths: Vec<String>,
-    files: js_sys::Array,
-    selection: Vec<String>,
-    on_progress: Option<js_sys::Function>,
-) -> Result<String, JsValue> {
-    let root = build_web_tree(&paths, &files)?;
-    let mut observe = |p: ScanProgress<'_>| notify(on_progress.as_ref(), &p);
-    render_root(&root, &selection, RenderOptions::default(), &mut observe)
-}
-
-/// The streaming `.iso` entry point: hand it a single OS-picked Blu-ray `.iso`
-/// `File` and get back the classic disc report.
-///
-/// Opens the image through the core read-only UDF 2.50 reader ([`UdfSource`]),
-/// reading its bytes synchronously at byte offsets through
-/// [`web_sys::FileReaderSync`] ([`WebIso`] is the [`IsoReader`] factory), so a
-/// multi-GB `.iso` never has to fit in memory. It then runs the **full measured**
-/// scan and renders the same report `bdinfo-rs <disc>.iso` writes. Like
-/// [`scan_files`], this MUST run in a Web Worker; `on_progress`, when
-/// supplied, is called as
-/// `(file, done, total)`; a non-empty `selection` measures only the named
-/// playlists (CLI `--mpls` semantics, unfiltered, in order), an empty one the
-/// standard `--whole` set.
-///
-/// # Errors
-/// Returns a `JsValue` if the image is not a readable UDF `.iso`, no readable
-/// Blu-ray structure is found inside it, or a non-empty `selection` names no
-/// playlist on the disc (the CLI's "No matching playlists found on BD").
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-pub fn scan_iso(
-    file: web_sys::File,
-    selection: Vec<String>,
-    on_progress: Option<js_sys::Function>,
-) -> Result<String, JsValue> {
-    let length = file.size() as u64;
-    let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
-        .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
-    let root = source.root();
-    let mut observe = |p: ScanProgress<'_>| notify(on_progress.as_ref(), &p);
-    render_root(&root, &selection, RenderOptions::default(), &mut observe)
-}
-
-/// The structural-scan entry point: the playlist selection table as JSON.
-///
-/// Hand it a `webkitdirectory`-selected BDMV folder and get back the rows the
-/// browser renders as a multi-select checklist before the measured scan,
-/// mirroring the CLI's playlist table.
-///
-/// Runs only the **structural** scan — no packet demux — so it is fast: it reads
-/// the playlist/clip metadata, not the multi-GB stream files. Each element is
-/// `{ position, group, name, length, estimatedBytes, hasHidden, hiddenBy }`;
-/// pass the chosen `name`s back to [`scan_files`] to measure just those
-/// playlists.
-///
-/// The listing drops short and looping playlists like the CLI's `--list`.
-/// `show_short_playlists` / `show_looping_playlists` switch off one rule each
-/// (the CLI's `--show-short-playlists` / `--show-looping-playlists`); omitting
-/// them, or passing `false`, keeps the standard set. Every row carries the rules
-/// that classify it as withheld in `hiddenBy` — empty for a row the standard
-/// filters keep — so a caller can list once with both options on and re-apply
-/// either rule to the rows without re-scanning.
-///
-/// # Errors
-/// As [`scan_files`]: `paths`/`files` length mismatch, a non-`File` entry, an
-/// incoherent selection, or no readable Blu-ray structure.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-pub fn list_playlists(
-    paths: Vec<String>,
-    files: js_sys::Array,
-    show_short_playlists: Option<bool>,
-    show_looping_playlists: Option<bool>,
-) -> Result<String, JsValue> {
-    let root = build_web_tree(&paths, &files)?;
-    let report = BdRom::open_resilient(&root, ScanMode::Metadata)
-        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
-    let filter = listing_filter(show_short_playlists, show_looping_playlists, None);
-    Ok(rows_to_json(&playlist_rows(&report.bdrom.playlists, &filter)))
-}
-
-/// The structural-scan `.iso` entry point: the playlist selection table as JSON.
-///
-/// Hand it a single OS-picked Blu-ray `.iso` `File` and get back the same rows
-/// [`list_playlists`] returns for a folder pick — opened through the UDF reader
-/// ([`UdfSource`]) instead of a `(relativePath, File)` list. Runs only the
-/// **structural** scan (no packet demux), so it is fast; pass the chosen
-/// `name`s back to [`scan_iso`] to measure just those playlists.
-/// `show_short_playlists` / `show_looping_playlists` and the rows' `hiddenBy`
-/// behave exactly as in [`list_playlists`].
-///
-/// # Errors
-/// Returns a `JsValue` if the image is not a readable UDF `.iso`, or holds no
-/// readable Blu-ray structure.
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-pub fn list_iso_playlists(
-    file: web_sys::File,
-    show_short_playlists: Option<bool>,
-    show_looping_playlists: Option<bool>,
-) -> Result<String, JsValue> {
-    let length = file.size() as u64;
-    let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
-        .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
-    let report = BdRom::open_resilient(&source.root(), ScanMode::Metadata)
-        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
-    let filter = listing_filter(show_short_playlists, show_looping_playlists, None);
-    Ok(rows_to_json(&playlist_rows(&report.bdrom.playlists, &filter)))
-}
-
 /// The structural-scan entry point for the whole disc model: a
 /// `webkitdirectory`-selected BDMV folder in, a [`Disc`] out.
 ///
-/// Runs the same **structural** scan [`list_playlists`] runs — no packet demux,
-/// so it reads the playlist and clip metadata rather than the multi-GB stream
-/// files — and returns the whole scanned model rather than the seven columns of
-/// a selection table. Every value a listing row carries is reachable from it,
-/// and so is everything the report prints that a metadata scan can know.
+/// Runs only the **structural** scan — no packet demux, so it reads the
+/// playlist and clip metadata rather than the multi-GB stream files — and
+/// returns everything the report prints that a metadata scan can know, plus
+/// every column of the selection table.
 ///
 /// `disc.measured` is false: the bitrates, packet counts and chapter rates are
 /// zero because nothing measured them.
 ///
-/// `show_short_playlists` / `show_looping_playlists` select which playlists
-/// `disc.playlists` holds, exactly as they select which rows
-/// [`list_playlists`] returns; the disc-level properties and the recorded
-/// failures are never filtered. `short_playlist_seconds` sets the length under
-/// which a playlist counts as short — absent or non-positive means the 20 s
-/// default. Passing both options widens the result to the whole disc, which is
-/// what lets a caller scan once and apply either rule to the playlists itself.
+/// `disc.playlists` holds every playlist on the disc, each carrying the rules
+/// that withhold it in `hiddenBy`, so a caller renders the standard selection
+/// table by keeping the playlists whose `hiddenBy` is empty and re-applies
+/// either rule without scanning again. `short_playlist_seconds` sets the length
+/// under which a playlist counts as short — absent or non-positive means the
+/// 20 s default.
 ///
 /// # Errors
 /// As [`scan_files`]: `paths`/`files` length mismatch, a non-`File` entry, an
@@ -1359,16 +1018,17 @@ pub fn list_iso_playlists(
 pub fn inspect_files(
     paths: Vec<String>,
     files: js_sys::Array,
-    show_short_playlists: Option<bool>,
-    show_looping_playlists: Option<bool>,
     short_playlist_seconds: Option<f64>,
 ) -> Result<Disc, JsValue> {
     let root = build_web_tree(&paths, &files)?;
     let report = BdRom::open_resilient(&root, ScanMode::Metadata)
         .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
-    let filter =
-        listing_filter(show_short_playlists, show_looping_playlists, short_playlist_seconds);
-    Ok(Disc::from_listing(&report.bdrom, &report.errors, &filter))
+    Ok(Disc::from_scan(
+        &report.bdrom,
+        &report.errors,
+        false,
+        &classification_filter(short_playlist_seconds),
+    ))
 }
 
 /// The structural-scan `.iso` entry point for the whole disc model: a single
@@ -1377,7 +1037,7 @@ pub fn inspect_files(
 /// Opens the image through the core read-only UDF 2.50 reader ([`UdfSource`])
 /// instead of a `(relativePath, File)` list, then behaves exactly as
 /// [`inspect_files`] — same structural scan, same `measured: false`, same
-/// meaning for the three filter parameters.
+/// meaning for `short_playlist_seconds`.
 ///
 /// # Errors
 /// Returns a `JsValue` if the image is not a readable UDF `.iso`, or holds no
@@ -1386,8 +1046,6 @@ pub fn inspect_files(
 #[wasm_bindgen]
 pub fn inspect_iso(
     file: web_sys::File,
-    show_short_playlists: Option<bool>,
-    show_looping_playlists: Option<bool>,
     short_playlist_seconds: Option<f64>,
 ) -> Result<Disc, JsValue> {
     let length = file.size() as u64;
@@ -1395,9 +1053,12 @@ pub fn inspect_iso(
         .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
     let report = BdRom::open_resilient(&source.root(), ScanMode::Metadata)
         .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
-    let filter =
-        listing_filter(show_short_playlists, show_looping_playlists, short_playlist_seconds);
-    Ok(Disc::from_listing(&report.bdrom, &report.errors, &filter))
+    Ok(Disc::from_scan(
+        &report.bdrom,
+        &report.errors,
+        false,
+        &classification_filter(short_playlist_seconds),
+    ))
 }
 
 /// Renders the classic disc report from a [`Disc`] — no media, no rescan.
@@ -1432,63 +1093,88 @@ pub fn render_report(
     text::render_with(&bdrom, &order, &errors, render_options(stream_diagnostics, quick_summary))
 }
 
-/// The measured-scan entry point returning both outputs: a
-/// `webkitdirectory`-selected BDMV folder in, the classic report **and** the
-/// scanned [`Disc`] out.
+/// The measured-scan entry point: a `webkitdirectory`-selected BDMV folder in,
+/// the classic report **and** the scanned [`Disc`] out.
 ///
-/// Runs exactly the scan [`scan_files`] runs — one M2TS demux, the same
-/// per-stream and per-chapter statistics — and derives both results from it, so
-/// a consumer that wants the report and the model never reads a multi-GB disc
-/// twice. `paths`, `files`, `selection` and `on_progress` behave as they do
-/// there; `stream_diagnostics` and `quick_summary` choose the optional report
-/// sections, and omitting them renders every section.
+/// Runs the **full measured** scan — M2TS demux + per-stream/per-chapter
+/// statistics, `run_packet_scan = true` — reading every file's bytes
+/// synchronously at byte offsets through [`web_sys::FileReaderSync`]. This MUST
+/// run in a Web Worker (see the module docs). Both results come from that one
+/// demux, so a consumer that wants the report and the model never reads a
+/// multi-GB disc twice.
+///
+/// When `on_progress` is supplied it is called as `(file, done, total)` after
+/// each demux read. A non-empty `selection` names the playlists to measure (CLI
+/// `--mpls` semantics — unfiltered, in order); an empty `selection` measures the
+/// standard `--whole` set. `stream_diagnostics` and `quick_summary` choose the
+/// optional report sections, and omitting them renders every section.
+/// `short_playlist_seconds` sets the length under which a playlist counts as
+/// short for `disc.playlists`, exactly as in [`inspect_files`]; it does not
+/// change what is measured or rendered.
 ///
 /// `result.disc.measured` is true: this scan measured the values, so a zero in
 /// it is a genuine zero. Re-render `result.disc` with other sections through
 /// [`render_report`] without scanning again.
 ///
 /// # Errors
-/// As [`scan_files`].
+/// Returns a `JsValue` if `paths` and `files` differ in length, any `files`
+/// entry is not a `File`, the paths do not form one coherent disc selection,
+/// no readable Blu-ray structure is found (so a wrong folder pick is reported
+/// rather than silently returning an empty report), or a non-empty `selection`
+/// names no playlist on the disc (the CLI's "No matching playlists found on BD").
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn scan_files_full(
+pub fn scan_files(
     paths: Vec<String>,
     files: js_sys::Array,
     selection: Vec<String>,
     on_progress: Option<js_sys::Function>,
     stream_diagnostics: Option<bool>,
     quick_summary: Option<bool>,
+    short_playlist_seconds: Option<f64>,
 ) -> Result<ScanResult, JsValue> {
     let root = build_web_tree(&paths, &files)?;
     let mut observe = |p: ScanProgress<'_>| notify(on_progress.as_ref(), &p);
     let scan = scan_root(&root, &selection, &mut observe)?;
-    Ok(measured_result(&scan, render_options(stream_diagnostics, quick_summary)))
+    Ok(measured_result(
+        &scan,
+        render_options(stream_diagnostics, quick_summary),
+        &classification_filter(short_playlist_seconds),
+    ))
 }
 
-/// The measured-scan `.iso` entry point returning both outputs: a single
-/// OS-picked Blu-ray `.iso` `File` in, the classic report **and** the scanned
-/// [`Disc`] out.
+/// The measured-scan `.iso` entry point: a single OS-picked Blu-ray `.iso`
+/// `File` in, the classic report **and** the scanned [`Disc`] out.
 ///
 /// Opens the image through the core read-only UDF 2.50 reader ([`UdfSource`])
-/// instead of a `(relativePath, File)` list, then behaves exactly as
-/// [`scan_files_full`] — one demux, both results.
+/// over the same windowed [`web_sys::FileReaderSync`] cursor ([`WebIso`] is the
+/// [`IsoReader`] factory), so a multi-GB image is never staged in memory, then
+/// behaves exactly as [`scan_files`] — one demux, both results, and the same
+/// meaning for every parameter it shares.
 ///
 /// # Errors
-/// As [`scan_iso`].
+/// Returns a `JsValue` if the image is not a readable UDF `.iso`, no readable
+/// Blu-ray structure is found inside it, or a non-empty `selection` names no
+/// playlist on the disc (the CLI's "No matching playlists found on BD").
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn scan_iso_full(
+pub fn scan_iso(
     file: web_sys::File,
     selection: Vec<String>,
     on_progress: Option<js_sys::Function>,
     stream_diagnostics: Option<bool>,
     quick_summary: Option<bool>,
+    short_playlist_seconds: Option<f64>,
 ) -> Result<ScanResult, JsValue> {
     let length = file.size() as u64;
     let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
         .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
     let scan = scan_root(&source.root(), &selection, &mut |p| notify(on_progress.as_ref(), &p))?;
-    Ok(measured_result(&scan, render_options(stream_diagnostics, quick_summary)))
+    Ok(measured_result(
+        &scan,
+        render_options(stream_diagnostics, quick_summary),
+        &classification_filter(short_playlist_seconds),
+    ))
 }
 
 #[cfg(test)]
@@ -1863,7 +1549,8 @@ mod tests {
         let scan = scan_whole(&build_tree(&fixture_blob()), &mut sink).expect("the fixture opens");
         // One scan, both outputs: the report is the pinned bytes and the disc
         // is the same scan mirrored, neither derived from the other.
-        let result = measured_result(&scan, RenderOptions::default());
+        let result =
+            measured_result(&scan, RenderOptions::default(), &super::classification_filter(None));
         assert_eq!(result.report.as_bytes(), GOLDEN);
         assert!(result.disc.measured, "the packet scan ran, so the values were measured");
         assert_eq!(result.disc.volume_label, "WASMDISC");
@@ -1977,17 +1664,13 @@ mod tests {
         assert_eq!(seek_target(SeekFrom::Current(i64::MAX), u64::MAX, 0).expect("sat"), u64::MAX);
     }
 
-    /// CLI-parity selection helpers: the structural playlist listing and the
+    /// CLI-parity selection helpers: the classification threshold and the
     /// by-name measured scan, native-tested.
     mod selection {
         use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary};
         use bdinfo_rs_core::bdrom::order::PlaylistFilter;
 
-        use crate::{
-            PlaylistRow, estimated_bytes, hidden_by, json_escape, listing_filter, named_selection,
-            normalize_playlist_name, playlist_rows, rows_to_json, selection_order,
-            selection_stream_files, table_length, table_rows,
-        };
+        use crate::{classification_filter, named_selection, normalize_playlist_name};
 
         /// A `ClipSummary` carrying just a name + length (the fields the
         /// selection helpers read); the measured tallies stay zero.
@@ -2032,79 +1715,13 @@ mod tests {
             }
         }
 
-        /// [`sample_playlist`] marked as looping — the input of the second
-        /// filter rule, which reads only `has_loops`.
-        fn looping_playlist(name: &str, total_length: f64, clips: &[&str]) -> PlaylistSummary {
-            PlaylistSummary { has_loops: true, ..sample_playlist(name, total_length, 0, 0, clips) }
-        }
-
-        /// A four-playlist disc: 00000 (100 s) shares clip A with 00001 (50 s) →
-        /// group 1; 00002 (70 s, clip B) → group 2; 00003 (5 s) is dropped by
-        /// the short filter.
-        fn disc() -> [PlaylistSummary; 4] {
-            [
-                sample_playlist("00000.MPLS", 100.0, 1000, 0, &["A.M2TS"]),
-                sample_playlist("00001.MPLS", 50.0, 500, 0, &["A.M2TS"]),
-                sample_playlist("00002.MPLS", 70.0, 0, 2000, &["B.M2TS"]),
-                sample_playlist("00003.MPLS", 5.0, 100, 0, &["C.M2TS"]),
-            ]
-        }
-
-        /// A disc holding one playlist per filter classification, each over its
-        /// own clip (so every kept playlist is its own group): 00000 (100 s) is
-        /// listed by every filter, 00001 (200 s) is looping, 00002 (5 s) is
-        /// short, and 00003 (5 s) is both.
-        fn mixed_disc() -> [PlaylistSummary; 4] {
-            [
-                sample_playlist("00000.MPLS", 100.0, 1000, 0, &["A.M2TS"]),
-                looping_playlist("00001.MPLS", 200.0, &["B.M2TS"]),
-                sample_playlist("00002.MPLS", 5.0, 100, 0, &["C.M2TS"]),
-                looping_playlist("00003.MPLS", 5.0, &["D.M2TS"]),
-            ]
-        }
-
-        /// The listed names under `filter`, in table order.
-        fn listed(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> Vec<String> {
-            playlist_rows(playlists, filter).into_iter().map(|row| row.name).collect()
-        }
-
         #[test]
-        fn table_rows_groups_and_filters_like_the_cli() {
-            // Sorted by length desc, grouped by shared clip, the short row dropped.
-            assert_eq!(table_rows(&disc(), &PlaylistFilter::default()), [(1, 0), (1, 1), (2, 2)]);
-        }
-
-        #[test]
-        fn listing_filter_switches_off_one_rule_per_option() {
-            // An absent option reads as `false`, so the plain call is the
-            // standard filtered set; each option switches off only its own rule.
-            // Comparing whole filters also pins what neither option touches: the
-            // short threshold stays at the default 20 s.
-            for (show_short, show_looping, short_on, looping_on) in [
-                (None, None, true, true),
-                (Some(false), Some(false), true, true),
-                (Some(true), None, false, true),
-                (None, Some(true), true, false),
-                (Some(true), Some(true), false, false),
-            ] {
-                assert_eq!(
-                    listing_filter(show_short, show_looping, None),
-                    PlaylistFilter {
-                        filter_short_playlists: short_on,
-                        filter_looping_playlists: looping_on,
-                        ..PlaylistFilter::default()
-                    },
-                    "{show_short:?} / {show_looping:?}"
-                );
-            }
-        }
-
-        #[test]
-        fn listing_filter_takes_the_threshold_and_falls_back_to_twenty_seconds() {
+        fn classification_filter_takes_the_threshold_and_falls_back_to_twenty_seconds() {
             // A positive threshold is used as given; anything else — absent,
-            // zero, negative, NaN — leaves the default 20 s in force, so the
-            // pre-threshold behaviour stays reachable. Whole filters are
-            // compared so the two switches are pinned as untouched too.
+            // zero, negative, NaN — leaves the default 20 s in force, so a
+            // caller that does not set one gets the classic classification.
+            // Whole filters are compared, so the two switches the exports no
+            // longer offer are pinned as left at their defaults.
             for (short_seconds, in_force) in [
                 (Some(5.0), 5.0),
                 (Some(0.5), 0.5),
@@ -2114,7 +1731,7 @@ mod tests {
                 (Some(f64::NAN), 20.0),
             ] {
                 assert_eq!(
-                    listing_filter(None, None, short_seconds),
+                    classification_filter(short_seconds),
                     PlaylistFilter {
                         filter_short_playlists: true,
                         filter_looping_playlists: true,
@@ -2123,129 +1740,27 @@ mod tests {
                     "{short_seconds:?}"
                 );
             }
+        }
+
+        #[test]
+        fn a_lowered_threshold_reclassifies_the_playlists_between_it_and_the_default() {
+            // A 5 s playlist is short under the default 20 s threshold and not
+            // short under a 5 s one, which is the whole of what the threshold
+            // changes — the looping rule does not read it.
+            let short = sample_playlist("00002.MPLS", 5.0, 100, 0, &["C.M2TS"]);
+            let looping = PlaylistSummary {
+                has_loops: true,
+                ..sample_playlist("00003.MPLS", 5.0, 0, 0, &[])
+            };
             assert_eq!(
-                listing_filter(Some(true), None, Some(5.0)),
-                PlaylistFilter {
-                    filter_short_playlists: false,
-                    filter_looping_playlists: true,
-                    short_playlist_seconds: 5.0,
-                }
+                classification_filter(None).classify(&short),
+                [bdinfo_rs_core::bdrom::order::HiddenRule::Short]
             );
-        }
-
-        #[test]
-        fn a_lowered_threshold_lists_and_reclassifies_the_playlists_between_it_and_the_default() {
-            // 00002 is 5 s: the default 20 s threshold withholds it and names it
-            // short, a 5 s threshold lists it and names no rule.
-            let playlists = mixed_disc();
-            let default = listing_filter(None, None, None);
-            let lowered = listing_filter(None, None, Some(5.0));
-            assert_eq!(listed(&playlists, &default), ["00000.MPLS"]);
-            assert_eq!(listed(&playlists, &lowered), ["00000.MPLS", "00002.MPLS"]);
-            assert_eq!(hidden_by(&playlists[2], &default), ["short"]);
-            assert!(hidden_by(&playlists[2], &lowered).is_empty());
-            // The looping rule is untouched by the threshold: 00003 is 5 s and
-            // looping, so it stays withheld and still names only `looping`.
-            assert_eq!(hidden_by(&playlists[3], &lowered), ["looping"]);
-        }
-
-        #[test]
-        fn hidden_by_names_each_rule_independently() {
-            let filter = PlaylistFilter::default();
-            let names: Vec<Vec<&str>> =
-                mixed_disc().iter().map(|playlist| hidden_by(playlist, &filter)).collect();
-            assert_eq!(names, [vec![], vec!["looping"], vec!["short"], vec!["short", "looping"]]);
-            // A playlist of exactly the threshold length is kept, so it names no
-            // rule — the same boundary `PlaylistFilter::keeps` draws.
-            assert!(
-                hidden_by(&sample_playlist("X", 20.0, 0, 0, &[]), &filter).is_empty(),
-                "20 s is not short"
-            );
-        }
-
-        #[test]
-        fn hidden_by_is_the_same_whatever_the_options_are() {
-            // The classification reads the rules, not the switches: a row listed
-            // only because its option was passed still names the rule that would
-            // have withheld it — the field a client re-filters on.
-            let widened = listing_filter(Some(true), Some(true), None);
-            let rows = playlist_rows(&mixed_disc(), &widened);
-            let view: Vec<(&str, &[&str])> =
-                rows.iter().map(|row| (row.name.as_str(), row.hidden_by.as_slice())).collect();
+            assert!(classification_filter(Some(5.0)).classify(&short).is_empty());
             assert_eq!(
-                view,
-                [
-                    ("00001.MPLS", ["looping"].as_slice()),
-                    ("00000.MPLS", [].as_slice()),
-                    ("00002.MPLS", ["short"].as_slice()),
-                    ("00003.MPLS", ["short", "looping"].as_slice()),
-                ]
+                classification_filter(Some(5.0)).classify(&looping),
+                [bdinfo_rs_core::bdrom::order::HiddenRule::Looping]
             );
-        }
-
-        #[test]
-        fn each_option_widens_the_listing_by_its_own_rule() {
-            let playlists = mixed_disc();
-            // The standard set lists neither the looping nor the short playlist.
-            assert_eq!(listed(&playlists, &listing_filter(None, None, None)), ["00000.MPLS"]);
-            // Showing short playlists reveals the short one but NOT the playlist
-            // that is short *and* looping — the rules are independent.
-            assert_eq!(
-                listed(&playlists, &listing_filter(Some(true), None, None)),
-                ["00000.MPLS", "00002.MPLS"]
-            );
-            assert_eq!(
-                listed(&playlists, &listing_filter(None, Some(true), None)),
-                ["00001.MPLS", "00000.MPLS"]
-            );
-            // Both options list the whole disc, longest first.
-            assert_eq!(
-                listed(&playlists, &listing_filter(Some(true), Some(true), None)),
-                ["00001.MPLS", "00000.MPLS", "00002.MPLS", "00003.MPLS"]
-            );
-        }
-
-        #[test]
-        fn playlist_rows_carry_the_table_columns() {
-            let rows = playlist_rows(&disc(), &PlaylistFilter::default());
-            let view: Vec<_> = rows
-                .iter()
-                .map(|row| {
-                    (
-                        row.position,
-                        row.group,
-                        row.name.as_str(),
-                        row.length.as_str(),
-                        row.estimated_bytes,
-                        row.has_hidden_streams,
-                        row.hidden_by.clone(),
-                    )
-                })
-                .collect();
-            assert_eq!(
-                view,
-                [
-                    (1, 1, "00000.MPLS", "00:01:40", Some(1000), false, vec![]),
-                    (2, 1, "00001.MPLS", "00:00:50", Some(500), false, vec![]),
-                    // group 2; the interleaved size is preferred over the m2ts size.
-                    (3, 2, "00002.MPLS", "00:01:10", Some(2000), false, vec![]),
-                ]
-            );
-        }
-
-        #[test]
-        fn table_length_truncates_and_wraps_the_day() {
-            assert_eq!(table_length(0.0), "00:00:00");
-            assert_eq!(table_length(3661.0), "01:01:01");
-            assert_eq!(table_length(-5.0), "00:00:00"); // a negative length clamps to zero
-            assert_eq!(table_length(90_061.0), "01:01:01"); // 25h01m01s wraps the day
-        }
-
-        #[test]
-        fn estimated_bytes_prefers_interleaved_then_m2ts_then_none() {
-            assert_eq!(estimated_bytes(&sample_playlist("X", 1.0, 500, 2000, &[])), Some(2000));
-            assert_eq!(estimated_bytes(&sample_playlist("X", 1.0, 500, 0, &[])), Some(500));
-            assert_eq!(estimated_bytes(&sample_playlist("X", 1.0, 0, 0, &[])), None);
         }
 
         #[test]
@@ -2275,70 +1790,6 @@ mod tests {
                 ["00002.MPLS", "00000.MPLS"]
             );
             assert!(named_selection(&playlists, &[]).is_empty());
-        }
-
-        #[test]
-        fn selection_stream_files_collects_every_selected_clip() {
-            let playlists = [
-                sample_playlist("00000.MPLS", 1.0, 0, 0, &["A.M2TS", "B.M2TS"]),
-                sample_playlist("00001.MPLS", 1.0, 0, 0, &["C.M2TS"]),
-            ];
-            let files = selection_stream_files(&playlists, &["00000.MPLS".to_owned()]);
-            assert_eq!(files.into_iter().collect::<Vec<_>>(), ["A.M2TS", "B.M2TS"]);
-            // an unknown name contributes nothing.
-            assert!(selection_stream_files(&playlists, &["99999.MPLS".to_owned()]).is_empty());
-        }
-
-        #[test]
-        fn selection_order_maps_names_to_indices_in_order() {
-            let playlists = [
-                sample_playlist("00000.MPLS", 1.0, 0, 0, &[]),
-                sample_playlist("00001.MPLS", 1.0, 0, 0, &[]),
-                sample_playlist("00002.MPLS", 1.0, 0, 0, &[]),
-            ];
-            assert_eq!(
-                selection_order(&playlists, &["00002.MPLS".to_owned(), "00000.MPLS".to_owned()]),
-                [2, 0]
-            );
-            // an unknown name maps to nothing.
-            assert!(selection_order(&playlists, &["99999.MPLS".to_owned()]).is_empty());
-        }
-
-        #[test]
-        fn json_escape_escapes_quotes_backslashes_controls_but_not_space() {
-            let mut out = String::new();
-            json_escape("a\"\\\n\t\r \u{1f}\u{0}z", &mut out);
-            assert_eq!(out, "a\\\"\\\\\\n\\t\\r \\u001f\\u0000z");
-        }
-
-        #[test]
-        fn rows_to_json_serializes_rows_commas_and_nulls() {
-            let rows = [
-                PlaylistRow {
-                    position: 1,
-                    group: 1,
-                    name: "00000.MPLS".to_owned(),
-                    length: "00:01:40".to_owned(),
-                    estimated_bytes: Some(1000),
-                    has_hidden_streams: false,
-                    hidden_by: Vec::new(),
-                },
-                PlaylistRow {
-                    position: 2,
-                    group: 2,
-                    name: "00001.MPLS".to_owned(),
-                    length: "00:00:50".to_owned(),
-                    estimated_bytes: None,
-                    has_hidden_streams: true,
-                    hidden_by: vec!["short", "looping"],
-                },
-            ];
-            assert_eq!(
-                rows_to_json(&rows),
-                "[{\"position\":1,\"group\":1,\"name\":\"00000.MPLS\",\"length\":\"00:01:40\",\"estimatedBytes\":1000,\"hasHidden\":false,\"hiddenBy\":[]},\
-                 {\"position\":2,\"group\":2,\"name\":\"00001.MPLS\",\"length\":\"00:00:50\",\"estimatedBytes\":null,\"hasHidden\":true,\"hiddenBy\":[\"short\",\"looping\"]}]"
-            );
-            assert_eq!(rows_to_json(&[]), "[]");
         }
 
         #[test]

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -13,6 +13,7 @@
 //! | [`ScanError`] | [`ScanError`](bdinfo_rs_core::error::ScanError) |
 //! | [`ScanStage`] | [`ScanStage`](bdinfo_rs_core::error::ScanStage) |
 //! | [`ScanErrorReason`] | [`BdError`](bdinfo_rs_core::error::BdError) |
+//! | [`HiddenRule`] | [`HiddenRule`](bdinfo_rs_core::bdrom::order::HiddenRule) |
 //!
 //! ## Conventions
 //!
@@ -43,21 +44,20 @@
 //!
 //! ## Building one, and taking it apart again
 //!
-//! [`Disc::from_scan`] mirrors a whole scanned disc and [`Disc::from_listing`] mirrors one as a
-//! filtered playlist listing; every other type here is reached through a [`From`] impl those two
-//! walk. [`Disc::into_scan`] goes back the other way, rebuilding the [`BdRom`] and the recorded
-//! failures so the report can be rendered from a mirror alone.
+//! [`Disc::from_scan`] mirrors a whole scanned disc; every other type here is reached through a
+//! [`From`] impl it walks. [`Disc::into_scan`] goes back the other way, rebuilding the [`BdRom`]
+//! and the recorded failures so the report can be rendered from a mirror alone.
 //!
 //! [`ScanResult`] is the one type here with no counterpart in the model: it pairs a rendered
 //! report with the [`Disc`] it was rendered beside, for a scan that returns both.
 
 use std::io;
 
-use bdinfo_rs_core::bdrom::chapters::ChapterSummary;
+use bdinfo_rs_core::bdrom::chapters::{ChapterSummary, seconds_to_ticks};
 use bdinfo_rs_core::bdrom::disc::{
     BdRom, ClipStreamTally, ClipSummary, PlaylistSummary, StreamSummary,
 };
-use bdinfo_rs_core::bdrom::order::PlaylistFilter;
+use bdinfo_rs_core::bdrom::order::{self, PlaylistFilter, table_rows};
 use bdinfo_rs_core::error;
 use bdinfo_rs_core::primitives::Pid;
 use bdinfo_rs_core::stream::TsStreamType;
@@ -128,13 +128,13 @@ pub struct Disc {
     /// Whether the disc carries PSP or mobile content: a `*.mnv` file under
     /// `SNP`.
     pub is_psp: bool,
-    /// The playlists, sorted by file name.
+    /// Every playlist on the disc, sorted by file name.
     ///
-    /// A scan puts every playlist on the disc here, the short and looping ones
-    /// a selection table would withhold included. A listing narrows it to the
-    /// playlists its filter keeps, which is what the two options on the
-    /// structural calls select; the disc-level values above and `errors` below
-    /// always describe the whole disc.
+    /// Nothing is ever filtered out, the short and looping playlists a
+    /// selection table withholds included: each one carries the rules that
+    /// withhold it in `hiddenBy`, so a consumer narrows the list itself
+    /// without scanning again. Sorting by file name rather than by table
+    /// position is what makes `position` a field.
     pub playlists: Vec<Playlist>,
     /// Whether the packet scan ran. When false the scan read only the disc
     /// metadata, and every measured value below — bitrates, packet counts,
@@ -155,6 +155,11 @@ pub struct Playlist {
     pub name: String,
     /// Total presentation length in seconds.
     pub total_length_seconds: f64,
+    /// The same length in 100 ns ticks, truncated toward zero — the unit the
+    /// report and the selection table format their `hh:mm:ss` cells from.
+    /// Integer-dividing this by 10,000,000 reproduces those cells exactly,
+    /// where formatting `totalLengthSeconds` can land a tick either side.
+    pub total_length_ticks: i64,
     /// Summed size of the clip `*.m2ts` files in bytes.
     pub file_size_bytes: u64,
     /// Summed size of the clip interleaved `*.ssif` files in bytes.
@@ -171,6 +176,32 @@ pub struct Playlist {
     /// file from the same in-time. A selection table withholds a looping
     /// playlist by default.
     pub has_loops: bool,
+    /// The shared-clip group this playlist belongs to, numbered from 1 — the
+    /// Group column of the selection table. Playlists sharing any clip file
+    /// land in one group, and the groups are numbered in table order, so group
+    /// 1 holds the longest playlist on the disc.
+    ///
+    /// Computed over the whole disc, so it does not move when a consumer
+    /// narrows the list.
+    pub group: usize,
+    /// Where this playlist sits in the selection table, numbered from 1 —
+    /// group order, and longest first inside each group.
+    ///
+    /// Computed over the whole disc, like `group`. Sorting `playlists` by it
+    /// reproduces the table the classic report prints, which is why it is a
+    /// field rather than the array index: the array stays in the file-name
+    /// order the disc records.
+    pub position: usize,
+    /// The filter rules that classify this playlist as withheld: `short` for a
+    /// playlist under the length threshold in force, `looping` for one that
+    /// replays a clip, both, or none.
+    ///
+    /// A selection table shows the playlists whose `hiddenBy` is empty, so
+    /// filtering on this field client-side is the whole of what the two
+    /// playlist-filter switches of the classic report do — no rescan needed.
+    /// The threshold behind `short` defaults to 20 seconds, and
+    /// `shortPlaylistSeconds` on the scanning calls is what moves it.
+    pub hidden_by: Vec<HiddenRule>,
     /// The presented streams, sorted by PID.
     pub streams: Vec<Stream>,
     /// The sequenced clips in playlist order, angle clips included.
@@ -179,6 +210,20 @@ pub struct Playlist {
     /// that chapter. Present without the packet scan too, but then only the
     /// times are filled in.
     pub chapters: Vec<Chapter>,
+}
+
+/// One reason a selection table withholds a playlist, and one member of a
+/// `hiddenBy`.
+///
+/// `short` means the playlist is strictly shorter than the length threshold in
+/// force — 20 seconds unless `shortPlaylistSeconds` moved it — and a playlist
+/// of exactly the threshold length is not short. `looping` means it replays a
+/// clip. The two rules are judged independently, so a playlist can name both.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum HiddenRule {
+    Short,
+    Looping,
 }
 
 /// One clip (`*.M2TS`) as one playlist sequences it.
@@ -465,31 +510,21 @@ impl Disc {
     /// mode rather than from the values: a measured scan can legitimately
     /// report a zero, and only the scan mode tells that apart from a value
     /// nothing ever measured.
+    ///
+    /// `filter` supplies the short-playlist threshold each playlist is
+    /// classified against for its `hiddenBy`; its two switches are not read,
+    /// because no playlist is ever dropped here.
     #[must_use]
-    pub fn from_scan(bdrom: &BdRom, errors: &[error::ScanError], measured: bool) -> Self {
-        Self::from_scan_filtered(bdrom, errors, measured, &PlaylistFilter::everything())
-    }
-
-    /// Mirrors a metadata-only scan as a playlist listing: as
-    /// [`from_scan`](Self::from_scan), except that `playlists` holds only the
-    /// playlists `filter` keeps and `measured` is false.
-    #[must_use]
-    pub fn from_listing(
-        bdrom: &BdRom,
-        errors: &[error::ScanError],
-        filter: &PlaylistFilter,
-    ) -> Self {
-        Self::from_scan_filtered(bdrom, errors, false, filter)
-    }
-
-    /// The body both constructors share; `from_scan` passes the filter that
-    /// keeps every playlist.
-    fn from_scan_filtered(
+    pub fn from_scan(
         bdrom: &BdRom,
         errors: &[error::ScanError],
         measured: bool,
         filter: &PlaylistFilter,
     ) -> Self {
+        // The table numbering describes the disc, not a view of it, so it is
+        // taken over every playlist: a group or a position that shifted when a
+        // consumer changed a display filter would be describing the view.
+        let rows = table_rows(&bdrom.playlists, &PlaylistFilter::everything());
         Self {
             volume_label: bdrom.volume_label.clone(),
             disc_title: bdrom.disc_title.clone(),
@@ -505,8 +540,23 @@ impl Disc {
             playlists: bdrom
                 .playlists
                 .iter()
-                .filter(|playlist| filter.keeps(playlist))
-                .map(Playlist::from)
+                .enumerate()
+                .map(|(index, playlist)| {
+                    // A keep-everything filter places every playlist in the
+                    // table exactly once, so the search always finds this one
+                    // and the (0, 0) default is unreachable.
+                    let (group, position) = rows
+                        .iter()
+                        .enumerate()
+                        .find(|(_, (_, at))| *at == index)
+                        .map_or((0, 0), |(row, (group, _))| (*group, row.saturating_add(1)));
+                    Playlist::mirror(
+                        playlist,
+                        group,
+                        position,
+                        filter.classify(playlist).into_iter().map(HiddenRule::from).collect(),
+                    )
+                })
                 .collect(),
             measured,
             errors: errors.iter().map(ScanError::from).collect(),
@@ -514,20 +564,41 @@ impl Disc {
     }
 }
 
-impl From<&PlaylistSummary> for Playlist {
-    fn from(playlist: &PlaylistSummary) -> Self {
+impl Playlist {
+    /// Mirrors one playlist, with the table numbering and the classification
+    /// its own fields cannot supply — those describe where the playlist sits
+    /// among the others, which only the whole disc knows.
+    fn mirror(
+        playlist: &PlaylistSummary,
+        group: usize,
+        position: usize,
+        hidden_by: Vec<HiddenRule>,
+    ) -> Self {
         Self {
             name: playlist.name.clone(),
             total_length_seconds: playlist.total_length,
+            total_length_ticks: seconds_to_ticks(playlist.total_length),
             file_size_bytes: playlist.file_size,
             interleaved_file_size_bytes: playlist.interleaved_file_size,
             chapter_count: playlist.chapter_count,
             stream_count: playlist.stream_count,
             angle_count: playlist.angle_count,
             has_loops: playlist.has_loops,
+            group,
+            position,
+            hidden_by,
             streams: playlist.streams.iter().map(Stream::from).collect(),
             clips: playlist.clips.iter().map(Clip::from).collect(),
             chapters: playlist.chapters.iter().map(Chapter::from).collect(),
+        }
+    }
+}
+
+impl From<order::HiddenRule> for HiddenRule {
+    fn from(rule: order::HiddenRule) -> Self {
+        match rule {
+            order::HiddenRule::Short => Self::Short,
+            order::HiddenRule::Looping => Self::Looping,
         }
     }
 }
@@ -750,6 +821,10 @@ impl Disc {
 }
 
 impl From<Playlist> for PlaylistSummary {
+    // Four mirror fields have no counterpart to rebuild and are dropped:
+    // `totalLengthTicks` is `totalLengthSeconds` in another unit, and `group`,
+    // `position` and `hiddenBy` are projections of the whole disc that the
+    // presentation order recomputes from the rebuilt playlists.
     fn from(playlist: Playlist) -> Self {
         Self {
             name: playlist.name,
@@ -905,8 +980,8 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::{
-        Chapter, Clip, ClipStream, Disc, Playlist, ScanError, ScanErrorReason, ScanStage, Stream,
-        borrowed_codec_alt_name,
+        Chapter, Clip, ClipStream, Disc, HiddenRule, Playlist, ScanError, ScanErrorReason,
+        ScanStage, Stream, borrowed_codec_alt_name, order,
     };
 
     // One fixture value and one hand-written wire form per mirror type, composed
@@ -1061,17 +1136,22 @@ mod tests {
         })
     }
 
-    /// A playlist with every field set to a distinct value.
+    /// A playlist with every field set to a distinct value. It is 3.5 s long
+    /// and loops, so the standard classification names both rules.
     fn a_playlist() -> Playlist {
         Playlist {
             name: "00000.MPLS".to_owned(),
             total_length_seconds: 3.5,
+            total_length_ticks: 35_000_000,
             file_size_bytes: 4,
             interleaved_file_size_bytes: 5,
             chapter_count: 6,
             stream_count: 7,
             angle_count: 8,
             has_loops: true,
+            group: 1,
+            position: 1,
+            hidden_by: vec![HiddenRule::Short, HiddenRule::Looping],
             streams: vec![a_stream()],
             clips: vec![a_clip()],
             chapters: vec![a_chapter()],
@@ -1083,12 +1163,16 @@ mod tests {
         json!({
             "name": "00000.MPLS",
             "totalLengthSeconds": 3.5,
+            "totalLengthTicks": 35_000_000,
             "fileSizeBytes": 4,
             "interleavedFileSizeBytes": 5,
             "chapterCount": 6,
             "streamCount": 7,
             "angleCount": 8,
             "hasLoops": true,
+            "group": 1,
+            "position": 1,
+            "hiddenBy": ["short", "looping"],
             "streams": [a_stream_json()],
             "clips": [a_clip_json()],
             "chapters": [a_chapter_json()],
@@ -1379,53 +1463,131 @@ mod tests {
         disc.playlists.iter().map(|playlist| playlist.name.as_str()).collect()
     }
 
-    /// The fixture disc scanned through the in-memory tree, mirrored.
+    /// The fixture disc scanned through the in-memory tree, mirrored under the
+    /// standard 20 s classification.
     fn a_fixture_disc(mode: ScanMode) -> Disc {
         let tree = crate::build_tree(&crate::tests::fixture_blob());
         let report = BdRom::open_resilient(&tree, mode).expect("the fixture disc opens");
-        Disc::from_scan(&report.bdrom, &report.errors, mode == ScanMode::Full)
+        Disc::from_scan(
+            &report.bdrom,
+            &report.errors,
+            mode == ScanMode::Full,
+            &PlaylistFilter::default(),
+        )
     }
 
     #[test]
     fn every_field_of_a_scanned_disc_maps_into_its_mirror() {
-        assert_eq!(Disc::from_scan(&a_core_bdrom(), &[a_core_scan_error()], true), a_disc());
+        assert_eq!(
+            Disc::from_scan(
+                &a_core_bdrom(),
+                &[a_core_scan_error()],
+                true,
+                &PlaylistFilter::default()
+            ),
+            a_disc()
+        );
     }
 
     #[test]
     fn the_scan_mode_alone_decides_the_measured_flag() {
         // Same disc, same values: only the flag differs, and it says whether a
         // zero below was measured or never looked at.
-        let unmeasured = Disc::from_scan(&a_core_bdrom(), &[], false);
+        let unmeasured = Disc::from_scan(&a_core_bdrom(), &[], false, &PlaylistFilter::default());
         assert!(!unmeasured.measured);
         assert!(unmeasured.errors.is_empty(), "a scan with no failures mirrors none");
         assert_eq!(Disc { measured: true, ..unmeasured }, Disc { errors: Vec::new(), ..a_disc() });
     }
 
     #[test]
-    fn from_scan_keeps_the_playlists_a_listing_would_withhold() {
-        let disc = Disc::from_scan(&a_mixed_core_bdrom(), &[], true);
-        assert_eq!(names(&disc), ["00000.MPLS", "00001.MPLS", "00002.MPLS"]);
+    fn a_mirrored_disc_holds_every_playlist_whatever_the_classification_withholds() {
+        // A short playlist and a looping one are both mirrored, under the
+        // standard filter that withholds them and under one that keeps them —
+        // the filter only ever decides what `hiddenBy` names.
+        let bdrom = a_mixed_core_bdrom();
+        for filter in [PlaylistFilter::default(), PlaylistFilter::everything()] {
+            let disc = Disc::from_scan(&bdrom, &[a_core_scan_error()], true, &filter);
+            assert_eq!(names(&disc), ["00000.MPLS", "00001.MPLS", "00002.MPLS"], "{filter:?}");
+            assert_eq!(disc.errors, vec![a_scan_error()], "the failures are not filtered");
+        }
     }
 
     #[test]
-    fn from_listing_holds_only_the_playlists_the_filter_keeps() {
+    fn every_playlist_carries_the_rules_that_withhold_it() {
         let bdrom = a_mixed_core_bdrom();
-        let listing = |filter: &PlaylistFilter| {
-            let disc = Disc::from_listing(&bdrom, &[a_core_scan_error()], filter);
-            assert!(!disc.measured, "a listing scan never ran the packet scan");
-            assert_eq!(disc.errors, vec![a_scan_error()], "the failures are not filtered");
-            names(&disc).into_iter().map(str::to_owned).collect::<Vec<_>>()
+        let rules = |filter: &PlaylistFilter| {
+            Disc::from_scan(&bdrom, &[], false, filter)
+                .playlists
+                .into_iter()
+                .map(|playlist| playlist.hidden_by)
+                .collect::<Vec<_>>()
         };
-        // The standard filter withholds the short and the looping playlist.
-        assert_eq!(listing(&PlaylistFilter::default()), ["00000.MPLS"]);
-        // A threshold the short playlist meets exactly keeps it: the boundary
-        // is the same one `PlaylistFilter::keeps` draws.
-        let lowered = PlaylistFilter { short_playlist_seconds: 5.0, ..PlaylistFilter::default() };
-        assert_eq!(listing(&lowered), ["00000.MPLS", "00001.MPLS"]);
+        // 00001 is 5 s and 00002 loops, so the standard 20 s threshold names
+        // one rule for each and none for the 100 s feature.
         assert_eq!(
-            listing(&PlaylistFilter::everything()),
-            ["00000.MPLS", "00001.MPLS", "00002.MPLS"]
+            rules(&PlaylistFilter::default()),
+            [vec![], vec![HiddenRule::Short], vec![HiddenRule::Looping]]
         );
+        // A threshold the short playlist meets exactly clears its rule — the
+        // same boundary `PlaylistFilter::keeps` draws — and leaves the looping
+        // rule, which does not read the threshold, alone.
+        let lowered = PlaylistFilter { short_playlist_seconds: 5.0, ..PlaylistFilter::default() };
+        assert_eq!(rules(&lowered), [vec![], vec![], vec![HiddenRule::Looping]]);
+        // A playlist that is both short and looping names both, Short first.
+        let both =
+            BdRom { playlists: vec![filtered_playlist("00003.MPLS", 5.0, true)], ..a_core_bdrom() };
+        let disc = Disc::from_scan(&both, &[], false, &PlaylistFilter::default());
+        let playlist = disc.playlists.first().expect("the one playlist");
+        assert_eq!(playlist.hidden_by, [HiddenRule::Short, HiddenRule::Looping]);
+    }
+
+    #[test]
+    fn every_hidden_rule_crosses_under_the_name_the_scan_reports() {
+        // The wire strings are the ones core prints in its hidden-playlist
+        // lines, so a relabelling there fails here rather than reaching a
+        // consumer as a silently different union member.
+        for rule in [order::HiddenRule::Short, order::HiddenRule::Looping] {
+            let wire = serde_json::to_value(HiddenRule::from(rule)).expect("serialize the rule");
+            assert_eq!(wire, Value::String(rule.label().to_owned()), "{rule:?}");
+        }
+    }
+
+    #[test]
+    fn the_table_numbering_describes_the_whole_disc_in_file_name_order() {
+        // 00002 (200 s, clip B) heads group 1; 00000 (100 s) and 00003 (50 s)
+        // share clip A, so they are group 2 in that order; 00001 (5 s, clip C)
+        // is group 3. The array itself stays in the file-name order the disc
+        // records, which is why the table position has to be a field.
+        let over = |name: &str, total_length: f64, clip: &str| PlaylistSummary {
+            clips: vec![ClipSummary { name: clip.to_owned(), ..a_core_clip() }],
+            ..filtered_playlist(name, total_length, false)
+        };
+        let bdrom = BdRom {
+            playlists: vec![
+                over("00000.MPLS", 100.0, "A.M2TS"),
+                over("00001.MPLS", 5.0, "C.M2TS"),
+                over("00002.MPLS", 200.0, "B.M2TS"),
+                over("00003.MPLS", 50.0, "A.M2TS"),
+            ],
+            ..a_core_bdrom()
+        };
+        // The standard filter would withhold the 5 s playlist; the numbering
+        // must not notice, since it describes the disc rather than a view.
+        let numbering = |filter: &PlaylistFilter| {
+            Disc::from_scan(&bdrom, &[], true, filter)
+                .playlists
+                .into_iter()
+                .map(|playlist| (playlist.name, playlist.group, playlist.position))
+                .collect::<Vec<_>>()
+        };
+        let want = vec![
+            ("00000.MPLS".to_owned(), 2, 2),
+            ("00001.MPLS".to_owned(), 3, 4),
+            ("00002.MPLS".to_owned(), 1, 1),
+            ("00003.MPLS".to_owned(), 2, 3),
+        ];
+        assert_eq!(numbering(&PlaylistFilter::default()), want);
+        assert_eq!(numbering(&PlaylistFilter::everything()), want);
     }
 
     #[test]

--- a/crates/bdinfo-rs-wasm/wasm-size-budget.txt
+++ b/crates/bdinfo-rs-wasm/wasm-size-budget.txt
@@ -1,9 +1,9 @@
 # Size budget (bytes) for the optimized browser payload
 # (web/pkg/bdinfo_rs_wasm_bg.wasm, after `wasm-opt -Oz`).
 #
-# A ceiling, not a target: the gate (scripts/wasm-compliance.ps1) and CI
-# (wasm.yml) fail if the optimized .wasm exceeds it. Current optimized size is
-# ~511,231 B (rustc 1.97.1 + wasm-bindgen 0.2.126 + binaryen 131.0.0).
+# A ceiling, not a target: the gate and CI (wasm.yml) fail if the optimized
+# .wasm exceeds it. Current optimized size is ~508,372 B (rustc 1.97.1 +
+# wasm-bindgen 0.2.126 + binaryen 131.0.0).
 #
 # The ceiling is 1 MiB, roughly double the current figure. It is deliberately
 # loose: a payload of this size is not a cost worth designing around for a tool
@@ -20,5 +20,6 @@
 # ~22,290 B, which is what pulls serde-wasm-bindgen into the payload. Taking a
 # disc model back IN added ~86,440 B: `Deserialize` over that same tree is the
 # larger half of serde, since reading a value needs a name-matching visitor per
-# field where writing one needs only a write.
+# field where writing one needs only a write. Deleting the hand-written JSON
+# row serializer and the four exports that fed it took ~2,859 B back off.
 1048576

--- a/crates/bdinfo-rs-wasm/wasm-size-budget.txt
+++ b/crates/bdinfo-rs-wasm/wasm-size-budget.txt
@@ -1,23 +1,24 @@
 # Size budget (bytes) for the optimized browser payload
 # (web/pkg/bdinfo_rs_wasm_bg.wasm, after `wasm-opt -Oz`).
 #
-# A RATCHET: the gate (scripts/wasm-compliance.ps1) and CI (wasm.yml) fail if the
-# optimized .wasm exceeds this. Lower it deliberately when the figure drops;
-# NEVER raise it without a written reason in the commit. Current optimized size
-# is ~511,231 B (rustc 1.96.0 + wasm-bindgen 0.2.126 + binaryen 131.0.0).
+# A ceiling, not a target: the gate (scripts/wasm-compliance.ps1) and CI
+# (wasm.yml) fail if the optimized .wasm exceeds it. Current optimized size is
+# ~511,231 B (rustc 1.97.1 + wasm-bindgen 0.2.126 + binaryen 131.0.0).
 #
-# Three steps account for the growth over the ~362,471 B this crate started at.
-# Linking the read-only UDF 2.50 reader for `.iso` input (the scan_iso /
-# list_iso_playlists exports + WebIso) took it to ~402,504 B; the reader had
-# been dead-code-eliminated out before, because nothing called it. The
-# structural disc-model exports (inspect_files / inspect_iso) then added
-# ~22,290 B by giving the serde `Serialize` tree over the mirror types its
-# first caller, which is what pulls serde-wasm-bindgen into the payload. Taking
-# a disc model back IN (render_report / scan_files_full / scan_iso_full) then
-# added ~86,440 B: `Deserialize` over that same tree is the larger half of
-# serde, since reading a value needs a name-matching visitor per field where
-# writing one needs only a write.
+# The ceiling is 1 MiB, roughly double the current figure. It is deliberately
+# loose: a payload of this size is not a cost worth designing around for a tool
+# that reads multi-GB disc images, so the budget exists to catch a runaway
+# regression - a dependency that pulls in a formatter, a panic path that keeps
+# its formatting machinery, a monomorphization blow-up - and not to arbitrate
+# ordinary feature growth. Raising it again means something went wrong; find
+# that before editing this number.
 #
-# The ceiling (512 KiB) carries a small headroom for patch-level toolchain
-# drift (binaryen is ^131.x).
-524288
+# For reference, what moved the figure so far: the crate started at ~362,471 B.
+# Linking the read-only UDF 2.50 reader for `.iso` input took it to ~402,504 B
+# (the reader had been dead-code-eliminated before, because nothing called it).
+# Giving serde `Serialize` over the disc-model mirror its first caller added
+# ~22,290 B, which is what pulls serde-wasm-bindgen into the payload. Taking a
+# disc model back IN added ~86,440 B: `Deserialize` over that same tree is the
+# larger half of serde, since reading a value needs a name-matching visitor per
+# field where writing one needs only a write.
+1048576

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -21,9 +21,9 @@ Firefox.
 npm i @bdinfo-rs/wasm
 ```
 
-The published payload is **~500 KB of WebAssembly + ~62 KB of JS**. Only the
-main-thread entry you import (~18 KB) loads up front; the scan Worker (~4 KB)
-and the wasm-bindgen glue (~40 KB) that hosts the `.wasm` are fetched lazily
+The published payload is **~497 KB of WebAssembly + ~44 KB of JS**. Only the
+main-thread entry you import (~9 KB) loads up front; the scan Worker (~3 KB)
+and the wasm-bindgen glue (~32 KB) that hosts the `.wasm` are fetched lazily
 inside the Worker, and nothing past the entry loads at all until the first scan.
 
 ## Usage
@@ -79,8 +79,24 @@ const { report } = await scan(isoInput.files[0]);
 cross as raw numbers with unit-bearing names — `bitrateBps`, `sampleRateHz`,
 `heightPixels`, `lengthSeconds` — so your UI can sort, filter and chart them
 rather than parse report text. The types (`Disc`, `Playlist`, `Stream`, `Clip`,
-`ClipStream`, `Chapter`, `ScanError`, `ScanResult`) are exported from the
-package entry and generated from the Rust definitions.
+`ClipStream`, `Chapter`, `ScanError`, `HiddenRule`, `ScanResult`) are exported
+from the package entry and generated from the Rust definitions.
+
+`disc.playlists` is in the disc's own file-name order and holds **every**
+playlist. Each one also carries where it sits in the classic selection table —
+`group` (shared-clip group, from 1), `position` (table order, from 1) and
+`hiddenBy` — so you can build that table without reimplementing its grouping:
+
+```ts
+const table = disc.playlists
+  .filter((playlist) => playlist.hiddenBy.length === 0)
+  .sort((a, b) => a.position - b.position);
+```
+
+`totalLengthTicks` is `totalLengthSeconds` in the 100 ns ticks the report
+formats its times from. Integer-divide it by 10,000,000 for the table's
+`hh:mm:ss` cell; computing that from the `f64` seconds can land a tick either
+side.
 
 `disc.measured` tells the two scans apart: `false` after `inspect`, where every
 measured value — bitrates, packet counts, chapter rates — is zero because
@@ -107,20 +123,31 @@ the rest at zero — scan again to measure them.
 
 ### Playlist filtering
 
-Like the classic report, `inspect` withholds playlists shorter than 20 seconds
-and looping ones. Pass `showShortPlaylists` / `showLoopingPlaylists` to include
-them, and `shortPlaylistSeconds` to move the length threshold:
+The classic report withholds playlists shorter than 20 seconds and looping
+ones. This package never withholds anything: every playlist crosses, and each
+carries the rules that classify it as withheld in `hiddenBy` — `"short"`,
+`"looping"`, both, or none. Filtering is therefore a client-side array
+operation, instant and rescan-free:
 
 ```ts
-const everything = await inspect(picked, {
-  showShortPlaylists: true,
-  showLoopingPlaylists: true,
-});
+const disc = await inspect(picked);
+const standard = disc.playlists.filter((playlist) => playlist.hiddenBy.length === 0);
+const withoutShort = disc.playlists.filter(
+  (playlist) => !playlist.hiddenBy.includes("short"),
+);
 ```
 
-The options only widen `disc.playlists`; the disc-level properties and
-`disc.errors` always describe the whole disc. A measured `scan` measures its
-`selection` unfiltered either way, and the report is unchanged.
+`shortPlaylistSeconds` moves the length threshold behind `"short"`. It is the
+one filter setting that has to be passed to the call, because it changes the
+classification rather than the view — pass it to `inspect` or `scan` and every
+playlist is judged against it:
+
+```ts
+const disc = await inspect(picked, { shortPlaylistSeconds: 5 });
+```
+
+Nothing else moves with it: which playlists a `Disc` holds, which ones a
+`selection` measures, and the rendered report are the same either way.
 
 ### Cancelling
 
@@ -132,24 +159,6 @@ failure by the rejection's `name`:
 const controller = new AbortController();
 const { report } = await scan(picked, undefined, { signal: controller.signal });
 ```
-
-### Deprecated calls
-
-`analyze`, `analyzeIso`, `listPlaylists` and `listPlaylistsIso` are the 2.0
-surface. They keep working exactly as before, and 3.0.0 removes them:
-
-| Deprecated | Replacement |
-| --- | --- |
-| `analyze(files, onProgress?, options?)` | `scan(files, onProgress?, options?)` |
-| `analyzeIso(file, onProgress?, options?)` | `scan(file, onProgress?, options?)` |
-| `listPlaylists(files, options?)` | `inspect(files, options?)` |
-| `listPlaylistsIso(file, options?)` | `inspect(file, options?)` |
-
-`listPlaylists` resolves with selection-table rows (`position`, `group`, `name`,
-`length`, `estimatedBytes`, `hasHidden`, `hiddenBy`). Of those, `position`,
-`group` and `hiddenBy` describe the table rather than the disc and are not on
-the `Disc`, so a UI that renders a selection table derives them from
-`disc.playlists` itself.
 
 See `index.html` in the source repository for a complete vanilla example (the
 demo is not shipped in the npm package).
@@ -198,6 +207,17 @@ The raw wasm-bindgen module is also exported directly for advanced use:
 ```ts
 import init, { scan_files } from "@bdinfo-rs/wasm/wasm";
 ```
+
+It exports `inspect_files`, `inspect_iso`, `scan_files`, `scan_iso` and
+`render_report` — what `inspect`, `scan` and `renderReport` call, minus the
+Worker — plus one entry point the package deliberately does not wrap:
+`scan_report(bytes)` takes a whole disc pre-framed into one length-prefixed
+byte buffer and renders it from memory. It exists as the in-memory seam the
+byte-parity tests drive through both the native and the browser build; it is
+not a fourth way to scan a disc, and a real consumer has no such buffer.
+
+Remember that every scanning export reads its bytes through `FileReaderSync`
+and therefore has to run inside a Web Worker.
 
 ## Browser support
 

--- a/crates/bdinfo-rs-wasm/web/src/analyze.ts
+++ b/crates/bdinfo-rs-wasm/web/src/analyze.ts
@@ -13,10 +13,6 @@
 // Each spawns the scan Worker (which hosts the WebAssembly module), hands it the
 // files, and resolves with the result — the rendered classic disc report being
 // the very bytes the native CLI writes to `BDINFO.<label>.txt`.
-//
-// `analyze`, `analyzeIso`, `listPlaylists` and `listPlaylistsIso` are the 2.0
-// surface: each returns one slice of what the three calls above return. They
-// keep working exactly as before and are deprecated for removal in 3.0.0.
 
 import type { Disc, ScanResult } from "../pkg/bdinfo_rs_wasm.js";
 
@@ -29,6 +25,7 @@ export type {
   Clip,
   ClipStream,
   Disc,
+  HiddenRule,
   Playlist,
   ScanError,
   ScanErrorReason,
@@ -62,47 +59,11 @@ export interface ScanProgress {
 /** A progress observer, called repeatedly as the scan demuxes. */
 export type ProgressFn = (progress: ScanProgress) => void;
 
-// Declared here rather than generated with the disc model: the WebAssembly
-// module builds these rows as JSON text through a serializer of its own, so no
-// TypeScript declaration is emitted for them — and `hiddenBy` is typed here as
-// the closed set of rule names that serializer can emit, which a generated
-// declaration would widen to `string[]`.
-/**
- * One playlist of the disc — a row of the selection table {@link listPlaylists}
- * returns, mirroring the CLI's `#`/Group/Playlist File/Length/Estimated Bytes
- * columns. Pass the chosen rows' {@link PlaylistRow.name}s to {@link analyze} as
- * `options.selection` to measure just those playlists.
- */
-export interface PlaylistRow {
-  /** 1-based position in the table — the handle the user picks. */
-  position: number;
-  /** Shared-clip group number (1-based). */
-  group: number;
-  /** The playlist file name, e.g. `00000.MPLS`. */
-  name: string;
-  /** `hh:mm:ss` total length. */
-  length: string;
-  /** Estimated bytes (interleaved `*.ssif` size, else `*.m2ts` size), or `null`. */
-  estimatedBytes: number | null;
-  /** Whether the playlist hides any stream (the CLI's `(*)` note). */
-  hasHidden: boolean;
-  /**
-   * The filter rules that classify this playlist as withheld: `"short"` (under
-   * 20 s), `"looping"`, both, or none. {@link listPlaylists} drops such
-   * playlists unless the matching option ({@link AnalyzeOptions.showShortPlaylists}
-   * / {@link AnalyzeOptions.showLoopingPlaylists}) was passed, so a row with a
-   * non-empty `hiddenBy` only appears when it was — but the rules it names are
-   * the same either way, so you can list once with both options on and re-apply
-   * either rule to the rows without re-scanning.
-   */
-  hiddenBy: ("short" | "looping")[];
-}
-
 /**
  * Optional overrides for every call in this module. Each option documents which
  * calls read it; a call ignores the ones it does not name.
  */
-export interface AnalyzeOptions {
+export interface ScanOptions {
   /**
    * A factory constructing the scan Worker to use. Defaults to
    * `new Worker(new URL("./worker.js", import.meta.url), { type: "module" })`,
@@ -116,47 +77,33 @@ export interface AnalyzeOptions {
    */
   createWorker?: () => Worker;
   /**
-   * The playlists to measure, by {@link PlaylistRow.name} — the browser
+   * The playlists to measure, by {@link Playlist.name} — the browser
    * equivalent of the CLI's `--mpls`, measured unfiltered in the given order.
    * Omitted or empty measures the standard `--whole` set.
    *
-   * Read by {@link scan}, {@link analyze} and {@link analyzeIso}.
+   * Read by {@link scan}.
    */
   selection?: string[];
-  /**
-   * Include playlists shorter than {@link AnalyzeOptions.shortPlaylistSeconds}
-   * — the CLI's `--show-short-playlists`.
-   *
-   * Read by {@link inspect}, {@link listPlaylists} and
-   * {@link listPlaylistsIso}, which withhold them by default. The measured
-   * scans measure their `selection` unfiltered, so it changes nothing there.
-   */
-  showShortPlaylists?: boolean;
-  /**
-   * Include looping playlists — the CLI's `--show-looping-playlists`. Read by
-   * the same calls as {@link AnalyzeOptions.showShortPlaylists}, and with the
-   * same effect on the others: none.
-   */
-  showLoopingPlaylists?: boolean;
   /**
    * The length in seconds under which a playlist counts as short, defaulting to
    * 20. Zero or less means that default.
    *
-   * Read by {@link inspect} only — {@link listPlaylists} and
-   * {@link listPlaylistsIso} always judge against the 20 s default.
+   * Read by {@link inspect} and {@link scan}, both of which classify every
+   * playlist against it and report the outcome in {@link Playlist.hiddenBy}.
+   * It changes no other value: which playlists a `Disc` holds, which ones a
+   * `selection` measures, and the rendered report are all the same either way.
    */
   shortPlaylistSeconds?: number;
   /**
    * Render the report's `STREAM DIAGNOSTICS:` section, defaulting to `true` —
    * the section the CLI's report carries.
    *
-   * Read by {@link scan} and {@link renderReport}. {@link analyze} and
-   * {@link analyzeIso} always render every section.
+   * Read by {@link scan} and {@link renderReport}.
    */
   streamDiagnostics?: boolean;
   /**
    * Render the report's `QUICK SUMMARY:` section, defaulting to `true`. Read by
-   * the same calls as {@link AnalyzeOptions.streamDiagnostics}.
+   * the same calls as {@link ScanOptions.streamDiagnostics}.
    */
   quickSummary?: boolean;
   /**
@@ -165,10 +112,7 @@ export interface AnalyzeOptions {
    * the signal's reason (an `AbortError`), so callers can tell a user cancel
    * from a real failure by the rejection's `name`.
    *
-   * Read by {@link inspect}, {@link scan}, {@link renderReport},
-   * {@link analyze} and {@link analyzeIso}. Ignored by {@link listPlaylists} /
-   * {@link listPlaylistsIso} — the structural scan is fast enough not to need
-   * it.
+   * Read by every call in this module.
    */
   signal?: AbortSignal;
 }
@@ -177,13 +121,12 @@ export interface AnalyzeOptions {
 type WorkerMessage =
   | ({ type: "progress" } & ScanProgress)
   | { type: "done"; report: string }
-  | { type: "rows"; rows: PlaylistRow[] }
   | { type: "disc"; disc: Disc }
   | { type: "result"; result: ScanResult }
   | { type: "error"; message: string };
 
 /** Spawns the scan Worker (a module worker by the bundler-aware convention). */
-function spawnWorker(options?: AnalyzeOptions): Worker {
+function spawnWorker(options?: ScanOptions): Worker {
   // The default path MUST stay a bare `new Worker(new URL("./worker.js",
   // import.meta.url), …)` literal: that exact shape is what Vite and webpack 5
   // statically detect to compile the Worker into a chunk and emit the `.wasm` it
@@ -205,31 +148,12 @@ function payload(files: BdmvFile[]): { paths: string[]; files: File[] } {
   };
 }
 
-/** The two playlist-filter opt-outs a listing request carries, defaulted off. */
-function listingOptions(options?: AnalyzeOptions): {
-  showShortPlaylists: boolean;
-  showLoopingPlaylists: boolean;
-} {
-  return {
-    showShortPlaylists: options?.showShortPlaylists ?? false,
-    showLoopingPlaylists: options?.showLoopingPlaylists ?? false,
-  };
-}
-
 /**
- * The playlist-filter options an {@link inspect} request carries: a listing's
- * two opt-outs plus the short-playlist threshold only this call reads. Zero is
- * how the WebAssembly module spells "use the 20 s default".
+ * The playlist-classification threshold a scanning request carries. Zero is how
+ * the WebAssembly module spells "use the 20 s default".
  */
-function inspectOptions(options?: AnalyzeOptions): {
-  showShortPlaylists: boolean;
-  showLoopingPlaylists: boolean;
-  shortPlaylistSeconds: number;
-} {
-  return {
-    ...listingOptions(options),
-    shortPlaylistSeconds: options?.shortPlaylistSeconds ?? 0,
-  };
+function classifyOptions(options?: ScanOptions): { shortPlaylistSeconds: number } {
+  return { shortPlaylistSeconds: options?.shortPlaylistSeconds ?? 0 };
 }
 
 /**
@@ -237,7 +161,7 @@ function inspectOptions(options?: AnalyzeOptions): {
  * `true` — an omitted option renders its section, so a render with no options
  * reproduces the report the CLI writes.
  */
-function reportOptions(options?: AnalyzeOptions): {
+function reportOptions(options?: ScanOptions): {
   streamDiagnostics: boolean;
   quickSummary: boolean;
 } {
@@ -277,7 +201,7 @@ function cancelledError(signal?: AbortSignal): DOMException {
 function request<T>(
   message: unknown,
   take: (reply: WorkerMessage) => { value: T } | null,
-  options?: AnalyzeOptions,
+  options?: ScanOptions,
   onProgress?: ProgressFn,
 ): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -337,17 +261,18 @@ function request<T>(
  * Show the playlists as a checklist, then hand the chosen
  * {@link Playlist.name}s to {@link scan}'s `options.selection`.
  *
- * `disc.playlists` holds the playlists the selection filter keeps, which
- * `options.showShortPlaylists`, `options.showLoopingPlaylists` and
- * `options.shortPlaylistSeconds` widen; the disc-level properties and
- * `disc.errors` always describe the whole disc.
+ * `disc.playlists` holds every playlist on the disc, each carrying its
+ * {@link Playlist.group}, {@link Playlist.position} and
+ * {@link Playlist.hiddenBy}, so the classic selection table is
+ * `disc.playlists.filter((p) => p.hiddenBy.length === 0)` sorted by `position`
+ * — a client-side filter, with no rescan to widen or narrow it.
  *
  * Everything runs locally: no bytes leave the page.
  */
-export function inspect(source: DiscSource, options?: AnalyzeOptions): Promise<Disc> {
+export function inspect(source: DiscSource, options?: ScanOptions): Promise<Disc> {
   const message = Array.isArray(source)
-    ? { kind: "inspect", ...payload(source), ...inspectOptions(options) }
-    : { kind: "inspect-iso", file: source, ...inspectOptions(options) };
+    ? { kind: "inspect", ...payload(source), ...classifyOptions(options) }
+    : { kind: "inspect-iso", file: source, ...classifyOptions(options) };
   return request(
     message,
     (reply) => (reply.type === "disc" ? { value: reply.disc } : null),
@@ -378,12 +303,13 @@ export function inspect(source: DiscSource, options?: AnalyzeOptions): Promise<D
 export function scan(
   source: DiscSource,
   onProgress?: ProgressFn,
-  options?: AnalyzeOptions,
+  options?: ScanOptions,
 ): Promise<ScanResult> {
   const selection = options?.selection ?? [];
+  const shared = { selection, ...reportOptions(options), ...classifyOptions(options) };
   const message = Array.isArray(source)
-    ? { kind: "scan-full", ...payload(source), selection, ...reportOptions(options) }
-    : { kind: "scan-iso-full", file: source, selection, ...reportOptions(options) };
+    ? { kind: "scan", ...payload(source), ...shared }
+    : { kind: "scan-iso", file: source, ...shared };
   return request(
     message,
     (reply) => (reply.type === "result" ? { value: reply.result } : null),
@@ -411,226 +337,10 @@ export function scan(
  * for the ones that scan named, so re-rendering it prints the rest at zero —
  * scan again to measure them.
  */
-export function renderReport(disc: Disc, options?: AnalyzeOptions): Promise<string> {
+export function renderReport(disc: Disc, options?: ScanOptions): Promise<string> {
   return request(
     { kind: "render", disc, ...reportOptions(options) },
     (reply) => (reply.type === "done" ? { value: reply.report } : null),
     options,
   );
-}
-
-/**
- * Lists the disc's playlists via the fast structural scan, resolving with the
- * selection-table rows (see {@link PlaylistRow}). No stream files are demuxed,
- * so it returns quickly; show the rows as a checklist, then hand the chosen
- * names to {@link analyze}'s `options.selection`.
- *
- * Short and looping playlists are dropped like the CLI's `--list`; pass
- * `options.showShortPlaylists` / `options.showLoopingPlaylists` to list them
- * too, and read each row's {@link PlaylistRow.hiddenBy} to tell them apart.
- *
- * Everything runs locally: no bytes leave the page.
- *
- * @deprecated since 2.1.0, removed in 3.0.0. Use {@link inspect}, which runs
- * the same structural scan and resolves with the whole {@link Disc} instead of
- * seven table columns. `position`, `group` and `hiddenBy` describe the table
- * rather than the disc and are not on the model, so a UI that renders a
- * selection table derives them from `disc.playlists` itself.
- */
-export function listPlaylists(files: BdmvFile[], options?: AnalyzeOptions): Promise<PlaylistRow[]> {
-  return new Promise<PlaylistRow[]>((resolve, reject) => {
-    const worker = spawnWorker(options);
-
-    worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
-      const message = event.data;
-      if (message.type === "rows") {
-        worker.terminate();
-        resolve(message.rows);
-      } else if (message.type === "error") {
-        worker.terminate();
-        reject(new Error(message.message));
-      }
-    };
-
-    worker.onerror = (event: ErrorEvent) => {
-      worker.terminate();
-      reject(new Error(event.message || "scan worker failed"));
-    };
-
-    worker.postMessage({ kind: "list", ...payload(files), ...listingOptions(options) });
-  });
-}
-
-/**
- * Lists a single Blu-ray `.iso`'s playlists via the fast structural scan,
- * resolving with the selection-table rows (see {@link PlaylistRow}) — the `.iso`
- * counterpart of {@link listPlaylists}. The image is opened through the UDF
- * reader; no stream data is demuxed, so it returns quickly. Hand the chosen
- * names to {@link analyzeIso}'s `options.selection`.
- *
- * Short and looping playlists are dropped like the CLI's `--list`; pass
- * `options.showShortPlaylists` / `options.showLoopingPlaylists` to list them
- * too, and read each row's {@link PlaylistRow.hiddenBy} to tell them apart.
- *
- * Everything runs locally: no bytes leave the page.
- *
- * @deprecated since 2.1.0, removed in 3.0.0. Use {@link inspect}, which takes
- * the `.iso` `File` directly and resolves with the whole {@link Disc}; see the
- * note on {@link listPlaylists} for the three row columns the model leaves to
- * the caller.
- */
-export function listPlaylistsIso(file: File, options?: AnalyzeOptions): Promise<PlaylistRow[]> {
-  return new Promise<PlaylistRow[]>((resolve, reject) => {
-    const worker = spawnWorker(options);
-
-    worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
-      const message = event.data;
-      if (message.type === "rows") {
-        worker.terminate();
-        resolve(message.rows);
-      } else if (message.type === "error") {
-        worker.terminate();
-        reject(new Error(message.message));
-      }
-    };
-
-    worker.onerror = (event: ErrorEvent) => {
-      worker.terminate();
-      reject(new Error(event.message || "scan worker failed"));
-    };
-
-    worker.postMessage({ kind: "list-iso", file, ...listingOptions(options) });
-  });
-}
-
-/**
- * Runs the full measured Blu-ray scan in a Worker and resolves with the classic
- * disc report. `onProgress`, if given, is called as the scan demuxes;
- * `options.selection` measures only the named playlists (see
- * {@link AnalyzeOptions}), defaulting to the standard `--whole` set.
- * `options.createWorker` overrides how the scan Worker is constructed.
- *
- * Everything runs locally: no bytes leave the page.
- *
- * @deprecated since 2.1.0, removed in 3.0.0. Use {@link scan}, which runs the
- * same measured scan and resolves with the same report plus the {@link Disc} it
- * was rendered from, takes the folder or the `.iso` through one parameter, and
- * accepts the report-section options.
- */
-export function analyze(
-  files: BdmvFile[],
-  onProgress?: ProgressFn,
-  options?: AnalyzeOptions,
-): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const signal = options?.signal;
-    if (signal?.aborted) {
-      reject(cancelledError(signal));
-      return;
-    }
-    const worker = spawnWorker(options);
-
-    // Cancel = terminate the Worker (its normal teardown path), just earlier.
-    const onAbort = () => {
-      worker.terminate();
-      reject(cancelledError(signal));
-    };
-    const unlisten = () => signal?.removeEventListener("abort", onAbort);
-    signal?.addEventListener("abort", onAbort, { once: true });
-
-    worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
-      const message = event.data;
-      switch (message.type) {
-        case "progress":
-          onProgress?.(message);
-          break;
-        case "done":
-          unlisten();
-          worker.terminate();
-          resolve(message.report);
-          break;
-        case "error":
-          unlisten();
-          worker.terminate();
-          reject(new Error(message.message));
-          break;
-        default:
-          break;
-      }
-    };
-
-    worker.onerror = (event: ErrorEvent) => {
-      unlisten();
-      worker.terminate();
-      reject(new Error(event.message || "scan worker failed"));
-    };
-
-    worker.postMessage({ kind: "scan", ...payload(files), selection: options?.selection ?? [] });
-  });
-}
-
-/**
- * Runs the full measured Blu-ray scan of a single `.iso` `File` in a Worker and
- * resolves with the classic disc report — the browser equivalent of
- * `bdinfo-rs <disc>.iso`. The image is opened through the read-only UDF reader
- * and streamed (its bytes are read on demand at byte offsets), never loaded
- * whole, so a multi-GB `.iso` is fine. `onProgress` and `options` behave exactly
- * as in {@link analyze}.
- *
- * Everything runs locally: no bytes leave the page.
- *
- * @deprecated since 2.1.0, removed in 3.0.0. Use {@link scan}, which takes the
- * `.iso` `File` directly and resolves with the report plus the {@link Disc} it
- * was rendered from.
- */
-export function analyzeIso(
-  file: File,
-  onProgress?: ProgressFn,
-  options?: AnalyzeOptions,
-): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const signal = options?.signal;
-    if (signal?.aborted) {
-      reject(cancelledError(signal));
-      return;
-    }
-    const worker = spawnWorker(options);
-
-    // Cancel = terminate the Worker (its normal teardown path), just earlier.
-    const onAbort = () => {
-      worker.terminate();
-      reject(cancelledError(signal));
-    };
-    const unlisten = () => signal?.removeEventListener("abort", onAbort);
-    signal?.addEventListener("abort", onAbort, { once: true });
-
-    worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
-      const message = event.data;
-      switch (message.type) {
-        case "progress":
-          onProgress?.(message);
-          break;
-        case "done":
-          unlisten();
-          worker.terminate();
-          resolve(message.report);
-          break;
-        case "error":
-          unlisten();
-          worker.terminate();
-          reject(new Error(message.message));
-          break;
-        default:
-          break;
-      }
-    };
-
-    worker.onerror = (event: ErrorEvent) => {
-      unlisten();
-      worker.terminate();
-      reject(new Error(event.message || "scan worker failed"));
-    };
-
-    worker.postMessage({ kind: "scan-iso", file, selection: options?.selection ?? [] });
-  });
 }

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -1,17 +1,54 @@
 // The vanilla (no-framework) demo driving the package's public API: pick or drop
-// a BDMV folder, list its playlists (structural scan), let the user select some,
-// run the measured scan in a Worker, and show the rendered report with copy +
-// download. No upload — everything stays in the browser. The settings dialog
-// holds the two playlist-filter opt-outs; they only widen what the table lists,
-// never what a scan measures or what the report says.
-import {
-  analyze,
-  analyzeIso,
-  type BdmvFile,
-  listPlaylists,
-  listPlaylistsIso,
-  type PlaylistRow,
-} from "./analyze.js";
+// a BDMV folder, inspect it (structural scan), let the user select some
+// playlists, run the measured scan in a Worker, and show the rendered report
+// with copy + download. No upload — everything stays in the browser. The
+// settings dialog holds the two playlist-filter opt-outs; they only widen what
+// the table lists, never what a scan measures or what the report says.
+import { type BdmvFile, type HiddenRule, inspect, type Playlist, scan } from "./analyze.js";
+
+/**
+ * One selection-table row — the CLI columns this page draws, distilled from a
+ * {@link Playlist}. The disc model carries the numbers; the table needs a
+ * formatted length cell and the two derived flags, so it computes them once
+ * here rather than in every cell.
+ */
+interface PlaylistRow {
+  position: number;
+  group: number;
+  name: string;
+  /** `hh:mm:ss`, truncated to the tick exactly as the CLI table truncates it. */
+  length: string;
+  /** Interleaved `*.ssif` size, else `*.m2ts` size, else null (the `-` cell). */
+  estimatedBytes: number | null;
+  /** Whether the playlist hides any stream (the CLI's `(*)` note). */
+  hasHidden: boolean;
+  hiddenBy: HiddenRule[];
+}
+
+/** The ticks in one second — the unit `totalLengthTicks` counts. */
+const TICKS_PER_SECOND = 10_000_000;
+
+/** A row per playlist, in the table order `position` records. */
+function playlistRows(playlists: Playlist[]): PlaylistRow[] {
+  return playlists
+    .map((playlist) => ({
+      position: playlist.position,
+      group: playlist.group,
+      name: playlist.name,
+      length: tableLength(playlist.totalLengthTicks),
+      estimatedBytes: playlist.interleavedFileSizeBytes || playlist.fileSizeBytes || null,
+      hasHidden: playlist.streams.some((stream) => stream.isHidden),
+      hiddenBy: playlist.hiddenBy,
+    }))
+    .sort((a, b) => a.position - b.position);
+}
+
+/** `hh:mm:ss` from playlist ticks, truncated like the CLI table (hours wrap at 24). */
+function tableLength(ticks: number): string {
+  const total = Math.max(0, Math.trunc(ticks / TICKS_PER_SECOND));
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${pad(Math.trunc(total / 3600) % 24)}:${pad(Math.trunc(total / 60) % 60)}:${pad(total % 60)}`;
+}
 
 function el<T extends HTMLElement>(id: string): T {
   const node = document.getElementById(id);
@@ -66,9 +103,9 @@ let discName = "disc";
 /** Aborts the in-progress measured scan; null when no scan is running. */
 let scanController: AbortController | null = null;
 /**
- * Every playlist of the picked disc: the listing is always made with BOTH
- * filter options on, and the settings are applied to these rows in the page. So
- * toggling a setting redraws the table instantly instead of re-scanning.
+ * Every playlist of the picked disc: a scan returns them all, tagged with the
+ * rules that withhold them, and the settings are applied to these rows in the
+ * page. So toggling a setting redraws the table instantly instead of rescanning.
  */
 let allRows: PlaylistRow[] = [];
 /** The playlists the user has unticked, by name — persists across a redraw. */
@@ -224,12 +261,9 @@ async function loadSource(src: Source): Promise<void> {
   hide(playlistsCard);
   show(listingBox);
   try {
-    // Always the widened set: the settings are applied to `allRows` in the page.
-    const options = { showShortPlaylists: true, showLoopingPlaylists: true };
-    const rows =
-      src.kind === "folder"
-        ? await listPlaylists(src.files, options)
-        : await listPlaylistsIso(src.file, options);
+    // The whole disc: the settings are applied to `allRows` in the page.
+    const disc = await inspect(src.kind === "folder" ? src.files : src.file);
+    const rows = playlistRows(disc.playlists);
     if (rows.length === 0) {
       showError(
         src.kind === "folder"
@@ -445,11 +479,11 @@ async function runScan(): Promise<void> {
     setProgress(percent, `Scanning ${file}`);
   };
   try {
-    const options = { selection, signal: controller.signal };
-    reportText =
-      src.kind === "folder"
-        ? await analyze(src.files, onProgress, options)
-        : await analyzeIso(src.file, onProgress, options);
+    const result = await scan(src.kind === "folder" ? src.files : src.file, onProgress, {
+      selection,
+      signal: controller.signal,
+    });
+    reportText = result.report;
     setProgress(100, "Done");
     showReport(reportText);
   } catch (error) {

--- a/crates/bdinfo-rs-wasm/web/src/worker.ts
+++ b/crates/bdinfo-rs-wasm/web/src/worker.ts
@@ -2,12 +2,9 @@
 // The scan Worker: hosts the WebAssembly module OFF the main thread. It serves
 // every request in `analyze.ts` over the same module instance:
 //   - `inspect` / `inspect-iso`: the fast STRUCTURAL scan → the whole disc model.
-//   - `scan-full` / `scan-iso-full`: the FULL measured scan → the rendered report
-//     and the disc model, from one demux.
+//   - `scan` / `scan-iso`: the FULL measured scan → the rendered report and the
+//     disc model, from one demux.
 //   - `render`: re-render the report from a disc model — no media touched.
-//   - `list` / `list-iso` and `scan` / `scan-iso`: what the deprecated 2.0 calls
-//     need — the selection table (parsed here, so the main thread receives
-//     structured rows, not JSON text) and the report alone.
 // The wasm reads each file's bytes synchronously at byte offsets through
 // `FileReaderSync` (the reason this must be a Worker — that API exists only in a
 // Worker scope), so a multi-GB stream never has to fit in memory. Progress is
@@ -21,19 +18,18 @@ import init, {
   type Disc,
   inspect_files,
   inspect_iso,
-  list_iso_playlists,
-  list_playlists,
   render_report,
   scan_files,
-  scan_files_full,
   scan_iso,
-  scan_iso_full,
 } from "../pkg/bdinfo_rs_wasm.js";
 
-/** The two playlist-filter opt-outs a listing request carries (see `analyze.ts`). */
-interface ListOptions {
-  showShortPlaylists: boolean;
-  showLoopingPlaylists: boolean;
+/**
+ * The playlist-classification threshold a scanning request carries: the length
+ * under which a playlist counts as short. Zero means the wasm module's 20 s
+ * default.
+ */
+interface ClassifyOptions {
+  shortPlaylistSeconds: number;
 }
 
 /**
@@ -45,64 +41,33 @@ interface ReportOptions {
   quickSummary: boolean;
 }
 
-/** List the playlists (structural scan) of the picked BDMV folder. */
-interface ListRequest extends ListOptions {
-  kind: "list";
+/** The whole disc model of the picked BDMV folder from a structural scan. */
+interface InspectRequest extends ClassifyOptions {
+  kind: "inspect";
   paths: string[];
   files: File[];
 }
 
-/** Measure `selection` (by playlist name; empty = the `--whole` set). */
-interface ScanRequest {
+/** The whole disc model of a single picked `.iso` from a structural scan. */
+interface InspectIsoRequest extends ClassifyOptions {
+  kind: "inspect-iso";
+  file: File;
+}
+
+/**
+ * Measure the picked BDMV folder, answering with the report AND the model.
+ * `selection` names the playlists to measure; empty is the `--whole` set.
+ */
+interface ScanRequest extends ReportOptions, ClassifyOptions {
   kind: "scan";
   paths: string[];
   files: File[];
   selection: string[];
 }
 
-/** List the playlists (structural scan) of a single picked `.iso`. */
-interface ListIsoRequest extends ListOptions {
-  kind: "list-iso";
-  file: File;
-}
-
-/** Measure a single picked `.iso` (`selection` by name; empty = `--whole`). */
-interface ScanIsoRequest {
-  kind: "scan-iso";
-  file: File;
-  selection: string[];
-}
-
-/**
- * The whole disc model of the picked BDMV folder from a structural scan.
- * `shortPlaylistSeconds` is the length under which a playlist counts as short;
- * zero means the wasm module's 20 s default.
- */
-interface InspectRequest extends ListOptions {
-  kind: "inspect";
-  paths: string[];
-  files: File[];
-  shortPlaylistSeconds: number;
-}
-
-/** The whole disc model of a single picked `.iso` from a structural scan. */
-interface InspectIsoRequest extends ListOptions {
-  kind: "inspect-iso";
-  file: File;
-  shortPlaylistSeconds: number;
-}
-
-/** Measure the picked BDMV folder, answering with the report AND the model. */
-interface ScanFullRequest extends ReportOptions {
-  kind: "scan-full";
-  paths: string[];
-  files: File[];
-  selection: string[];
-}
-
 /** Measure a single picked `.iso`, answering with the report AND the model. */
-interface ScanIsoFullRequest extends ReportOptions {
-  kind: "scan-iso-full";
+interface ScanIsoRequest extends ReportOptions, ClassifyOptions {
+  kind: "scan-iso";
   file: File;
   selection: string[];
 }
@@ -113,16 +78,7 @@ interface RenderRequest extends ReportOptions {
   disc: Disc;
 }
 
-type Request =
-  | ListRequest
-  | ScanRequest
-  | ListIsoRequest
-  | ScanIsoRequest
-  | InspectRequest
-  | InspectIsoRequest
-  | ScanFullRequest
-  | ScanIsoFullRequest
-  | RenderRequest;
+type Request = InspectRequest | InspectIsoRequest | ScanRequest | ScanIsoRequest | RenderRequest;
 
 let ready: Promise<unknown> | null = null;
 
@@ -139,84 +95,42 @@ self.onmessage = async (event: MessageEvent<Request>) => {
       self.postMessage({ type: "progress", file, done, total });
     };
     switch (data.kind) {
-      case "list":
-        self.postMessage({
-          type: "rows",
-          rows: JSON.parse(
-            list_playlists(
-              data.paths,
-              data.files,
-              data.showShortPlaylists,
-              data.showLoopingPlaylists,
-            ),
-          ),
-        });
-        break;
-      case "list-iso":
-        self.postMessage({
-          type: "rows",
-          rows: JSON.parse(
-            list_iso_playlists(data.file, data.showShortPlaylists, data.showLoopingPlaylists),
-          ),
-        });
-        break;
-      case "scan":
-        self.postMessage({
-          type: "done",
-          report: scan_files(data.paths, data.files, data.selection, onProgress),
-        });
-        break;
-      case "scan-iso":
-        self.postMessage({
-          type: "done",
-          report: scan_iso(data.file, data.selection, onProgress),
-        });
-        break;
       case "inspect":
         self.postMessage({
           type: "disc",
-          disc: inspect_files(
-            data.paths,
-            data.files,
-            data.showShortPlaylists,
-            data.showLoopingPlaylists,
-            data.shortPlaylistSeconds,
-          ),
+          disc: inspect_files(data.paths, data.files, data.shortPlaylistSeconds),
         });
         break;
       case "inspect-iso":
         self.postMessage({
           type: "disc",
-          disc: inspect_iso(
-            data.file,
-            data.showShortPlaylists,
-            data.showLoopingPlaylists,
-            data.shortPlaylistSeconds,
-          ),
+          disc: inspect_iso(data.file, data.shortPlaylistSeconds),
         });
         break;
-      case "scan-full":
+      case "scan":
         self.postMessage({
           type: "result",
-          result: scan_files_full(
+          result: scan_files(
             data.paths,
             data.files,
             data.selection,
             onProgress,
             data.streamDiagnostics,
             data.quickSummary,
+            data.shortPlaylistSeconds,
           ),
         });
         break;
-      case "scan-iso-full":
+      case "scan-iso":
         self.postMessage({
           type: "result",
-          result: scan_iso_full(
+          result: scan_iso(
             data.file,
             data.selection,
             onProgress,
             data.streamDiagnostics,
             data.quickSummary,
+            data.shortPlaylistSeconds,
           ),
         });
         break;

--- a/crates/bdinfo-rs-wasm/web/test/harness.html
+++ b/crates/bdinfo-rs-wasm/web/test/harness.html
@@ -6,26 +6,17 @@
     <title>bdinfo-rs wasm parity harness</title>
   </head>
   <body>
-    <!-- Headless-Chrome parity harness: exposes the package's public calls on the
-         window so the Playwright test can hand them File objects (a folder pick,
-         and a single `.iso`) built from the committed Big Buck Bunny fixture,
-         compare each report to its golden, drive the filter options through the
-         real Worker, and round-trip a disc model back into a report. -->
+    <!-- Headless-Chrome parity harness: exposes the package's three public calls
+         on the window so the Playwright test can hand them File objects (a folder
+         pick, and a single `.iso`) built from the committed Big Buck Bunny
+         fixture, compare each report to its golden, drive the playlist
+         classification through the real Worker, and round-trip a disc model back
+         into a report. -->
     <script type="module">
-      import {
-        analyze,
-        analyzeIso,
-        inspect,
-        listPlaylists,
-        renderReport,
-        scan,
-      } from "/dist/analyze.js";
+      import { inspect, renderReport, scan } from "/dist/analyze.js";
       window.__inspect = inspect;
       window.__scan = scan;
       window.__renderReport = renderReport;
-      window.__analyze = analyze;
-      window.__analyzeIso = analyzeIso;
-      window.__listPlaylists = listPlaylists;
       window.__ready = true;
     </script>
   </body>

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -100,8 +100,6 @@ async function main() {
     args: ["--no-sandbox"],
   });
 
-  let report;
-  let isoReport;
   let listings;
   let structured;
   let isoStructured;
@@ -126,13 +124,12 @@ async function main() {
       });
     }, entries);
 
-    // The folder path: the fixture handed in as a `(relativePath, File)` list.
-    report = await page.evaluate(async () => await window.__analyze(window.__files));
-
-    // The listing's filter options, driven through the real Worker: the same
+    // The playlist classification, driven through the real Worker: the same
     // disc plus a second playlist over the same clip patched to ~10 s (the first
     // PlayItem's OUT_time is a u32-BE at file offset 86, 45_000 ticks a second),
-    // which the short-playlist rule withholds unless the option is passed.
+    // which the short-playlist rule withholds until the threshold drops below
+    // its length. Both playlists are always returned; only `hiddenBy` moves.
+    // Sharing a clip also puts them in one group, longest first.
     listings = await page.evaluate(async () => {
       const source = window.__files.find((entry) => entry.path.endsWith("00000.mpls"));
       const bytes = new Uint8Array(await source.file.arrayBuffer());
@@ -144,18 +141,21 @@ async function main() {
           file: new File([bytes], "00001.mpls"),
         },
       ];
-      const names = async (options) =>
-        (await window.__listPlaylists(files, options)).map((row) => `${row.name}:${row.hiddenBy}`);
-      // The threshold only `inspect` takes: at 5 s the ~10 s playlist is no
-      // longer short, where the default 20 s withholds it.
+      const rules = (playlists) =>
+        playlists.map((playlist) => `${playlist.name}:${playlist.hiddenBy}`);
       const inspected = async (options) =>
-        (await window.__inspect(files, options)).playlists.map((playlist) => playlist.name);
+        rules((await window.__inspect(files, options)).playlists);
       return {
-        standard: await names(),
-        widened: await names({ showShortPlaylists: true }),
-        looping: await names({ showLoopingPlaylists: true }),
-        inspectStandard: await inspected(),
-        inspectLowered: await inspected({ shortPlaylistSeconds: 5 }),
+        standard: await inspected(),
+        lowered: await inspected({ shortPlaylistSeconds: 5 }),
+        // The measured export takes the same threshold, so a disc means the
+        // same thing whichever call produced it.
+        measured: rules(
+          (await window.__scan(files, undefined, { shortPlaylistSeconds: 5 })).disc.playlists,
+        ),
+        numbering: (await window.__inspect(files)).playlists.map(
+          (playlist) => `${playlist.group}/${playlist.position}`,
+        ),
       };
     });
 
@@ -172,6 +172,10 @@ async function main() {
           playlists: disc.playlists.map((playlist) => playlist.name),
           streams: disc.playlists[0].streams.length,
           rates: disc.playlists[0].streams.map((stream) => stream.bitrateBps),
+          group: disc.playlists[0].group,
+          position: disc.playlists[0].position,
+          hiddenBy: disc.playlists[0].hiddenBy,
+          ticks: disc.playlists[0].totalLengthTicks,
         },
         measured: scanned.disc.measured,
         rate: scanned.disc.playlists[0].streams[0].bitrateBps,
@@ -181,15 +185,8 @@ async function main() {
       };
     });
 
-    // The `.iso` path: the same disc fetched as one `File` and opened through the
-    // UDF reader — the real-browser Worker + FileReaderSync `scan_iso` seam.
-    isoReport = await page.evaluate(async () => {
-      const buf = await (await fetch("/__fixture.iso")).arrayBuffer();
-      const file = new File([new Uint8Array(buf)], "BigBuckBunny.iso");
-      return await window.__analyzeIso(file);
-    });
-
-    // The same image through the structured API. One `File` rather than a list
+    // The `.iso` path: the same disc fetched as one `File` and opened through
+    // the UDF reader — the real-browser Worker + FileReaderSync seam. One `File`
     // is what tells `inspect` and `scan` to open it as an `.iso`, so this is the
     // check that the two sources are told apart; the volume label is the genuine
     // one recorded in the filesystem, where a folder pick can only use the
@@ -235,28 +232,25 @@ async function main() {
     return false;
   }
 
-  const folderOk = compare("measured scan", report, golden);
-  const isoOk = compare(".iso scan", isoReport, isoGolden);
-
-  // Each listing is `name:hiddenBy` per row: the short playlist is listed only
-  // with its own option, and always names the rule that withholds it. The two
-  // `inspect` entries are playlist names, filtered by the threshold instead.
+  // Every call returns both playlists; the threshold moves only `hiddenBy`, and
+  // the table numbering describes the disc rather than any view of it.
   const want = {
-    standard: ["00000.MPLS:"],
-    widened: ["00000.MPLS:", "00001.MPLS:short"],
-    looping: ["00000.MPLS:"],
-    inspectStandard: ["00000.MPLS"],
-    inspectLowered: ["00000.MPLS", "00001.MPLS"],
+    standard: ["00000.MPLS:", "00001.MPLS:short"],
+    lowered: ["00000.MPLS:", "00001.MPLS:"],
+    measured: ["00000.MPLS:", "00001.MPLS:"],
+    numbering: ["1/1", "1/2"],
   };
   const listOk = JSON.stringify(listings) === JSON.stringify(want);
   if (listOk) {
-    console.log("PASS — Worker listing options widen the table by their own rule.");
+    console.log("PASS — Worker classification follows the threshold and withholds nothing.");
   } else {
-    console.error(`FAIL — listing options: got ${JSON.stringify(listings)}`);
+    console.error(`FAIL — classification: got ${JSON.stringify(listings)}`);
   }
 
   // The structural model: no demux ran, so `measured` is false and every rate is
-  // zero because nothing measured it.
+  // zero because nothing measured it. The one ~30 s playlist is group 1,
+  // position 1 and withheld by nothing; its 301,133,999 ticks integer-divide to
+  // the 30 s the table cell prints, which the 30.1134 s float cannot promise.
   const inspectOk =
     JSON.stringify(structured.inspected) ===
     JSON.stringify({
@@ -265,6 +259,10 @@ async function main() {
       playlists: ["00000.MPLS"],
       streams: 2,
       rates: [0, 0],
+      group: 1,
+      position: 1,
+      hiddenBy: [],
+      ticks: 301_133_999,
     });
   if (inspectOk) {
     console.log("PASS — Worker inspect returns the unmeasured disc model.");
@@ -310,7 +308,7 @@ async function main() {
     );
   }
 
-  process.exit(folderOk && isoOk && listOk && inspectOk && scanOk && isoStructuredOk ? 0 : 1);
+  process.exit(listOk && inspectOk && scanOk && isoStructuredOk ? 0 : 1);
 }
 
 main().catch((err) => {

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -12,8 +12,8 @@
 // locked-output contract on every gate run, with only Node + the built wasm.
 //
 // The same golden also pins the round trip through the structured disc model:
-// the `disc` that `scan_files_full` returns beside the report, handed straight
-// back to `render_report`, must render those bytes again — so the model reaches
+// the `disc` that `scan_files` returns beside the report, handed straight back
+// to `render_report`, must render those bytes again — so the model reaches
 // JavaScript and comes back carrying every value the report prints.
 //
 // Prereq: `npm run build` (emits pkg/). Run with `npm run test:node`.
@@ -94,18 +94,8 @@ function shortPlaylist(mpls) {
 async function main() {
   const golden = await readFile(goldenPath);
 
-  const {
-    initSync,
-    scan_files,
-    list_playlists,
-    scan_iso,
-    list_iso_playlists,
-    inspect_files,
-    inspect_iso,
-    scan_files_full,
-    scan_iso_full,
-    render_report,
-  } = await import("../pkg/bdinfo_rs_wasm.js");
+  const { initSync, scan_files, scan_iso, inspect_files, inspect_iso, render_report } =
+    await import("../pkg/bdinfo_rs_wasm.js");
   initSync({ module: await readFile(wasmPath) });
 
   const paths = [];
@@ -118,45 +108,17 @@ async function main() {
     files.push(new ShimFile(bytes, name));
   }
 
-  const report = scan_files(paths, files, []);
-  const got = Buffer.from(report, "utf8");
+  const full = scan_files(paths, files, []);
+  const got = Buffer.from(full.report, "utf8");
 
-  // The new CLI-parity exports: the structural list, and a by-name selective
-  // scan. On this single-playlist fixture, selecting the only playlist measures
-  // the same bytes as `--whole`, so its report must equal the golden too.
-  const rows = JSON.parse(list_playlists(paths, files));
-  const selReport = Buffer.from(scan_files(paths, files, ["00000.MPLS"]), "utf8");
-  const listOk =
-    Array.isArray(rows) &&
-    rows.length === 1 &&
-    rows[0].name === "00000.MPLS" &&
-    rows[0].position === 1 &&
-    Array.isArray(rows[0].hiddenBy) &&
-    rows[0].hiddenBy.length === 0;
+  // A by-name selective scan. On this single-playlist fixture, selecting the
+  // only playlist measures the same bytes as `--whole`, so its report must
+  // equal the golden too.
+  const selReport = Buffer.from(scan_files(paths, files, ["00000.MPLS"]).report, "utf8");
   const selOk = selReport.equals(golden);
-  if (!listOk) {
-    console.error(`FAIL — list_playlists rows unexpected: ${JSON.stringify(rows)}`);
-  }
-
-  // The filter options: the same disc plus a second playlist over the same clip,
-  // patched to ~10 s so the short rule withholds it. Omitting the options (and
-  // passing `false`) must list only the feature; passing `show_short_playlists`
-  // must add the short playlist, tagged `hiddenBy: ["short"]`.
-  const mpls = new Uint8Array(await readFile(join(fixtures, "PLAYLIST/00000.mpls")));
-  const shortPaths = [...paths, "WASMDISC/BDMV/PLAYLIST/00001.mpls"];
-  const shortFiles = [...files, new ShimFile(shortPlaylist(mpls), "00001.mpls")];
-  const listNames = (...options) =>
-    JSON.parse(list_playlists(shortPaths, shortFiles, ...options)).map((row) => row.name);
-  const widened = JSON.parse(list_playlists(shortPaths, shortFiles, true));
-  const optionsOk =
-    JSON.stringify(listNames()) === '["00000.MPLS"]' &&
-    JSON.stringify(listNames(false, false)) === '["00000.MPLS"]' &&
-    JSON.stringify(listNames(false, true)) === '["00000.MPLS"]' &&
-    JSON.stringify(widened.map((row) => row.name)) === '["00000.MPLS","00001.MPLS"]' &&
-    JSON.stringify(widened.map((row) => row.hiddenBy)) === '[[],["short"]]';
-  if (!optionsOk) {
+  if (!selOk) {
     console.error(
-      `FAIL — filter options unexpected: ${JSON.stringify(listNames())} / ${JSON.stringify(widened)}`,
+      `FAIL — selective scan (${selReport.length} bytes) diverged from golden (${golden.length} bytes).`,
     );
   }
 
@@ -183,23 +145,50 @@ async function main() {
     console.error(`FAIL — inspect_files disc unexpected: ${JSON.stringify(inspected)}`);
   }
 
-  // The short-playlist threshold, which only the inspect exports take: the
-  // ~10 s playlist the default 20 s rule withholds is listed once the threshold
-  // drops below its length, and a zero threshold means the default.
-  const inspectNames = (...options) =>
-    inspect_files(shortPaths, shortFiles, ...options).playlists.map((playlist) => playlist.name);
-  const thresholdOk =
-    JSON.stringify(inspectNames()) === '["00000.MPLS"]' &&
-    JSON.stringify(inspectNames(false, false, 0)) === '["00000.MPLS"]' &&
-    JSON.stringify(inspectNames(false, false, 5)) === '["00000.MPLS","00001.MPLS"]';
-  if (!thresholdOk) {
+  // The four selection-table fields on the model. The fixture disc is one
+  // ~30 s playlist, so it is group 1, position 1, withheld by nothing, and its
+  // tick count divides exactly into the `00:00:30` the table cell prints.
+  const tableOk =
+    inspectedPlaylist.group === 1 &&
+    inspectedPlaylist.position === 1 &&
+    Array.isArray(inspectedPlaylist.hiddenBy) &&
+    inspectedPlaylist.hiddenBy.length === 0 &&
+    inspectedPlaylist.totalLengthTicks ===
+      Math.trunc(inspectedPlaylist.totalLengthSeconds * 10_000_000) &&
+    Math.trunc(inspectedPlaylist.totalLengthTicks / 10_000_000) === 30;
+  if (!tableOk) {
     console.error(
-      `FAIL — short-playlist threshold unexpected: ${JSON.stringify(inspectNames(false, false, 5))}`,
+      `FAIL — selection-table fields unexpected: group ${inspectedPlaylist.group}, position ${inspectedPlaylist.position}, hiddenBy ${JSON.stringify(inspectedPlaylist.hiddenBy)}, ticks ${inspectedPlaylist.totalLengthTicks}.`,
     );
   }
-  if (!selOk) {
+
+  // The short-playlist threshold and the classification it drives. The disc
+  // gains a second playlist over the same clip, patched to ~10 s: every export
+  // returns BOTH playlists whatever the threshold, and only `hiddenBy` moves.
+  // Sharing the clip also puts both in group 1, longest first.
+  const mpls = new Uint8Array(await readFile(join(fixtures, "PLAYLIST/00000.mpls")));
+  const shortPaths = [...paths, "WASMDISC/BDMV/PLAYLIST/00001.mpls"];
+  const shortFiles = [...files, new ShimFile(shortPlaylist(mpls), "00001.mpls")];
+  const classify = (playlists) =>
+    JSON.stringify(playlists.map((playlist) => `${playlist.name}:${playlist.hiddenBy}`));
+  const numbering = (playlists) =>
+    JSON.stringify(playlists.map((playlist) => [playlist.group, playlist.position]));
+  const standard = inspect_files(shortPaths, shortFiles).playlists;
+  const lowered = inspect_files(shortPaths, shortFiles, 5).playlists;
+  const measuredShort = scan_files(shortPaths, shortFiles, [], undefined, true, true, 5).disc;
+  const thresholdOk =
+    classify(standard) === '["00000.MPLS:","00001.MPLS:short"]' &&
+    classify(inspect_files(shortPaths, shortFiles, 0).playlists) ===
+      '["00000.MPLS:","00001.MPLS:short"]' &&
+    classify(lowered) === '["00000.MPLS:","00001.MPLS:"]' &&
+    numbering(standard) === "[[1,1],[1,2]]" &&
+    numbering(lowered) === "[[1,1],[1,2]]" &&
+    // The measured export applies the same threshold, so a `Disc` means the
+    // same thing whichever call produced it.
+    classify(measuredShort.playlists) === '["00000.MPLS:","00001.MPLS:"]';
+  if (!thresholdOk) {
     console.error(
-      `FAIL — selective scan (${selReport.length} bytes) diverged from golden (${golden.length} bytes).`,
+      `FAIL — classification unexpected: standard ${classify(standard)}, lowered ${classify(lowered)}, numbering ${numbering(standard)}, measured ${classify(measuredShort.playlists)}.`,
     );
   }
 
@@ -208,12 +197,10 @@ async function main() {
   // `render_report` must reproduce the same bytes — which is what proves the
   // model crossed to JavaScript and back without losing a value the report
   // prints. Switching a section off must then drop it and nothing else.
-  const full = scan_files_full(paths, files, []);
   const reRendered = Buffer.from(render_report(full.disc), "utf8");
   const noDiagnostics = render_report(full.disc, false);
   const noSummary = render_report(full.disc, true, false);
   const fullOk =
-    Buffer.from(full.report, "utf8").equals(golden) &&
     full.disc.measured === true &&
     full.disc.playlists[0].streams[0].bitrateBps > 0 &&
     reRendered.equals(golden) &&
@@ -223,31 +210,21 @@ async function main() {
     !noSummary.includes("QUICK SUMMARY:");
   if (!fullOk) {
     console.error(
-      `FAIL — scan_files_full/render_report round trip: report ${full.report.length} B, re-rendered ${reRendered.length} B, golden ${golden.length} B, measured ${full.disc.measured}.`,
+      `FAIL — scan_files/render_report round trip: report ${full.report.length} B, re-rendered ${reRendered.length} B, golden ${golden.length} B, measured ${full.disc.measured}.`,
     );
   }
 
   // The streaming `.iso` path: the same disc opened through the UDF reader as one
-  // `File`. scan_iso (whole + by-name) and list_iso_playlists must match the
-  // native `.iso` golden / table, exercising WebIso's FileReaderSync windowed
-  // reads through the same shims scan_files uses.
+  // `File`. scan_iso (whole + by-name) must match the native `.iso` golden,
+  // exercising WebIso's FileReaderSync windowed reads through the same shims
+  // scan_files uses.
   const isoGolden = await readFile(isoGoldenPath);
   const isoFile = new ShimFile(new Uint8Array(await readFile(isoPath)), "BigBuckBunny.iso");
-  const isoReport = Buffer.from(scan_iso(isoFile, []), "utf8");
-  const isoRows = JSON.parse(list_iso_playlists(isoFile));
-  const isoSelReport = Buffer.from(scan_iso(isoFile, ["00000.MPLS"]), "utf8");
+  const isoFull = scan_iso(isoFile, []);
+  const isoReport = Buffer.from(isoFull.report, "utf8");
+  const isoSelReport = Buffer.from(scan_iso(isoFile, ["00000.MPLS"]).report, "utf8");
   const isoOk = isoReport.equals(isoGolden);
-  const isoListOk =
-    Array.isArray(isoRows) &&
-    isoRows.length === 1 &&
-    isoRows[0].name === "00000.MPLS" &&
-    isoRows[0].position === 1 &&
-    Array.isArray(isoRows[0].hiddenBy) &&
-    isoRows[0].hiddenBy.length === 0;
   const isoSelOk = isoSelReport.equals(isoGolden);
-  if (!isoListOk) {
-    console.error(`FAIL — list_iso_playlists rows unexpected: ${JSON.stringify(isoRows)}`);
-  }
   // The disc model over the same image: the UDF volume label is the genuine
   // one recorded in the filesystem, where the folder pick above can only use
   // the picked folder name.
@@ -257,20 +234,21 @@ async function main() {
     isoInspected.volumeLabel === "Blu-Ray" &&
     isoInspected.playlists.length === 1 &&
     isoInspected.playlists[0].name === "00000.MPLS" &&
+    isoInspected.playlists[0].position === 1 &&
+    isoInspected.playlists[0].hiddenBy.length === 0 &&
     isoInspected.playlists[0].clips.length === 1;
   if (!isoInspectOk) {
     console.error(`FAIL — inspect_iso disc unexpected: ${JSON.stringify(isoInspected)}`);
   }
-  // The same both-outputs scan over the image, round-tripped the same way.
-  const isoFull = scan_iso_full(isoFile, []);
+  // The both-outputs scan over the image, round-tripped the same way.
   const isoFullOk =
-    Buffer.from(isoFull.report, "utf8").equals(isoGolden) &&
+    isoOk &&
     isoFull.disc.measured === true &&
     isoFull.disc.volumeLabel === "Blu-Ray" &&
     Buffer.from(render_report(isoFull.disc), "utf8").equals(isoGolden);
   if (!isoFullOk) {
     console.error(
-      `FAIL — scan_iso_full/render_report round trip: report ${isoFull.report.length} B, iso golden ${isoGolden.length} B.`,
+      `FAIL — scan_iso/render_report round trip: report ${isoFull.report.length} B, iso golden ${isoGolden.length} B.`,
     );
   }
   if (!isoSelOk) {
@@ -297,20 +275,18 @@ async function main() {
 
   if (
     got.equals(golden) &&
-    listOk &&
     selOk &&
-    optionsOk &&
     inspectOk &&
+    tableOk &&
     thresholdOk &&
     fullOk &&
     isoOk &&
-    isoListOk &&
     isoSelOk &&
     isoInspectOk &&
     isoFullOk
   ) {
     console.log(
-      `PASS — Node measured scan matches the golden (${golden.length} bytes); list + options + inspect + selection + round trip + .iso OK.`,
+      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + selection + round trip + .iso OK.`,
     );
     process.exit(0);
   }


### PR DESCRIPTION
Replaces the string-and-rows half of the browser API with the structured disc
model, after completing that model so nothing is lost with it.

Breaking. The wasm crate exports go from ten to six and the package from seven
calls to three.

## The model absorbs the selection table

Playlist gains four fields, each one a fact the deleted selection-table row
carried and the model did not:

- group and position: the shared-clip group and the place in the presentation
  table, both taken over the WHOLE disc through core's table_rows with a
  keep-everything filter. A number that moved when a display filter changed
  would describe the view rather than the disc. position has to be a field
  because Disc.playlists stays in the disc's own file-name order, which is what
  the report round trip rebuilds from.
- hiddenBy: which filter rules withhold the playlist, mirrored 1:1 from core's
  HiddenRule so the generated TypeScript is the union "short" | "looping"
  rather than string[]. The strings are pinned by test against
  HiddenRule::label(), so a relabelling in core fails this crate's gate.
- totalLengthTicks: the exact tick count the hh:mm:ss cell truncates from.
  Formatting from the f64 seconds drifts by a tick on some values; the fixture
  playlist is one of them, at 301,133,999 ticks against a 30.1134 s float.

All four come from core's projection layer, none is re-derived here.

## Deletions

Wasm exports: scan_files and scan_iso in their report-only form,
list_playlists and list_iso_playlists. scan_files_full and scan_iso_full take
the freed names. What remains is inspect_files, inspect_iso, scan_files,
scan_iso, render_report and scan_report.

Row machinery: the Rust PlaylistRow, playlist_rows, rows_to_json, json_escape,
table_length, estimated_bytes, hidden_by, and the crate's local table_rows,
selection_order and selection_stream_files copies, which now import core's.

Package: analyze, analyzeIso, listPlaylists, listPlaylistsIso and the
hand-written PlaylistRow interface. AnalyzeOptions becomes ScanOptions.

## The filter switches leave the boundary

showShortPlaylists and showLoopingPlaylists are gone. Every export now returns
every playlist on the disc, so a caller filters client-side and instantly:

    disc.playlists.filter((p) => p.hiddenBy.length === 0)

shortPlaylistSeconds stays, on all four scanning exports, because it changes
the classification rather than the view. It is applied identically by each, so
a Disc means the same thing whichever call produced it. An inspect disc and a
scan disc now differ only in measured.

## Verification

The report bytes do not move. The round-trip gate renders both goldens
byte-exact over the renamed exports, in Node and through the real-browser
Worker in both directions. Coverage stays at 100% lines/regions/functions and
the diff mutation pass is 0 missed. The optimized module drops 2,859 B to
508,372 B, and dist/analyze.js halves to 9 KB.
