### PR TITLE
ci: align the gui mutation-job comment with the gate default scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
           cargo mutants --no-shuffle --in-diff pr.diff
 
   # Advisory in-diff mutation over the GUI crate on the PR path: mirrors
-  # the local `gui-compliance.ps1 -InDiff` dev loop — the diff is taken
+  # the local `gui-compliance.ps1` gate's default mt scope — the diff is taken
   # --relative from inside the crate so its paths match cargo-mutants' working
   # directory, and --in-place because a temp copy would not carry the
   # ../bdinfo-rs-core path dep. When the `gui` area fired via the core edge


### PR DESCRIPTION
The comment above the advisory gui in-diff mutation job referenced a dev-loop switch the local gate script no longer has. The local gate mutation step is diff-scoped by default now, so the comment names the default scope instead. Comment-only change.