### PR TITLE
feat(wasm): complete the demo settings with report options and size formats

### DIFF
--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -388,6 +388,81 @@
         accent-color: var(--accent);
         cursor: pointer;
       }
+      /* sortable playlist-table headers: click to sort, arrow shows direction */
+      th[data-sort] {
+        cursor: pointer;
+        user-select: none;
+      }
+      th[data-sort]:hover {
+        color: var(--text);
+      }
+      th .arrow {
+        display: inline-block;
+        min-width: 0.8em;
+        margin-left: 0.15rem;
+        font-size: 0.62rem;
+        color: var(--accent);
+      }
+      /* the active (master-detail) row driving the panes below the table */
+      tbody tr.active {
+        box-shadow: inset 2px 0 0 var(--accent);
+        background: var(--surface-2);
+      }
+      tbody tr.active.sel {
+        background: var(--accent-dim);
+      }
+
+      /* ── detail panes (stream files + codecs of the active playlist) ── */
+      .panes {
+        display: grid;
+        grid-template-columns: 1fr;
+        border-top: 1px solid var(--border);
+      }
+      .pane {
+        min-width: 0;
+      }
+      .pane + .pane {
+        border-top: 1px solid var(--border);
+      }
+      @media (min-width: 62rem) {
+        .panes {
+          grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+        }
+        .pane + .pane {
+          border-top: none;
+          border-left: 1px solid var(--border);
+        }
+      }
+      .pane h3 {
+        display: flex;
+        align-items: baseline;
+        gap: 0.5rem;
+        margin: 0;
+        padding: 0.6rem 1.1rem;
+        font-size: 0.74rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--muted);
+        border-bottom: 1px solid var(--border);
+      }
+      .pane-label {
+        font-family: var(--mono);
+        font-weight: 500;
+        text-transform: none;
+        letter-spacing: 0;
+        color: var(--text);
+      }
+      .pane .table-wrap {
+        max-height: 16rem;
+      }
+      .pane tbody tr {
+        cursor: default;
+      }
+      .pane tbody tr:hover {
+        background: transparent;
+      }
+
       .card-foot {
         display: flex;
         align-items: center;
@@ -660,15 +735,52 @@
               <thead>
                 <tr>
                   <th class="col-check"></th>
-                  <th>#</th>
-                  <th>Playlist</th>
-                  <th>Group</th>
-                  <th>Length</th>
-                  <th class="num">Est. Size</th>
+                  <th data-sort="position">#<span class="arrow"></span></th>
+                  <th data-sort="name">Playlist<span class="arrow"></span></th>
+                  <th data-sort="group">Group<span class="arrow"></span></th>
+                  <th data-sort="length">Length<span class="arrow"></span></th>
+                  <th class="num" data-sort="size">Est. Size<span class="arrow"></span></th>
                 </tr>
               </thead>
               <tbody id="playlist-body"></tbody>
             </table>
+          </div>
+          <!-- master-detail: the active (highlighted) playlist row fills these
+               two panes, mirroring the desktop app's lower panes. -->
+          <div class="panes" id="detail-panes" hidden>
+            <div class="pane">
+              <h3>Stream Files <span class="pane-label" id="pane-playlist"></span></h3>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Stream File</th>
+                      <th>#</th>
+                      <th>Length</th>
+                      <th class="num">Est. Size</th>
+                      <th class="num">Meas. Size</th>
+                    </tr>
+                  </thead>
+                  <tbody id="files-body"></tbody>
+                </table>
+              </div>
+            </div>
+            <div class="pane">
+              <h3>Streams</h3>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Codec</th>
+                      <th>Language</th>
+                      <th class="num">Bit Rate</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody id="codecs-body"></tbody>
+                </table>
+              </div>
+            </div>
           </div>
           <p class="hint" id="hidden-hint" hidden></p>
           <div class="card-foot">

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -509,10 +509,50 @@
         font-size: 0.9rem;
         cursor: pointer;
       }
+      /* the toggle-plus-threshold row: the label toggles, the number does not,
+         so they are siblings rather than one label. */
+      .setting-row {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.4rem 0;
+        font-size: 0.9rem;
+      }
+      .setting-row .setting {
+        padding: 0;
+      }
+      .threshold {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+        color: var(--muted);
+        font-size: 0.85rem;
+      }
+      .threshold input[type="number"] {
+        width: 4.2rem;
+        font: inherit;
+        font-size: 0.85rem;
+        color: var(--text);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 0.25rem 0.4rem;
+      }
+      /* the hairline separating the display settings from the report ones */
+      .settings hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 0.8rem 0 0.4rem;
+      }
       .setting-note {
         margin: 0.7rem 0 0;
         color: var(--muted);
         font-size: 0.8rem;
+      }
+      .setting-note.discard {
+        margin: 0.2rem 0 0;
+        color: var(--accent);
       }
       .dialog-foot {
         display: flex;
@@ -835,17 +875,54 @@
       <!-- settings: a native modal dialog (Esc closes, the backdrop dims) -->
       <dialog class="settings" id="settings-dialog" aria-labelledby="settings-title">
         <h2 id="settings-title">Settings</h2>
-        <label class="setting">
-          <input type="checkbox" id="opt-short" />
-          <span>Show short playlists</span>
-        </label>
+        <div class="setting-row">
+          <label class="setting">
+            <input type="checkbox" id="opt-short" />
+            <span>Show short playlists</span>
+          </label>
+          <span class="threshold">
+            <span>short&nbsp;=&nbsp;under</span>
+            <input
+              type="number"
+              id="opt-short-seconds"
+              min="1"
+              max="86400"
+              aria-label="Short-playlist threshold in seconds"
+            />
+            <span>s</span>
+          </span>
+        </div>
+        <p class="setting-note discard" id="discard-note" hidden>
+          Measured results cleared — the classification changed. Scan again to measure.
+        </p>
         <label class="setting">
           <input type="checkbox" id="opt-looping" />
           <span>Show looping playlists</span>
         </label>
+        <label class="setting">
+          <input type="checkbox" id="opt-human-sizes" />
+          <span>Human-readable sizes</span>
+        </label>
+        <label class="setting">
+          <input type="checkbox" id="opt-chapters" />
+          <span>Chapter count in playlist names</span>
+        </label>
         <p class="setting-note">
-          The playlist table hides playlists shorter than 20 seconds and looping ones, like the
+          The playlist table hides playlists shorter than the threshold and looping ones, like the
           classic report. Showing them never changes the report a scan produces.
+        </p>
+        <hr />
+        <label class="setting">
+          <input type="checkbox" id="opt-diagnostics" />
+          <span>Stream diagnostics in the report</span>
+        </label>
+        <label class="setting">
+          <input type="checkbox" id="opt-summary" />
+          <span>Quick summary in the report</span>
+        </label>
+        <p class="setting-note">
+          The report sections re-render from the disc the scan already returned — instantly, without
+          scanning again.
         </p>
         <div class="dialog-foot">
           <button class="btn primary" id="settings-close" type="button">Done</button>

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -2,9 +2,21 @@
 // a BDMV folder, inspect it (structural scan), let the user select some
 // playlists, run the measured scan in a Worker, and show the rendered report
 // with copy + download. No upload — everything stays in the browser. The
-// settings dialog holds the two playlist-filter opt-outs; they only widen what
-// the table lists, never what a scan measures or what the report says.
-import { type BdmvFile, type HiddenRule, inspect, type Playlist, scan } from "./analyze.js";
+// playlist table is the master of a master-detail flow: the active (highlighted)
+// row populates the two detail panes below it — the playlist's stream files and
+// its codecs — the same lower panes the bdinfo-rs desktop app and the classic
+// BDInfo window show. The settings dialog holds the two playlist-filter
+// opt-outs; they only widen what the table lists, never what a scan measures or
+// what the report says.
+import {
+  type BdmvFile,
+  type Clip,
+  type HiddenRule,
+  inspect,
+  type Playlist,
+  type Stream,
+  scan,
+} from "./analyze.js";
 
 /**
  * One selection-table row — the CLI columns this page draws, distilled from a
@@ -18,7 +30,9 @@ interface PlaylistRow {
   name: string;
   /** `hh:mm:ss`, truncated to the tick exactly as the CLI table truncates it. */
   length: string;
-  /** Interleaved `*.ssif` size, else `*.m2ts` size, else null (the `-` cell). */
+  /** The raw ticks behind `length` — the Length column's sort key. */
+  lengthTicks: number;
+  /** Interleaved `*.ssif` size, else `*.m2ts` size, else null (the `—` cell). */
   estimatedBytes: number | null;
   /** Whether the playlist hides any stream (the CLI's `(*)` note). */
   hasHidden: boolean;
@@ -36,6 +50,7 @@ function playlistRows(playlists: Playlist[]): PlaylistRow[] {
       group: playlist.group,
       name: playlist.name,
       length: tableLength(playlist.totalLengthTicks),
+      lengthTicks: playlist.totalLengthTicks,
       estimatedBytes: playlist.interleavedFileSizeBytes || playlist.fileSizeBytes || null,
       hasHidden: playlist.streams.some((stream) => stream.isHidden),
       hiddenBy: playlist.hiddenBy,
@@ -67,6 +82,10 @@ const pickedCount = el("picked-count");
 const playlistsCard = el("playlists-card");
 const discLabel = el("disc-label");
 const playlistBody = el<HTMLTableSectionElement>("playlist-body");
+const panesBox = el("detail-panes");
+const paneLabel = el("pane-playlist");
+const filesBody = el<HTMLTableSectionElement>("files-body");
+const codecsBody = el<HTMLTableSectionElement>("codecs-body");
 const selectAllBtn = el<HTMLButtonElement>("select-all");
 const clearBtn = el<HTMLButtonElement>("clear-sel");
 const selCount = el("sel-count");
@@ -103,13 +122,23 @@ let discName = "disc";
 /** Aborts the in-progress measured scan; null when no scan is running. */
 let scanController: AbortController | null = null;
 /**
- * Every playlist of the picked disc: a scan returns them all, tagged with the
- * rules that withhold them, and the settings are applied to these rows in the
+ * Every playlist of the picked disc, from the latest call that returned one: the
+ * structural `inspect` on pick, replaced by the measured `scan`'s disc when a
+ * scan finishes — which is what fills the panes' measured cells in place.
+ */
+let playlists: Playlist[] = [];
+/**
+ * The table rows over `playlists`: a scan returns every playlist, tagged with
+ * the rules that withhold it, and the settings are applied to these rows in the
  * page. So toggling a setting redraws the table instantly instead of rescanning.
  */
 let allRows: PlaylistRow[] = [];
+/** The rows as last drawn — filter, numbering and sort applied, top to bottom. */
+let displayed: PlaylistRow[] = [];
 /** The playlists the user has unticked, by name — persists across a redraw. */
 const unchecked = new Set<string>();
+/** The playlist whose details the panes show; null before the first draw. */
+let activeName: string | null = null;
 
 // ── settings ─────────────────────────────────────────────────────────────────
 
@@ -263,8 +292,7 @@ async function loadSource(src: Source): Promise<void> {
   try {
     // The whole disc: the settings are applied to `allRows` in the page.
     const disc = await inspect(src.kind === "folder" ? src.files : src.file);
-    const rows = playlistRows(disc.playlists);
-    if (rows.length === 0) {
+    if (disc.playlists.length === 0) {
       showError(
         src.kind === "folder"
           ? "No Blu-ray playlists found. Point at a disc's BDMV folder (or the disc root)."
@@ -272,7 +300,13 @@ async function loadSource(src: Source): Promise<void> {
       );
       return;
     }
-    renderPlaylists(rows);
+    sort = null;
+    activeName = null;
+    unchecked.clear();
+    adoptPlaylists(disc.playlists);
+    discLabel.textContent = discName;
+    show(playlistsCard);
+    playlistsCard.scrollIntoView({ behavior: "smooth", block: "nearest" });
   } catch (error) {
     showError(errMessage(error));
   } finally {
@@ -280,13 +314,15 @@ async function loadSource(src: Source): Promise<void> {
   }
 }
 
-function renderPlaylists(rows: PlaylistRow[]): void {
-  allRows = rows;
-  unchecked.clear();
+/**
+ * Takes `next` as the disc's playlists and redraws everything derived from
+ * them, keeping the view state — ticks, active row, sort — so a measured scan
+ * can fill in the panes' `—` cells without resetting what the user set up.
+ */
+function adoptPlaylists(next: Playlist[]): void {
+  playlists = next;
+  allRows = playlistRows(next);
   renderRows();
-  discLabel.textContent = discName;
-  show(playlistsCard);
-  playlistsCard.scrollIntoView({ behavior: "smooth", block: "nearest" });
 }
 
 /**
@@ -299,6 +335,81 @@ function isShown(row: PlaylistRow): boolean {
   );
 }
 
+// ── sorting ──────────────────────────────────────────────────────────────────
+
+/** A sortable playlist-table column; the sort key is the row's raw value. */
+type SortColumn = "position" | "name" | "group" | "length" | "size";
+
+/** The playlist table's active sort — a column and a direction. */
+interface Sort {
+  column: SortColumn;
+  ascending: boolean;
+}
+
+/** The active sort; null draws the CLI's table order (by `position`). */
+let sort: Sort | null = null;
+
+/**
+ * Compares two rows under `by`, on the raw values, never the cell strings. The
+ * absent estimated size (the `—` cell) orders after every present value in
+ * BOTH directions, so the dashes sit at the bottom whichever way the column
+ * sorts — the desktop app's rule.
+ */
+function compareRows(a: PlaylistRow, b: PlaylistRow, by: Sort): number {
+  const dir = (ordering: number): number => (by.ascending ? ordering : -ordering);
+  switch (by.column) {
+    case "position":
+      return dir(a.position - b.position);
+    case "name":
+      return dir(a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+    case "group":
+      return dir(a.group - b.group);
+    case "length":
+      return dir(a.lengthTicks - b.lengthTicks);
+    case "size":
+      if (a.estimatedBytes === null || b.estimatedBytes === null) {
+        return (a.estimatedBytes === null ? 1 : 0) - (b.estimatedBytes === null ? 1 : 0);
+      }
+      return dir(a.estimatedBytes - b.estimatedBytes);
+  }
+}
+
+/** Whether `rows` already read ascending by `column` (ties allowed). */
+function isAscending(rows: PlaylistRow[], column: SortColumn): boolean {
+  const probe: Sort = { column, ascending: true };
+  return rows.every((row, index) => index === 0 || compareRows(rows[index - 1], row, probe) <= 0);
+}
+
+/**
+ * The desktop app's header-click rule: a click on the current sort column flips
+ * its direction; a click on any other column starts it ascending — unless the
+ * rows already read ascending by that column, in which case it starts
+ * descending. That keeps every click a visible re-order.
+ */
+function clickSort(column: SortColumn): void {
+  const ascending = sort?.column === column ? !sort.ascending : !isAscending(displayed, column);
+  sort = { column, ascending };
+  renderRows();
+}
+
+/** Points the header arrows (and `aria-sort`) at the active sort column. */
+function renderSortIndicators(): void {
+  for (const th of playlistsCard.querySelectorAll<HTMLTableCellElement>("th[data-sort]")) {
+    const current = sort !== null && th.dataset.sort === sort.column ? sort : null;
+    const arrow = th.querySelector(".arrow");
+    if (arrow !== null) {
+      arrow.textContent = current === null ? "" : current.ascending ? "▲" : "▼";
+    }
+    if (current === null) {
+      th.removeAttribute("aria-sort");
+    } else {
+      th.setAttribute("aria-sort", current.ascending ? "ascending" : "descending");
+    }
+  }
+}
+
+// ── the playlist table ───────────────────────────────────────────────────────
+
 /** Draws the rows the settings show, and the hint for the ones they do not. */
 function renderRows(): void {
   const shown = allRows.filter(isShown);
@@ -306,11 +417,25 @@ function renderRows(): void {
   // reads like a scan made with these settings rather than like the widened
   // listing it is sliced from. Group numbers keep their identity because the
   // rows arrive grouped: the distinct values, in order, are the new 1, 2, 3.
+  // Numbering happens before sorting, so a sorted table shuffles the numbers
+  // with their rows instead of re-counting the new order.
   const groups = [...new Set(shown.map((row) => row.group))];
+  const numbered = shown.map((row, index) => ({
+    row,
+    position: index + 1,
+    group: groups.indexOf(row.group) + 1,
+  }));
+  const by = sort;
+  if (by !== null) {
+    numbered.sort((a, b) => compareRows(a.row, b.row, by));
+  }
+  displayed = numbered.map((entry) => entry.row);
   playlistBody.replaceChildren(
-    ...shown.map((row, index) => playlistRow(row, index + 1, groups.indexOf(row.group) + 1)),
+    ...numbered.map((entry) => playlistRow(entry.row, entry.position, entry.group)),
   );
+  renderSortIndicators();
   renderHint();
+  ensureActive();
   updateSelection();
 }
 
@@ -362,6 +487,15 @@ function textCell(text: string, className?: string): HTMLTableCellElement {
   return td;
 }
 
+/** A `*` marker span — hidden tracks in the master table, hidden streams below. */
+function star(title: string): HTMLSpanElement {
+  const marker = document.createElement("span");
+  marker.className = "star";
+  marker.textContent = "*";
+  marker.title = title;
+  return marker;
+}
+
 function playlistRow(row: PlaylistRow, position: number, group: number): HTMLTableRowElement {
   const tr = document.createElement("tr");
   tr.dataset.name = row.name;
@@ -378,11 +512,7 @@ function playlistRow(row: PlaylistRow, position: number, group: number): HTMLTab
   const nameCell = cell("name");
   nameCell.textContent = row.name;
   if (row.hasHidden) {
-    const star = document.createElement("span");
-    star.className = "star";
-    star.textContent = "*";
-    star.title = "Has hidden tracks";
-    nameCell.appendChild(star);
+    nameCell.appendChild(star("Has hidden tracks"));
   }
   tr.appendChild(nameCell);
 
@@ -390,12 +520,18 @@ function playlistRow(row: PlaylistRow, position: number, group: number): HTMLTab
   tr.appendChild(textCell(row.length));
   tr.appendChild(textCell(humanBytes(row.estimatedBytes), "num"));
 
-  // Clicking anywhere on the row toggles its checkbox.
+  // The check cell toggles the tick; the rest of the row activates the
+  // playlist and fills the detail panes, like the desktop table.
   tr.addEventListener("click", (event) => {
-    if (event.target !== check) {
-      check.checked = !check.checked;
+    if (event.target === check || event.target === checkCell) {
+      if (event.target === checkCell) {
+        check.checked = !check.checked;
+      }
+      updateSelection();
+      return;
     }
-    updateSelection();
+    activeName = row.name;
+    applyActive();
   });
   check.addEventListener("change", updateSelection);
   return tr;
@@ -446,6 +582,100 @@ function setAll(checked: boolean): void {
   updateSelection();
 }
 
+// ── the detail panes ─────────────────────────────────────────────────────────
+
+/**
+ * Keeps a row active and the panes filled: when the settings hide the active
+ * row (or nothing is active yet), the first shown row takes over — so the
+ * panes always describe a row that is on screen.
+ */
+function ensureActive(): void {
+  if (activeName === null || !displayed.some((row) => row.name === activeName)) {
+    activeName = displayed[0]?.name ?? null;
+  }
+  applyActive();
+}
+
+/** Highlights the active row and redraws both panes from its playlist. */
+function applyActive(): void {
+  for (const tr of playlistBody.querySelectorAll("tr")) {
+    tr.classList.toggle("active", tr.dataset.name === activeName);
+  }
+  renderPanes();
+}
+
+/** Fills both panes from the active playlist, or hides them without one. */
+function renderPanes(): void {
+  const playlist = playlists.find((entry) => entry.name === activeName);
+  if (playlist === undefined) {
+    hide(panesBox);
+    return;
+  }
+  show(panesBox);
+  paneLabel.textContent = playlist.name;
+  filesBody.replaceChildren(...streamFileRows(playlist.clips));
+  codecsBody.replaceChildren(...playlist.streams.map(codecRow));
+}
+
+/**
+ * The "Stream Files" rows — one per clip, formatted like the desktop pane: the
+ * index counts the main (angle-0) clips, so an extra-angle clip shares its
+ * main clip's index and gets a ` (N)` angle suffix on the file name; the
+ * estimated size prefers the interleaved `*.ssif` over the plain `*.m2ts`; a
+ * size that is not yet known (no file on disk / nothing demuxed) shows as `—`.
+ */
+function streamFileRows(clips: Clip[]): HTMLTableRowElement[] {
+  let index = 0;
+  return clips.map((clip) => {
+    if (clip.angleIndex === 0) {
+      index += 1;
+    }
+    const file =
+      clip.angleIndex > 0 ? `${clip.displayName} (${clip.angleIndex})` : clip.displayName;
+    const estimated =
+      clip.interleavedFileSizeBytes > 0 ? clip.interleavedFileSizeBytes : clip.fileSizeBytes;
+    const tr = document.createElement("tr");
+    tr.appendChild(textCell(file, "name"));
+    tr.appendChild(textCell(String(index)));
+    // The clip carries seconds only; truncating them to ticks first is the
+    // table-time rule every `hh:mm:ss` cell follows.
+    tr.appendChild(textCell(tableLength(Math.trunc(clip.lengthSeconds * TICKS_PER_SECOND))));
+    tr.appendChild(textCell(humanBytes(estimated > 0 ? estimated : null), "num"));
+    // The packet-derived size: 192 bytes per transport packet.
+    tr.appendChild(
+      textCell(humanBytes(clip.packetCount > 0 ? clip.packetCount * 192 : null), "num"),
+    );
+    return tr;
+  });
+}
+
+/**
+ * One "Streams" (codec) row, formatted like the desktop pane. The description
+ * is `fullDescription` — the same string the locked report prints — so the
+ * pane matches the report; a hidden stream's codec name is marked with `*`.
+ */
+function codecRow(stream: Stream): HTMLTableRowElement {
+  const tr = document.createElement("tr");
+  const codecCell = cell();
+  codecCell.textContent = stream.codecName;
+  if (stream.isHidden) {
+    codecCell.appendChild(star("Hidden stream"));
+  }
+  tr.appendChild(codecCell);
+  tr.appendChild(textCell(stream.languageName));
+  tr.appendChild(textCell(bitrateCell(stream.bitrateBps), "num"));
+  tr.appendChild(textCell(stream.fullDescription));
+  return tr;
+}
+
+/** The bit-rate cell: `N kbps` (thousands-grouped), or `—` while unmeasured. */
+function bitrateCell(bitsPerSecond: number): string {
+  const kbps = Math.trunc(bitsPerSecond / 1000);
+  return kbps > 0 ? `${kbps.toLocaleString("en-US")} kbps` : "—";
+}
+
+// ── scan + report ────────────────────────────────────────────────────────────
+
 function setProgress(percent: number, text: string): void {
   bar.value = percent;
   pctLabel.textContent = `${percent}%`;
@@ -485,6 +715,9 @@ async function runScan(): Promise<void> {
     });
     reportText = result.report;
     setProgress(100, "Done");
+    // The measured disc replaces the structural one, so the panes' measured
+    // sizes and bit rates fill in for the playlists this scan measured.
+    adoptPlaylists(result.disc.playlists);
     showReport(reportText);
   } catch (error) {
     // A cancel is a user action, not a failure — reset quietly, no error shown.
@@ -590,6 +823,12 @@ for (const box of [optShort, optLooping]) {
     settings.showLoopingPlaylists = optLooping.checked;
     saveSettings();
     renderRows();
+  });
+}
+
+for (const th of playlistsCard.querySelectorAll<HTMLTableCellElement>("th[data-sort]")) {
+  th.addEventListener("click", () => {
+    clickSort(th.dataset.sort as SortColumn);
   });
 }
 

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -5,15 +5,20 @@
 // playlist table is the master of a master-detail flow: the active (highlighted)
 // row populates the two detail panes below it — the playlist's stream files and
 // its codecs — the same lower panes the bdinfo-rs desktop app and the classic
-// BDInfo window show. The settings dialog holds the two playlist-filter
-// opt-outs; they only widen what the table lists, never what a scan measures or
-// what the report says.
+// BDInfo window show. The settings dialog mirrors the desktop app's: the two
+// playlist-filter opt-outs, the size format and the chapter-count suffix are
+// pure re-projections of the model the page already holds; only the
+// short-playlist threshold (a fresh `inspect`) and the two report sections (a
+// `renderReport` over the held disc) reach the WebAssembly module, and nothing
+// in the dialog ever repeats a measured scan.
 import {
   type BdmvFile,
   type Clip,
+  type Disc,
   type HiddenRule,
   inspect,
   type Playlist,
+  renderReport,
   type Stream,
   scan,
 } from "./analyze.js";
@@ -37,6 +42,8 @@ interface PlaylistRow {
   /** Whether the playlist hides any stream (the CLI's `(*)` note). */
   hasHidden: boolean;
   hiddenBy: HiddenRule[];
+  /** Chapter count behind the optional ` [NN Chapters]` name suffix. */
+  chapterCount: number;
 }
 
 /** The ticks in one second — the unit `totalLengthTicks` counts. */
@@ -54,6 +61,7 @@ function playlistRows(playlists: Playlist[]): PlaylistRow[] {
       estimatedBytes: playlist.interleavedFileSizeBytes || playlist.fileSizeBytes || null,
       hasHidden: playlist.streams.some((stream) => stream.isHidden),
       hiddenBy: playlist.hiddenBy,
+      chapterCount: playlist.chapterCount,
     }))
     .sort((a, b) => a.position - b.position);
 }
@@ -108,7 +116,13 @@ const settingsBtn = el<HTMLButtonElement>("settings-btn");
 const settingsDialog = el<HTMLDialogElement>("settings-dialog");
 const settingsClose = el<HTMLButtonElement>("settings-close");
 const optShort = el<HTMLInputElement>("opt-short");
+const optShortSeconds = el<HTMLInputElement>("opt-short-seconds");
+const discardNote = el("discard-note");
 const optLooping = el<HTMLInputElement>("opt-looping");
+const optHumanSizes = el<HTMLInputElement>("opt-human-sizes");
+const optChapters = el<HTMLInputElement>("opt-chapters");
+const optDiagnostics = el<HTMLInputElement>("opt-diagnostics");
+const optSummary = el<HTMLInputElement>("opt-summary");
 const hiddenHint = el("hidden-hint");
 
 /** The picked disc — a `webkitdirectory` BDMV folder, or a single `.iso`. */
@@ -122,10 +136,29 @@ let discName = "disc";
 /** Aborts the in-progress measured scan; null when no scan is running. */
 let scanController: AbortController | null = null;
 /**
- * Every playlist of the picked disc, from the latest call that returned one: the
- * structural `inspect` on pick, replaced by the measured `scan`'s disc when a
- * scan finishes — which is what fills the panes' measured cells in place.
+ * The ONE disc the page holds — never two at a time, never fields blended
+ * between an old disc and a new one. The structural `inspect` on pick fills it;
+ * a finished `scan` replaces it with the measured twin (same playlists, same
+ * classification, measured values filled in); a threshold change replaces it
+ * with a re-inspected one and discards everything measured, because a measured
+ * disc classified under a stale threshold would disagree with the table.
  */
+let disc: Disc | null = null;
+/** The short-playlist threshold `disc` was classified under, in seconds. */
+let discThreshold = 0;
+/**
+ * The report-section switches `reportText` was rendered with; null while no
+ * report is held. Re-applying the same pair is a no-op — no render request.
+ */
+let renderedWith: { streamDiagnostics: boolean; quickSummary: boolean } | null = null;
+/**
+ * Stamps every WebAssembly request so a slow completion cannot overwrite the
+ * state a faster later action produced: each request captures the counter,
+ * every newer request bumps it, and a completion whose stamp is stale is
+ * dropped on the floor.
+ */
+let generation = 0;
+/** `disc.playlists`, kept unwrapped for the table and pane renderers. */
 let playlists: Playlist[] = [];
 /**
  * The table rows over `playlists`: a scan returns every playlist, tagged with
@@ -142,20 +175,36 @@ let activeName: string | null = null;
 
 // ── settings ─────────────────────────────────────────────────────────────────
 
-/** The two playlist-filter opt-outs, mirroring the CLI's two switches. */
+/** The dialog's settings, mirroring the desktop app's seven browser-relevant ones. */
 interface Settings {
   showShortPlaylists: boolean;
   showLoopingPlaylists: boolean;
+  /** What "short" means, in whole seconds — the one setting that re-runs `inspect`. */
+  shortPlaylistSeconds: number;
+  /** Size cells as `83.62 GB` instead of thousands-grouped bytes. */
+  humanReadableSizes: boolean;
+  /** Append ` [NN Chapters]` to a playlist name when the count exceeds one. */
+  displayChapterCount: boolean;
+  /** Render the report's `STREAM DIAGNOSTICS:` section. */
+  reportStreamDiagnostics: boolean;
+  /** Render the report's `QUICK SUMMARY:` section. */
+  reportQuickSummary: boolean;
 }
 
 /** Where the settings persist between visits. */
 const SETTINGS_KEY = "bdinfo-rs.settings";
 
+/** The default short-playlist threshold, matching the CLI flag's default. */
+const DEFAULT_SHORT_SECONDS = 20;
+
 /**
- * Reads the stored settings, defaulting both off (the standard filtered set).
- * `localStorage` throws outright when the page is sandboxed or site data is
- * blocked, so every access is guarded — the demo then runs with the defaults
- * and the choice simply does not survive a reload.
+ * Reads the stored settings, defaulting to the standard filtered table with
+ * every report section on. Sizes default to human-readable — the desktop app
+ * ships thousands-grouped bytes instead, and this page has always shown
+ * human-readable sizes, so it keeps its own default. `localStorage` throws
+ * outright when the page is sandboxed or site data is blocked, so every access
+ * is guarded — the demo then runs with the defaults and the choice simply does
+ * not survive a reload.
  */
 function loadSettings(): Settings {
   let stored: Partial<Settings> = {};
@@ -167,9 +216,18 @@ function loadSettings(): Settings {
   } catch {
     stored = {};
   }
+  const seconds = stored.shortPlaylistSeconds;
   return {
     showShortPlaylists: stored.showShortPlaylists === true,
     showLoopingPlaylists: stored.showLoopingPlaylists === true,
+    shortPlaylistSeconds:
+      typeof seconds === "number" && Number.isInteger(seconds) && seconds > 0
+        ? seconds
+        : DEFAULT_SHORT_SECONDS,
+    humanReadableSizes: stored.humanReadableSizes !== false,
+    displayChapterCount: stored.displayChapterCount !== false,
+    reportStreamDiagnostics: stored.reportStreamDiagnostics !== false,
+    reportQuickSummary: stored.reportQuickSummary !== false,
   };
 }
 
@@ -199,10 +257,17 @@ function errMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/** A byte count as `83.62 GB` / `335.37 MB` (1024-based, like BDInfo), or `—`. */
-function humanBytes(bytes: number | null): string {
+/**
+ * A size cell under the size-format setting: `83.62 GB` / `335.37 MB`
+ * (1024-based, like BDInfo) when human-readable, the thousands-grouped exact
+ * byte count (`11,145,216`) when not, and `—` for a size nothing knows yet.
+ */
+function sizeCell(bytes: number | null): string {
   if (bytes === null || bytes <= 0) {
     return "—";
+  }
+  if (!settings.humanReadableSizes) {
+    return bytes.toLocaleString("en-US");
   }
   const units = ["B", "KB", "MB", "GB", "TB"];
   let value = bytes;
@@ -288,11 +353,24 @@ async function loadSource(src: Source): Promise<void> {
   hide(reportCard);
   hide(progressCard);
   hide(playlistsCard);
+  hide(discardNote);
   show(listingBox);
+  // A fresh pick discards everything held for the previous one.
+  scanController?.abort();
+  disc = null;
+  reportText = "";
+  renderedWith = null;
+  const gen = ++generation;
+  const threshold = settings.shortPlaylistSeconds;
   try {
     // The whole disc: the settings are applied to `allRows` in the page.
-    const disc = await inspect(src.kind === "folder" ? src.files : src.file);
-    if (disc.playlists.length === 0) {
+    const next = await inspect(src.kind === "folder" ? src.files : src.file, {
+      shortPlaylistSeconds: threshold,
+    });
+    if (gen !== generation) {
+      return;
+    }
+    if (next.playlists.length === 0) {
       showError(
         src.kind === "folder"
           ? "No Blu-ray playlists found. Point at a disc's BDMV folder (or the disc root)."
@@ -303,7 +381,7 @@ async function loadSource(src: Source): Promise<void> {
     sort = null;
     activeName = null;
     unchecked.clear();
-    adoptPlaylists(disc.playlists);
+    adoptDisc(next, threshold);
     discLabel.textContent = discName;
     show(playlistsCard);
     playlistsCard.scrollIntoView({ behavior: "smooth", block: "nearest" });
@@ -315,13 +393,16 @@ async function loadSource(src: Source): Promise<void> {
 }
 
 /**
- * Takes `next` as the disc's playlists and redraws everything derived from
- * them, keeping the view state — ticks, active row, sort — so a measured scan
- * can fill in the panes' `—` cells without resetting what the user set up.
+ * Takes `next` as THE held disc (classified under `threshold`) and redraws
+ * everything derived from it, keeping the view state — ticks, active row,
+ * sort — so a measured scan can fill in the panes' `—` cells without resetting
+ * what the user set up.
  */
-function adoptPlaylists(next: Playlist[]): void {
-  playlists = next;
-  allRows = playlistRows(next);
+function adoptDisc(next: Disc, threshold: number): void {
+  disc = next;
+  discThreshold = threshold;
+  playlists = next.playlists;
+  allRows = playlistRows(next.playlists);
   renderRows();
 }
 
@@ -510,7 +591,11 @@ function playlistRow(row: PlaylistRow, position: number, group: number): HTMLTab
   tr.appendChild(textCell(String(position)));
 
   const nameCell = cell("name");
-  nameCell.textContent = row.name;
+  // The desktop app's suffix rule verbatim: two-digit count, only past one.
+  nameCell.textContent =
+    settings.displayChapterCount && row.chapterCount > 1
+      ? `${row.name} [${String(row.chapterCount).padStart(2, "0")} Chapters]`
+      : row.name;
   if (row.hasHidden) {
     nameCell.appendChild(star("Has hidden tracks"));
   }
@@ -518,7 +603,7 @@ function playlistRow(row: PlaylistRow, position: number, group: number): HTMLTab
 
   tr.appendChild(textCell(String(group)));
   tr.appendChild(textCell(row.length));
-  tr.appendChild(textCell(humanBytes(row.estimatedBytes), "num"));
+  tr.appendChild(textCell(sizeCell(row.estimatedBytes), "num"));
 
   // The check cell toggles the tick; the rest of the row activates the
   // playlist and fills the detail panes, like the desktop table.
@@ -640,11 +725,9 @@ function streamFileRows(clips: Clip[]): HTMLTableRowElement[] {
     // The clip carries seconds only; truncating them to ticks first is the
     // table-time rule every `hh:mm:ss` cell follows.
     tr.appendChild(textCell(tableLength(Math.trunc(clip.lengthSeconds * TICKS_PER_SECOND))));
-    tr.appendChild(textCell(humanBytes(estimated > 0 ? estimated : null), "num"));
+    tr.appendChild(textCell(sizeCell(estimated > 0 ? estimated : null), "num"));
     // The packet-derived size: 192 bytes per transport packet.
-    tr.appendChild(
-      textCell(humanBytes(clip.packetCount > 0 ? clip.packetCount * 192 : null), "num"),
-    );
+    tr.appendChild(textCell(sizeCell(clip.packetCount > 0 ? clip.packetCount * 192 : null), "num"));
     return tr;
   });
 }
@@ -701,6 +784,7 @@ async function runScan(): Promise<void> {
   scanController = controller;
   hide(errorBox);
   hide(reportCard);
+  hide(discardNote);
   show(progressCard);
   setProgress(0, "Preparing…");
   scanBtn.disabled = true;
@@ -708,16 +792,28 @@ async function runScan(): Promise<void> {
     const percent = total > 0 ? Math.floor((done / total) * 100) : 0;
     setProgress(percent, `Scanning ${file}`);
   };
+  const gen = ++generation;
+  const threshold = settings.shortPlaylistSeconds;
+  const sections = {
+    streamDiagnostics: settings.reportStreamDiagnostics,
+    quickSummary: settings.reportQuickSummary,
+  };
   try {
     const result = await scan(src.kind === "folder" ? src.files : src.file, onProgress, {
       selection,
       signal: controller.signal,
+      shortPlaylistSeconds: threshold,
+      ...sections,
     });
+    if (gen !== generation) {
+      return;
+    }
     reportText = result.report;
+    renderedWith = sections;
     setProgress(100, "Done");
     // The measured disc replaces the structural one, so the panes' measured
     // sizes and bit rates fill in for the playlists this scan measured.
-    adoptPlaylists(result.disc.playlists);
+    adoptDisc(result.disc, threshold);
     showReport(reportText);
   } catch (error) {
     // A cancel is a user action, not a failure — reset quietly, no error shown.
@@ -731,6 +827,10 @@ async function runScan(): Promise<void> {
     hide(progressCard);
     scanBtn.disabled = selectedNames().length === 0;
   }
+  // A report switch flipped while the scan ran was deferred (the disc it would
+  // have rendered was about to be replaced); one cheap re-render catches up,
+  // and is a no-op when nothing was flipped.
+  void applyReportSections();
 }
 
 async function copyReport(): Promise<void> {
@@ -808,8 +908,99 @@ dropzone.addEventListener("drop", (event) => {
   void collectAndLoad(roots);
 });
 
+/**
+ * Applies the report-section switches: a `renderReport` over the held measured
+ * disc, replacing the held report text only — never a rescan. Without a
+ * measured disc there is nothing to re-render and the choice just waits for the
+ * next scan; re-applying the pair the held report was rendered with sends
+ * nothing at all.
+ */
+async function applyReportSections(): Promise<void> {
+  if (disc === null || !disc.measured) {
+    return;
+  }
+  // Mid-scan the held disc is about to be replaced: leave it alone and let the
+  // scan's own completion re-run this once the new disc is in.
+  if (scanController !== null) {
+    return;
+  }
+  const wanted = {
+    streamDiagnostics: settings.reportStreamDiagnostics,
+    quickSummary: settings.reportQuickSummary,
+  };
+  if (
+    renderedWith !== null &&
+    renderedWith.streamDiagnostics === wanted.streamDiagnostics &&
+    renderedWith.quickSummary === wanted.quickSummary
+  ) {
+    return;
+  }
+  const held = disc;
+  const gen = ++generation;
+  try {
+    const text = await renderReport(held, wanted);
+    if (gen !== generation) {
+      return;
+    }
+    reportText = text;
+    renderedWith = wanted;
+    // Replace the text in place — no scroll: the dialog is open over the page.
+    reportPre.textContent = text;
+    show(reportCard);
+  } catch (error) {
+    showError(errMessage(error));
+  }
+}
+
+/**
+ * Applies a committed threshold value — the one setting that still costs a
+ * scan, because `hiddenBy` is classified against the threshold in force. The
+ * held disc is replaced by a fresh `inspect` under the new value, and anything
+ * measured is DISCARDED with a visible note beside the control: a measured disc
+ * classified under the old threshold would disagree with the re-classified
+ * table. A value equal to the one in force changes nothing and sends nothing.
+ */
+async function applyThreshold(): Promise<void> {
+  const parsed = Number(optShortSeconds.value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    optShortSeconds.value = String(settings.shortPlaylistSeconds);
+    return;
+  }
+  settings.shortPlaylistSeconds = parsed;
+  saveSettings();
+  if (source === null || disc === null || parsed === discThreshold) {
+    return;
+  }
+  const src = source;
+  const discarding = disc.measured;
+  // A scan still running would land measured results classified under the old
+  // threshold — the exact stale completion the generation stamp exists to drop.
+  scanController?.abort();
+  const gen = ++generation;
+  try {
+    const next = await inspect(src.kind === "folder" ? src.files : src.file, {
+      shortPlaylistSeconds: parsed,
+    });
+    if (gen !== generation) {
+      return;
+    }
+    reportText = "";
+    renderedWith = null;
+    hide(reportCard);
+    adoptDisc(next, parsed);
+    discardNote.hidden = !discarding;
+  } catch (error) {
+    showError(errMessage(error));
+  }
+}
+
 optShort.checked = settings.showShortPlaylists;
 optLooping.checked = settings.showLoopingPlaylists;
+optShortSeconds.value = String(settings.shortPlaylistSeconds);
+optHumanSizes.checked = settings.humanReadableSizes;
+optChapters.checked = settings.displayChapterCount;
+optDiagnostics.checked = settings.reportStreamDiagnostics;
+optSummary.checked = settings.reportQuickSummary;
 
 settingsBtn.addEventListener("click", () => {
   settingsDialog.showModal();
@@ -817,14 +1008,29 @@ settingsBtn.addEventListener("click", () => {
 settingsClose.addEventListener("click", () => {
   settingsDialog.close();
 });
-for (const box of [optShort, optLooping]) {
+// The four display settings are pure re-projections of the held disc: redraw
+// the table and panes from what the page holds, no WebAssembly call.
+for (const box of [optShort, optLooping, optHumanSizes, optChapters]) {
   box.addEventListener("change", () => {
     settings.showShortPlaylists = optShort.checked;
     settings.showLoopingPlaylists = optLooping.checked;
+    settings.humanReadableSizes = optHumanSizes.checked;
+    settings.displayChapterCount = optChapters.checked;
     saveSettings();
     renderRows();
   });
 }
+for (const box of [optDiagnostics, optSummary]) {
+  box.addEventListener("change", () => {
+    settings.reportStreamDiagnostics = optDiagnostics.checked;
+    settings.reportQuickSummary = optSummary.checked;
+    saveSettings();
+    void applyReportSections();
+  });
+}
+optShortSeconds.addEventListener("change", () => {
+  void applyThreshold();
+});
 
 for (const th of playlistsCard.querySelectorAll<HTMLTableCellElement>("th[data-sort]")) {
   th.addEventListener("click", () => {

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -213,15 +213,30 @@ async function main() {
       };
     });
     // The demo page, end to end. A second playlist (the same clip, OUT_time
-    // patched to ~40 s the same way as above) makes the table two rows, so
-    // ordering is observable. A constructed `File` has an empty read-only
-    // `webkitRelativePath`; an own property carries the folder path the demo's
-    // picker handler reads.
+    // patched to ~40 s the same way as above, plus a second chapter mark so the
+    // chapter-count suffix has a playlist to appear on) makes the table two
+    // rows, so ordering is observable; a third playlist patched to ~10 s is
+    // withheld by the short rule at the default threshold, so the filter
+    // toggles and the threshold have something to reveal. A constructed `File`
+    // has an empty read-only `webkitRelativePath`; an own property carries the
+    // folder path the demo's picker handler reads.
     const demoPage = await browser.newPage();
     demoPage.on("console", (msg) => console.log(`  [demo] ${msg.text()}`));
     demoPage.on("pageerror", (err) => console.log(`  [demo pageerror] ${err.message}`));
     await demoPage.goto(`${base}/index.html`);
     await demoPage.evaluate((items) => {
+      // Record every request the page posts to a scan Worker, so the checks
+      // below can assert which settings cost a wasm call and which cost none.
+      const NativeWorker = window.Worker;
+      window.__calls = [];
+      window.Worker = class extends NativeWorker {
+        postMessage(message, ...rest) {
+          if (typeof message === "object" && message !== null && "kind" in message) {
+            window.__calls.push(message.kind);
+          }
+          super.postMessage(message, ...rest);
+        }
+      };
       const decode = (b64) => {
         const binary = atob(b64);
         const bytes = new Uint8Array(binary.length);
@@ -235,11 +250,36 @@ async function main() {
         Object.defineProperty(file, "webkitRelativePath", { value: path });
         return file;
       };
+      const withLength = (bytes, seconds) => {
+        const out = bytes.slice();
+        new DataView(out.buffer).setUint32(86, 27_000_000 + 45_000 * seconds);
+        return out;
+      };
+      // Appends a copy of the playlist's single chapter mark, 10 s later: the
+      // PlayListMark block is the file's last section (extension data start is
+      // 0), so growing it needs only its length u32, its mark count u16, and
+      // the appended 14-byte entry (timestamp at entry offset 4).
+      const withSecondChapter = (bytes) => {
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        const marks = view.getUint32(12);
+        const out = new Uint8Array(bytes.length + 14);
+        out.set(bytes);
+        out.set(bytes.slice(marks + 6, marks + 6 + 14), bytes.length);
+        const outView = new DataView(out.buffer);
+        outView.setUint32(marks, view.getUint32(marks) + 14);
+        outView.setUint16(marks + 4, view.getUint16(marks + 4) + 1);
+        outView.setUint32(bytes.length + 4, view.getUint32(marks + 6 + 4) + 45_000 * 10);
+        return out;
+      };
       const files = items.map((item) => toFile(item.path, decode(item.b64)));
       const source = items.find((item) => item.path.endsWith("00000.mpls"));
-      const patched = decode(source.b64);
-      new DataView(patched.buffer).setUint32(86, 27_000_000 + 45_000 * 40);
-      files.push(toFile("WASMDISC/BDMV/PLAYLIST/00001.mpls", patched));
+      files.push(
+        toFile(
+          "WASMDISC/BDMV/PLAYLIST/00001.mpls",
+          withSecondChapter(withLength(decode(source.b64), 40)),
+        ),
+      );
+      files.push(toFile("WASMDISC/BDMV/PLAYLIST/00002.mpls", withLength(decode(source.b64), 10)));
       const transfer = new DataTransfer();
       for (const file of files) {
         transfer.items.add(file);
@@ -254,7 +294,8 @@ async function main() {
     );
 
     // One structural snapshot of the page: table order and numbers, the active
-    // row, and both panes' cell texts.
+    // row, both panes' cell texts, the hint, the cards' visibility, and every
+    // Worker request posted so far.
     const readDemo = () =>
       demoPage.evaluate(() => {
         const texts = (selector) =>
@@ -266,13 +307,26 @@ async function main() {
         return {
           names: texts("#playlist-body td.name"),
           positions: texts("#playlist-body tr td:nth-child(2)"),
+          sizes: texts("#playlist-body tr td:nth-child(6)"),
           active: document.querySelector("#playlist-body tr.active")?.dataset.name ?? null,
           panesVisible: !document.getElementById("detail-panes").hidden,
           paneLabel: document.getElementById("pane-playlist").textContent,
           files: grid("#files-body tr"),
           codecs: grid("#codecs-body tr"),
+          hintHidden: document.getElementById("hidden-hint").hidden,
+          hintText: document.getElementById("hidden-hint").textContent,
+          reportHidden: document.getElementById("report-card").hidden,
+          progressHidden: document.getElementById("progress-card").hidden,
+          discardHidden: document.getElementById("discard-note").hidden,
+          calls: window.__calls.slice(),
         };
       });
+    const rowCountIs = (count) =>
+      demoPage.waitForFunction(
+        (want) => document.querySelectorAll("#playlist-body tr").length === want,
+        count,
+        { timeout: 30000 },
+      );
 
     const initial = await readDemo();
 
@@ -293,14 +347,73 @@ async function main() {
     });
     const activated = await readDemo();
 
-    // The measured scan through the page (both rows are ticked by default):
-    // the report card appears and the panes' measured cells fill in place.
+    // The display settings: each one re-projects the model the page already
+    // holds, so the request log must not grow while the table changes.
+    await demoPage.click("#settings-btn");
+    await demoPage.click("#opt-short");
+    await rowCountIs(3);
+    const shortShown = await readDemo();
+    await demoPage.click("#opt-short");
+    await rowCountIs(2);
+    await demoPage.click("#opt-human-sizes");
+    const grouped = await readDemo();
+    await demoPage.click("#opt-human-sizes");
+    await demoPage.click("#opt-chapters");
+    const noSuffix = await readDemo();
+    await demoPage.click("#opt-chapters");
+    await demoPage.click("#settings-close");
+    const preScan = await readDemo();
+
+    // Back to the table order before scanning, so the page's selection order is
+    // the disc's presentation order — which is what makes the re-rendered
+    // report below comparable to the scan's own, byte for byte.
+    await demoPage.click('th[data-sort="position"]');
+
+    // The measured scan through the page (both shown rows are ticked): the
+    // report card appears and the panes' measured cells fill in place.
     await demoPage.click("#scan-btn");
     await demoPage.waitForFunction(() => !document.getElementById("report-card").hidden, {
       timeout: 120000,
     });
     const scanned = await readDemo();
     const report = await demoPage.evaluate(() => document.getElementById("report").textContent);
+
+    // The report-section switches: every flip re-renders the held disc through
+    // the package — the displayed text changes while the request log gains only
+    // `render` kinds and the progress card never shows. Both orders of turning
+    // the two sections off are walked, so the switches' composition is pinned.
+    const reportNow = () => demoPage.evaluate(() => document.getElementById("report").textContent);
+    const toggleSection = async (selector) => {
+      const before = await reportNow();
+      await demoPage.click(selector);
+      await demoPage.waitForFunction(
+        (prev) => document.getElementById("report").textContent !== prev,
+        before,
+        { timeout: 60000 },
+      );
+      return reportNow();
+    };
+    await demoPage.click("#settings-btn");
+    const sdOff = await toggleSection("#opt-diagnostics");
+    const bothOff1 = await toggleSection("#opt-summary");
+    const qsOff = await toggleSection("#opt-diagnostics");
+    const restored = await toggleSection("#opt-summary");
+    const qsOff2 = await toggleSection("#opt-summary");
+    const bothOff2 = await toggleSection("#opt-diagnostics");
+    const sdOff2 = await toggleSection("#opt-summary");
+    const restored2 = await toggleSection("#opt-diagnostics");
+    const afterRenders = await readDemo();
+
+    // The threshold: committing the value already in force must send nothing;
+    // committing a new one re-runs `inspect`, re-classifies the table, and
+    // visibly discards the measured results and the held report.
+    await demoPage.fill("#opt-short-seconds", "20");
+    await demoPage.locator("#opt-short-seconds").blur();
+    await demoPage.fill("#opt-short-seconds", "5");
+    await demoPage.locator("#opt-short-seconds").blur();
+    await rowCountIs(3);
+    const thresholdApplied = await readDemo();
+    await demoPage.click("#settings-close");
 
     // A phone-width viewport must not scroll the page sideways — wide tables
     // scroll inside their own wrapper instead.
@@ -309,15 +422,43 @@ async function main() {
       () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
     );
 
+    // The settings survive a reload through `localStorage`; the dialog's
+    // controls are initialized from what was stored.
+    await demoPage.reload();
+    const persisted = await demoPage.evaluate(() => ({
+      seconds: document.getElementById("opt-short-seconds").value,
+      short: document.getElementById("opt-short").checked,
+      looping: document.getElementById("opt-looping").checked,
+      human: document.getElementById("opt-human-sizes").checked,
+      chapters: document.getElementById("opt-chapters").checked,
+      diagnostics: document.getElementById("opt-diagnostics").checked,
+      summary: document.getElementById("opt-summary").checked,
+    }));
+
     demo = {
       initial,
       positionSorted,
       nameFirst,
       nameSecond,
       activated,
+      shortShown,
+      grouped,
+      noSuffix,
+      preScan,
       scanned,
       report,
+      sdOff,
+      bothOff1,
+      qsOff,
+      restored,
+      qsOff2,
+      bothOff2,
+      sdOff2,
+      restored2,
+      afterRenders,
+      thresholdApplied,
       pageScrolls,
+      persisted,
     };
   } finally {
     await browser.close();
@@ -438,15 +579,45 @@ async function main() {
     );
     return false;
   };
+  // A report section under the locked format runs from its heading line
+  // through the second blank line below it (heading, blank, body, blank), and
+  // the optional sections repeat once per rendered playlist — so a switch is
+  // checked by stripping EVERY occurrence of its heading's section.
+  const stripSection = (text, heading) => {
+    const lines = text.split("\r\n");
+    if (!lines.includes(heading)) {
+      throw new Error(`section ${heading} not found`);
+    }
+    let start = lines.indexOf(heading);
+    while (start !== -1) {
+      let end = start;
+      let blanks = 0;
+      while (end + 1 < lines.length && blanks < 2) {
+        end += 1;
+        if (lines[end] === "") {
+          blanks += 1;
+        }
+      }
+      lines.splice(start, end - start + 1);
+      start = lines.indexOf(heading);
+    }
+    return lines.join("\r\n");
+  };
   let demoOk = true;
   demoOk &= demoEq("initial table order (by position)", demo.initial.names, [
-    "00001.MPLS",
+    "00001.MPLS [02 Chapters]",
     "00000.MPLS",
   ]);
   demoOk &= demoEq("initial numbering", demo.initial.positions, ["1", "2"]);
   demoOk &= demoEq("initial active row", demo.initial.active, "00001.MPLS");
   demoOk &= demoEq("panes visible", demo.initial.panesVisible, true);
   demoOk &= demoEq("pane label", demo.initial.paneLabel, "00001.MPLS");
+  demoOk &= demoEq(
+    "initial hint names the short playlist",
+    demo.initial.hintText,
+    ["Hidden by filters (short): 00002.MPLS - enable in settings"].join("\n"),
+  );
+  demoOk &= demoEq("load cost one inspect", demo.initial.calls, ["inspect"]);
   demoOk &= demoEq("stream-file pane (unmeasured)", demo.initial.files, [
     ["00000.M2TS", "1", "00:00:40", "10.63 MB", "—"],
   ]);
@@ -469,20 +640,36 @@ async function main() {
   );
   demoOk &= demoEq("first click on the ascending # column descends", demo.positionSorted.names, [
     "00000.MPLS",
-    "00001.MPLS",
+    "00001.MPLS [02 Chapters]",
   ]);
   demoOk &= demoEq("numbers travel with their rows", demo.positionSorted.positions, ["2", "1"]);
   demoOk &= demoEq("first click on the ascending name column descends", demo.nameFirst.names, [
-    "00001.MPLS",
+    "00001.MPLS [02 Chapters]",
     "00000.MPLS",
   ]);
   demoOk &= demoEq("second click flips to ascending", demo.nameSecond.names, [
     "00000.MPLS",
-    "00001.MPLS",
+    "00001.MPLS [02 Chapters]",
   ]);
   demoOk &= demoEq("row click activates", demo.activated.active, "00000.MPLS");
   demoOk &= demoEq("pane follows the active row", demo.activated.paneLabel, "00000.MPLS");
   demoOk &= demoEq("active playlist clip length", demo.activated.files[0][2], "00:00:30");
+  demoOk &= demoEq("show-short lists the withheld playlist", demo.shortShown.names, [
+    "00000.MPLS",
+    "00001.MPLS [02 Chapters]",
+    "00002.MPLS",
+  ]);
+  demoOk &= demoEq("show-short retires the hint", demo.shortShown.hintHidden, true);
+  demoOk &= demoEq("grouped bytes in the size cells", demo.grouped.sizes, [
+    "11,145,216",
+    "11,145,216",
+  ]);
+  demoOk &= demoEq("chapter suffix off", demo.noSuffix.names, ["00000.MPLS", "00001.MPLS"]);
+  demoOk &= demoEq("human-readable size cells return", demo.preScan.sizes, [
+    "10.63 MB",
+    "10.63 MB",
+  ]);
+  demoOk &= demoEq("display settings cost no wasm call", demo.preScan.calls, ["inspect"]);
   demoOk &= demoEq("scan keeps the active row", demo.scanned.active, "00000.MPLS");
   demoOk &= demoEq("measured size fills after the scan", demo.scanned.files, [
     ["00000.M2TS", "1", "00:00:30", "10.63 MB", "10.55 MB"],
@@ -495,7 +682,80 @@ async function main() {
     ["973 kbps", "1,536 kbps"],
   );
   demoOk &= demoEq("the demo report renders", demo.report.includes("QUICK SUMMARY:"), true);
+  demoOk &= demoEq("the scan cost one scan call", demo.scanned.calls, ["inspect", "scan"]);
+
+  // The section switches: eight flips, eight `render` requests, no scan and no
+  // progress bar; every rendering equals the scan's own report minus exactly
+  // the switched-off sections, whichever order the switches went down in.
+  const strippedSd = stripSection(demo.report, "STREAM DIAGNOSTICS:");
+  const strippedQs = stripSection(demo.report, "QUICK SUMMARY:");
+  const strippedBoth = stripSection(strippedSd, "QUICK SUMMARY:");
+  demoOk &= compare("demo render: diagnostics off", demo.sdOff, Buffer.from(strippedSd));
+  demoOk &= compare(
+    "demo render: both off (diagnostics first)",
+    demo.bothOff1,
+    Buffer.from(strippedBoth),
+  );
+  demoOk &= compare("demo render: summary off", demo.qsOff, Buffer.from(strippedQs));
+  demoOk &= compare("demo render: both back on", demo.restored, Buffer.from(demo.report));
+  demoOk &= compare("demo render: summary off (second pass)", demo.qsOff2, Buffer.from(strippedQs));
+  demoOk &= compare(
+    "demo render: both off (summary first)",
+    demo.bothOff2,
+    Buffer.from(strippedBoth),
+  );
+  demoOk &= compare(
+    "demo render: diagnostics off (second pass)",
+    demo.sdOff2,
+    Buffer.from(strippedSd),
+  );
+  demoOk &= compare("demo render: restored again", demo.restored2, Buffer.from(demo.report));
+  demoOk &= demoEq("section flips cost renders only", demo.afterRenders.calls, [
+    "inspect",
+    "scan",
+    ...Array(8).fill("render"),
+  ]);
+  demoOk &= demoEq("no scan ran while re-rendering", demo.afterRenders.progressHidden, true);
+  demoOk &= demoEq("measured cells survive the re-renders", demo.afterRenders.files, [
+    ["00000.M2TS", "1", "00:00:30", "10.63 MB", "10.55 MB"],
+  ]);
+
+  // The threshold transition: the same value again sent nothing; 5 s re-ran
+  // `inspect` (one request), re-classified the 10 s playlist into the table,
+  // and visibly discarded the measured results and the held report.
+  demoOk &= demoEq("threshold change cost one inspect", demo.thresholdApplied.calls, [
+    "inspect",
+    "scan",
+    ...Array(8).fill("render"),
+    "inspect",
+  ]);
+  demoOk &= demoEq("threshold re-classifies the table", demo.thresholdApplied.names, [
+    "00001.MPLS [02 Chapters]",
+    "00000.MPLS",
+    "00002.MPLS",
+  ]);
+  demoOk &= demoEq("threshold retires the hint", demo.thresholdApplied.hintHidden, true);
+  demoOk &= demoEq("threshold discards the measured sizes", demo.thresholdApplied.files, [
+    ["00000.M2TS", "1", "00:00:30", "10.63 MB", "—"],
+  ]);
+  demoOk &= demoEq(
+    "threshold discards the measured rates",
+    demo.thresholdApplied.codecs.map((row) => row[2]),
+    ["—", "—"],
+  );
+  demoOk &= demoEq("threshold hides the report", demo.thresholdApplied.reportHidden, true);
+  demoOk &= demoEq("the discard is visible", demo.thresholdApplied.discardHidden, false);
+  demoOk &= demoEq("threshold keeps the active row", demo.thresholdApplied.active, "00000.MPLS");
   demoOk &= demoEq("no sideways page scroll at phone width", demo.pageScrolls, false);
+  demoOk &= demoEq("settings survive a reload", demo.persisted, {
+    seconds: "5",
+    short: false,
+    looping: false,
+    human: true,
+    chapters: true,
+    diagnostics: true,
+    summary: true,
+  });
   demoOk = Boolean(demoOk);
 
   process.exit(listOk && inspectOk && scanOk && isoStructuredOk && demoOk ? 0 : 1);

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -13,6 +13,13 @@
 // golden bytes again — the round trip through structured clone in both
 // directions, which the Node test (raw wasm exports, no Worker) cannot see.
 //
+// It then drives the demo page itself (`index.html` + `dist/demo.js`, served
+// the same static way `dev.mjs` serves it): the fixture goes in through the
+// real folder picker, and the master-detail behaviour — pane population from
+// the active row, header-click sorting, the measured cells filling after a
+// scan — is asserted in the page. That is the demo's only executable check:
+// biome and tsc prove nothing about behaviour.
+//
 // Prereq: `npm run build` (emits `pkg/` + `dist/`). Run with `npm run test:chrome`.
 
 import { readFile } from "node:fs/promises";
@@ -103,6 +110,7 @@ async function main() {
   let listings;
   let structured;
   let isoStructured;
+  let demo;
   try {
     const page = await browser.newPage();
     page.on("console", (msg) => console.log(`  [page] ${msg.text()}`));
@@ -204,6 +212,113 @@ async function main() {
         reRendered: await window.__renderReport(scanned.disc),
       };
     });
+    // The demo page, end to end. A second playlist (the same clip, OUT_time
+    // patched to ~40 s the same way as above) makes the table two rows, so
+    // ordering is observable. A constructed `File` has an empty read-only
+    // `webkitRelativePath`; an own property carries the folder path the demo's
+    // picker handler reads.
+    const demoPage = await browser.newPage();
+    demoPage.on("console", (msg) => console.log(`  [demo] ${msg.text()}`));
+    demoPage.on("pageerror", (err) => console.log(`  [demo pageerror] ${err.message}`));
+    await demoPage.goto(`${base}/index.html`);
+    await demoPage.evaluate((items) => {
+      const decode = (b64) => {
+        const binary = atob(b64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+          bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes;
+      };
+      const toFile = (path, bytes) => {
+        const file = new File([bytes], path.split("/").pop());
+        Object.defineProperty(file, "webkitRelativePath", { value: path });
+        return file;
+      };
+      const files = items.map((item) => toFile(item.path, decode(item.b64)));
+      const source = items.find((item) => item.path.endsWith("00000.mpls"));
+      const patched = decode(source.b64);
+      new DataView(patched.buffer).setUint32(86, 27_000_000 + 45_000 * 40);
+      files.push(toFile("WASMDISC/BDMV/PLAYLIST/00001.mpls", patched));
+      const transfer = new DataTransfer();
+      for (const file of files) {
+        transfer.items.add(file);
+      }
+      const picker = document.getElementById("picker");
+      picker.files = transfer.files;
+      picker.dispatchEvent(new Event("change"));
+    }, entries);
+    await demoPage.waitForFunction(
+      () => document.querySelectorAll("#playlist-body tr").length === 2,
+      { timeout: 30000 },
+    );
+
+    // One structural snapshot of the page: table order and numbers, the active
+    // row, and both panes' cell texts.
+    const readDemo = () =>
+      demoPage.evaluate(() => {
+        const texts = (selector) =>
+          [...document.querySelectorAll(selector)].map((node) => node.textContent);
+        const grid = (selector) =>
+          [...document.querySelectorAll(selector)].map((tr) =>
+            [...tr.children].map((td) => td.textContent),
+          );
+        return {
+          names: texts("#playlist-body td.name"),
+          positions: texts("#playlist-body tr td:nth-child(2)"),
+          active: document.querySelector("#playlist-body tr.active")?.dataset.name ?? null,
+          panesVisible: !document.getElementById("detail-panes").hidden,
+          paneLabel: document.getElementById("pane-playlist").textContent,
+          files: grid("#files-body tr"),
+          codecs: grid("#codecs-body tr"),
+        };
+      });
+
+    const initial = await readDemo();
+
+    // The table loads ascending by `#`, so the first click on that column must
+    // go straight to descending — a first click never leaves the order as-is.
+    await demoPage.click('th[data-sort="position"]');
+    const positionSorted = await readDemo();
+    // The rows now read ascending by name too, so a first click on the name
+    // column is descending again; the second click flips it.
+    await demoPage.click('th[data-sort="name"]');
+    const nameFirst = await readDemo();
+    await demoPage.click('th[data-sort="name"]');
+    const nameSecond = await readDemo();
+
+    // Activating the other row swaps both panes to its playlist.
+    await demoPage.evaluate(() => {
+      document.querySelector('#playlist-body tr[data-name="00000.MPLS"] td.name').click();
+    });
+    const activated = await readDemo();
+
+    // The measured scan through the page (both rows are ticked by default):
+    // the report card appears and the panes' measured cells fill in place.
+    await demoPage.click("#scan-btn");
+    await demoPage.waitForFunction(() => !document.getElementById("report-card").hidden, {
+      timeout: 120000,
+    });
+    const scanned = await readDemo();
+    const report = await demoPage.evaluate(() => document.getElementById("report").textContent);
+
+    // A phone-width viewport must not scroll the page sideways — wide tables
+    // scroll inside their own wrapper instead.
+    await demoPage.setViewportSize({ width: 390, height: 844 });
+    const pageScrolls = await demoPage.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+
+    demo = {
+      initial,
+      positionSorted,
+      nameFirst,
+      nameSecond,
+      activated,
+      scanned,
+      report,
+      pageScrolls,
+    };
   } finally {
     await browser.close();
     server.close();
@@ -308,7 +423,82 @@ async function main() {
     );
   }
 
-  process.exit(listOk && inspectOk && scanOk && isoStructuredOk ? 0 : 1);
+  // The demo page. Cell values are pinned where the fixture pins them: the
+  // 40 s patched playlist outranks the 30 s one (longest first in the shared
+  // group), the clip's on-disk 11,145,216 B reads 10.63 MB, its packet-derived
+  // 11,064,384 B reads 10.55 MB, and the two codec rows carry the report's own
+  // codec names and measured rates.
+  const demoEq = (label, got, wantValue) => {
+    if (JSON.stringify(got) === JSON.stringify(wantValue)) {
+      console.log(`PASS — demo ${label}.`);
+      return true;
+    }
+    console.error(
+      `FAIL — demo ${label}: got ${JSON.stringify(got)}, want ${JSON.stringify(wantValue)}`,
+    );
+    return false;
+  };
+  let demoOk = true;
+  demoOk &= demoEq("initial table order (by position)", demo.initial.names, [
+    "00001.MPLS",
+    "00000.MPLS",
+  ]);
+  demoOk &= demoEq("initial numbering", demo.initial.positions, ["1", "2"]);
+  demoOk &= demoEq("initial active row", demo.initial.active, "00001.MPLS");
+  demoOk &= demoEq("panes visible", demo.initial.panesVisible, true);
+  demoOk &= demoEq("pane label", demo.initial.paneLabel, "00001.MPLS");
+  demoOk &= demoEq("stream-file pane (unmeasured)", demo.initial.files, [
+    ["00000.M2TS", "1", "00:00:40", "10.63 MB", "—"],
+  ]);
+  // The LPCM row's language is three NUL bytes: the fixture's playlist declares
+  // that as the language code, and the locked report prints it verbatim (the
+  // golden's Language cell carries the same bytes), so the model and the pane
+  // carry it too.
+  demoOk &= demoEq(
+    "codec pane names + unmeasured rates",
+    demo.initial.codecs.map((row) => [row[0], row[1], row[2]]),
+    [
+      ["MPEG-4 AVC Video", "", "—"],
+      ["LPCM Audio", "\u0000\u0000\u0000", "—"],
+    ],
+  );
+  demoOk &= demoEq(
+    "codec descriptions populate",
+    demo.initial.codecs.every((row) => row[3].length > 0),
+    true,
+  );
+  demoOk &= demoEq("first click on the ascending # column descends", demo.positionSorted.names, [
+    "00000.MPLS",
+    "00001.MPLS",
+  ]);
+  demoOk &= demoEq("numbers travel with their rows", demo.positionSorted.positions, ["2", "1"]);
+  demoOk &= demoEq("first click on the ascending name column descends", demo.nameFirst.names, [
+    "00001.MPLS",
+    "00000.MPLS",
+  ]);
+  demoOk &= demoEq("second click flips to ascending", demo.nameSecond.names, [
+    "00000.MPLS",
+    "00001.MPLS",
+  ]);
+  demoOk &= demoEq("row click activates", demo.activated.active, "00000.MPLS");
+  demoOk &= demoEq("pane follows the active row", demo.activated.paneLabel, "00000.MPLS");
+  demoOk &= demoEq("active playlist clip length", demo.activated.files[0][2], "00:00:30");
+  demoOk &= demoEq("scan keeps the active row", demo.scanned.active, "00000.MPLS");
+  demoOk &= demoEq("measured size fills after the scan", demo.scanned.files, [
+    ["00000.M2TS", "1", "00:00:30", "10.63 MB", "10.55 MB"],
+  ]);
+  // 973, not the report's 974: the pane integer-divides bits/s to kbps like the
+  // desktop pane, where the report's codec table rounds.
+  demoOk &= demoEq(
+    "measured bit rates fill after the scan",
+    demo.scanned.codecs.map((row) => row[2]),
+    ["973 kbps", "1,536 kbps"],
+  );
+  demoOk &= demoEq("the demo report renders", demo.report.includes("QUICK SUMMARY:"), true);
+  demoOk &= demoEq("no sideways page scroll at phone width", demo.pageScrolls, false);
+  demoOk = Boolean(demoOk);
+
+  process.exit(listOk && inspectOk && scanOk && isoStructuredOk && demoOk ? 0 : 1);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Rebuilds the demo page around the structured disc model and completes its settings dialog.

The playlist table becomes the master of a master-detail flow: clicking a row outside its checkbox cell activates it and fills two panes below the table - the playlist's stream files and its codecs - matching the desktop app's lower panes. The five columns sort on raw values with the desktop's click rules (same column flips; a new column starts ascending unless the rows already read ascending), and the number columns are renumbered before sorting so they travel with their rows. After a measured scan the returned disc replaces the structural one in place, so the panes' measured cells fill without a rescan and the selection, sort and active row survive.

The settings dialog grows to the seven desktop settings that matter in a browser, split by a hairline into display and report groups: the two playlist-filter toggles, the short-playlist threshold, the size format (human-readable or thousands-grouped bytes), the chapter-count name suffix, and the two report sections.

Size format, chapter count and the filter toggles re-project the disc model the page already holds - no wasm call. The report-section switches re-render the held measured disc through renderReport, replacing the report text without a rescan. The threshold is the one backward transition: it re-runs inspect under the new value, replaces the held disc, and discards measured results and the held report with a visible note beside the control. The page holds at most one disc at a time, together with the threshold it was classified under; every wasm request carries a generation stamp and a stale completion is dropped. Settings persist in localStorage behind the existing throw guard.

The Chrome parity harness gates the behaviour with 55 checks: pane population from the active row, header-click sorting, measured cells filling in place, display toggles changing the table while the Worker request log stays flat, each report-section flip posting exactly one render - with both switches off equal to the section-stripped scan report in either toggle order, and both on byte-identical to the scan report - the threshold transition's visible discard, and the dialog surviving a reload.