### PR TITLE
docs(fuzz): correct the tag upload claim and record measured tier costs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -44,11 +44,13 @@ env:
   GUARDS: -timeout=25 -rss_limit_mb=2048
 
 jobs:
-  # Release tag: a longer fresh-fuzz budget per target. New corpus growth and any
-  # crash artifacts are uploaded for inspection. A crash fails THIS fuzz run and
-  # surfaces the regression; the publish workflows triggered by the same tag run
-  # independently (this job does not `needs:`-gate them), so treat a crash as a
-  # fast-follow patch trigger, not a release blocker.
+  # Release tag: a longer fresh-fuzz budget per target. Crash artifacts are
+  # uploaded, and only when the job fails; the corpus grown during the run is
+  # never uploaded and dies with the runner, so every tag run restarts from the
+  # committed seeds. A crash fails THIS fuzz run and surfaces the regression; the
+  # publish workflows triggered by the same tag run independently (this job does
+  # not `needs:`-gate them), so treat a crash as a fast-follow patch trigger, not
+  # a release blocker.
   extended:
     name: extended fuzz (release tag)
     runs-on: ubuntu-latest

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -39,11 +39,38 @@ of byte fuzzing).
 
 ```sh
 cargo install cargo-fuzz                              # once
-cargo +nightly fuzz run read_be   -- -runs=0          # PR: replay committed corpus (fast, regression gate)
-cargo +nightly fuzz run read_be   -- -max_total_time=300   # nightly: time-boxed (5 min)
+cargo +nightly fuzz run read_be   -- -runs=0          # replay the committed corpus (the regression gate)
+cargo +nightly fuzz run read_be   -- -max_total_time=300   # fresh-fuzz this target, time-boxed (5 min)
 cargo +nightly fuzz cmin read_be                      # minimize the corpus
 cargo +nightly fuzz list                              # show targets
 ```
 
 Seed corpora live in `corpus/<target>/` (empty / boundary / valid / garbage inputs) and are
 committed so `-runs=0` is a deterministic replay.
+
+## What a run costs (measured 2026-08-03, x86_64 Linux, cargo-fuzz 0.13.2)
+
+**Replaying the whole corpus takes about 4 seconds for all ten targets** — 0.13 s
+(`discovery`) to 1.03 s (`m2ts`). The `-runs=0` gate costs a build, not a run.
+
+**Fresh-fuzz throughput spans three orders of magnitude**, because a unit means something
+different per target: `discovery` classifies a filename at ~10^6 units/s, while an `m2ts`
+unit is a full transport-stream scan of up to 98,304 bytes at ~600/s. Budget per target
+accordingly — an equal time budget is not an equal experiment.
+
+Where a target stops learning — from fresh runs of 120 s on all ten, and 900 s on `m2ts`,
+`codec`, `parse_report` and `source`:
+
+| target | new edges after its corpus is loaded |
+|---|---|
+| `read_be` | none at all |
+| `bitstream` | none in 120 s (two new feature combinations, no new edge) |
+| `discovery` | stops at ~66 s |
+| `udf` | stops at ~13 s |
+| `source`, `codec` | stop at ~205 s and ~245 s |
+| `m2ts` | slows sharply after ~250 s, still gaining at 843 s |
+| `parse_report` | still gaining linearly at 900 s |
+
+`parse_report` is the one target where a longer budget keeps paying: it is the end-to-end
+harness, and it reaches only 13% of `report::text`'s regions, so most of the renderer has
+never seen a fuzzed disc.


### PR DESCRIPTION
Two factual corrections to the fuzz tier's documentation. No fuzzing behaviour changes.

The extended tag job's comment claimed new corpus growth is uploaded. It is not: the only
upload step is if: failure() over fuzz/artifacts/, so a run's corpus dies with the runner
and each tag restarts from the committed seeds. The comment now describes that.

fuzz/README.md gains the measured cost of running the tier, taken 2026-08-03 against
nightly 1.99.0 with cargo-fuzz 0.13.2 on x86_64 Linux:

- replaying all ten corpora takes about 4 seconds, 0.13 s to 1.03 s per target, so the
  -runs=0 gate costs a build rather than a run
- fresh-fuzz throughput spans three orders of magnitude, from 990,019 units per second on
  discovery to 584 on m2ts, because a unit is a filename classification in one target and
  a full transport-stream scan of up to 98,304 bytes in the other
- read_be adds no new coverage at all; udf, discovery and bitstream stop within 91
  seconds; source and codec flatten near 205 and 245 seconds; m2ts slows sharply after 250
  seconds; parse_report is still gaining linearly at 900 seconds and reaches 13 percent of
  the report renderer's regions

The time-boxed example in the same block carried a cadence label for a schedule this
repository does not run; it now describes only what the command does.

A full corpus replay of all ten targets, a 120-second fresh run on each, and 900-second
runs on m2ts, codec, parse_report and source all completed with no crash, hang, timeout or
memory-limit kill.
