### PR TITLE
test(fuzz): tune per-target discovery flags on measured evidence

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -35,12 +35,118 @@ Every untrusted-input surface now carries a target; the only deliberate exceptio
 `vfs::fs` (OS-mediated folder IO, exercised by fault-injecting mock-tree tests instead
 of byte fuzzing).
 
+## Per-target discovery flags
+
+`targets.txt` is the one place the per-target flags live — one row per target, a
+dictionary column and a `-max_len` column. It documents its own format; read it from a
+shell loop with:
+
+```sh
+awk '!/^[[:space:]]*#/ && NF { print $1, $2, $3 }' targets.txt
+```
+
+These flags belong to **fresh (discovery) fuzzing only**. The `-runs=0` corpus replay
+that gates every pull request takes neither: a dictionary steers mutation and there is
+no mutation at zero runs, while `-max_len` would silently drop seeds longer than the cap
+and weaken the regression set.
+
+Dictionaries live in `dictionaries/`. Every token is derived from **the code that
+consumes it** — the literal a parser compares an input byte range against — and each
+file's header comment names the module every token comes from, so an entry can be
+checked against the source. To extend one, add a token when that module gains a new
+literal comparison over input bytes. To add one for a target that has none, write the
+file, point `targets.txt` at it, and measure it as below; a dictionary that does not
+move coverage does not belong in the table.
+
+### What a dictionary is worth here — measured 2026-08-03
+
+Six dictionaries were written, one per format with a gate, covering the seven targets
+below (`udf` and `source` read the same format), and compared against the tier's existing
+flags: same corpus copy, same 300 s budget, same host, repeated independent samples per
+arm. `cov` (inline 8-bit counters reached) is the metric.
+
+| target | base `cov` | with a dictionary | wired up |
+|---|---|---|---|
+| `mpls` | 718, 718 | 717, 718 | no |
+| `clpi` | 391, 391 | 391, 391 | no |
+| `m2ts` | 1605, 1631 | 1612, 1629 | no |
+| `codec` | 2625, 2625 | 2627, 2627 | no |
+| `udf` | 589, 586 | 586, 588 | no |
+| `source` | 735, 735, 735 | **784, 784, 757, 736** | **yes** |
+| `parse_report` | 3683, 3717 | 3649, 3597 | no — it costs 2% |
+
+The zeroes have one cause: **libFuzzer's own comparison tracing already recovers a
+format magic without help.** Its end-of-run recommended dictionary from the plain base
+runs contains `MPLS0240`, `HDMV0240` and a one-byte-off `*UDF Metadata Partition`, all
+found unaided inside the budget. A magic string is exactly the shape tracing solves, so
+writing one down for it buys nothing.
+
+`source` is the exception because its gate is **not a literal**. Every `vfs::udf`
+descriptor parser starts at `Tag::parse`, which validates the modulo-256 `TagChecksum` —
+a value computed *from* the input bytes, so there is no constant for tracing to latch
+onto, and random bytes clear it once in 256 tries. Handing the fuzzer eleven
+checksum-valid tags skips that gate. The effect is intermittent rather than uniform,
+which is what clearing a discrete gate inside a fixed budget looks like: the base arm
+sits on exactly 735 in three runs while the dictionary arm reaches 784, 784, 757 and
+736.
+
+Only the `source` target feels it. The per-parser `udf` target uses the same file and
+gains nothing, because it already feeds every parser at offset 0 and so is not gated the
+same way — which is why the table is keyed by target rather than by format.
+
+`parse_report` is the opposite case, and the reason is worth knowing before writing
+another dictionary for a target framed like it. Its input is a run of `u16` big-endian
+length-prefixed sections, so inserting or overwriting a token shifts the bytes a length
+prefix counts and desynchronises the split of all six files. **A dictionary and a
+length-prefixed container do not compose.**
+
+### What `-max_len` is worth here — measured 2026-08-03
+
+`-max_len` does not truncate an over-long seed; libFuzzer **drops** it. Shortening the
+cap therefore trades seeds for throughput, and only pays when the throughput buys back
+more than the discarded seeds carried. Of the ten targets, only `m2ts` and `source` have
+a cap above the 4096-byte default at all, because libFuzzer takes it from the largest
+seed.
+
+`m2ts` pays. Nine independent 300 s samples per arm, its 98,304-byte corpus-derived cap
+against 16,384:
+
+| arm | `cov` samples | mean | exec/s |
+|---|---|---|---|
+| corpus-derived (98,304) | 1574, 1584, 1589, 1605, 1606, 1610, 1615, 1627, 1631 | 1605 | ~445 |
+| `-max_len=16384` | 1596, 1612, 1617, 1626, 1633, 1665, 1685, 1825, 2003 | **1696** | ~720 |
+
++5.7% mean on 62% more throughput. The medians nearly touch; what separates the arms is
+the tail — **four of the nine shorter-unit runs beat the best run the full-length arm
+ever produced, and none of the full-length runs did.** A 16 KiB cap keeps 161 of the 415
+seeds, so it starts about 46 counters behind at `INITED` (1363 against 1410, averaged
+over the same nine runs each) and still finishes ahead. 8 KiB, 32 KiB and 64 KiB were
+also measured and none beat 16 KiB.
+
+`source` does not pay, and shows the failure mode. Capping it at 8 KiB costs 24% of its
+reach (784 → 557) — deep multi-extent structures stop being expressible — while the
+throughput number improves. Its cap is left as the corpus sets it.
+
+Raising a cap was measured too and is not worth it. libFuzzer ramps its per-unit length
+with execution count and `parse_report` never reaches its 4096 ceiling in a short run;
+forcing it there with `-len_control=0` *loses* coverage (3683 → 3640), and raising the
+ceiling to 16 KiB on top loses more (3556). Its units cost more than they discover.
+
+Value profile (`-use_value_profile=1`) was measured on all seven and is wired on none.
+It never gained a counter outside `m2ts`, where a shorter `max_len` beats it and it
+*subtracts* from that; and it costs 13% throughput on `mpls` and `codec`, 25% on
+`source`, 61% on `clpi` and 78% on `udf`. Since the length ramp advances with execution
+count, that throughput cost is also a reach cost: `parse_report`'s `lim` after 300 s
+falls from 1915 to 615 with it on.
+
 ## Running (Linux / WSL / CI, nightly)
 
 ```sh
 cargo install cargo-fuzz                              # once
 cargo +nightly fuzz run read_be   -- -runs=0          # replay the committed corpus (the regression gate)
 cargo +nightly fuzz run read_be   -- -max_total_time=300   # fresh-fuzz this target, time-boxed (5 min)
+cargo +nightly fuzz run source    -- -max_total_time=300 -dict=dictionaries/udf.dict  # ... with its targets.txt flags
+cargo +nightly fuzz run m2ts      -- -max_total_time=300 -max_len=16384               # ... likewise
 cargo +nightly fuzz cmin read_be                      # minimize the corpus
 cargo +nightly fuzz list                              # show targets
 ```
@@ -55,8 +161,8 @@ committed so `-runs=0` is a deterministic replay.
 
 **Fresh-fuzz throughput spans three orders of magnitude**, because a unit means something
 different per target: `discovery` classifies a filename at ~10^6 units/s, while an `m2ts`
-unit is a full transport-stream scan of up to 98,304 bytes at ~600/s. Budget per target
-accordingly — an equal time budget is not an equal experiment.
+unit is a full transport-stream scan of thousands of bytes at ~500-800/s. Budget per
+target accordingly — an equal time budget is not an equal experiment.
 
 Where a target stops learning — from fresh runs of 120 s on all ten, and 900 s on `m2ts`,
 `codec`, `parse_report` and `source`:

--- a/fuzz/dictionaries/udf.dict
+++ b/fuzz/dictionaries/udf.dict
@@ -1,0 +1,44 @@
+# libFuzzer dictionary — UDF 2.50 / ECMA-167 disc structures. Shared by the
+# `udf` target (each parser fed sector bytes at offset 0) and the `source`
+# target (a whole `.iso` image mapped so the input starts at the anchor sector).
+#
+# Every descriptor parser in `bdinfo_rs_core::vfs::udf` begins with
+# `Tag::parse`, which validates the 8-bit `TagChecksum` at byte 4 — the sum of
+# the other fifteen tag bytes, modulo 256 (ECMA-167 §3/7.2.3). Random bytes pass
+# that gate once in 256 tries, so it, not the tag identifier, is what keeps the
+# fuzzer out of every descriptor body.
+#
+# Each token below is therefore a complete 16-byte descriptor tag: the
+# `TagIdentifier` (`Uint16`, little-endian — UDF is the one little-endian format
+# this crate reads), `DescriptorVersion` 2, the matching checksum, and zeros for
+# the serial number, CRC, CRC length and location, none of which any parser
+# here checks.
+#
+# The OSTA CS0 compression identifiers (8 and 16) are deliberately absent: a
+# single byte is cheaper for the mutator to hit than a dictionary lookup.
+#
+# To extend: add a token when `vfs::udf` compares a new `TagIdentifier`,
+# recomputing byte 4 as the modulo-256 sum of the other fifteen.
+
+# Volume-level descriptors (`vfs::udf::descriptor`).
+tag_primary_volume="\x01\x00\x02\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+tag_anchor_volume_pointer="\x02\x00\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+tag_volume_descriptor_pointer="\x03\x00\x02\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+tag_partition="\x05\x00\x02\x00\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+tag_logical_volume="\x06\x00\x02\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+
+# The terminating descriptor that ends a volume descriptor sequence
+# (`vfs::udf::source`).
+tag_terminating="\x08\x00\x02\x00\x0a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+
+# File-set, directory and file structures (`vfs::udf::descriptor`,
+# `vfs::udf::fid`, `vfs::udf::icb`, `vfs::udf::source`).
+tag_file_set="\x00\x01\x02\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+tag_file_identifier="\x01\x01\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+tag_allocation_extent="\x02\x01\x02\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+tag_file_entry="\x05\x01\x02\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+tag_extended_file_entry="\x0a\x01\x02\x00\x0d\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+
+# The `EntityID` identifier that marks a type-2 partition map as a metadata
+# partition (UDF 2.50 §2.2.10), compared at offset 5 of the map.
+metadata_partition_id="*UDF Metadata Partition"

--- a/fuzz/targets.txt
+++ b/fuzz/targets.txt
@@ -1,0 +1,36 @@
+# The fuzz tier's targets and their per-target discovery flags — one row per
+# `[[bin]]` in Cargo.toml, in the order the runners walk them. Adding a target
+# means adding it in both places (and in the target lists the CI workflows
+# carry); a row here with no `[[bin]]` behind it fails the run that reaches it.
+#
+# Columns, whitespace-separated, `-` meaning "no value":
+#
+#   target    the [[bin]] name; also the corpus directory under corpus/
+#   dict      a libFuzzer dictionary, relative to this file's directory
+#   max_len   the per-unit length cap passed as -max_len
+#
+# These flags belong to fresh (discovery) fuzzing only. The `-runs=0` corpus
+# replay that gates every pull request passes neither: a dictionary steers
+# mutation, and there is no mutation at zero runs, while -max_len does not
+# truncate an over-long seed but DROPS it, which would quietly shrink the
+# regression set.
+#
+# Read it from a shell loop with, e.g.:
+#
+#   awk '!/^[[:space:]]*#/ && NF { print $1, $2, $3 }' fuzz/targets.txt
+#
+# An empty cell is a measured verdict, not an omission. fuzz/README.md records
+# what was tried per target and what it bought; a flag that does not move
+# coverage in a controlled comparison does not belong in this table.
+
+# target        dict                    max_len
+read_be         -                       -
+discovery       -                       -
+bitstream       -                       -
+clpi            -                       -
+mpls            -                       -
+m2ts            -                       16384
+codec           -                       -
+udf             -                       -
+source          dictionaries/udf.dict   -
+parse_report    -                       -


### PR DESCRIPTION
Adds fuzz/targets.txt, one row per target holding the flags fresh (discovery)
fuzzing runs it under, and fuzz/dictionaries/udf.dict.

Every flag was measured before being wired: same corpus copy, same 300 s budget,
same host, repeated independent samples per arm, comparing against the flags the
tier runs today. 53 runs in total.

Wired:

- source gains the dictionary. Its gate is Tag::parse's modulo-256 TagChecksum,
  a value computed from the input rather than compared against a literal, so
  libFuzzer's comparison tracing cannot shortcut it and random bytes clear it
  once in 256 tries. Base coverage is deterministic at 735 counters across three
  runs; with the dictionary 736 / 757 / 784 / 784.
- m2ts gains a 16384-byte max_len. Mean coverage 1605 to 1696 across nine
  samples per arm, on 62 percent more throughput. The medians nearly touch; the
  tail is the effect. Four of the nine shorter-unit runs beat the best run the
  full-length arm produced in nine tries, and no full-length run exceeded 1631.

Measured and not wired:

- Dictionaries for mpls, clpi, m2ts, codec, udf and parse_report. libFuzzer's
  comparison tracing already recovers the format magics unaided, which the plain
  base runs show in their own recommended-dictionary output. parse_report
  measurably loses 2 percent because its input is a run of length-prefixed
  sections and a token shifts the bytes a length prefix counts.
- Value profile on all seven targets. No gain outside m2ts, where a shorter
  max_len beats it, and it costs 13 to 78 percent of throughput elsewhere.
- Every max_len raise, and every other max_len cut. Forcing parse_report's
  length ramp with len_control loses coverage, and capping source at 8192 costs
  24 percent of its reach.

fuzz/README.md records each result, so the same dictionaries do not get written
again. These flags are documented as discovery-only: the corpus replay that
gates every pull request takes neither, since max_len drops over-long seeds
rather than truncating them.

No crash, hang, OOM or timeout in any run.

Nothing under .github/ changes here, so the scheduled fuzz leg is unaffected
until the table is wired into CI.
