### PR TITLE
ci(fuzz): fuzz each discovery leg on all four runner vCPUs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,6 +18,14 @@ name: fuzz
 # 14,178 units and discarded every one of them, so run N+1 learned roughly what
 # run N learned.
 #
+# Each leg runs FOUR libFuzzer processes over its one shared corpus directory,
+# not one. A standard hosted runner is 4 vCPU / 16 GB on a PUBLIC repository and
+# 2 vCPU / 8 GB on a private one — the public figure is the one that applies here
+# and the one that is easy to get wrong — so a single-process leg used a quarter
+# of the machine. Buying the other three cores buys executions INSIDE the
+# existing budget, which is the direction the cadence measurement below points;
+# raising FUZZ_SECONDS instead would push against it.
+#
 # NIGHTLY rather than weekly, deliberately: GitHub evicts a cache unused for 7
 # days, so a weekly schedule rides the eviction boundary and would silently
 # reset discovery to the seeds — and this repository's cron fires 2-4 h late
@@ -54,6 +62,9 @@ on:
       seconds:
         description: Per-target fresh-fuzz budget in seconds
         default: "300"
+      workers:
+        description: Concurrent libFuzzer processes per target - 4 = one per runner vCPU, 1 = the single-process arm, 0 = no multi-process wrapper at all
+        default: "4"
       file_issues:
         description: File crash / corpus-growth issues from this run (schedule and tag runs always do)
         type: boolean
@@ -83,6 +94,10 @@ env:
   # unit's wall time (non-termination guard); -rss_limit_mb bounds its memory
   # (allocation-amplification guard). Both turn a hang or an allocation blow-up
   # into a libFuzzer crash, which is what makes them reportable below.
+  # -rss_limit_mb is PER FUZZER PROCESS and WORKERS of them run at once, so the
+  # guard now bounds the leg at 4 x 2048 MiB = 8 GiB against the runner's 16 GB.
+  # Raising either number has to be checked against that product, not against
+  # the single-process figure this line used to mean.
   GUARDS: -timeout=25 -rss_limit_mb=2048
 
 jobs:
@@ -134,6 +149,17 @@ jobs:
       # The `inputs` context is read only under the event that populates it, so
       # a scheduled run never depends on how an absent context resolves.
       FUZZ_SECONDS: ${{ github.event_name == 'push' && '600' || github.event_name == 'workflow_dispatch' && inputs.seconds || '300' }}
+      # libFuzzer's own multi-process mode: -jobs is how many fuzzer processes
+      # to run in total, -workers how many at a time. Equal values start them
+      # all together for the same -max_total_time, so the leg's wall time is
+      # unchanged and only its execution count moves. BOTH are set on purpose:
+      # given -jobs alone libFuzzer defaults -workers to min(jobs, cores/2),
+      # which is 2 on a 4-vCPU runner and leaves half the machine idle.
+      # The processes share one corpus directory and libFuzzer's -reload
+      # default (1) makes each pick up what the others write.
+      # Dispatching with workers=1 gives the single-process arm on the same
+      # code path, which is how the comparison in fuzz/README.md was run.
+      WORKERS: ${{ github.event_name == 'workflow_dispatch' && inputs.workers || '4' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -248,13 +274,40 @@ jobs:
               if ($2 != "-") printf " -dict=%s/%s", dir, $2
               if ($3 != "-") printf " -max_len=%s", $3
             }' fuzz/targets.txt)
-          echo "budget ${FUZZ_SECONDS}s, guards $GUARDS, flags:${flags:- (none)}"
+          echo "budget ${FUZZ_SECONDS}s x ${WORKERS} process(es), guards $GUARDS, flags:${flags:- (none)}"
           set +e
           cargo +"$NIGHTLY" fuzz run "$TARGET" --target "$FUZZ_TARGET" -- \
-            -max_total_time="$FUZZ_SECONDS" $GUARDS $flags -print_final_stats=1 2>&1 | tee fuzz-run.log
+            -max_total_time="$FUZZ_SECONDS" -jobs="$WORKERS" -workers="$WORKERS" \
+            $GUARDS $flags -print_final_stats=1 2>&1 | tee fuzz-parent.log
           rc=${PIPESTATUS[0]}
           set -e
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+          # WHAT THE CLASSIFIER READS. In multi-process mode the parent does not
+          # fuzz: it spawns each worker with its stdout and stderr redirected to
+          # fuzz-<N>.log beside the fuzz binary, and copies that whole file to
+          # its own stderr as the job exits. So the tee above does carry every
+          # worker's panic header, libFuzzer ERROR block and -print_final_stats
+          # counters (measured 2026-08-04 on cargo-fuzz 0.13.2 / the pinned
+          # nightly; parent rc is still 0 clean / 1 on a crashing job).
+          #
+          # Read the worker files anyway, for two reasons. The copy is an
+          # upstream implementation detail, and the classifier is exactly the
+          # path this repository has already had silently disarmed once by an
+          # upstream output change; and reading only the files means the
+          # per-worker aggregation below cannot count a worker twice. The
+          # parent's stream is the fallback for a failure with no worker at all
+          # (a build break, a missing toolchain), which writes no fuzz-<N>.log.
+          # Only the parent's per-job exit codes are kept from it.
+          logs=$(find . -maxdepth 2 -name 'fuzz-[0-9]*.log' | sort)
+          if [ -n "$logs" ]; then
+            grep -h 'exited with exit code' fuzz-parent.log > fuzz-run.log || true
+            # shellcheck disable=SC2086  # one word per worker log, all name-safe
+            cat $logs >> fuzz-run.log
+          else
+            cp fuzz-parent.log fuzz-run.log
+          fi
+          echo "captured $(echo "$logs" | grep -c .) worker log(s), $(wc -l < fuzz-run.log) lines"
           if [ "$rc" -eq 0 ]; then echo "$TARGET: clean"; else echo "$TARGET: exit $rc"; fi
 
       # libFuzzer writes a crashing input to fuzz/artifacts/, never to the
@@ -334,14 +387,32 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force result | Out-Null
           $log = if (Test-Path fuzz-run.log) { Get-Content -Raw fuzz-run.log } else { '' }
-          # libFuzzer's last progress line carries the run's final figures:
+          # One DONE line per worker, each carrying that process's final figures:
           # `#N DONE cov: 1696 ft: 5719 corp: 402/15Mb ... exec/s: 720 ...`.
-          $cov = if ($log -match '(?s).*\bcov:\s*(\d+)') { [int]$Matches[1] } else { 0 }
-          $ft = if ($log -match '(?s).*\bft:\s*(\d+)') { [int]$Matches[1] } else { 0 }
-          $execs = if ($log -match '(?s).*\bexec/s:\s*(\d+)') { [int]$Matches[1] } else { 0 }
+          # cov and ft are per-process views of a SHARED corpus that -reload
+          # keeps in sync, so the highest is the leg's reach; exec/s and the
+          # executed-unit count are per process, so their SUM is the leg's
+          # throughput — and that sum against the single-process arm is the
+          # whole question this parallelism is answering.
+          $done = [regex]::Matches($log, '(?m)^#\d+\s+DONE\s+cov:\s*(\d+)\s+ft:\s*(\d+).*?\bexec/s:\s*(\d+)')
+          $units = [regex]::Matches($log, '(?m)^stat::number_of_executed_units:\s*(\d+)')
+          if ($done.Count -gt 0) {
+            $cov = ($done | ForEach-Object { [int]$_.Groups[1].Value } | Measure-Object -Maximum).Maximum
+            $ft = ($done | ForEach-Object { [int]$_.Groups[2].Value } | Measure-Object -Maximum).Maximum
+            $execs = [int](($done | ForEach-Object { [int]$_.Groups[3].Value } | Measure-Object -Sum).Sum)
+          }
+          else {
+            # A crashing process never reaches its DONE line, so fall back to the
+            # last progress line anywhere in the capture. Measured: a run whose
+            # every worker panicked prints no DONE at all.
+            $cov = if ($log -match '(?s).*\bcov:\s*(\d+)') { [int]$Matches[1] } else { 0 }
+            $ft = if ($log -match '(?s).*\bft:\s*(\d+)') { [int]$Matches[1] } else { 0 }
+            $execs = if ($log -match '(?s).*\bexec/s:\s*(\d+)') { [int]$Matches[1] } else { 0 }
+          }
           $stats = [ordered]@{
             target = $env:TARGET
             seconds = [int]$env:FUZZ_SECONDS
+            workers = [int]$env:WORKERS
             seeds = [int]$env:SEEDS
             restored = [int]$env:RESTORED
             grown = [int]$env:GROWN
@@ -349,13 +420,14 @@ jobs:
             cov = $cov
             ft = $ft
             execs_per_sec = $execs
+            units_executed = [int64](($units | ForEach-Object { [int64]$_.Groups[1].Value } | Measure-Object -Sum).Sum)
             rc = [int]$env:RC
           }
           $stats | ConvertTo-Json | Set-Content result/stats.json
           @(
             "### $($env:TARGET)"
             ''
-            "$($env:SEEDS) distinct committed seeds, $($env:RESTORED) restored, $($env:NEW) new after minimisation - cov $cov, ft $ft, $execs exec/s, exit $($env:RC)"
+            "$($env:SEEDS) distinct committed seeds, $($env:RESTORED) restored, $($env:NEW) new after minimisation - $($env:WORKERS) process(es), cov $cov, ft $ft, $execs exec/s, exit $($env:RC)"
           ) -join "`n" | Add-Content $env:GITHUB_STEP_SUMMARY
           if (-not $env:REPRO) { exit 0 }
 
@@ -403,7 +475,16 @@ jobs:
             # its fix, while a tmin'd unit is small enough to paste. Skipped
             # above 16 KiB, which no minimised unit has reached.
             repro_base64 = if ($bytes.Length -le 16384) { [Convert]::ToBase64String($bytes) } else { $null }
-            log_tail = ($log -split "`n" | Select-Object -Last 40) -join "`n"
+            # Anchored on the crash, not on the end of the capture: with several
+            # workers concatenated the last lines belong to whichever process
+            # finished last, which is usually a clean one. Falls back to the tail
+            # when nothing matched, which is the shape a build break leaves.
+            log_tail = (& {
+              $lines = $log -split "`r?`n"
+              $at = ($lines | Select-String -Pattern 'panicked at|ERROR: libFuzzer' | Select-Object -First 1).LineNumber
+              if ($at) { $lines[[math]::Max(0, $at - 6) .. [math]::Min($lines.Count - 1, $at + 33)] }
+              else { $lines | Select-Object -Last 40 }
+            }) -join "`n"
             run_url = $env:RUN_URL
           }
           $crash | ConvertTo-Json | Set-Content result/crash.json
@@ -510,7 +591,7 @@ jobs:
           @(
             '## Discovery pass'
             ''
-            "Budget $((@($stats).Count ? $stats[0].seconds : 0))s per target. Accumulated corpus: $totalRestored units in, $totalNew out after minimisation against the committed seeds."
+            "Budget $((@($stats).Count ? $stats[0].seconds : 0))s per target across $((@($stats).Count ? $stats[0].workers : 0)) concurrent libFuzzer process(es). Accumulated corpus: $totalRestored units in, $totalNew out after minimisation against the committed seeds."
             ''
             '| target | seeds | restored | new | cov | ft | exec/s |'
             '|---|---|---|---|---|---|---|'

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -210,7 +210,7 @@ Three legs, two of them adversarial and one of them a gate:
 | leg | when | what it does |
 |---|---|---|
 | corpus replay (`core.yml`) | every pull request and push touching the `fuzz` area, and daily through the sweep | `-runs=0` over the committed seeds — a deterministic regression check, and a **required status check** |
-| nightly discovery (`fuzz.yml`) | 21:11 UTC daily, one job per target, 300 s each | fresh fuzzing that **starts where last night stopped** |
+| nightly discovery (`fuzz.yml`) | 21:11 UTC daily, one job per target, 300 s each on four concurrent libFuzzer processes | fresh fuzzing that **starts where last night stopped** |
 | release-tag pass (`fuzz.yml`) | every `v*` tag, 600 s per target | a release checkpoint; runs alongside the publish workflows and blocks none of them |
 
 **Discovery compounds through a per-target Actions cache.** A nightly leg restores
@@ -236,6 +236,61 @@ keys on the target and the guard that fired. The reproducer is minimised with `t
 uploaded as an artifact, and inlined base64 in the issue so the evidence outlives the
 90-day artifact retention. **A human closes a crash issue with the fix**: a later green
 run is not evidence, because the fuzzer need not have replayed that input.
+
+### What the runner's other three cores are worth — measured 2026-08-04
+
+A standard hosted runner is **4 vCPU / 16 GB** on a public repository (2 vCPU / 8 GB on a
+private one — that is the figure that is easy to get wrong), and a discovery leg used one
+core. libFuzzer's own answer is several processes over one shared corpus directory, with
+`-reload` (on by default) carrying each process's finds to the others. **Both flags are
+needed**: given `-jobs` alone libFuzzer sets `-workers` to `min(cores / 2, jobs)`, which is
+2 here. `-rss_limit_mb` is per process, so four workers bound a leg at 8 GiB of the
+runner's 16 GB.
+
+Two independent pairs of 300 s runs, single process (`workers=0`, which never enters
+libFuzzer's multi-process path) against four. All four runs restored the **identical**
+accumulated corpus on every target, so the arms differ only in process count.
+
+| target | `cov` 1 process | `cov` 4 processes | mean delta | executions |
+|---|---|---|---|---|
+| `m2ts` | 2189, 2175 | 2571, 2316 | **+12.0%** | x1.40 |
+| `source` | 807, 837 | 847, 848 | +3.1% | x2.71 |
+| `wasm_report` | 5330, 5440 | 5457, 5553 | +2.2% | x1.68 |
+| `wasm_iso` | 818, 802 | 827, 824 | +1.9% | x2.51 |
+| `parse_report` | 5562, 5634 | 5657, 5657 | +1.1% | x1.47 |
+| `gui_settings` | 446, 446 | 450, 446 | +0.4% | x2.18 |
+| `codec` | 2624, 2624 | 2627, 2625 | +0.1% | x2.15 |
+| `wasm_disc` | 5141, 5024 | 5100, 5061 | −0.0% | x1.26 |
+| `bitstream` | 309, 309 | 309, 309 | 0.0% | x2.14 |
+| `clpi` | 392, 392 | 392, 392 | 0.0% | x2.44 |
+| `discovery` | 227, 227 | 227, 227 | 0.0% | x2.21 |
+| `mpls` | 718, 718 | 718, 718 | 0.0% | x2.20 |
+| `read_be` | 74, 74 | 74, 74 | 0.0% | x2.00 |
+| `udf` | 589, 589 | 589, 589 | 0.0% | x2.26 |
+
+**Four processes on four vCPUs buy x2.13 the executions, not x4** (446.5 M against 949.2 M
+over the whole tier). The heaviest targets scale worst — `wasm_disc` x1.26, `m2ts` x1.40,
+`parse_report` x1.47 against x2.0–2.7 for the light ones — so the ceiling is not CPU alone.
+Budget throughput from the measured multiplier, never from the core count.
+
+**No target lost coverage, and the gains land exactly where a longer budget would have
+put them.** The six targets pinned to an identical counter across all four runs are the
+ones measured as finished inside 120 s; the ones that gained are the ones still learning at
+300 s. Parallelism is therefore the same lever as a longer run, bought without lengthening
+the night — which is what the cadence finding above asks for.
+
+**Sample the noisy targets before quoting a per-target figure.** The first pair alone read
+`m2ts` at +17.5%; the second read +6.5%. That is the same tail behaviour the `-max_len`
+measurement found (1574–2003 across nine 300 s runs), and one sample would have overstated
+the gain by nearly 2x. The six deterministic targets are what make the *shape* of this
+table trustworthy on two pairs: where the measurement can move, it does; where the target
+is saturated, all four runs agree to the counter.
+
+**Sizing the matrix — for whoever widens it next.** The tier is **14 targets**, one leg
+each, and the GitHub Free plan allows **20 concurrent jobs**. So the matrix has six legs of
+headroom, and a target-by-architecture expansion at 28 legs would queue rather than run.
+Throughput per leg is the lever that does not spend that budget; it is now spent to x2.13,
+and the remaining headroom is six legs.
 
 ## Running (Linux / WSL / CI, nightly)
 


### PR DESCRIPTION
Each nightly discovery leg ran one libFuzzer process on a runner with four vCPUs. It now
runs four, over its one shared corpus directory, buying executions inside the existing
per-target budget rather than a longer schedule.

Both `-jobs` and `-workers` are set: given `-jobs` alone libFuzzer defaults `-workers` to
`min(cores / 2, jobs)`, which is 2 here. `-rss_limit_mb` is per process, so the guard now
bounds a leg at 8 GiB against the runner's 16 GB, and the comment says so.

### Crash classification

The parent process does not fuzz in this mode. It redirects each worker to its own
`fuzz-<N>.log` and copies that file to its stderr as the job exits, so the existing capture
did still carry every panic header and counter — measured, not assumed. Classification
reads the worker logs directly anyway: that copy is an unguaranteed upstream detail, this
is the path a toolchain output change silently disarmed in #229, and reading only the files
keeps the new per-worker aggregation from counting a worker twice.

Consequent changes: `cov` and `ft` take the maximum across workers and `exec/s` and the
executed-unit count take the sum; a crashing worker prints no `DONE` line, so the parser
falls back to the last progress line; and the crash excerpt in an issue body is anchored on
the crash rather than on the end of the capture, which with four workers concatenated
belongs to a process that did not crash.

**The failure path was exercised before this was believed.** A target temporarily rigged to
panic on a four-byte magic the fuzzer had to find was run through this workflow at
`workers=4`. All four workers found it, the leg went red, and the run classified it as a
panic at the right source location, minimised the reproducer to the four trigger bytes,
anchored the excerpt on the panic, and filed **one** signature rather than four — the
digit-folding key collapsing crashes on 4-, 5- and 8-byte inputs, a case that cannot arise
single-process. Corpus accounting stayed correct with four processes writing one directory.
The rig is not in this branch.

### Measured

Two independent pairs of 300 s runs over all 14 targets, single process against four, every
run restoring the identical accumulated corpus.

- Executions **x2.13**, not x4 (446.5 M to 949.2 M over the tier); the heaviest targets
  scale worst, x1.26 to x1.47 against x2.0 to x2.7 for the light ones.
- Coverage rises where the target is still learning at 300 s — `m2ts` +12.0%, `source`
  +3.1%, `wasm_report` +2.2%, `wasm_iso` +1.9%, `parse_report` +1.1% — and is identical to
  the counter across all four runs on the six targets measured as finished inside 120 s. No
  target lost coverage.
- Summed `ft` +4.5%, including targets whose `cov` is pinned.
- The two pairs read `m2ts` at +17.5% and +6.5%, so `fuzz/README.md` records that the noisy
  targets need sampling before a figure is quoted.

`fuzz/README.md` also records the 14-target leg count against the plan's 20 concurrent
jobs, which is the headroom any widening of the matrix has to fit inside.

Unchanged: the per-target budget, the cron, the target list and its flags, the matrix
width, and the `-runs=0` replay gate, which takes no parallelism because there is no
mutation at zero runs.
