### PR TITLE
ci: refresh stale Node, setup-homebrew and cloudsmith-cli pins

### DIFF
--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install convco (prebuilt, no from-source compile)
         uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
         with:
-          tool: convco@0.7.0
+          tool: convco@0.7.1
           fallback: none
 
       # Prove the banned-word regex still rejects attribution and passes innocent

--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install convco (prebuilt, no from-source compile)
         uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
         with:
-          tool: convco@0.7.1
+          tool: convco@0.7.0
           fallback: none
 
       # Prove the banned-word regex still rejects attribution and passes innocent

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           # Keep in lockstep with wasm.yml + publish-npm.yml (version-freshness.yml
           # cross-checks the three agree). The active Node line: 26 -> LTS Oct 2026.
-          node-version: "26.5.1"
+          node-version: "26.6.0"
 
       - name: Install the web toolchain (binaryen / typescript / biome)
         working-directory: crates/bdinfo-rs-wasm/web

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -55,7 +55,7 @@ jobs:
       # nags (files an issue) when Homebrew master moves past this SHA, and the bump
       # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
       # releases, and this repo has none).
-      - uses: Homebrew/actions/setup-homebrew@5037c6f1012cc5ea0b9f03fedbaf9955ed9e51e0 # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@726029484f4d6a3cc19c735a5fb22595f8655a9a # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its
@@ -118,7 +118,7 @@ jobs:
     steps:
       # A SHA-frozen Homebrew/actions pin — the full rationale sits on the
       # homebrew job's identical line above.
-      - uses: Homebrew/actions/setup-homebrew@5037c6f1012cc5ea0b9f03fedbaf9955ed9e51e0 # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@726029484f4d6a3cc19c735a5fb22595f8655a9a # zizmor: ignore[ref-version-mismatch]
 
       # The same tap-trust story as the homebrew job above, for its reasons.
       - name: Trust the taps (ours + the runner's pre-tapped ones)

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -284,7 +284,7 @@ jobs:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
           set -euo pipefail
-          pipx install cloudsmith-cli==1.20.2 >/dev/null
+          pipx install cloudsmith-cli==1.21.0 >/dev/null
           ver="${VERSION#v}"
           repo=bdinfo-rs/bdinfo-rs
           file="dl/bdinfo-rs-${{ matrix.triple }}.deb"
@@ -363,7 +363,7 @@ jobs:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
           set -euo pipefail
-          pipx install cloudsmith-cli==1.20.2 >/dev/null
+          pipx install cloudsmith-cli==1.21.0 >/dev/null
           ver="${VERSION#v}"
           repo=bdinfo-rs/bdinfo-rs
           file="dl/bdinfo-rs-${{ matrix.triple }}.rpm"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           # The active Node line (26 -> LTS Oct 2026); kept in lockstep with
           # wasm.yml + deploy-pages.yml (version-freshness.yml cross-checks the three).
-          node-version: "26.5.1"
+          node-version: "26.6.0"
 
       # Staged publishing (`npm stage publish`) needs npm >= 11.15.0, and
       # `--provenance` needs a working bundled `sigstore`. npm 12.0.0 shipped

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -33,7 +33,7 @@ permissions:
 
 env:
   NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + core.yml
-  NODE_VERSION: "26.5.1"      # the active Node line (26 -> LTS Oct 2026); watched by version-freshness.yml
+  NODE_VERSION: "26.6.0"      # the active Node line (26 -> LTS Oct 2026); watched by version-freshness.yml
   # Keep the cached target/ small: no incremental-compilation metadata, and
   # line tables instead of full DWARF (still enough for file:line in a test
   # backtrace). A called workflow inherits none of its caller's env, so these


### PR DESCRIPTION
Bumps three of the four pins flagged by the daily version-freshness check.

- Node 26.5.1 to 26.6.0, lockstepped across wasm.yml, deploy-pages.yml and publish-npm.yml
- Homebrew/actions/setup-homebrew re-pinned to 726029484f4d6a3cc19c735a5fb22595f8655a9a, the current master HEAD; the issue named an older HEAD that has since moved
- cloudsmith-cli 1.20.2 to 1.21.0, both call sites in packages.yml

convco stays at 0.7.0. taiki-e/install-action publishes no manifest for convco 0.7.1 (manifests/convco.json lists 0.7.0 as latest, through release 2.85.7), and this step runs with fallback: none, so 0.7.1 cannot be installed. Refs #237, which stays open for that pin.

The five NIGHTLY pins are unchanged, and no cargo-dist pin is involved, so DIST_SHA256 needs no re-take.