### PR TITLE
feat(core)!: detect AACS-encrypted discs and refuse the CLI scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "bdinfo-rs-core",
  "clap",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "proptest",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["crates/bdinfo-rs-core", "crates/bdinfo-rs"]
 exclude = ["fuzz", "crates/bdinfo-rs-wasm", "crates/bdinfo-rs-gui"]
 
 [workspace.package]
-version = "2.0.0"
+version = "3.0.0"
 edition = "2024"
 rust-version = "1.96"
 # LGPL (unlike GPL) permits use from other applications.
@@ -123,7 +123,7 @@ private_intra_doc_links = "allow"
 
 [workspace.dependencies]
 # Internal (version + path so bdinfo-rs is publishable to crates.io).
-bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "2.0.0" }
+bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "3.0.0" }
 # External (pinned to latest stable minor; deny.toml forbids wildcards).
 clap = { version = "4.6", features = ["derive"] }
 proptest = "1.11"

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -1,7 +1,7 @@
 //! Disc-level orchestration: discovery plus the metadata scan.
 //!
 //! [`BdRom::open`] locates the BD directories case-insensitively through the
-//! [`crate::vfs`] seam, reads the disc flags (3D/UHD/BD+/BD-Java/PSP), the
+//! [`crate::vfs`] seam, reads the disc flags (3D/UHD/AACS/BD+/BD-Java/PSP), the
 //! recursive byte [`size`](BdRom::size), the volume label and disc title, then
 //! scans the clip and playlist metadata into the per-playlist
 //! [`PlaylistSummary`] rows the report emits.
@@ -379,7 +379,7 @@ pub struct StreamSummary {
 #[derive(Debug, Clone, PartialEq)]
 #[expect(
     clippy::struct_excessive_bools,
-    reason = "the seven flags are independent disc properties (3D/50Hz/UHD/BD+/BD-Java/D-BOX/PSP), not a state machine"
+    reason = "the eight flags are independent disc properties (3D/50Hz/UHD/AACS/BD+/BD-Java/D-BOX/PSP), not a state machine"
 )]
 pub struct BdRom {
     /// Disc volume label — the genuine UDF `LogicalVolumeIdentifier` for
@@ -400,6 +400,12 @@ pub struct BdRom {
     pub is_50hz: bool,
     /// 4K UHD disc — `index.bdmv` version magic `INDX0300`.
     pub is_uhd: bool,
+    /// AACS-encrypted stream content — the disc root carries the
+    /// `AACS/Unit_Key_RO.inf` key file AND the sampled stream heads show the
+    /// AACS encryption fingerprint (see [`detect_aacs_encryption`]). State
+    /// only: the report never mentions it, and the measured scan still runs if
+    /// a caller asks — whether to scan ciphertext is the caller's policy.
+    pub is_aacs_encrypted: bool,
     /// BD+ copy protection — a `BDSVM`/`SLYVM`/`ANYVM` directory.
     pub is_bd_plus: bool,
     /// BD-Java — a non-empty `BDJO` directory.
@@ -797,6 +803,9 @@ impl BdRom {
         let (size, interleaved_size) =
             sink.absorb(ScanStage::Discovery, &root_name, (0, 0), directory_size(root))?;
         let is_uhd = read_uhd_flag(&*bdmv, &backup_index, sink)?;
+        // Deliberately outside the sink: the verdict is disc state, not disc
+        // damage — a failed probe is a "not encrypted" verdict, never an error.
+        let is_aacs_encrypted = detect_aacs_encryption(root, stream.as_deref());
         let is_bd_plus =
             sink.absorb(ScanStage::Discovery, &root_name, false, has_bd_plus_dir(root))?;
         let is_bd_java = match &bdjo {
@@ -875,6 +884,7 @@ impl BdRom {
             is_3d,
             is_50hz,
             is_uhd,
+            is_aacs_encrypted,
             is_bd_plus,
             is_bd_java,
             is_dbox,
@@ -1027,6 +1037,112 @@ fn has_bd_plus_dir(root: &dyn BdDir) -> Result<bool, BdError> {
         }
     }
     Ok(false)
+}
+
+/// One BDAV source packet in bytes: a 4-byte `TP_extra_header` followed by a
+/// 188-byte TS packet whose first byte is the `0x47` sync (see [`super::m2ts`]).
+const SOURCE_PACKET_BYTES: usize = 192;
+
+/// One AACS Aligned Unit in bytes — 32 source packets of
+/// [`SOURCE_PACKET_BYTES`]. AACS encrypts each Aligned Unit of a stream file
+/// separately, leaving only its first 16 bytes cleartext (AACS Blu-ray Disc
+/// Prerecorded Book 0.953 §3.10), so packet 0's sync byte survives encryption
+/// and the other 31 syncs vanish into ciphertext.
+const ALIGNED_UNIT_BYTES: usize = 6144;
+
+/// How many stream files [`stream_content_encrypted`] samples. Two, the
+/// largest first: every sampled unit must agree for an "encrypted" verdict,
+/// and the largest files are the feature streams — never the sub-Aligned-Unit
+/// menu stubs whose short read would fail the probe open.
+const SAMPLED_STREAM_FILES: usize = 2;
+
+/// How many leading Aligned Units [`file_head_encrypted`] checks per sampled
+/// stream file.
+const SAMPLED_UNITS_PER_FILE: usize = 2;
+
+/// The most `0x47` bytes tolerated at the 31 ciphertext sync positions of an
+/// Aligned Unit that still counts as encrypted. Ciphertext is uniform, so each
+/// position matches with chance 1/256 (~0.12 expected per unit); three keeps
+/// the false-"clear" chance negligible while staying far under the 31/31 a
+/// clear unit shows.
+const MAX_STRAY_SYNCS: usize = 3;
+
+/// Whether the disc's stream content is AACS-encrypted (`is_aacs_encrypted`):
+/// the disc root carries `AACS/Unit_Key_RO.inf` — mandatory on every encrypted
+/// disc (AACS Blu-ray Disc Prerecorded Book 0.953 §3.9.3), but routinely left
+/// behind by decrypting rippers, so its existence alone proves nothing — AND
+/// the sampled stream heads show the encryption fingerprint
+/// ([`stream_content_encrypted`]).
+///
+/// Fail-open by design: every failure — IO error, missing directory, short or
+/// damaged stream — resolves to `false`. A false "not encrypted" costs a
+/// caller one pointless scan of ciphertext; a false "encrypted" would brand a
+/// readable disc unreadable. Damage therefore stays with the damaged-disc
+/// machinery (the resilient sink), which this probe never touches.
+fn detect_aacs_encryption(root: &dyn BdDir, stream: Option<&dyn BdDir>) -> bool {
+    has_aacs_key_file(root) && stream.is_some_and(stream_content_encrypted)
+}
+
+/// Whether the disc root has an `AACS` directory holding `Unit_Key_RO.inf`,
+/// both matched ASCII case-insensitively like the rest of the discovery. The
+/// file's contents are never read — existence is the whole hint. Enumeration
+/// failures read as "absent" (the probe's fail-open rule).
+fn has_aacs_key_file(root: &dyn BdDir) -> bool {
+    let Ok(dirs) = root.get_directories() else {
+        return false;
+    };
+    dirs.iter().filter(|dir| dir.name().eq_ignore_ascii_case("AACS")).any(|dir| {
+        dir.get_files().is_ok_and(|files| {
+            files.iter().any(|file| file.name().eq_ignore_ascii_case("Unit_Key_RO.inf"))
+        })
+    })
+}
+
+/// Whether the sampled stream content confirms encryption: the
+/// [`SAMPLED_STREAM_FILES`] largest `*.m2ts` files (ties broken by name, so
+/// the verdict never depends on directory enumeration order) must **all** pass
+/// [`file_head_encrypted`]. No stream files, an enumeration failure, or any
+/// non-fingerprint sample resolves to `false` (fail-open).
+fn stream_content_encrypted(stream: &dyn BdDir) -> bool {
+    let Ok(mut files) = vfs::find_files(stream, BdFileKind::Stream) else {
+        return false;
+    };
+    if files.is_empty() {
+        return false;
+    }
+    files.sort_by(|a, b| b.length().cmp(&a.length()).then_with(|| a.name().cmp(b.name())));
+    files.truncate(SAMPLED_STREAM_FILES);
+    files.iter().all(|file| file_head_encrypted(&**file))
+}
+
+/// Whether `file`'s first [`SAMPLED_UNITS_PER_FILE`] Aligned Units all show
+/// the encryption fingerprint. A failed open, a short read (a file under
+/// 2 × [`ALIGNED_UNIT_BYTES`]), or any non-fingerprint unit reads `false`.
+fn file_head_encrypted(file: &dyn BdFile) -> bool {
+    let Ok(mut reader) = file.open_read() else {
+        return false;
+    };
+    let mut unit = [0_u8; ALIGNED_UNIT_BYTES];
+    for _ in 0..SAMPLED_UNITS_PER_FILE {
+        if reader.read_exact(&mut unit).is_err() || !unit_shows_encryption(&unit) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Whether one Aligned Unit shows the AACS encryption fingerprint: packet 0's
+/// `0x47` sync byte intact (it sits inside the unit's 16 cleartext bytes) and
+/// at most [`MAX_STRAY_SYNCS`] of the 31 encrypted packets' sync positions
+/// matching by ciphertext chance. A clear unit shows all 32 (the container
+/// guarantees them); anything else — damage, garbage, a partial wipe — is not
+/// this fingerprint and reads `false`.
+fn unit_shows_encryption(unit: &[u8; ALIGNED_UNIT_BYTES]) -> bool {
+    let mut syncs =
+        unit.chunks_exact(SOURCE_PACKET_BYTES).map(|packet| packet.get(4) == Some(&0x47));
+    let first = syncs.next() == Some(true);
+    let strays = syncs.filter(|&hit| hit).count();
+    first && strays <= MAX_STRAY_SYNCS
 }
 
 /// Whether `dir` contains at least one file.
@@ -2055,13 +2171,14 @@ mod tests {
     use proptest::prelude::{prop_assert, prop_assert_eq, proptest};
 
     use super::{
-        BdError, BdRom, ClipMeta, ClipSummary, MAX_METADATA_BYTES, MVC_PID, PlaylistFilter,
-        PlaylistSummary, Progress, ScanMode, ScanProgress, ScanStage, Sink, TsPlaylistFile,
-        TsStreamFile, backup_subdir_files, build_chapter_summaries, build_clip_summaries,
-        build_sorted_streams, clear_measurements, clip_has_50hz_video, clip_stem, collect_backups,
-        merge_stream, rate_over, read_disc_title, read_file, read_file_capped,
-        resolve_playlist_streams, scan_stream_files, scan_total, select_reference, stream_summary,
-        walked_disc_root,
+        ALIGNED_UNIT_BYTES, BdError, BdRom, ClipMeta, ClipSummary, MAX_METADATA_BYTES, MVC_PID,
+        PlaylistFilter, PlaylistSummary, Progress, SOURCE_PACKET_BYTES, ScanMode, ScanProgress,
+        ScanStage, Sink, TsPlaylistFile, TsStreamFile, backup_subdir_files,
+        build_chapter_summaries, build_clip_summaries, build_sorted_streams, clear_measurements,
+        clip_has_50hz_video, clip_stem, collect_backups, has_aacs_key_file, merge_stream,
+        rate_over, read_disc_title, read_file, read_file_capped, resolve_playlist_streams,
+        scan_stream_files, scan_total, select_reference, stream_content_encrypted, stream_summary,
+        unit_shows_encryption, walked_disc_root,
     };
     use crate::bdrom::clpi::TsStreamClip;
     use crate::bdrom::interleaved::{MemBdFile, TsInterleavedFile};
@@ -2932,6 +3049,7 @@ mod tests {
         assert!(bd.is_bd_java);
         assert!(bd.is_dbox);
         assert!(bd.is_psp);
+        assert!(!bd.is_aacs_encrypted); // no AACS/Unit_Key_RO.inf
         assert!(bd.is_50hz);
         // Every extras label, in the fixed presentation order.
         assert_eq!(
@@ -3007,6 +3125,7 @@ mod tests {
         assert!(!bd.is_bd_java); // BDJO empty
         assert!(!bd.is_dbox); // no FilmIndex.xml in the root
         assert!(!bd.is_psp); // SNP has no *.mnv
+        assert!(!bd.is_aacs_encrypted); // no AACS/Unit_Key_RO.inf
         assert!(bd.extra_features().is_empty()); // no flag set, no label
         assert!(!bd.is_50hz); // 24 fps
         assert_eq!(bd.disc_title, None); // META has no bdmt_eng.xml
@@ -3021,6 +3140,294 @@ mod tests {
         assert_eq!(clip0.interleaved_file_size, 0);
         assert_eq!(pl.chapter_count, 0);
         assert_eq!(pl.stream_count, 1);
+    }
+
+    // ── AACS encryption detection ───────────────────────────────────────────
+
+    /// One Aligned Unit: `0x47` at the sync positions `present` selects
+    /// (packet 0 first), `0xAA` everywhere else.
+    fn unit_with_syncs(present: &[bool; 32]) -> [u8; ALIGNED_UNIT_BYTES] {
+        let mut unit = [0xAA_u8; ALIGNED_UNIT_BYTES];
+        for (packet, &sync) in unit.chunks_exact_mut(SOURCE_PACKET_BYTES).zip(present) {
+            if sync && let Some(byte) = packet.get_mut(4) {
+                *byte = 0x47;
+            }
+        }
+        unit
+    }
+
+    /// One Aligned Unit with the exact encryption fingerprint: packet 0's sync
+    /// intact, the other 31 sync positions ciphertext (no chance matches).
+    fn encrypted_unit() -> [u8; ALIGNED_UNIT_BYTES] {
+        let mut present = [false; 32];
+        present[0] = true;
+        unit_with_syncs(&present)
+    }
+
+    /// The first two Aligned Units of an AACS-encrypted stream file.
+    fn encrypted_stream() -> Vec<u8> {
+        [encrypted_unit().as_slice(), encrypted_unit().as_slice()].concat()
+    }
+
+    /// Two clear Aligned Units: all 32 sync bytes in place in each.
+    fn clear_stream() -> Vec<u8> {
+        let unit = unit_with_syncs(&[true; 32]);
+        [unit.as_slice(), unit.as_slice()].concat()
+    }
+
+    #[test]
+    fn the_unit_fingerprint_needs_the_first_sync_and_tolerates_only_stray_ones() {
+        let mut present = [false; 32];
+        present[0] = true;
+        // The exact fingerprint, and up to MAX_STRAY_SYNCS chance matches.
+        assert!(unit_shows_encryption(&unit_with_syncs(&present)));
+        present[7] = true;
+        present[15] = true;
+        present[31] = true;
+        assert!(unit_shows_encryption(&unit_with_syncs(&present)));
+        // One stray past the tolerance is no longer the fingerprint.
+        present[20] = true;
+        assert!(!unit_shows_encryption(&unit_with_syncs(&present)));
+        // Without packet 0's sync nothing reads encrypted, however few strays.
+        present[0] = false;
+        assert!(!unit_shows_encryption(&unit_with_syncs(&present)));
+        assert!(!unit_shows_encryption(&unit_with_syncs(&[false; 32])));
+        // A clear unit shows all 32 syncs — the container guarantee.
+        assert!(!unit_shows_encryption(&unit_with_syncs(&[true; 32])));
+    }
+
+    #[test]
+    fn an_encrypted_disc_sets_the_aacs_flag_without_a_scan_error() {
+        let disc = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF"],
+            &[
+                ("AACS/Unit_Key_RO.inf", Vec::new()),
+                ("BDMV/STREAM/00000.m2ts", encrypted_stream()),
+                ("BDMV/STREAM/00001.m2ts", encrypted_stream()),
+            ],
+        );
+        assert!(disc.open().expect("scan encrypted disc").is_aacs_encrypted);
+        // State only: the resilient sink records nothing for the verdict.
+        let report = BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
+            .expect("resilient scan");
+        assert!(report.bdrom.is_aacs_encrypted);
+        assert!(report.errors.is_empty());
+    }
+
+    #[test]
+    fn the_aacs_marker_matches_case_insensitively_and_one_stream_file_suffices() {
+        let disc = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF"],
+            &[("aacs/UNIT_KEY_RO.INF", Vec::new()), ("BDMV/STREAM/00000.m2ts", encrypted_stream())],
+        );
+        assert!(disc.open().expect("scan encrypted disc").is_aacs_encrypted);
+    }
+
+    #[test]
+    fn a_decrypted_rip_keeping_the_aacs_folder_is_not_encrypted() {
+        // The feature's safety proof: the key file plus clear streams is a
+        // decrypted rip, and it must scan exactly like any clear disc.
+        let disc = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF"],
+            &[
+                ("AACS/Unit_Key_RO.inf", Vec::new()),
+                ("BDMV/STREAM/00000.m2ts", clear_stream()),
+                ("BDMV/STREAM/00001.m2ts", clear_stream()),
+            ],
+        );
+        assert!(!disc.open().expect("scan decrypted rip").is_aacs_encrypted);
+    }
+
+    #[test]
+    fn encrypted_looking_streams_without_the_key_file_stay_unflagged() {
+        // No AACS directory at all…
+        let bare = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF"],
+            &[("BDMV/STREAM/00000.m2ts", encrypted_stream())],
+        );
+        assert!(!bare.open().expect("scan").is_aacs_encrypted);
+        // …and an AACS directory without Unit_Key_RO.inf.
+        let keyless = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF"],
+            &[("AACS/Content000.cer", vec![b'x']), ("BDMV/STREAM/00000.m2ts", encrypted_stream())],
+        );
+        assert!(!keyless.open().expect("scan").is_aacs_encrypted);
+    }
+
+    #[test]
+    fn a_keyed_disc_without_confirmable_stream_content_is_not_encrypted() {
+        // No STREAM directory…
+        let streamless = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF"],
+            &[("AACS/Unit_Key_RO.inf", Vec::new())],
+        );
+        assert!(!streamless.open().expect("scan").is_aacs_encrypted);
+        // …an empty STREAM directory (the all-of-nothing guard)…
+        let empty = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF", "BDMV/STREAM"],
+            &[("AACS/Unit_Key_RO.inf", Vec::new())],
+        );
+        assert!(!empty.open().expect("scan").is_aacs_encrypted);
+        // …and a stream file too short for two Aligned Units.
+        let short = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF"],
+            &[
+                ("AACS/Unit_Key_RO.inf", Vec::new()),
+                ("BDMV/STREAM/00000.m2ts", encrypted_unit().to_vec()),
+            ],
+        );
+        assert!(!short.open().expect("scan").is_aacs_encrypted);
+    }
+
+    #[test]
+    fn any_clear_sample_resolves_to_not_encrypted() {
+        // One encrypted and one clear stream file: mixed content is damage or
+        // a partial rip, never the fingerprint.
+        let mixed = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF"],
+            &[
+                ("AACS/Unit_Key_RO.inf", Vec::new()),
+                ("BDMV/STREAM/00000.m2ts", encrypted_stream()),
+                ("BDMV/STREAM/00001.m2ts", clear_stream()),
+            ],
+        );
+        assert!(!mixed.open().expect("scan").is_aacs_encrypted);
+        // A file whose second Aligned Unit is clear: every sampled unit must
+        // agree, not just the first.
+        let clear_tail = [encrypted_unit(), unit_with_syncs(&[true; 32])].concat();
+        let tailed = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF"],
+            &[("AACS/Unit_Key_RO.inf", Vec::new()), ("BDMV/STREAM/00000.m2ts", clear_tail)],
+        );
+        assert!(!tailed.open().expect("scan").is_aacs_encrypted);
+    }
+
+    #[test]
+    fn the_probe_samples_the_two_largest_stream_files() {
+        // Two feature-sized encrypted files plus a tiny menu stub: the stub is
+        // never sampled, so its short read cannot fail the verdict open.
+        let disc = TempDisc::build(
+            &["BDMV/PLAYLIST", "BDMV/CLIPINF"],
+            &[
+                ("AACS/Unit_Key_RO.inf", Vec::new()),
+                ("BDMV/STREAM/00000.m2ts", encrypted_stream()),
+                ("BDMV/STREAM/00001.m2ts", encrypted_stream()),
+                ("BDMV/STREAM/00002.m2ts", vec![0_u8; 100]),
+            ],
+        );
+        assert!(disc.open().expect("scan").is_aacs_encrypted);
+    }
+
+    #[test]
+    fn equal_sized_samples_are_chosen_by_name_not_listing_order() {
+        let trip = Trip::new(usize::MAX);
+        let mk = |name: &str, bytes: Vec<u8>| MockFile {
+            name: name.to_owned(),
+            extension: ".m2ts".to_owned(),
+            bytes,
+            trip: trip.clone(),
+            fail_read: false,
+        };
+        let four_units = [encrypted_stream(), encrypted_stream()].concat();
+        // Listed out of name order: the sample must be the largest file plus —
+        // by the name tie-break, not listing position — the *clear* 00001, so
+        // the verdict is `false`; sampling by listing order would take the two
+        // encrypted files and read `true`.
+        let stream = MockDir {
+            name: "STREAM".to_owned(),
+            dirs: Vec::new(),
+            files: vec![
+                mk("00000.m2ts", four_units.clone()),
+                mk("00002.m2ts", encrypted_stream()),
+                mk("00001.m2ts", clear_stream()),
+            ],
+            trip: trip.clone(),
+        };
+        assert!(!stream_content_encrypted(&stream));
+        // Largest-first, deterministically: with the sizes distinct and listed
+        // smallest-first, the two largest (encrypted) files win over the short
+        // stub whose sampling would fail the verdict open.
+        let sized = MockDir {
+            name: "STREAM".to_owned(),
+            dirs: Vec::new(),
+            files: vec![
+                mk("00002.m2ts", vec![0_u8; 100]),
+                mk("00001.m2ts", encrypted_stream()),
+                mk("00000.m2ts", four_units),
+            ],
+            trip: trip.clone(),
+        };
+        assert!(stream_content_encrypted(&sized));
+    }
+
+    #[test]
+    fn every_probe_io_failure_reads_as_not_encrypted() {
+        let ok = Trip::new(usize::MAX);
+        let key = |trip: &Trip| MockFile {
+            name: "Unit_Key_RO.inf".to_owned(),
+            extension: ".inf".to_owned(),
+            bytes: Vec::new(),
+            trip: trip.clone(),
+            fail_read: false,
+        };
+        let aacs = |trip: &Trip| MockDir {
+            name: "AACS".to_owned(),
+            dirs: Vec::new(),
+            files: vec![key(&ok)],
+            trip: trip.clone(),
+        };
+        // The root listing fails → no marker.
+        let root = MockDir {
+            name: "disc".to_owned(),
+            dirs: vec![aacs(&ok)],
+            files: Vec::new(),
+            trip: Trip::new(0),
+        };
+        assert!(!has_aacs_key_file(&root));
+        // The AACS directory's file listing fails → no marker.
+        let root = MockDir {
+            name: "disc".to_owned(),
+            dirs: vec![aacs(&Trip::new(0))],
+            files: Vec::new(),
+            trip: ok.clone(),
+        };
+        assert!(!has_aacs_key_file(&root));
+        // The STREAM listing fails → no confirmation.
+        let stream = MockDir {
+            name: "STREAM".to_owned(),
+            dirs: Vec::new(),
+            files: Vec::new(),
+            trip: Trip::new(0),
+        };
+        assert!(!stream_content_encrypted(&stream));
+        // A stream file that cannot open → not encrypted.
+        let unopenable = MockDir {
+            name: "STREAM".to_owned(),
+            dirs: Vec::new(),
+            files: vec![MockFile {
+                name: "00000.m2ts".to_owned(),
+                extension: ".m2ts".to_owned(),
+                bytes: encrypted_stream(),
+                trip: Trip::new(0),
+                fail_read: false,
+            }],
+            trip: ok.clone(),
+        };
+        assert!(!stream_content_encrypted(&unopenable));
+        // A stream file whose reader fails mid-unit → not encrypted.
+        let unreadable = MockDir {
+            name: "STREAM".to_owned(),
+            dirs: Vec::new(),
+            files: vec![MockFile {
+                name: "00000.m2ts".to_owned(),
+                extension: ".m2ts".to_owned(),
+                bytes: encrypted_stream(),
+                trip: ok.clone(),
+                fail_read: true,
+            }],
+            trip: ok,
+        };
+        assert!(!stream_content_encrypted(&unreadable));
     }
 
     // ── orchestration: the truly-minimal disc (None branches) ───────────────
@@ -4225,16 +4632,23 @@ mod tests {
         assert!(total > 12, "expected many io ops, got {total}");
 
         // Failing each successive IO op must surface as an error (never a panic),
-        // walking every `?` propagation arm in `open` and its helpers.
+        // walking every `?` propagation arm in `open` and its helpers. The one
+        // exception is the AACS probe (fail-open by design): a failure it
+        // absorbs must leave the scan identical to the clean one.
+        let mut fail_open = 0_usize;
         for fail_at in 0..total {
             let trip = Trip::new(fail_at);
             // Each injected io failure surfaces as an error (never a panic); the io
             // path only ever yields `BdError::Io`.
-            assert!(
-                BdRom::open(&mock_disc(&trip), ScanMode::Full).is_err(),
-                "io failure at op {fail_at}"
-            );
+            if let Ok(scanned) = BdRom::open(&mock_disc(&trip), ScanMode::Full) {
+                assert_eq!(scanned, bd, "io failure at op {fail_at} altered the scan");
+                fail_open = fail_open.saturating_add(1);
+            }
         }
+        // Exactly the probe's root listing: with no `AACS` directory the probe
+        // short-circuits after one op, so exactly one failure is absorbed — more
+        // would mean the probe kept sampling without its key-file hint.
+        assert_eq!(fail_open, 1);
     }
 
     #[test]
@@ -4689,20 +5103,29 @@ mod tests {
         let total = probe.used();
 
         let mut absorbed = 0_usize;
+        let mut fail_open = 0_usize;
         for fail_at in 0..total {
             let trip = Trip::new(fail_at);
-            // An `Err` is the fatal BDMV/CLIPINF/PLAYLIST block; everything else
-            // must complete with the failure recorded.
+            // An `Err` is the fatal BDMV/CLIPINF/PLAYLIST block; a completed scan
+            // must either record the failure or — only in the fail-open AACS
+            // probe — absorb it with the scan left identical to the clean one.
             if let Ok(report) = BdRom::open_resilient(&mock_disc(&trip), ScanMode::Full) {
-                assert!(
-                    !report.errors.is_empty(),
-                    "io failure at op {fail_at} was swallowed without a record"
-                );
-                absorbed = absorbed.saturating_add(1);
+                if report.errors.is_empty() {
+                    assert_eq!(
+                        report.bdrom, clean.bdrom,
+                        "io failure at op {fail_at} was swallowed and altered the scan"
+                    );
+                    fail_open = fail_open.saturating_add(1);
+                } else {
+                    absorbed = absorbed.saturating_add(1);
+                }
             }
         }
         // Most ops are isolated (only the directory-locating block is fatal).
         assert!(absorbed > total.saturating_div(2), "absorbed {absorbed} of {total}");
+        // Exactly the AACS probe's root listing (no `AACS` directory here, so
+        // the probe short-circuits after one op).
+        assert_eq!(fail_open, 1);
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/report/text.rs
+++ b/crates/bdinfo-rs-core/src/report/text.rs
@@ -944,6 +944,7 @@ mod tests {
             is_3d: false,
             is_50hz: false,
             is_uhd: false,
+            is_aacs_encrypted: false,
             is_bd_plus: false,
             is_bd_java: false,
             is_dbox: false,

--- a/crates/bdinfo-rs-core/src/vfs/udf/source.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/source.rs
@@ -2116,6 +2116,76 @@ mod tests {
         assert!(UdfSource::read_label(&*factory).is_err());
     }
 
+    /// One 6144-byte AACS Aligned Unit (32 source packets of 192 bytes): the
+    /// `0x47` sync byte at every packet's offset 4 when `clear`, at packet 0's
+    /// alone otherwise (the encryption fingerprint), `0xAA` filler elsewhere.
+    fn aligned_unit(clear: bool) -> Vec<u8> {
+        let mut unit = vec![0xAA_u8; 6144];
+        for (index, packet) in unit.chunks_exact_mut(192).enumerate() {
+            if (clear || index == 0)
+                && let Some(byte) = packet.get_mut(4)
+            {
+                *byte = 0x47;
+            }
+        }
+        unit
+    }
+
+    /// Builds a single-physical-partition `.iso` holding a minimal BD-ROM
+    /// layout — `BDMV/{CLIPINF,PLAYLIST,STREAM/00000.m2ts}` plus
+    /// `AACS/Unit_Key_RO.inf` — whose stream file holds two [`aligned_unit`]s.
+    fn bd_iso(clear_streams: bool) -> Vec<u8> {
+        let head = [aligned_unit(clear_streams), aligned_unit(clear_streams)].concat();
+        let mut iso = Iso::new(300);
+        iso.write(256, &avdp(257, 3 * SS as u32));
+        iso.write(257, &pd(0, 260, 50));
+        iso.write(258, &lvd("BDVOL", SS as u32, 1, 0, &phys_map(0), 1));
+        iso.write(261, &fsd(0, 2));
+        // Partition 0 starts at sector 260 (block N → sector 260 + N). Root
+        // dir FE at block 2, its FID data at block 3.
+        let root_fids =
+            dir_data(&[fid(0x0A, "", 2, 0), fid(0x02, "BDMV", 4, 0), fid(0x02, "AACS", 5, 0)]);
+        let root_len = root_fids.len() as u64;
+        iso.write(262, &fe(261, 4, 0, root_len, &sad(0, root_len as u32, 3)));
+        iso.write(263, &root_fids);
+        // BDMV: embedded dir with the three BD children, themselves embedded.
+        let bdmv_fids = dir_data(&[
+            fid(0x0A, "", 4, 0),
+            fid(0x02, "CLIPINF", 6, 0),
+            fid(0x02, "PLAYLIST", 7, 0),
+            fid(0x02, "STREAM", 8, 0),
+        ]);
+        iso.write(264, &fe(261, 4, 3, bdmv_fids.len() as u64, &bdmv_fids));
+        let aacs_fids = dir_data(&[fid(0x0A, "", 5, 0), fid(0x00, "Unit_Key_RO.inf", 9, 0)]);
+        iso.write(265, &fe(261, 4, 3, aacs_fids.len() as u64, &aacs_fids));
+        let clipinf_fids = dir_data(&[fid(0x0A, "", 6, 0)]);
+        iso.write(266, &fe(261, 4, 3, clipinf_fids.len() as u64, &clipinf_fids));
+        let playlist_fids = dir_data(&[fid(0x0A, "", 7, 0)]);
+        iso.write(267, &fe(261, 4, 3, playlist_fids.len() as u64, &playlist_fids));
+        let stream_fids = dir_data(&[fid(0x0A, "", 8, 0), fid(0x00, "00000.m2ts", 10, 0)]);
+        iso.write(268, &fe(261, 4, 3, stream_fids.len() as u64, &stream_fids));
+        // Unit_Key_RO.inf: an empty embedded file (existence is what counts).
+        iso.write(269, &fe(261, 5, 3, 0, b""));
+        // 00000.m2ts: one 12288-byte extent at block 20 (sectors 280..286).
+        iso.write(270, &fe(261, 5, 0, head.len() as u64, &sad(0, head.len() as u32, 20)));
+        iso.write(280, &head);
+        iso.into_bytes()
+    }
+
+    #[test]
+    fn a_bd_iso_reports_aacs_encryption_through_the_udf_backend() {
+        use crate::bdrom::disc::{BdRom, ScanMode};
+        // Encrypted stream heads → the flag is set on the `.iso` backend, with
+        // the marker file and the stream both found through the UDF tree.
+        let encrypted = UdfSource::open(MemIso::boxed(bd_iso(false))).expect("open encrypted iso");
+        let bd = BdRom::open(&encrypted.root(), ScanMode::Metadata).expect("scan encrypted iso");
+        assert!(bd.is_aacs_encrypted);
+        // The same image with clear streams is a decrypted rip: not encrypted.
+        let ripped = UdfSource::open(MemIso::boxed(bd_iso(true))).expect("open ripped iso");
+        let bd = BdRom::open(&ripped.root(), ScanMode::Metadata).expect("scan ripped iso");
+        assert!(!bd.is_aacs_encrypted);
+    }
+
     /// The largest length a 30-bit `short_ad` extent can encode (~1 GiB).
     const MAX_EXTENT: u32 = 0x3FFF_FFFF;
 

--- a/crates/bdinfo-rs-gui/Cargo.lock
+++ b/crates/bdinfo-rs-gui/Cargo.lock
@@ -270,7 +270,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "roxmltree 0.21.1",
  "thiserror 2.0.19",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-gui"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "bdinfo-rs-core",
  "iced",

--- a/crates/bdinfo-rs-gui/Cargo.toml
+++ b/crates/bdinfo-rs-gui/Cargo.toml
@@ -3,7 +3,7 @@ name = "bdinfo-rs-gui"
 # Lock-stepped with the root workspace's version by hand (this independent
 # workspace cannot inherit [workspace.package]); the gui-release.yml tag guard
 # and the gui-publish.yml crates leg both refuse a gui-v* tag that disagrees.
-version = "2.0.0"
+version = "3.0.0"
 edition = "2024"
 rust-version = "1.96"
 license = "LGPL-2.1-or-later"
@@ -53,7 +53,7 @@ path = "src/main.rs"
 # path + version, the same shape as the root [workspace.dependencies] pin, so
 # the crate is publishable: cargo strips the path on publish and resolves the
 # registry copy from the version alone. Keep lock-stepped with `version` above.
-bdinfo-rs-core = { path = "../bdinfo-rs-core", version = "2.0.0" }
+bdinfo-rs-core = { path = "../bdinfo-rs-core", version = "3.0.0" }
 # Pure-Rust GUI: wgpu (+ tiny-skia CPU fallback) / cosmic-text / winit. No C.
 # `tokio` makes iced's executor a Tokio runtime — the ambient context zbus's
 # tokio backend (forced tree-wide by rfd below; cargo features are additive)

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -977,6 +977,7 @@ mod tests {
             is_3d: false,
             is_50hz: false,
             is_uhd: false,
+            is_aacs_encrypted: false,
             is_bd_plus: false,
             is_bd_java: false,
             is_dbox: false,

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -3424,6 +3424,7 @@ mod harness {
                 is_3d: false,
                 is_50hz: false,
                 is_uhd: false,
+                is_aacs_encrypted: false,
                 is_bd_plus: false,
                 is_bd_java: false,
                 is_dbox: false,

--- a/crates/bdinfo-rs-wasm/Cargo.lock
+++ b/crates/bdinfo-rs-wasm/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "roxmltree",
  "thiserror",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-wasm"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "bdinfo-rs-core",
  "js-sys",

--- a/crates/bdinfo-rs-wasm/Cargo.toml
+++ b/crates/bdinfo-rs-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdinfo-rs-wasm"
-version = "2.0.0"
+version = "3.0.0"
 publish = false
 edition = "2024"
 rust-version = "1.96"

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -814,6 +814,10 @@ impl Disc {
             is_3d: self.is_3d,
             is_50hz: self.is_50hz,
             is_uhd: self.is_uhd,
+            // The mirror does not carry the AACS flag yet, so the rebuild
+            // defaults it — the same degrade-until-mirrored rule the unknown
+            // scan-error kinds follow (see [`ScanErrorKind`]).
+            is_aacs_encrypted: false,
             is_bd_plus: self.is_bd_plus,
             is_bd_java: self.is_bd_java,
             is_dbox: self.is_dbox,
@@ -1435,6 +1439,7 @@ mod tests {
             is_3d: true,
             is_50hz: false,
             is_uhd: true,
+            is_aacs_encrypted: false,
             is_bd_plus: false,
             is_bd_java: true,
             is_dbox: false,

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -45,9 +45,13 @@
 //! Exit codes: `0` success (a bare invocation prints the help and lands here
 //! too), `1` malformed/not a BD structure or no matching playlist, `2` no such
 //! path / unusable `REPORT_DEST` / unwritable report file / an invalid
-//! argument, `3` completed with errors (a partial report was written), `130`
-//! scan cancelled by Ctrl+C (the Unix `128 + SIGINT` spelling, used on every
-//! platform; no report is written).
+//! argument, `3` completed with errors (a partial report was written), `4`
+//! AACS-encrypted disc — the scan is refused up front (no picker, no scan, no
+//! report file), since only ciphertext would be measured; `--list` still
+//! works, its output being entirely database-derived, and exits by its own
+//! rules with the same stderr notice, `130` scan cancelled by Ctrl+C (the
+//! Unix `128 + SIGINT` spelling, used on every platform; no report is
+//! written).
 //!
 //! Ctrl+C during the packet scan, on the styled (ANSI-terminal) progress
 //! path, cancels cooperatively: the terminal is put in raw mode for the scan
@@ -286,6 +290,18 @@ fn run(cli: &Cli) -> u8 {
                 return 1;
             }
         };
+    if bdrom.is_aacs_encrypted {
+        // One dry notice on stderr either way; only `--list` continues — its
+        // output is entirely database-derived, so it is correct on an
+        // encrypted disc, while a measured scan would demux ciphertext.
+        eprintln!(
+            "Disc is AACS-encrypted: stream data cannot be analyzed. Playlists can still be \
+             listed with --list."
+        );
+        if !cli.list {
+            return EXIT_ENCRYPTED;
+        }
+    }
 
     let selection: Vec<String> = if cli.mpls.is_empty() {
         // Every mode but `--mpls` starts from the playlist table, over the
@@ -407,6 +423,12 @@ fn scan_and_report(
 /// from `3` (scan errors) and recognizable everywhere — it carries no special
 /// meaning on Windows but is documented in the crate docs' exit-code list.
 const EXIT_CANCELLED: u8 = 130;
+
+/// The AACS-refusal exit code: the disc opened fine but its stream content is
+/// encrypted ([`BdRom::is_aacs_encrypted`]), so the measured scan was refused
+/// before any selection. Distinct from `1` (the disc did not open) and `3`
+/// (the disc was scanned, with damage).
+const EXIT_ENCRYPTED: u8 = 4;
 
 /// The Ctrl+C interception decision for one observed press.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1190,6 +1212,22 @@ mod tests {
             bd
         }
 
+        /// [`with_item_playlist`](Self::with_item_playlist) turned into an
+        /// AACS-encrypted disc: the `AACS/Unit_Key_RO.inf` key file plus the
+        /// stream file rewritten as two encrypted Aligned Units.
+        fn with_encrypted_stream() -> Self {
+            let bd = Self::with_item_playlist();
+            std::fs::create_dir_all(bd.root.join("AACS")).expect("create AACS");
+            std::fs::write(bd.root.join("AACS").join("Unit_Key_RO.inf"), [])
+                .expect("write key file");
+            std::fs::write(
+                bd.root.join("BDMV").join("STREAM").join("00000.m2ts"),
+                encrypted_m2ts(),
+            )
+            .expect("write m2ts");
+            bd
+        }
+
         /// The folder's expected report-file path (the default `REPORT_DEST`
         /// is the disc folder; the label is the directory name).
         fn report_file(&self) -> PathBuf {
@@ -1241,6 +1279,16 @@ mod tests {
         buf.extend_from_slice(&[0_u8; 4]); // PlayListMark length
         buf.extend_from_slice(&0_u16.to_be_bytes()); // zero marks
         buf
+    }
+
+    /// Two AACS-encrypted 6144-byte Aligned Units: in each, only packet 0's
+    /// `0x47` sync byte (offset 4, inside the unit's 16 cleartext bytes)
+    /// survives; the other 31 packets' sync positions read ciphertext (`0xAA`).
+    fn encrypted_m2ts() -> Vec<u8> {
+        let mut unit = vec![0xAA_u8; 4];
+        unit.push(0x47);
+        unit.resize(6144, 0xAA);
+        [unit.clone(), unit].concat()
     }
 
     /// A valid `*.clpi` declaring one AVC 1080p video stream at PID 0x1011.
@@ -1538,6 +1586,40 @@ mod tests {
         let path = bd.root.to_string_lossy().into_owned();
         assert_eq!(run_args(&[&path, "--whole"]), 3);
         // The (partial) report is still written.
+        assert!(bd.report_file().is_file());
+    }
+
+    #[test]
+    fn an_encrypted_disc_refuses_every_scanning_mode_with_exit_4() {
+        let bd = TempBd::with_encrypted_stream();
+        let path = bd.root.to_string_lossy().into_owned();
+        // The default (picker), `--whole`, and `--mpls` modes all refuse
+        // before any table, picker, or scan.
+        assert_eq!(run_args(&[&path]), 4);
+        assert_eq!(run_args(&[&path, "--whole"]), 4);
+        assert_eq!(run_args(&[&path, "--mpls", "00000"]), 4);
+        assert!(!bd.report_file().exists(), "no report is written");
+    }
+
+    #[test]
+    fn list_still_works_on_an_encrypted_disc() {
+        // `--list` output is entirely database-derived, so it stays correct
+        // and keeps its own exit rules on an encrypted disc.
+        let bd = TempBd::with_encrypted_stream();
+        let path = bd.root.to_string_lossy().into_owned();
+        assert_eq!(run_args(&[&path, "--list"]), 0);
+        assert!(!bd.report_file().exists());
+    }
+
+    #[test]
+    fn a_leftover_aacs_folder_with_clear_streams_refuses_nothing() {
+        // A decrypted rip that kept the key file: the content probe resolves
+        // to "not encrypted" and the scan runs to a report.
+        let bd = TempBd::with_item_playlist();
+        std::fs::create_dir_all(bd.root.join("AACS")).expect("create AACS");
+        std::fs::write(bd.root.join("AACS").join("Unit_Key_RO.inf"), []).expect("write key file");
+        let path = bd.root.to_string_lossy().into_owned();
+        assert_eq!(run_args(&[&path, "--whole"]), 0);
         assert!(bd.report_file().is_file());
     }
 

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -13,7 +13,7 @@
 
 pub mod common;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use common::{bdinfo_rs, real_fixture};
 
@@ -251,7 +251,7 @@ fn filtered_bd(tag: &str) -> PathBuf {
 }
 
 /// The default report file for a disc folder: `BDINFO.{dir name}.txt` inside it.
-fn report_file(root: &std::path::Path) -> PathBuf {
+fn report_file(root: &Path) -> PathBuf {
     let label = root.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default();
     root.join(format!("BDINFO.{label}.txt"))
 }
@@ -407,7 +407,7 @@ fn list_prints_the_playlist_table_and_exits() {
     clippy::expect_used,
     reason = "end-to-end test driver; a failed spawn should abort the test loudly"
 )]
-fn listing(disc: &std::path::Path, switches: &[&str]) -> String {
+fn listing(disc: &Path, switches: &[&str]) -> String {
     let mut args = vec![disc.to_string_lossy().into_owned(), "--list".to_owned()];
     args.extend(switches.iter().map(|&s| s.to_owned()));
     let output = bdinfo_rs().args(&args).output().expect("spawn bdinfo-rs");
@@ -658,7 +658,7 @@ fn a_subcommand_style_invocation_is_just_a_bad_path() {
 /// Scan `disc` with `-m 00000` into a fresh temp dest and return the report it
 /// writes as `BDINFO.{label}.txt`. `label` is the disc label the scan derives: a
 /// folder takes its directory name, an `.iso` its UDF volume label.
-fn scan_report(disc: &std::path::Path, label: &str, tag: &str) -> String {
+fn scan_report(disc: &Path, label: &str, tag: &str) -> String {
     scan_report_with(disc, label, tag, &[])
 }
 
@@ -667,7 +667,7 @@ fn scan_report(disc: &std::path::Path, label: &str, tag: &str) -> String {
     clippy::expect_used,
     reason = "end-to-end test driver; a failed spawn / read / decode should abort the test loudly"
 )]
-fn scan_report_with(disc: &std::path::Path, label: &str, tag: &str, switches: &[&str]) -> String {
+fn scan_report_with(disc: &Path, label: &str, tag: &str, switches: &[&str]) -> String {
     let dest = std::env::temp_dir().join(format!("bdinfo-rs-real-{tag}-{}", std::process::id()));
     std::fs::create_dir_all(&dest).expect("create dest");
     let output = bdinfo_rs()
@@ -759,6 +759,111 @@ fn a_real_whole_folder_scan_matches_the_golden_byte_for_byte() {
         include_str!("fixtures/golden/folder.txt"),
         "the default `--whole` selection drifted from the `-m 00000` golden"
     );
+}
+
+// --- AACS-encrypted discs: the refusal, `--list`, and the decrypted-rip pin ---
+
+/// Copies the committed `BigBuckBunny` folder fixture to a fresh temp disc
+/// root still named `BigBuckBunny` — the folder-derived disc label, and with
+/// it the report's name and bytes, must not change. Returns the copy's root
+/// and the parent to remove for cleanup.
+#[expect(
+    clippy::expect_used,
+    reason = "end-to-end test driver; a failed copy should abort the test loudly"
+)]
+fn copy_fixture(tag: &str) -> (PathBuf, PathBuf) {
+    fn copy_tree(from: &Path, to: &Path) {
+        std::fs::create_dir_all(to).expect("create copy dir");
+        for entry in std::fs::read_dir(from).expect("list fixture") {
+            let entry = entry.expect("fixture entry");
+            let target = to.join(entry.file_name());
+            if entry.file_type().expect("entry type").is_dir() {
+                copy_tree(&entry.path(), &target);
+            } else {
+                std::fs::copy(entry.path(), &target).expect("copy fixture file");
+            }
+        }
+    }
+    let parent = std::env::temp_dir().join(format!("bdinfo-rs-aacs-{tag}-{}", std::process::id()));
+    let root = parent.join("BigBuckBunny");
+    copy_tree(&real_fixture("BigBuckBunny"), &root);
+    (root, parent)
+}
+
+/// Stamps the copied disc with the AACS marker: an *empty*
+/// `AACS/Unit_Key_RO.inf`, zero bytes so the report's disc-size line — and
+/// with it every report byte — is unchanged.
+#[expect(
+    clippy::expect_used,
+    reason = "end-to-end test driver; a failed write should abort the test loudly"
+)]
+fn add_aacs_marker(root: &Path) {
+    std::fs::create_dir_all(root.join("AACS")).expect("create AACS");
+    std::fs::write(root.join("AACS").join("Unit_Key_RO.inf"), []).expect("write key file");
+}
+
+/// Rewrites the stream file the way AACS encryption leaves it: every
+/// 6144-byte Aligned Unit keeps its first 16 bytes cleartext, the rest
+/// becomes ciphertext-like filler.
+#[expect(
+    clippy::expect_used,
+    reason = "end-to-end test driver; a failed rewrite should abort the test loudly"
+)]
+fn encrypt_stream(root: &Path) {
+    let path = root.join("BDMV").join("STREAM").join("00000.m2ts");
+    let mut bytes = std::fs::read(&path).expect("read the stream file");
+    for unit in bytes.chunks_mut(6144) {
+        for byte in unit.iter_mut().skip(16) {
+            *byte = 0xAA;
+        }
+    }
+    std::fs::write(&path, bytes).expect("write the encrypted stream");
+}
+
+#[test]
+fn a_decrypted_rip_with_a_leftover_aacs_folder_matches_the_golden_byte_for_byte() {
+    // The feature's safety pin at the report level: the AACS key file over
+    // clear streams (a decrypted rip) changes not one byte of the report.
+    let (root, parent) = copy_fixture("rip");
+    add_aacs_marker(&root);
+    let got = scan_report(&root, "BigBuckBunny", "ripdest");
+    let _ = std::fs::remove_dir_all(&parent).is_ok();
+    assert_eq!(
+        got,
+        include_str!("fixtures/golden/folder.txt"),
+        "a decrypted rip's report drifted from the clear-disc golden"
+    );
+}
+
+#[test]
+fn an_encrypted_disc_refuses_the_scan_with_exit_4_and_a_notice() {
+    let (root, parent) = copy_fixture("enc");
+    add_aacs_marker(&root);
+    encrypt_stream(&root);
+    let output =
+        bdinfo_rs().args([root.as_os_str(), "-w".as_ref()]).output().expect("spawn bdinfo-rs");
+    let wrote_report = root.join("BDINFO.BigBuckBunny.txt").exists();
+    let _ = std::fs::remove_dir_all(&parent).is_ok();
+    assert_eq!(output.status.code(), Some(4), "the refusal has its own exit code");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("AACS-encrypted"), "the notice names the cause: {stderr}");
+    assert!(stderr.contains("--list"), "the notice points at --list: {stderr}");
+    assert!(!wrote_report, "a refused scan writes no report file");
+}
+
+#[test]
+fn list_on_an_encrypted_disc_prints_the_table_with_the_notice() {
+    let (root, parent) = copy_fixture("enclist");
+    add_aacs_marker(&root);
+    encrypt_stream(&root);
+    let output =
+        bdinfo_rs().args([root.as_os_str(), "--list".as_ref()]).output().expect("spawn bdinfo-rs");
+    let _ = std::fs::remove_dir_all(&parent).is_ok();
+    assert_eq!(output.status.code(), Some(0), "--list keeps its own exit rules");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("1   1      00000.MPLS"), "the table still lists: {stdout}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("AACS-encrypted"), "the notice still prints: {stderr}");
 }
 
 #[test]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -270,7 +270,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "roxmltree 0.21.1",
  "thiserror 2.0.19",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-gui"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "bdinfo-rs-core",
  "iced",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-wasm"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "bdinfo-rs-core",
  "js-sys",


### PR DESCRIPTION
Core detects AACS encryption at open and exposes it as queryable state; the CLI refuses the pointless measured scan up front.

Detection (BdRom::is_aacs_encrypted, set during open on both VFS backends):

- Hint: AACS/Unit_Key_RO.inf exists at the disc root, matched case-insensitively (AACS BD Prerecorded Book 0.953, section 3.9.3). Decrypted rips routinely keep this folder, so the hint alone proves nothing.
- Confirmation: the two largest stream files' first two 6144-byte Aligned Units must each show the encryption fingerprint - packet 0's 0x47 sync byte intact (only the unit's first 16 bytes stay cleartext under AACS) with at most 3 of the remaining 31 sync positions matching by ciphertext chance.
- Fail-open: any other pattern - IO error, short file, all-garbage, mixed content - resolves to "not encrypted" and stays with the existing damaged-disc machinery. A decrypted rip with a leftover AACS folder scans byte-identically to a clear disc, pinned against the committed golden report.

The verdict is state, not an error: nothing enters the scan-error sink, the report renderer is untouched, and the measured scan remains fully functional for callers that run it anyway.

CLI: after the metadata scan an encrypted disc prints one stderr notice and exits with the dedicated code 4 - no table, no picker, no scan, no report file. --list keeps working (its output is entirely database-derived) accompanied by the same notice, keeping its own exit rules. The exit-code list in the crate docs now reads 0/1/2/3/4/130.

Breaking: BdRom gains a public field, so external struct literals must name it. The workspace version moves to 3.0.0 with the wasm and GUI crates lock-stepped; the wasm mirror rebuilds the flag as false until it gains a typed member of its own (a follow-up owns that).

Tests: fingerprint boundary units; folder and UDF iso fixtures covering encrypted, keyless, streamless, short, mixed and decrypted-rip cases; fault injection over every probe IO arm; CLI unit tests for exit 4 and --list; end-to-end integration tests including the byte-identical rip golden.
