### PR TITLE
feat(wasm): expose the encrypted-disc flag in the structured API

### DIFF
--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -93,7 +93,7 @@ pub struct ScanResult {
 #[serde(rename_all = "camelCase")]
 #[expect(
     clippy::struct_excessive_bools,
-    reason = "seven independent disc properties (3D/50Hz/UHD/BD+/BD-Java/D-BOX/PSP) plus the scan-mode flag, not a state machine"
+    reason = "eight independent disc properties (3D/50Hz/UHD/AACS/BD+/BD-Java/D-BOX/PSP) plus the scan-mode flag, not a state machine"
 )]
 pub struct Disc {
     /// The disc volume label. For a disc image this is the volume identifier
@@ -117,6 +117,18 @@ pub struct Disc {
     /// Whether the disc is 4K UHD: the `INDX0300` version magic in
     /// `index.bdmv`.
     pub is_uhd: bool,
+    /// Whether the disc's stream content is AACS-encrypted: the disc root
+    /// carries the `AACS/Unit_Key_RO.inf` key file and the sampled stream heads
+    /// show the AACS encryption fingerprint.
+    ///
+    /// Data, not an error: the scanning calls return the disc either way and
+    /// never throw for it. Everything structural — playlists, streams as the
+    /// disc declares them, chapters — is read from cleartext metadata and is
+    /// correct. What no key can be recovered for is the stream content, so a
+    /// measured scan of an encrypted disc demuxes ciphertext and every value it
+    /// measures is meaningless. Deciding what to do about that — refuse the
+    /// measured scan, warn, or scan anyway — is the consumer's policy.
+    pub is_aacs_encrypted: bool,
     /// Whether the disc carries BD+ copy protection: a `BDSVM`, `SLYVM` or
     /// `ANYVM` directory.
     pub is_bd_plus: bool,
@@ -537,6 +549,7 @@ impl Disc {
             is_3d: bdrom.is_3d,
             is_50hz: bdrom.is_50hz,
             is_uhd: bdrom.is_uhd,
+            is_aacs_encrypted: bdrom.is_aacs_encrypted,
             is_bd_plus: bdrom.is_bd_plus,
             is_bd_java: bdrom.is_bd_java,
             is_dbox: bdrom.is_dbox,
@@ -814,10 +827,7 @@ impl Disc {
             is_3d: self.is_3d,
             is_50hz: self.is_50hz,
             is_uhd: self.is_uhd,
-            // The mirror does not carry the AACS flag yet, so the rebuild
-            // defaults it — the same degrade-until-mirrored rule the unknown
-            // scan-error kinds follow (see [`ScanErrorKind`]).
-            is_aacs_encrypted: false,
+            is_aacs_encrypted: self.is_aacs_encrypted,
             is_bd_plus: self.is_bd_plus,
             is_bd_java: self.is_bd_java,
             is_dbox: self.is_dbox,
@@ -1215,6 +1225,7 @@ mod tests {
             is_3d: true,
             is_50hz: false,
             is_uhd: true,
+            is_aacs_encrypted: true,
             is_bd_plus: false,
             is_bd_java: true,
             is_dbox: false,
@@ -1235,6 +1246,7 @@ mod tests {
             "is3d": true,
             "is50hz": false,
             "isUhd": true,
+            "isAacsEncrypted": true,
             "isBdPlus": false,
             "isBdJava": true,
             "isDbox": false,
@@ -1264,6 +1276,26 @@ mod tests {
         assert_eq!(wire.get("discTitle"), Some(&Value::Null));
         let back: Disc = serde_json::from_value(wire).expect("deserialize a disc with no title");
         assert_eq!(back, disc);
+    }
+
+    #[test]
+    fn the_encrypted_flag_crosses_and_rebuilds_at_both_values() {
+        // Both values, both directions. The whole-fields fixtures pin the flag
+        // set; an unencrypted disc is the value a consumer sees on nearly every
+        // disc, and mirroring it as a constant either way would be invisible
+        // there.
+        for encrypted in [false, true] {
+            let bdrom = BdRom { is_aacs_encrypted: encrypted, ..a_core_bdrom() };
+            let disc = Disc::from_scan(&bdrom, &[], false, &PlaylistFilter::default());
+            assert_eq!(disc.is_aacs_encrypted, encrypted);
+
+            let wire = serde_json::to_value(&disc).expect("serialize the mirror");
+            assert_eq!(wire.get("isAacsEncrypted"), Some(&Value::Bool(encrypted)));
+
+            let back: Disc = serde_json::from_value(wire).expect("deserialize the mirror");
+            assert_eq!(back, disc);
+            assert_eq!(back.into_scan().0.is_aacs_encrypted, encrypted);
+        }
     }
 
     #[test]
@@ -1439,7 +1471,7 @@ mod tests {
             is_3d: true,
             is_50hz: false,
             is_uhd: true,
-            is_aacs_encrypted: false,
+            is_aacs_encrypted: true,
             is_bd_plus: false,
             is_bd_java: true,
             is_dbox: false,

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -102,6 +102,13 @@ side.
 measured value — bitrates, packet counts, chapter rates — is zero because
 nothing measured it; `true` after `scan`, where a zero is a genuine zero.
 
+`disc.isAacsEncrypted` says the disc's stream content is AACS-encrypted. Neither
+call throws for it: the structure — playlists, streams as the disc declares
+them, chapters — comes from cleartext metadata and is correct either way. Only
+the stream content is unreadable, so a measured `scan` of such a disc demuxes
+ciphertext and every value it measures is meaningless. What to do about that is
+yours to decide; the demo tells the user and offers no measured scan.
+
 ### Re-rendering the report
 
 The model carries **every value the report prints**, so `renderReport(disc)`

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -822,6 +822,11 @@
               </div>
             </div>
           </div>
+          <p class="hint" id="encrypted-note" hidden>
+            This disc is AACS-encrypted — its stream data cannot be analyzed, so
+            the measured scan is unavailable. Everything above is read from the
+            disc's own metadata and is correct.
+          </p>
           <p class="hint" id="hidden-hint" hidden></p>
           <div class="card-foot">
             <span class="muted" id="sel-count">0 selected</span>

--- a/crates/bdinfo-rs-wasm/web/package-lock.json
+++ b/crates/bdinfo-rs-wasm/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bdinfo-rs/wasm",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bdinfo-rs/wasm",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "LGPL-2.1-or-later",
       "devDependencies": {
         "@biomejs/biome": "^2",

--- a/crates/bdinfo-rs-wasm/web/package.json
+++ b/crates/bdinfo-rs-wasm/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bdinfo-rs/wasm",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "type": "module",
   "sideEffects": [
     "./dist/worker.js",

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -124,6 +124,7 @@ const optChapters = el<HTMLInputElement>("opt-chapters");
 const optDiagnostics = el<HTMLInputElement>("opt-diagnostics");
 const optSummary = el<HTMLInputElement>("opt-summary");
 const hiddenHint = el("hidden-hint");
+const encryptedNote = el("encrypted-note");
 
 /** The picked disc — a `webkitdirectory` BDMV folder, or a single `.iso`. */
 type Source =
@@ -354,6 +355,7 @@ async function loadSource(src: Source): Promise<void> {
   hide(progressCard);
   hide(playlistsCard);
   hide(discardNote);
+  hide(encryptedNote);
   show(listingBox);
   // A fresh pick discards everything held for the previous one.
   scanController?.abort();
@@ -403,7 +405,19 @@ function adoptDisc(next: Disc, threshold: number): void {
   discThreshold = threshold;
   playlists = next.playlists;
   allRows = playlistRows(next.playlists);
+  encryptedNote.hidden = !next.isAacsEncrypted;
   renderRows();
+}
+
+/**
+ * Whether the measured scan is offered: never for an AACS-encrypted disc, whose
+ * stream data is ciphertext, so every value the scan would measure is
+ * meaningless. The page still lists it — the structure comes from cleartext
+ * metadata and is correct. The library imposes no such policy; this is the
+ * demo's, and the desktop app's.
+ */
+function scanOffered(): boolean {
+  return disc !== null && !disc.isAacsEncrypted;
 }
 
 /**
@@ -646,7 +660,7 @@ function updateSelection(): void {
     }
   }
   selCount.textContent = `${count} selected`;
-  scanBtn.disabled = count === 0;
+  scanBtn.disabled = count === 0 || !scanOffered();
 }
 
 function selectedNames(): string[] {
@@ -772,7 +786,7 @@ function showReport(text: string): void {
 }
 
 async function runScan(): Promise<void> {
-  if (source === null) {
+  if (source === null || !scanOffered()) {
     return;
   }
   const selection = selectedNames();
@@ -825,7 +839,7 @@ async function runScan(): Promise<void> {
   } finally {
     scanController = null;
     hide(progressCard);
-    scanBtn.disabled = selectedNames().length === 0;
+    scanBtn.disabled = selectedNames().length === 0 || !scanOffered();
   }
   // A report switch flipped while the scan ran was deferred (the disc it would
   // have rendered was about to be replaced); one cheap re-render catches up,


### PR DESCRIPTION
Prompt 02 gave core a queryable AACS verdict. This mirrors it into the browser package.

The structured Disc gains a typed isAacsEncrypted field, replacing the compile shim the rebuild carried, so the mirror is lossless again and a consumer decides its own treatment. The scanning calls still never throw for an encrypted disc: the structure is read from cleartext metadata and is correct either way, and only the measured values would be meaningless.

Round-trip parity covers the field at both values, in both directions, on top of the whole-fields fixtures.

The demo applies the same policy the desktop app will: a notice under the playlist table, and no measured scan offered.

Also lock-steps web/package.json to 3.0.0. The crates moved to 3.0.0 in #246 while the package stayed at 2.0.0, and publish-npm.yml refuses to publish when the tag base and the package version disagree.