### PR TITLE
feat(gui): flag encrypted discs and disable the scan

### DIFF
--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -811,18 +811,19 @@ impl Flow {
     }
 
     /// Whether the loaded disc's stream content is AACS-encrypted — the
-    /// encrypted-disc indicator in the info box, and the reason the measured
-    /// scan is refused ([`Listing::scannable`]).
+    /// encrypted-disc indicator in the info box, and the reason
+    /// [`can_scan`](Self::can_scan) is false for a disc that lists perfectly
+    /// well.
     #[must_use]
     pub fn disc_encrypted(&self) -> bool {
         self.any_listing().is_some_and(|listing| listing.bdrom.is_aacs_encrypted)
     }
 
-    /// Whether a measured scan can start now — an editable state over a
-    /// [scannable](Listing::scannable) disc. The selection may be empty:
-    /// scanning with nothing checked scans the whole disc (`BDInfo`'s
-    /// behaviour), so the "Scan Bitrates" button is live as soon as a disc is
-    /// listed.
+    /// Whether a measured scan can start now — an editable state holding a disc
+    /// with at least one listed playlist that is not
+    /// [encrypted](Self::disc_encrypted). The selection may be empty: scanning
+    /// with nothing checked scans the whole disc (`BDInfo`'s behaviour), so the
+    /// "Scan Bitrates" button is live as soon as a disc is listed.
     #[must_use]
     pub fn can_scan(&self) -> bool {
         self.editable_listing().is_some_and(Listing::scannable)

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -161,6 +161,18 @@ impl Listing {
         self.rows = rows;
     }
 
+    /// Whether a measured scan of this disc is worth running: it has at least
+    /// one listed playlist, and its stream content is not AACS-encrypted.
+    ///
+    /// Encryption leaves only the first 16 bytes of each 6144-byte Aligned Unit
+    /// in the clear (AACS Blu-ray Prerecorded Book §3.10), so a demux of the
+    /// rest reads ciphertext and every value it measures is meaningless. The
+    /// core scan runs on such a disc if asked — refusing is this application's
+    /// policy, and the CLI applies the same one.
+    const fn scannable(&self) -> bool {
+        !self.rows.is_empty() && !self.bdrom.is_aacs_encrypted
+    }
+
     /// The playlists the **settings'** filter withholds — what the
     /// hidden-count line reports whether or not the transient reveal is on
     /// (with it on, the line names what restoring the settings view would
@@ -798,22 +810,32 @@ impl Flow {
         self.any_listing().is_some_and(|listing| listing.selection.all())
     }
 
-    /// Whether a measured scan can start now — an editable state with at least one
-    /// listed playlist. The selection may be empty: scanning with nothing checked
-    /// scans the whole disc (`BDInfo`'s behaviour), so the "Scan Bitrates" button
-    /// is live as soon as a disc is listed.
+    /// Whether the loaded disc's stream content is AACS-encrypted — the
+    /// encrypted-disc indicator in the info box, and the reason the measured
+    /// scan is refused ([`Listing::scannable`]).
+    #[must_use]
+    pub fn disc_encrypted(&self) -> bool {
+        self.any_listing().is_some_and(|listing| listing.bdrom.is_aacs_encrypted)
+    }
+
+    /// Whether a measured scan can start now — an editable state over a
+    /// [scannable](Listing::scannable) disc. The selection may be empty:
+    /// scanning with nothing checked scans the whole disc (`BDInfo`'s
+    /// behaviour), so the "Scan Bitrates" button is live as soon as a disc is
+    /// listed.
     #[must_use]
     pub fn can_scan(&self) -> bool {
-        self.editable_listing().is_some_and(|listing| !listing.rows.is_empty())
+        self.editable_listing().is_some_and(Listing::scannable)
     }
 
     /// The measured-scan request, when [`Flow::can_scan`]. Scans the checked
     /// playlists, or — when nothing is checked — every listed playlist (scan-all).
     #[must_use]
     pub fn scan_request(&self) -> Option<ScanRequest> {
-        // The same gate as can_scan, through one fallible read: an editable
-        // listing with at least one row.
-        let listing = self.editable_listing().filter(|listing| !listing.rows.is_empty())?;
+        // The same gate as can_scan, through one fallible read — so a scan
+        // message that reaches `update` without the button (a stale event, a
+        // future shortcut) is refused on exactly the same terms.
+        let listing = self.editable_listing().filter(|listing| listing.scannable())?;
         let selection = listing.scan_names();
         let scan_files = selection_stream_files(&listing.bdrom.playlists, &selection);
         Some(ScanRequest {
@@ -1218,6 +1240,33 @@ mod tests {
         let one = flow.scan_request().expect("a request once a row is checked");
         assert_eq!(one.selection, ["00000.MPLS"]);
         assert_eq!(one.scan_files.into_iter().collect::<Vec<_>>(), ["A.M2TS"]);
+    }
+
+    #[test]
+    fn an_encrypted_disc_lists_but_never_scans() {
+        // The same two-playlist disc, encrypted: it lists, browses and reports
+        // structurally exactly as the plain one does…
+        let mut structural = structural();
+        structural.bdrom.is_aacs_encrypted = true;
+        let mut flow =
+            Flow::start_listing(input()).listed(&input(), Ok(structural), ViewSettings::default());
+        assert!(flow.disc_encrypted());
+        assert_eq!(flow.row_count(), 2);
+        assert!(flow.editable());
+        assert!(flow.report_available());
+        // …and the measured scan is refused, checked rows or not.
+        assert!(!flow.can_scan());
+        assert!(flow.scan_request().is_none());
+        flow.select_all();
+        assert!(!flow.can_scan());
+        assert!(flow.scan_request().is_none());
+        // The plain disc is the control: same rows, scan available.
+        let plain = listed();
+        assert!(!plain.disc_encrypted());
+        assert!(plain.can_scan());
+        assert!(plain.scan_request().is_some());
+        // A state with no disc reports neither.
+        assert!(!Flow::idle().disc_encrypted());
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -3667,7 +3667,9 @@ mod interaction {
     use bdinfo_rs_gui::model::{Sort, SortColumn};
     use bdinfo_rs_gui::theme::ThemePref;
 
-    use super::harness::{bounds, click, encrypted_app, filtered_app, listed_app, sees, structural};
+    use super::harness::{
+        bounds, click, encrypted_app, filtered_app, listed_app, sees, structural,
+    };
     use super::{App, ENCRYPTED_BADGE, Message};
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -2383,7 +2383,20 @@ impl App {
             lines = lines.push(text(HIDDEN_NOTE).size(ui::TEXT_XS).color(p.text_muted));
         }
 
-        container(lines)
+        // The indicator takes the slack the strip already has to the right of
+        // its lines, so it costs no layout: the lines keep the full width they
+        // draw in (each is `Shrink`-wide and never wraps, so a narrower column
+        // does not move them), and the badge is one `TEXT_XS` line tall — the
+        // height of the line it sits beside — so the strip does not grow. A
+        // disc with the badge and the same disc without it are pixel-identical
+        // everywhere but the badge itself.
+        let mut strip = Row::new().width(Length::Fill).align_y(Vertical::Top).spacing(ui::GAP_3);
+        strip = strip.push(lines);
+        if self.flow.disc_encrypted() {
+            strip = strip.push(encrypted_badge(p));
+        }
+
+        container(strip)
             .width(Length::Fill)
             .padding([ui::GAP_2, ui::GAP_3])
             .style(ui::info_strip(p))
@@ -2531,14 +2544,21 @@ impl App {
                 .on_press(Message::Cancel)
                 .into()
         } else {
+            let scan = button(text("Scan Bitrates").size(ui::TEXT_SM).font(ui::UI_SEMIBOLD))
+                .padding([ui::GAP_2, ui::GAP_4])
+                .style(ui::primary_button(p))
+                .on_press_maybe(self.flow.can_scan().then_some(Message::ScanSelected));
+            // An encrypted disc leaves the button in place and dead — the same
+            // greyed control every other unavailable action shows — and says
+            // why on hover rather than in a dialog the user has to dismiss.
+            let scan: Element<'_, Message> = if self.flow.disc_encrypted() {
+                tooltip(scan, encrypted_bubble(p), tooltip::Position::Top).into()
+            } else {
+                scan.into()
+            };
             Row::new()
                 .spacing(ui::GAP_2)
-                .push(
-                    button(text("Scan Bitrates").size(ui::TEXT_SM).font(ui::UI_SEMIBOLD))
-                        .padding([ui::GAP_2, ui::GAP_4])
-                        .style(ui::primary_button(p))
-                        .on_press_maybe(self.flow.can_scan().then_some(Message::ScanSelected)),
-                )
+                .push(scan)
                 .push(
                     button(text("View Report...").size(ui::TEXT_SM).font(ui::UI_MEDIUM))
                         .padding([ui::GAP_2, ui::GAP_4])
@@ -2578,6 +2598,19 @@ impl App {
 /// listed playlist hides a stream.
 const HIDDEN_NOTE: &str =
     "(*) Some playlists on this disc have hidden tracks. These tracks are marked with an asterisk.";
+
+/// The encrypted-disc indicator in the info box: a warning sign and the
+/// condition, spelled out rather than left to the glyph alone — the glyph is
+/// what catches the eye, the words are what make it findable.
+///
+/// U+26A0 is in the bundled Inter face, so it draws under the default Basic
+/// shaping like the rest of the fixed chrome.
+const ENCRYPTED_BADGE: &str = "⚠ AACS-encrypted";
+
+/// Why the encrypted-disc indicator is up and the measured scan is dead — the
+/// hover text on both of them, so the two read as one statement wherever the
+/// user meets it first.
+const ENCRYPTED_REASON: &str = "This disc is AACS-encrypted — stream data cannot be analyzed";
 
 // ── stateless widget builders ────────────────────────────────────────────────
 
@@ -3305,6 +3338,30 @@ fn info_line<'a>(p: Palette, label: &str, value: String, mono: bool) -> Element<
         .into()
 }
 
+/// The encrypted-disc indicator: [`ENCRYPTED_BADGE`] in the palette's warning
+/// tone, explaining itself on hover.
+///
+/// The tone is a token, so it reads correctly in both palettes; the bubble
+/// opens to the left because the badge sits at the right edge of the info
+/// strip.
+fn encrypted_badge<'a>(p: Palette) -> Element<'a, Message> {
+    tooltip(
+        text(ENCRYPTED_BADGE).size(ui::TEXT_XS).font(ui::UI_MEDIUM).color(p.warning),
+        encrypted_bubble(p),
+        tooltip::Position::Left,
+    )
+    .into()
+}
+
+/// The hover bubble both encrypted-disc controls carry — the indicator and the
+/// dead "Scan Bitrates" button.
+fn encrypted_bubble<'a>(p: Palette) -> Element<'a, Message> {
+    container(text(ENCRYPTED_REASON).size(ui::TEXT_XS).color(p.text))
+        .padding([ui::GAP_1, ui::GAP_2])
+        .style(ui::tooltip(p))
+        .into()
+}
+
 /// One right/centre-aligned numeric cell in the table's tabular monospace.
 fn num_cell<'a>(
     p: Palette,
@@ -3452,6 +3509,21 @@ mod harness {
         App { flow, ..App::default() }
     }
 
+    /// An app listed from the same synthetic disc as [`listed_app`], flagged
+    /// AACS-encrypted. The two differ in exactly that one flag, so anything
+    /// that differs between their views is the encrypted-disc treatment.
+    pub fn encrypted_app() -> App {
+        let mut structural = structural();
+        structural.bdrom.is_aacs_encrypted = true;
+        let input = Input::Folder("disc".into());
+        let flow = Flow::start_listing(input.clone()).listed(
+            &input,
+            Ok(structural),
+            ViewSettings::default(),
+        );
+        App { flow, ..App::default() }
+    }
+
     /// An app listed from a disc the default filters withhold two playlists
     /// from — one per rule: 00002 (80 s) loops and 00003 (5 s) is short,
     /// alongside the listed 00000 (100 s) and 00001 (70 s). The state the
@@ -3525,6 +3597,13 @@ mod harness {
         ui(app).find(label).is_ok()
     }
 
+    /// The laid-out rectangle of the text widget reading exactly `label` — the
+    /// position and size the renderer would draw it at, so two views can be
+    /// compared for layout rather than for content.
+    pub fn bounds(app: &App, label: &str) -> iced::Rectangle {
+        ui(app).find(label).expect("the label is on screen").bounds()
+    }
+
     /// Renders the app's view offscreen and ties it to the committed SHA-256
     /// under `snapshots/<family>/` (created on first run — commit it). On a
     /// mismatch the rendered PNG is dumped under `target/snapshot-failures/`
@@ -3588,8 +3667,8 @@ mod interaction {
     use bdinfo_rs_gui::model::{Sort, SortColumn};
     use bdinfo_rs_gui::theme::ThemePref;
 
-    use super::harness::{click, filtered_app, listed_app, sees, structural};
-    use super::{App, Message};
+    use super::harness::{bounds, click, encrypted_app, filtered_app, listed_app, sees, structural};
+    use super::{App, ENCRYPTED_BADGE, Message};
 
     #[test]
     fn the_scan_flow_reaches_the_report_through_clicks() {
@@ -3618,6 +3697,54 @@ mod interaction {
         assert!(sees(&app, "THE REPORT BODY"), "the report text is on screen");
         click(&mut app, "← Back");
         assert!(!app.showing_report);
+    }
+
+    #[test]
+    fn an_encrypted_disc_shows_the_indicator_and_the_scan_stays_dead() {
+        let mut app = encrypted_app();
+        assert!(sees(&app, ENCRYPTED_BADGE), "the info box flags the disc");
+        assert!(!sees(&listed_app(), ENCRYPTED_BADGE), "an ordinary disc does not");
+
+        // The control is still there and still says what it does — it just
+        // does nothing. Clicking it dispatches no message…
+        assert!(sees(&app, "Scan Bitrates"));
+        assert!(click(&mut app, "Scan Bitrates").is_empty(), "the button is dead");
+        assert_eq!(app.flow.stage(), Stage::Listed);
+        // …and neither does the message it would have dispatched, so a road
+        // that skips the button cannot start the scan either.
+        let _ = app.update(Message::ScanSelected);
+        assert_eq!(app.flow.stage(), Stage::Listed);
+        assert!(app.scan_cancel.is_none(), "no worker was ever handed a cancel flag");
+
+        // Everything structural stays browsable: the playlists list, the panes
+        // fill from the active row, and the pre-scan report is still offered.
+        assert_eq!(app.flow.row_count(), 2);
+        assert!(sees(&app, "00000.MPLS"));
+        click(&mut app, "View Report...");
+        assert!(app.showing_report);
+    }
+
+    #[test]
+    fn the_encrypted_indicator_costs_no_layout() {
+        // The indicator draws into the slack the info strip already has, so
+        // every other widget is laid out at the same rectangle as on the same
+        // disc without it — the info-box lines it sits beside, the table above
+        // and the actions below. A shift shows up here as a moved rectangle.
+        let plain = listed_app();
+        let flagged = encrypted_app();
+        for label in [
+            "Disc Title:",
+            "Detected BDMV Folder:",
+            "Detected Features:",
+            "Disc Size:",
+            "00000.MPLS",
+            "0 of 2 selected",
+            "Scan Bitrates",
+            "View Report...",
+            "Settings...",
+        ] {
+            assert_eq!(bounds(&plain, label), bounds(&flagged, label), "{label} moved");
+        }
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -177,28 +177,40 @@ pub const fn no_progress(_: ScanProgress<'_>) {}
 /// A short message when the input holds no readable Blu-ray structure (no
 /// `BDMV`/`CLIPINF`/`PLAYLIST`, or a `.iso` that is not a readable UDF volume).
 pub fn scan_structural(input: &Input) -> Result<Structural, String> {
-    // `Metadata` first, for the encryption verdict. The quick codec pass stops
-    // at the packet that completes the last stream's codec detail, so on an
-    // AACS-encrypted disc — where the payloads are ciphertext and no scanner
-    // ever initializes — it has no stopping point and reads every stream file
-    // to EOF: tens of gigabytes off an optical drive, for a codec detail that
-    // cannot be recovered. `Metadata` reads no packets at all and still carries
-    // the flag, so it is what decides whether the deeper pass is worth running.
-    //
-    // `Codecs` mode then gives the panes their full codec detail (profile /
-    // HDR / Dolby Vision) right after opening, like BDInfo, without the
-    // whole-file bitrate scan. On a disc whose streams are readable it ends at
-    // codec init, so it carries no cancel affordance. Re-reading the clip
-    // metadata to get there costs a second parse of files the first pass just
-    // read, which the filesystem cache serves.
-    let scan =
-        |mode| open(input, mode, None, &mut no_progress, &AtomicBool::new(false)).map_err(
-            |err: BdError| err.to_string(),
-        );
+    let scan = |mode| {
+        open(input, mode, None, &mut no_progress, &AtomicBool::new(false))
+            .map_err(|err: BdError| err.to_string())
+    };
     let cheap = scan(ScanMode::Metadata)?;
-    let (bdrom, errors) = if cheap.0.is_aacs_encrypted { cheap } else { scan(ScanMode::Codecs)? };
+    let (bdrom, errors) = listing_scan(cheap, || scan(ScanMode::Codecs))?;
     let features = bdrom.extra_features().into_iter().map(str::to_owned).collect();
     Ok(Structural { bdrom, features, warnings: error_lines(&errors) })
+}
+
+/// Chooses which open the selection table is built from: `cheap` — the
+/// packet-free `Metadata` open already in hand — for an AACS-encrypted disc,
+/// else whatever `deep` reads.
+///
+/// The quick codec pass stops at the packet that completes the last stream's
+/// codec detail. On an encrypted disc the payloads are ciphertext, so no
+/// scanner ever initializes, the pass has no stopping point, and it reads every
+/// stream file to EOF — tens of gigabytes off an optical drive, for detail no
+/// key can recover. `deep` is therefore never even called for such a disc.
+///
+/// For every other disc `deep` is the `Codecs` open, which gives the panes
+/// their full codec detail (profile / HDR / Dolby Vision) right after opening,
+/// like `BDInfo`, without the whole-file bitrate scan; on readable streams it
+/// ends at codec init, so it carries no cancel affordance. Reaching it costs a
+/// second parse of the clip metadata the first open just read, which the
+/// filesystem cache serves.
+///
+/// # Errors
+/// Whatever `deep` reports, for a disc that is not encrypted.
+fn listing_scan(
+    cheap: (BdRom, Vec<ScanError>),
+    deep: impl FnOnce() -> Result<(BdRom, Vec<ScanError>), String>,
+) -> Result<(BdRom, Vec<ScanError>), String> {
+    if cheap.0.is_aacs_encrypted { Ok(cheap) } else { deep() }
 }
 
 /// Runs the **measured** scan over `input`, narrowed to the selected clips.
@@ -477,8 +489,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
         copy_tree(&fixture("BigBuckBunny"), &root);
         std::fs::create_dir_all(root.join("AACS")).expect("the AACS dir creates");
-        std::fs::write(root.join("AACS/Unit_Key_RO.inf"), b"key")
-            .expect("the key file writes");
+        std::fs::write(root.join("AACS/Unit_Key_RO.inf"), b"key").expect("the key file writes");
 
         let stream = root.join("BDMV/STREAM/00000.m2ts");
         let real = std::fs::read(&stream).expect("the fixture stream reads");
@@ -503,13 +514,53 @@ mod tests {
         // if the untouched fixture it is built from does NOT read as encrypted
         // — the key file alone must never be the verdict.
         let root = encrypted_fixture("aacs-probe");
-        let encrypted = BdRom::open(&FsDir::new(&root), ScanMode::Metadata)
-            .expect("the crafted disc opens");
+        let encrypted =
+            BdRom::open(&FsDir::new(&root), ScanMode::Metadata).expect("the crafted disc opens");
         assert!(encrypted.is_aacs_encrypted, "the crafted stream shows the fingerprint");
 
         let plain = BdRom::open(&FsDir::new(fixture("BigBuckBunny")), ScanMode::Metadata)
             .expect("the fixture disc opens");
         assert!(!plain.is_aacs_encrypted, "an ordinary disc is not encrypted");
+    }
+
+    /// The metadata open the listing seam decides from, flagged or not.
+    fn cheap_open(is_aacs_encrypted: bool) -> (BdRom, Vec<super::ScanError>) {
+        let bdrom = BdRom::open(&FsDir::new(fixture("BigBuckBunny")), ScanMode::Metadata)
+            .expect("the fixture disc opens");
+        (BdRom { is_aacs_encrypted, ..bdrom }, Vec::new())
+    }
+
+    #[test]
+    fn the_listing_seam_never_opens_an_encrypted_disc_a_second_time() {
+        // Not "the deeper open returns nothing useful" — it is never called at
+        // all, which is the whole point: calling it is what reads the disc end
+        // to end.
+        let (bdrom, errors) = super::listing_scan(cheap_open(true), || {
+            panic!("an encrypted disc must not reach the codec pass")
+        })
+        .expect("the metadata open stands in");
+        assert!(bdrom.is_aacs_encrypted);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn the_listing_seam_takes_the_deeper_open_for_an_ordinary_disc() {
+        let deep = cheap_open(false).0;
+        let label = deep.volume_label.clone();
+        let (bdrom, _) = super::listing_scan(cheap_open(false), || {
+            Ok((BdRom { volume_label: format!("{label}-deep"), ..deep }, Vec::new()))
+        })
+        .expect("the deeper open answers");
+        assert_eq!(bdrom.volume_label, format!("{label}-deep"), "the deeper open won");
+    }
+
+    #[test]
+    fn the_listing_seam_reports_a_failed_deeper_open() {
+        // The media going away between the two opens: the failure is the
+        // listing's, not a silently degraded table.
+        let message = super::listing_scan(cheap_open(false), || Err("the disc vanished".to_owned()))
+            .expect_err("the deeper failure propagates");
+        assert_eq!(message, "the disc vanished");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -545,13 +545,13 @@ mod tests {
         };
 
         let (bdrom, errors) =
-            super::listing_scan(cheap_open(true), &deep).expect("the metadata open stands in");
+            super::listing_scan(cheap_open(true), deep).expect("the metadata open stands in");
         assert_eq!(calls.get(), 0, "an encrypted disc must not reach the codec pass");
         assert!(bdrom.is_aacs_encrypted);
         assert!(errors.is_empty());
 
         let (bdrom, _) =
-            super::listing_scan(cheap_open(false), &deep).expect("the deeper open answers");
+            super::listing_scan(cheap_open(false), deep).expect("the deeper open answers");
         assert_eq!(calls.get(), 1, "an ordinary disc reaches it exactly once");
         assert_eq!(bdrom.volume_label, "DEEP", "the deeper open is what the listing keeps");
     }

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -177,13 +177,26 @@ pub const fn no_progress(_: ScanProgress<'_>) {}
 /// A short message when the input holds no readable Blu-ray structure (no
 /// `BDMV`/`CLIPINF`/`PLAYLIST`, or a `.iso` that is not a readable UDF volume).
 pub fn scan_structural(input: &Input) -> Result<Structural, String> {
-    // `Codecs` mode runs the bounded quick pass — reads only the head of each
-    // stream file — so the panes show full codec detail (profile / HDR / Dolby
-    // Vision) right after opening, like BDInfo, without the whole-file bitrate scan.
-    // Bounded and fast, so it carries no cancel affordance: the flag never trips.
-    let (bdrom, errors) =
-        open(input, ScanMode::Codecs, None, &mut no_progress, &AtomicBool::new(false))
-            .map_err(|err| err.to_string())?;
+    // `Metadata` first, for the encryption verdict. The quick codec pass stops
+    // at the packet that completes the last stream's codec detail, so on an
+    // AACS-encrypted disc — where the payloads are ciphertext and no scanner
+    // ever initializes — it has no stopping point and reads every stream file
+    // to EOF: tens of gigabytes off an optical drive, for a codec detail that
+    // cannot be recovered. `Metadata` reads no packets at all and still carries
+    // the flag, so it is what decides whether the deeper pass is worth running.
+    //
+    // `Codecs` mode then gives the panes their full codec detail (profile /
+    // HDR / Dolby Vision) right after opening, like BDInfo, without the
+    // whole-file bitrate scan. On a disc whose streams are readable it ends at
+    // codec init, so it carries no cancel affordance. Re-reading the clip
+    // metadata to get there costs a second parse of files the first pass just
+    // read, which the filesystem cache serves.
+    let scan =
+        |mode| open(input, mode, None, &mut no_progress, &AtomicBool::new(false)).map_err(
+            |err: BdError| err.to_string(),
+        );
+    let cheap = scan(ScanMode::Metadata)?;
+    let (bdrom, errors) = if cheap.0.is_aacs_encrypted { cheap } else { scan(ScanMode::Codecs)? };
     let features = bdrom.extra_features().into_iter().map(str::to_owned).collect();
     Ok(Structural { bdrom, features, warnings: error_lines(&errors) })
 }
@@ -288,7 +301,7 @@ impl<F: FnOnce()> Drop for PanicAlarm<F> {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use super::Input;
+    use super::{BdRom, FsDir, Input, ScanMode};
 
     /// A scratch directory under the crate's target dir (unique per test).
     fn scratch(name: &str) -> PathBuf {
@@ -444,6 +457,101 @@ mod tests {
         )
         .expect_err("no Blu-ray structure to open");
         assert!(!message.is_empty(), "the failure carries a user-facing message");
+    }
+
+    /// The committed fixture disc copied to `name` and made to look
+    /// AACS-encrypted: the `AACS/Unit_Key_RO.inf` key file the probe looks for,
+    /// and a stream file whose first two 6144-byte Aligned Units carry the
+    /// encryption fingerprint — a sync byte at the head of the unit and none in
+    /// the 31 source packets after it (AACS Blu-ray Prerecorded Book §3.10
+    /// leaves only each unit's first 16 bytes in the clear).
+    ///
+    /// The disc's real packets follow that prefix, so the codec pass still has
+    /// something to find if it runs — which is what lets a test tell a skipped
+    /// pass from a completed one.
+    fn encrypted_fixture(name: &str) -> PathBuf {
+        const UNIT: usize = 6144;
+        const PACKET: usize = 192;
+
+        let root = scratch(name);
+        let _ = std::fs::remove_dir_all(&root);
+        copy_tree(&fixture("BigBuckBunny"), &root);
+        std::fs::create_dir_all(root.join("AACS")).expect("the AACS dir creates");
+        std::fs::write(root.join("AACS/Unit_Key_RO.inf"), b"key")
+            .expect("the key file writes");
+
+        let stream = root.join("BDMV/STREAM/00000.m2ts");
+        let real = std::fs::read(&stream).expect("the fixture stream reads");
+        // 0xA5 fills the ciphertext: any byte but the 0x47 sync the probe
+        // counts. Each unit then gets its one leading sync back.
+        let mut bytes = vec![0xA5_u8; UNIT.checked_mul(2).expect("two units fit")];
+        for unit in bytes.chunks_exact_mut(UNIT) {
+            let sync = unit.get_mut(4).expect("a unit holds a first packet header");
+            *sync = 0x47;
+        }
+        bytes.extend_from_slice(&real);
+        std::fs::write(&stream, &bytes).expect("the encrypted-looking stream writes");
+        // The prefix is a whole number of source packets, so the real packets
+        // after it stay on the 192-byte grid the demux walks.
+        assert_eq!(bytes.len() % PACKET, real.len() % PACKET, "the packet grid is preserved");
+        root
+    }
+
+    #[test]
+    fn the_crafted_encrypted_fixture_reads_as_encrypted() {
+        // The fixture builder is only useful if the probe agrees with it, and
+        // if the untouched fixture it is built from does NOT read as encrypted
+        // — the key file alone must never be the verdict.
+        let root = encrypted_fixture("aacs-probe");
+        let encrypted = BdRom::open(&FsDir::new(&root), ScanMode::Metadata)
+            .expect("the crafted disc opens");
+        assert!(encrypted.is_aacs_encrypted, "the crafted stream shows the fingerprint");
+
+        let plain = BdRom::open(&FsDir::new(fixture("BigBuckBunny")), ScanMode::Metadata)
+            .expect("the fixture disc opens");
+        assert!(!plain.is_aacs_encrypted, "an ordinary disc is not encrypted");
+    }
+
+    #[test]
+    fn an_encrypted_disc_lists_without_running_the_codec_pass() {
+        // The quick codec pass ends at the packet that completes the last
+        // stream's codec detail. Ciphertext never completes one, so on an
+        // encrypted disc the pass has no stopping point and reads every stream
+        // file to EOF — tens of gigabytes off an optical drive, for detail no
+        // key can recover. The listing must stop at the metadata pass instead.
+        let root = encrypted_fixture("aacs-listing");
+        let listed = super::scan_structural(&Input::Folder(root.clone()))
+            .expect("an encrypted disc still lists");
+        assert!(listed.bdrom.is_aacs_encrypted);
+        assert!(!listed.bdrom.playlists.is_empty(), "the structure still lists");
+
+        let metadata =
+            BdRom::open(&FsDir::new(&root), ScanMode::Metadata).expect("the metadata pass opens");
+        assert_eq!(listed.bdrom.playlists, metadata.playlists, "the listing ran the codec pass");
+
+        // The proof that the assertion above discriminates: over this very
+        // disc the codec pass produces different streams, so a listing that ran
+        // it could not have matched the metadata pass.
+        let codecs =
+            BdRom::open(&FsDir::new(&root), ScanMode::Codecs).expect("the codec pass opens");
+        assert_ne!(
+            codecs.playlists, metadata.playlists,
+            "the fixture cannot tell the two passes apart, so the assertion above proves nothing"
+        );
+    }
+
+    #[test]
+    fn an_ordinary_disc_still_gets_the_codec_pass() {
+        // The other side of the same gate: an unencrypted disc must keep the
+        // scanned codec detail the panes show, so the listing has to be the
+        // deeper pass rather than the metadata one.
+        let root = fixture("BigBuckBunny");
+        let listed =
+            super::scan_structural(&Input::Folder(root.clone())).expect("the fixture lists");
+        assert!(!listed.bdrom.is_aacs_encrypted);
+        let codecs =
+            BdRom::open(&FsDir::new(&root), ScanMode::Codecs).expect("the codec pass opens");
+        assert_eq!(listed.bdrom.playlists, codecs.playlists, "the listing skipped the codec pass");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -177,40 +177,38 @@ pub const fn no_progress(_: ScanProgress<'_>) {}
 /// A short message when the input holds no readable Blu-ray structure (no
 /// `BDMV`/`CLIPINF`/`PLAYLIST`, or a `.iso` that is not a readable UDF volume).
 pub fn scan_structural(input: &Input) -> Result<Structural, String> {
-    let scan = |mode| {
+    let (bdrom, errors) = listing_scan(|mode| {
         open(input, mode, None, &mut no_progress, &AtomicBool::new(false))
             .map_err(|err: BdError| err.to_string())
-    };
-    let cheap = scan(ScanMode::Metadata)?;
-    let (bdrom, errors) = listing_scan(cheap, || scan(ScanMode::Codecs))?;
+    })?;
     let features = bdrom.extra_features().into_iter().map(str::to_owned).collect();
     Ok(Structural { bdrom, features, warnings: error_lines(&errors) })
 }
 
-/// Chooses which open the selection table is built from: `cheap` — the
-/// packet-free `Metadata` open already in hand — for an AACS-encrypted disc,
-/// else whatever `deep` reads.
+/// Opens the disc for the selection table, choosing how deep to read: the
+/// packet-free [`ScanMode::Metadata`] open alone for an AACS-encrypted disc,
+/// else a second [`ScanMode::Codecs`] open over the same disc.
 ///
 /// The quick codec pass stops at the packet that completes the last stream's
 /// codec detail. On an encrypted disc the payloads are ciphertext, so no
 /// scanner ever initializes, the pass has no stopping point, and it reads every
 /// stream file to EOF — tens of gigabytes off an optical drive, for detail no
-/// key can recover. `deep` is therefore never even called for such a disc.
+/// key can recover. `open` is therefore never called a second time for such a
+/// disc.
 ///
-/// For every other disc `deep` is the `Codecs` open, which gives the panes
-/// their full codec detail (profile / HDR / Dolby Vision) right after opening,
-/// like `BDInfo`, without the whole-file bitrate scan; on readable streams it
-/// ends at codec init, so it carries no cancel affordance. Reaching it costs a
-/// second parse of the clip metadata the first open just read, which the
-/// filesystem cache serves.
+/// For every other disc the `Codecs` open gives the panes their full codec
+/// detail (profile / HDR / Dolby Vision) right away, like `BDInfo`, without the
+/// whole-file bitrate scan; on readable streams it ends at codec init, so it
+/// carries no cancel affordance. Reaching it costs a second parse of the clip
+/// metadata the first open just read, which the filesystem cache serves.
 ///
 /// # Errors
-/// Whatever `deep` reports, for a disc that is not encrypted.
+/// Whatever `open` reports, from either call.
 fn listing_scan(
-    cheap: (BdRom, Vec<ScanError>),
-    deep: impl Fn() -> Result<(BdRom, Vec<ScanError>), String>,
+    open: impl Fn(ScanMode) -> Result<(BdRom, Vec<ScanError>), String>,
 ) -> Result<(BdRom, Vec<ScanError>), String> {
-    if cheap.0.is_aacs_encrypted { Ok(cheap) } else { deep() }
+    let cheap = open(ScanMode::Metadata)?;
+    if cheap.0.is_aacs_encrypted { Ok(cheap) } else { open(ScanMode::Codecs) }
 }
 
 /// Runs the **measured** scan over `input`, narrowed to the selected clips.
@@ -311,7 +309,7 @@ impl<F: FnOnce()> Drop for PanicAlarm<F> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
+    use std::cell::RefCell;
     use std::path::{Path, PathBuf};
 
     use super::{BdRom, FsDir, Input, ScanMode};
@@ -531,39 +529,57 @@ mod tests {
         (BdRom { is_aacs_encrypted, ..bdrom }, Vec::new())
     }
 
-    #[test]
-    fn the_listing_seam_opens_a_second_time_only_for_a_disc_that_can_finish() {
-        // Counted, not inferred from the result: an encrypted disc must not
-        // *reach* the codec pass, because calling it at all is what reads the
-        // disc end to end. Both cases drive the one closure, so the count is
-        // the whole assertion.
-        let calls = Cell::new(0_u32);
-        let deep = || {
-            calls.set(calls.get().saturating_add(1));
-            let bdrom = cheap_open(false).0;
-            Ok((BdRom { volume_label: "DEEP".to_owned(), ..bdrom }, Vec::new()))
-        };
-
-        let (bdrom, errors) =
-            super::listing_scan(cheap_open(true), deep).expect("the metadata open stands in");
-        assert_eq!(calls.get(), 0, "an encrypted disc must not reach the codec pass");
-        assert!(bdrom.is_aacs_encrypted);
-        assert!(errors.is_empty());
-
-        let (bdrom, _) =
-            super::listing_scan(cheap_open(false), deep).expect("the deeper open answers");
-        assert_eq!(calls.get(), 1, "an ordinary disc reaches it exactly once");
-        assert_eq!(bdrom.volume_label, "DEEP", "the deeper open is what the listing keeps");
+    /// Records every mode the seam asks for, answering each from `answer`.
+    fn opened_modes<F>(answer: F) -> (Result<(BdRom, Vec<super::ScanError>), String>, Vec<ScanMode>)
+    where
+        F: Fn(ScanMode) -> Result<(BdRom, Vec<super::ScanError>), String>,
+    {
+        let modes = RefCell::new(Vec::new());
+        let result = super::listing_scan(|mode| {
+            modes.borrow_mut().push(mode);
+            answer(mode)
+        });
+        (result, modes.into_inner())
     }
 
     #[test]
-    fn the_listing_seam_reports_a_failed_deeper_open() {
-        // The media going away between the two opens: the failure is the
-        // listing's, not a silently degraded table.
-        let message =
-            super::listing_scan(cheap_open(false), || Err("the disc vanished".to_owned()))
-                .expect_err("the deeper failure propagates");
-        assert_eq!(message, "the disc vanished");
+    fn the_listing_seam_stops_at_the_metadata_open_for_an_encrypted_disc() {
+        // Recorded, not inferred from the result: the codec pass must never be
+        // *asked for*, because asking is what reads the disc end to end.
+        let (result, modes) = opened_modes(|_| Ok(cheap_open(true)));
+        let (bdrom, errors) = result.expect("the metadata open stands in");
+        assert_eq!(modes, [ScanMode::Metadata], "the codec pass must not be reached");
+        assert!(bdrom.is_aacs_encrypted);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn the_listing_seam_takes_the_codec_pass_for_an_ordinary_disc() {
+        let (result, modes) = opened_modes(|mode| {
+            let bdrom = cheap_open(false).0;
+            let label = if mode == ScanMode::Codecs { "DEEP" } else { "CHEAP" };
+            Ok((BdRom { volume_label: label.to_owned(), ..bdrom }, Vec::new()))
+        });
+        let (bdrom, _) = result.expect("the codec pass answers");
+        assert_eq!(modes, [ScanMode::Metadata, ScanMode::Codecs], "both opens, in that order");
+        assert_eq!(bdrom.volume_label, "DEEP", "the codec pass is what the listing keeps");
+    }
+
+    #[test]
+    fn the_listing_seam_reports_a_failure_from_either_open() {
+        // The first open failing is the ordinary "not a Blu-ray" road; the
+        // second failing means the media went away between the two, and is the
+        // listing's failure rather than a silently degraded table.
+        let (result, modes) = opened_modes(|_| Err("no disc".to_owned()));
+        assert_eq!(result.expect_err("the metadata failure propagates"), "no disc");
+        assert_eq!(modes, [ScanMode::Metadata], "a failed first open reaches no further");
+
+        let (result, modes) = opened_modes(|mode| match mode {
+            ScanMode::Metadata => Ok(cheap_open(false)),
+            _ => Err("the disc vanished".to_owned()),
+        });
+        assert_eq!(result.expect_err("the codec failure propagates"), "the disc vanished");
+        assert_eq!(modes, [ScanMode::Metadata, ScanMode::Codecs]);
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -158,6 +158,11 @@ fn open(
     }
 }
 
+/// What one open of the disc yields: the scanned disc paired with the per-file
+/// failures recorded getting there, or a user-facing message for a disc that
+/// holds no readable structure at all.
+type Opened = Result<(BdRom, Vec<ScanError>), String>;
+
 /// Recorded scan failures as display strings, for the UI's warning surfaces.
 fn error_lines(errors: &[ScanError]) -> Vec<String> {
     errors.iter().map(ToString::to_string).collect()
@@ -204,9 +209,7 @@ pub fn scan_structural(input: &Input) -> Result<Structural, String> {
 ///
 /// # Errors
 /// Whatever `open` reports, from either call.
-fn listing_scan(
-    open: impl Fn(ScanMode) -> Result<(BdRom, Vec<ScanError>), String>,
-) -> Result<(BdRom, Vec<ScanError>), String> {
+fn listing_scan(open: impl Fn(ScanMode) -> Opened) -> Opened {
     let cheap = open(ScanMode::Metadata)?;
     if cheap.0.is_aacs_encrypted { Ok(cheap) } else { open(ScanMode::Codecs) }
 }
@@ -530,9 +533,9 @@ mod tests {
     }
 
     /// Records every mode the seam asks for, answering each from `answer`.
-    fn opened_modes<F>(answer: F) -> (Result<(BdRom, Vec<super::ScanError>), String>, Vec<ScanMode>)
+    fn opened_modes<F>(answer: F) -> (super::Opened, Vec<ScanMode>)
     where
-        F: Fn(ScanMode) -> Result<(BdRom, Vec<super::ScanError>), String>,
+        F: Fn(ScanMode) -> super::Opened,
     {
         let modes = RefCell::new(Vec::new());
         let result = super::listing_scan(|mode| {

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -208,7 +208,7 @@ pub fn scan_structural(input: &Input) -> Result<Structural, String> {
 /// Whatever `deep` reports, for a disc that is not encrypted.
 fn listing_scan(
     cheap: (BdRom, Vec<ScanError>),
-    deep: impl FnOnce() -> Result<(BdRom, Vec<ScanError>), String>,
+    deep: impl Fn() -> Result<(BdRom, Vec<ScanError>), String>,
 ) -> Result<(BdRom, Vec<ScanError>), String> {
     if cheap.0.is_aacs_encrypted { Ok(cheap) } else { deep() }
 }
@@ -311,6 +311,7 @@ impl<F: FnOnce()> Drop for PanicAlarm<F> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
     use std::path::{Path, PathBuf};
 
     use super::{BdRom, FsDir, Input, ScanMode};
@@ -531,35 +532,37 @@ mod tests {
     }
 
     #[test]
-    fn the_listing_seam_never_opens_an_encrypted_disc_a_second_time() {
-        // Not "the deeper open returns nothing useful" — it is never called at
-        // all, which is the whole point: calling it is what reads the disc end
-        // to end.
-        let (bdrom, errors) = super::listing_scan(cheap_open(true), || {
-            panic!("an encrypted disc must not reach the codec pass")
-        })
-        .expect("the metadata open stands in");
+    fn the_listing_seam_opens_a_second_time_only_for_a_disc_that_can_finish() {
+        // Counted, not inferred from the result: an encrypted disc must not
+        // *reach* the codec pass, because calling it at all is what reads the
+        // disc end to end. Both cases drive the one closure, so the count is
+        // the whole assertion.
+        let calls = Cell::new(0_u32);
+        let deep = || {
+            calls.set(calls.get().saturating_add(1));
+            let bdrom = cheap_open(false).0;
+            Ok((BdRom { volume_label: "DEEP".to_owned(), ..bdrom }, Vec::new()))
+        };
+
+        let (bdrom, errors) =
+            super::listing_scan(cheap_open(true), &deep).expect("the metadata open stands in");
+        assert_eq!(calls.get(), 0, "an encrypted disc must not reach the codec pass");
         assert!(bdrom.is_aacs_encrypted);
         assert!(errors.is_empty());
-    }
 
-    #[test]
-    fn the_listing_seam_takes_the_deeper_open_for_an_ordinary_disc() {
-        let deep = cheap_open(false).0;
-        let label = deep.volume_label.clone();
-        let (bdrom, _) = super::listing_scan(cheap_open(false), || {
-            Ok((BdRom { volume_label: format!("{label}-deep"), ..deep }, Vec::new()))
-        })
-        .expect("the deeper open answers");
-        assert_eq!(bdrom.volume_label, format!("{label}-deep"), "the deeper open won");
+        let (bdrom, _) =
+            super::listing_scan(cheap_open(false), &deep).expect("the deeper open answers");
+        assert_eq!(calls.get(), 1, "an ordinary disc reaches it exactly once");
+        assert_eq!(bdrom.volume_label, "DEEP", "the deeper open is what the listing keeps");
     }
 
     #[test]
     fn the_listing_seam_reports_a_failed_deeper_open() {
         // The media going away between the two opens: the failure is the
         // listing's, not a silently degraded table.
-        let message = super::listing_scan(cheap_open(false), || Err("the disc vanished".to_owned()))
-            .expect_err("the deeper failure propagates");
+        let message =
+            super::listing_scan(cheap_open(false), || Err("the disc vanished".to_owned()))
+                .expect_err("the deeper failure propagates");
         assert_eq!(message, "the disc vanished");
     }
 


### PR DESCRIPTION
An AACS-encrypted disc lists, browses and reports structurally exactly as any other disc does - that data comes from cleartext metadata. Only its stream content is ciphertext, so a measured scan would demux noise and report meaningless numbers. The app now says so and refuses the scan.

The info strip carries a warning glyph plus the words AACS-encrypted, in the palette warning tone so it reads in both themes, explaining itself in full on hover. It draws into the slack the strip already has to the right of its lines, so it costs no layout: a test compares the laid-out rectangle of every info line, the table and the action buttons against the same disc without the flag, and they are identical. Verified by eye in both themes as well.

Scan Bitrates stays in place and dead, with the same hover text. No dialog, no overlay, nothing to dismiss. The refusal sits in the flow gate that both the button and the message road read, so a scan message arriving without the button is refused on the same terms. Autosave only ever fires on a finished measured scan, so no hollow report can be written; the pre-scan structural report stays available exactly as it is for any other disc.

This also fixes a defect the indicator work uncovered, on the same road. The listing opened every disc with the quick codec pass, which ends at the packet completing the last stream codec detail. Ciphertext never completes one, so the pass had no stopping point and read every stream file to EOF - measured against a real encrypted disc at 9.5 GB in ten minutes off a USB optical drive, with roughly seventy minutes still to go, while the window sat on its please-wait modal. The listing now opens Metadata first, which reads no packets and still carries the encryption verdict, and reaches the codec pass only for a disc whose streams can resolve. The CLI and the browser package were never exposed: both already list in Metadata mode.

Core is untouched. Report bytes are unchanged.