### PR TITLE
fix(udf): clamp CS0 dstring used length and correct the resilient-mode doc comment

### DIFF
--- a/crates/bdinfo-rs-core/src/vfs/udf/cs0.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/cs0.rs
@@ -51,17 +51,22 @@ pub fn decode_dchars(data: &[u8]) -> String {
 ///
 /// The used bytes (compression ID + characters) are decoded via
 /// [`decode_dchars`]. Returns the empty string for an empty field or a used
-/// length that runs past the field (malformed). Used for the volume / file-set
-/// identifiers in the LVD and FSD.
+/// length past the `field.len() - 1` bytes the content may occupy (malformed).
+/// Used for the volume / file-set identifiers in the LVD and FSD.
 #[must_use]
 pub fn decode_dstring(field: &[u8]) -> String {
-    let Some(&used_len) = field.last() else {
+    let Some((&used_len, body)) = field.split_last() else {
         return String::new();
     };
     let used = usize::from(used_len);
     // The used bytes (compression ID + characters) sit at the front of the
-    // field; an out-of-range used length is malformed → empty.
-    field.get(..used).map_or_else(String::new, decode_dchars)
+    // field, and the length byte itself is excluded from them — UDF 2.50 §2.1.3
+    // caps the content at `field.len() - 1`, so a used length equal to the full
+    // field would otherwise decode the length byte as a character. Indexing
+    // `body` (the field minus that byte) applies the cap; an out-of-range used
+    // length is malformed → empty. libudfread clamps to the same bound instead
+    // (`_decode_dstring`); empty matches this module's other malformed cases.
+    body.get(..used).map_or_else(String::new, decode_dchars)
 }
 
 #[cfg(test)]
@@ -140,6 +145,16 @@ mod tests {
     fn dstring_zero_used_is_empty() {
         let field = [8_u8, b'X', b'Y', 0];
         assert_eq!(decode_dstring(&field), "");
+    }
+
+    #[test]
+    fn dstring_used_length_of_the_whole_field_is_empty() {
+        // A 4-byte field: the content may occupy at most 3 bytes, so a used
+        // length of 3 decodes compId 8 + "AB"...
+        assert_eq!(decode_dstring(&[8, b'A', b'B', 3]), "AB");
+        // ...while 4 is malformed — the length byte is not a character, and a
+        // clamp to 3 would be wrong here too (the byte is 0x04, not 'C').
+        assert_eq!(decode_dstring(&[8, b'A', b'B', 4]), "");
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/vfs/udf/source.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/source.rs
@@ -1523,8 +1523,13 @@ enum ChildKind {
 
 /// Reads the directory File Entry at `(dir_ref, dir_block)`, enumerates its File
 /// Identifier Descriptors, and resolves each non-parent, non-deleted child into a
-/// [`Child`]. A directory whose File Entry or data cannot be read yields no
-/// children (it stays an empty directory) rather than failing the whole scan.
+/// [`Child`]. A directory whose File Entry sector is unresolvable, unparsable, or
+/// not marked as a directory yields no children (it stays an empty directory), and
+/// a child whose File Entry is unresolvable, unreadable, or unparsable is skipped.
+/// Three reads are *not* degraded: the directory's own File Entry, its directory
+/// data, and a child file's body all propagate an IO error, failing
+/// [`UdfSource::open`] in both modes — resilience covers file-data reads made after
+/// the open, not the tree walk.
 fn expand_directory(
     reader: &mut dyn ReadSeek,
     volume: &Volume,


### PR DESCRIPTION
Two UDF findings from the spec-conformance review.

CS0 dstring decoding accepted a used-length byte equal to the full field length, which let that length byte itself decode as a character on a malformed volume label. UDF 2.50 section 2.1.3 caps the content at len - 1; decoding from the field minus its trailing byte applies the cap. An over-long used length stays empty, matching how the module already treats malformed dstring values (libudfread clamps to the same bound instead).

The expand_directory doc comment claimed that a directory whose File Entry or data cannot be read yields no children rather than failing the scan. In fact only unresolvable, unparsable and non-directory entries degrade that way: an IO error at any of the three tree-walk reads propagates and fails the open in both strict and resilient mode. The comment now states the real behavior; no code change there.

Well-formed volumes decode byte-identically, so no report byte moves.