### PR TITLE
fix(wasm): treat a zero short-playlist threshold as disabling the filter

### DIFF
--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -713,16 +713,19 @@ fn build_web_tree(paths: &[String], files: &js_sys::Array) -> Result<Node<WebFil
 /// The filter the disc model is classified against: the standard rules with
 /// `short_seconds` as the length under which a playlist counts as short.
 ///
-/// An absent or non-positive `short_seconds` means the 20 s default, so a
-/// caller that does not care about the threshold passes `None` and gets the
-/// classic behaviour. Only the threshold is read downstream — no export filters
-/// the playlists any more — so the two switches keep their defaults.
+/// A present, finite, non-negative `short_seconds` is taken literally, so `0`
+/// leaves no playlist short and disables the short rule — the meaning the CLI's
+/// `--short-playlist-seconds 0` and the desktop app's threshold setting carry.
+/// An absent, negative or non-finite one means the 20 s default, so a caller
+/// that does not care about the threshold passes `None` and gets the classic
+/// behaviour. Only the threshold is read downstream — no export filters the
+/// playlists any more — so the two switches keep their defaults.
 #[cfg(any(target_arch = "wasm32", test))]
 fn classification_filter(short_seconds: Option<f64>) -> PlaylistFilter {
     let standard = PlaylistFilter::default();
     PlaylistFilter {
         short_playlist_seconds: short_seconds
-            .filter(|seconds| *seconds > 0.0)
+            .filter(|seconds| seconds.is_finite() && *seconds >= 0.0)
             .unwrap_or(standard.short_playlist_seconds),
         ..standard
     }
@@ -1007,8 +1010,8 @@ pub fn scan_report(data: &[u8]) -> String {
 /// that withhold it in `hiddenBy`, so a caller renders the standard selection
 /// table by keeping the playlists whose `hiddenBy` is empty and re-applies
 /// either rule without scanning again. `short_playlist_seconds` sets the length
-/// under which a playlist counts as short — absent or non-positive means the
-/// 20 s default.
+/// under which a playlist counts as short, `0` leaving no playlist short;
+/// absent, negative or non-finite means the 20 s default.
 ///
 /// # Errors
 /// As [`scan_files`]: `paths`/`files` length mismatch, a non-`File` entry, an
@@ -1717,18 +1720,19 @@ mod tests {
 
         #[test]
         fn classification_filter_takes_the_threshold_and_falls_back_to_twenty_seconds() {
-            // A positive threshold is used as given; anything else — absent,
-            // zero, negative, NaN — leaves the default 20 s in force, so a
-            // caller that does not set one gets the classic classification.
-            // Whole filters are compared, so the two switches the exports no
-            // longer offer are pinned as left at their defaults.
+            // Any finite threshold from zero up is used as given; a value no
+            // caller can have meant — absent, negative, non-finite — leaves the
+            // default 20 s in force, so a caller that does not set one gets the
+            // classic classification. Whole filters are compared, so the two
+            // switches the exports do not offer are pinned at their defaults.
             for (short_seconds, in_force) in [
                 (Some(5.0), 5.0),
                 (Some(0.5), 0.5),
+                (Some(0.0), 0.0),
                 (None, 20.0),
-                (Some(0.0), 20.0),
                 (Some(-1.0), 20.0),
                 (Some(f64::NAN), 20.0),
+                (Some(f64::INFINITY), 20.0),
             ] {
                 assert_eq!(
                     classification_filter(short_seconds),
@@ -1759,6 +1763,23 @@ mod tests {
             assert!(classification_filter(Some(5.0)).classify(&short).is_empty());
             assert_eq!(
                 classification_filter(Some(5.0)).classify(&looping),
+                [bdinfo_rs_core::bdrom::order::HiddenRule::Looping]
+            );
+        }
+
+        #[test]
+        fn a_zero_threshold_leaves_no_playlist_short() {
+            // Nothing is strictly shorter than zero seconds, so a zero
+            // threshold is how a caller switches the short rule off — the
+            // looping rule keeps judging independently.
+            let brief = sample_playlist("00002.MPLS", 1.0, 100, 0, &["C.M2TS"]);
+            let looping = PlaylistSummary {
+                has_loops: true,
+                ..sample_playlist("00003.MPLS", 1.0, 0, 0, &[])
+            };
+            assert!(classification_filter(Some(0.0)).classify(&brief).is_empty());
+            assert_eq!(
+                classification_filter(Some(0.0)).classify(&looping),
                 [bdinfo_rs_core::bdrom::order::HiddenRule::Looping]
             );
         }

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -153,6 +153,10 @@ playlist is judged against it:
 const disc = await inspect(picked, { shortPlaylistSeconds: 5 });
 ```
 
+It defaults to 20 seconds when omitted. Zero switches the short rule off — no
+playlist is shorter than zero seconds — so no `Disc` from that call names
+`"short"` in its `hiddenBy`.
+
 Nothing else moves with it: which playlists a `Disc` holds, which ones a
 `selection` measures, and the rendered report are the same either way.
 

--- a/crates/bdinfo-rs-wasm/web/src/analyze.ts
+++ b/crates/bdinfo-rs-wasm/web/src/analyze.ts
@@ -86,7 +86,8 @@ export interface ScanOptions {
   selection?: string[];
   /**
    * The length in seconds under which a playlist counts as short, defaulting to
-   * 20. Zero or less means that default.
+   * 20 when omitted. Zero switches the short rule off, since no playlist is
+   * shorter than zero seconds; a negative or non-finite value means the default.
    *
    * Read by {@link inspect} and {@link scan}, both of which classify every
    * playlist against it and report the outcome in {@link Playlist.hiddenBy}.
@@ -149,11 +150,12 @@ function payload(files: BdmvFile[]): { paths: string[]; files: File[] } {
 }
 
 /**
- * The playlist-classification threshold a scanning request carries. Zero is how
- * the WebAssembly module spells "use the 20 s default".
+ * The playlist-classification threshold a scanning request carries. An omitted
+ * one is forwarded as `undefined`, which is how the WebAssembly module spells
+ * "use the 20 s default" — zero means the caller switched the short rule off.
  */
-function classifyOptions(options?: ScanOptions): { shortPlaylistSeconds: number } {
-  return { shortPlaylistSeconds: options?.shortPlaylistSeconds ?? 0 };
+function classifyOptions(options?: ScanOptions): { shortPlaylistSeconds: number | undefined } {
+  return { shortPlaylistSeconds: options?.shortPlaylistSeconds };
 }
 
 /**

--- a/crates/bdinfo-rs-wasm/web/src/worker.ts
+++ b/crates/bdinfo-rs-wasm/web/src/worker.ts
@@ -25,11 +25,11 @@ import init, {
 
 /**
  * The playlist-classification threshold a scanning request carries: the length
- * under which a playlist counts as short. Zero means the wasm module's 20 s
- * default.
+ * under which a playlist counts as short. Absent means the wasm module's 20 s
+ * default; zero switches the short rule off.
  */
 interface ClassifyOptions {
-  shortPlaylistSeconds: number;
+  shortPlaylistSeconds: number | undefined;
 }
 
 /**

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -178,8 +178,10 @@ async function main() {
   const measuredShort = scan_files(shortPaths, shortFiles, [], undefined, true, true, 5).disc;
   const thresholdOk =
     classify(standard) === '["00000.MPLS:","00001.MPLS:short"]' &&
+    // A zero threshold switches the short rule off: nothing is shorter than
+    // zero seconds, so neither playlist is withheld.
     classify(inspect_files(shortPaths, shortFiles, 0).playlists) ===
-      '["00000.MPLS:","00001.MPLS:short"]' &&
+      '["00000.MPLS:","00001.MPLS:"]' &&
     classify(lowered) === '["00000.MPLS:","00001.MPLS:"]' &&
     numbering(standard) === "[[1,1],[1,2]]" &&
     numbering(lowered) === "[[1,1],[1,2]]" &&


### PR DESCRIPTION
The three surfaces disagreed on what a short-playlist threshold of 0 means. The CLI (`--short-playlist-seconds 0`) and the desktop app take it literally — the classifier drops playlists strictly shorter than the threshold, so 0 drops nothing. The wasm crate instead mapped any non-positive value to the 20 s default, leaving a JS caller no way to switch short filtering off.

`classification_filter` now uses a present, finite, non-negative value literally; absent, negative and non-finite values keep the 20 s default. The JS wrapper forwards an omitted `shortPlaylistSeconds` as `undefined` instead of 0.

Raw export signatures are unchanged. The doc comments, the package README and the Node parity assertion that pinned the superseded contract are updated with it.