### PR TITLE
ci: bump convco to 0.7.1 and install-action to v2.85.8

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -39,7 +39,7 @@ jobs:
       # `fallback: none`: install only from install-action's checksummed manifest,
       # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install cargo-deny (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-deny
           fallback: none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
       # action's checksummed manifest, never its runtime-resolved cargo-binstall
       # fallback (rationale in core.yml).
       - name: Install mutation tools
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-mutants,cargo-nextest
           fallback: none
@@ -296,7 +296,7 @@ jobs:
 
       - name: Install mutation tools
         if: steps.marker.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-mutants,cargo-nextest
           fallback: none
@@ -352,7 +352,7 @@ jobs:
 
       - name: Install mutation tools
         if: steps.marker.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-mutants,cargo-nextest
           fallback: none

--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -52,9 +52,9 @@ jobs:
       # `fallback: none`: install only from install-action's checksummed manifest,
       # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install convco (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
-          tool: convco@0.7.0
+          tool: convco@0.7.1
           fallback: none
 
       # Prove the banned-word regex still rejects attribution and passes innocent

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -226,7 +226,7 @@ jobs:
       # downgrade to that path, and does the same for a pinned `tool@version` the
       # manifest stops carrying.
       - name: Install gate tools
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-machete,cargo-shear,cargo-semver-checks
           fallback: none
@@ -293,7 +293,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install coverage tools
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-llvm-cov,cargo-nextest
           fallback: none
@@ -489,7 +489,7 @@ jobs:
           persist-credentials: false
 
       - name: Install cargo-deny (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-deny
           fallback: none
@@ -736,7 +736,7 @@ jobs:
       # `command -v cargo-deb` guard finds them and skips its (slower) source compile,
       # and the smoke test packages with the exact release tools.
       - name: Install cargo-deb (release pin, prebuilt)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-deb@3.7.0
           fallback: none

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -60,7 +60,7 @@ jobs:
       # `fallback: none`: install only from install-action's checksummed manifest,
       # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install wasm-bindgen-cli (pinned to the crate version)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: wasm-bindgen-cli@0.2.126
           fallback: none

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -110,7 +110,7 @@ jobs:
       # action's checksummed manifest, never its runtime-resolved cargo-binstall
       # fallback (rationale in core.yml).
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-nextest
           fallback: none
@@ -305,7 +305,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install the Rust gate tools (llvm-cov / nextest / machete / shear / deny / typos)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-llvm-cov,cargo-nextest,cargo-machete,cargo-shear,cargo-deny,typos-cli
           fallback: none
@@ -475,7 +475,7 @@ jobs:
       # from source if missing — this pre-install just makes the smoke fast.
       - name: Install cargo-deb (release-pinned, prebuilt)
         if: runner.os == 'Linux'
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-deb@3.7.0
           fallback: none

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -142,7 +142,7 @@ jobs:
       # `fallback: none`: install only from install-action's checksummed manifest,
       # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install wasm-bindgen-cli (pinned to the crate version)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: wasm-bindgen-cli@0.2.126
           fallback: none

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -127,7 +127,7 @@ jobs:
           persist-credentials: false
 
       - name: Install taplo (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           # Pinned (not latest) so a new taplo can't reformat/relint the tree and
           # red-X an unrelated PR; version-freshness watches it against crates.io
@@ -164,7 +164,7 @@ jobs:
           persist-credentials: false
 
       - name: Install zizmor (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: zizmor
           fallback: none
@@ -196,7 +196,7 @@ jobs:
           persist-credentials: false
 
       - name: Install typos
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: typos
           fallback: none

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -162,7 +162,7 @@ jobs:
       # fallback (rationale in core.yml).
       - name: Install mutation tools
         if: steps.marker.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-mutants,cargo-nextest
           fallback: none
@@ -257,7 +257,7 @@ jobs:
 
       - name: Install mutation tools
         if: steps.marker.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-mutants,cargo-nextest
           fallback: none
@@ -327,7 +327,7 @@ jobs:
 
       - name: Install mutation tools
         if: steps.marker.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-mutants,cargo-nextest
           fallback: none

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -88,7 +88,7 @@ jobs:
       # action's checksummed manifest, never its runtime-resolved cargo-binstall
       # fallback (rationale in core.yml).
       - name: Install wasm-bindgen-cli (pinned to the crate version)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: wasm-bindgen-cli@0.2.126
           fallback: none
@@ -111,7 +111,7 @@ jobs:
           }
 
       - name: Install the Rust gate tools (llvm-cov / nextest / machete / shear / typos)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-llvm-cov,cargo-nextest,cargo-machete,cargo-shear,cargo-deny,typos-cli
           fallback: none

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -37,7 +37,7 @@ jobs:
       # `fallback: none`: install only from install-action's checksummed manifest,
       # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install zizmor (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: zizmor
           fallback: none


### PR DESCRIPTION
convco 0.7.1 is now present in taiki-e/install-action's checksummed manifest, first shipped in install-action v2.85.8. The conventional.yml install step runs with fallback none, so the convco pin is only installable once the action version carrying that manifest entry is in use.

Bumps all 23 install-action pins in lockstep to v2.85.8 and the convco pin in conventional.yml to 0.7.1. The other three pins named in the issue (Node 26.6.0, setup-homebrew, cloudsmith-cli 1.21.0) are already current on master.

action-validator, ryl and zizmor pass locally.

Closes #237