### PR TITLE
fix(gate): deny yanked crates in the gui and wasm workspaces

### DIFF
--- a/crates/bdinfo-rs-gui/deny.toml
+++ b/crates/bdinfo-rs-gui/deny.toml
@@ -46,6 +46,10 @@ ignore = [
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
 ]
+# A yanked crate version defaults to a WARN in advisories v2 (so it would pass
+# `cargo deny check` silently). A yanked dep is one the publisher pulled — treat it
+# as a hard error so it cannot slip through the audit the gate claims to cover.
+yanked = "deny"
 
 [licenses]
 version = 2

--- a/crates/bdinfo-rs-wasm/deny.toml
+++ b/crates/bdinfo-rs-wasm/deny.toml
@@ -22,6 +22,10 @@ all-features = true
 version = 2
 # Add advisory IDs here ONLY with a comment explaining why the risk is accepted.
 ignore = []
+# A yanked crate version defaults to a WARN in advisories v2 (so it would pass
+# `cargo deny check` silently). A yanked dep is one the publisher pulled — treat it
+# as a hard error so it cannot slip through the audit the gate claims to cover.
+yanked = "deny"
 
 [licenses]
 version = 2


### PR DESCRIPTION
The root `deny.toml` sets `yanked = "deny"`; neither sibling workspace set the
key, so a yanked dependency in the iced/wgpu or wasm-bindgen trees passed their
`cargo deny check` with only a warning (advisories v2 defaults yanked to WARN).

Adds the key, with the root's rationale, to both crate-local `deny.toml` files.
`cargo deny check` passes on both workspaces.