### PR TITLE
build(gate): add the gate command aliases to the gui and wasm workspaces

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Clippy (calibrated, -D warnings)
         working-directory: crates/bdinfo-rs-gui
-        run: cargo clippy --all-targets --locked -- -D warnings
+        run: cargo lt
 
       - name: Build
         working-directory: crates/bdinfo-rs-gui
@@ -125,7 +125,7 @@ jobs:
 
       - name: Test (unit + proptests + golden ties + iced_test interactions)
         working-directory: crates/bdinfo-rs-gui
-        run: cargo nextest run --locked --no-tests=fail -E 'not test(/^snapshots::/)'
+        run: cargo nx
 
       # The SHIPPED configuration — opt-level="s" + fat LTO + codegen-units=1 +
       # strip + (Windows) windows_subsystem — compiles on every shipped arch.
@@ -181,7 +181,7 @@ jobs:
       - name: Test (release mode)
         if: matrix.os == 'ubuntu-latest'
         working-directory: crates/bdinfo-rs-gui
-        run: cargo nextest run --release --locked --no-tests=fail -E 'not test(/^snapshots::/)'
+        run: cargo nx --release
 
       # BLOCKING per-arch: the tiny-skia snapshot ties against the committed
       # per-OS-family hashes (snapshots/{windows,unix}/ — the first 6-arch run
@@ -195,7 +195,7 @@ jobs:
       - name: Snapshot hashes (tiny-skia — per-OS-family pins)
         id: snapshots
         working-directory: crates/bdinfo-rs-gui
-        run: cargo nextest run --locked --no-tests=fail --no-fail-fast -E 'test(/^snapshots::/)'
+        run: cargo snap --no-fail-fast
 
       - name: Upload mismatched snapshot renders
         if: failure() && steps.snapshots.outcome == 'failure'
@@ -328,26 +328,29 @@ jobs:
 
       - name: Machete (unused deps)
         working-directory: crates/bdinfo-rs-gui
-        run: cargo machete
+        run: cargo mc
 
       - name: Shear (unused deps, AST)
         working-directory: crates/bdinfo-rs-gui
-        run: cargo shear
+        run: cargo sh
 
       # Supply-chain audit of the GUI crate's OWN dependency tree (iced / wgpu /
       # winit / cosmic-text — compiled into the shipped binary but invisible to
       # the root audit, which `exclude`s this independent workspace). Uses the
       # crate-local crates/bdinfo-rs-gui/deny.toml; deliberately deny-only — no
-      # cargo-vet for this leaf (the wasm precedent). Run from the repo root so
-      # the manifest path resolves.
+      # cargo-vet for this leaf (the wasm precedent). Run from the crate
+      # directory: cargo-deny discovers deny.toml from the target manifest's
+      # workspace root, and the `dn` alias lives in that directory's
+      # .cargo/config.toml.
       - name: cargo-deny (gui dep audit — advisories / licenses / bans / sources)
-        run: cargo deny --manifest-path crates/bdinfo-rs-gui/Cargo.toml check
+        working-directory: crates/bdinfo-rs-gui
+        run: cargo dn
 
       - name: Doc (warnings = errors)
         working-directory: crates/bdinfo-rs-gui
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo doc --no-deps --document-private-items --locked
+        run: cargo dc
 
       # Tier-A coverage at the 100% floor. main.rs + ui.rs are Tier B (the iced
       # shell and the style vocabulary, verified by the interaction suite +

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -146,28 +146,30 @@ jobs:
 
       - name: Machete (unused deps)
         working-directory: crates/bdinfo-rs-wasm
-        run: cargo machete
+        run: cargo mc
 
       - name: Shear (unused deps, AST)
         working-directory: crates/bdinfo-rs-wasm
-        run: cargo shear
+        run: cargo sh
 
       # Supply-chain audit of the wasm crate's OWN dependency tree (js-sys /
       # wasm-bindgen / web-sys — compiled into the shipped `.wasm` but invisible to
       # the root audit, which `exclude`s this independent workspace). Uses the
       # crate-local crates/bdinfo-rs-wasm/deny.toml, which mirrors the root
       # allowlist + posture; cargo-deny discovers it from the target manifest's
-      # workspace root. Run from the repo root so the manifest path resolves.
+      # workspace root. Run from the crate directory, where the `dn` alias lives
+      # (.cargo/config.toml).
       - name: cargo-deny (wasm dep audit — advisories / licenses / bans / sources)
-        run: cargo deny --manifest-path crates/bdinfo-rs-wasm/Cargo.toml check
+        working-directory: crates/bdinfo-rs-wasm
+        run: cargo dn
 
       - name: Clippy (wasm32, calibrated, -D warnings)
         working-directory: crates/bdinfo-rs-wasm
-        run: cargo clippy --target wasm32-unknown-unknown --all-targets --release --locked -- -D warnings
+        run: cargo ltw
 
       - name: Clippy (native, -D warnings)
         working-directory: crates/bdinfo-rs-wasm
-        run: cargo clippy --all-targets --locked -- -D warnings
+        run: cargo lt
 
       - name: Build (wasm32, release)
         working-directory: crates/bdinfo-rs-wasm
@@ -177,7 +179,7 @@ jobs:
         working-directory: crates/bdinfo-rs-wasm
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo doc --target wasm32-unknown-unknown --no-deps --document-private-items --locked
+        run: cargo dc
 
       - name: Coverage (llvm-cov nextest, native — Tier A 100% lines/regions/functions)
         working-directory: crates/bdinfo-rs-wasm

--- a/crates/bdinfo-rs-gui/.cargo/config.toml
+++ b/crates/bdinfo-rs-gui/.cargo/config.toml
@@ -1,0 +1,35 @@
+# Cargo aliases for the INDEPENDENT native GUI workspace. Cargo merges config
+# files from the invocation directory upward, so running inside this directory
+# also picks up the repo-root .cargo/config.toml; the aliases below shadow the
+# root ones of the same name, which are spelled for the root workspace
+# (`--workspace`, core coverage floors) and are wrong for this crate.
+#
+# These spellings are the SINGLE home for what the GUI gate runs — the tracked
+# .github/workflows/gui.yml invokes them, so a flag added here reaches CI. They
+# only apply when cargo runs with this directory as its working directory.
+
+[alias]
+# Lint with warnings promoted to errors, across all targets (incl. tests).
+lt = "clippy --all-targets --locked -- -D warnings"
+# rustdoc with warnings = errors (RUSTDOCFLAGS is set by the caller); private
+# items too, so the internal links resolve.
+dc = "doc --no-deps --document-private-items --locked"
+# The suite minus the snapshot ties: unit + proptests, the golden ties, and the
+# iced_test interaction suite. --locked rejects a stale Cargo.lock;
+# --no-tests=fail makes an empty selection an error.
+#
+# The two nextest aliases are arrays because their `-E` filterset contains
+# spaces, and they are named `nx`/`snap` rather than the root's `nt` because
+# cargo refuses to merge an array alias over a string alias of the same name
+# ("expected array, but found string") — the repo-root .cargo/config.toml,
+# which cargo also reads here, spells `nt` as a string.
+nx = ["nextest", "run", "--locked", "--no-tests=fail", "-E", "not test(/^snapshots::/)"]
+# The tiny-skia snapshot ties alone, against the committed per-OS-family hashes.
+snap = ["nextest", "run", "--locked", "--no-tests=fail", "-E", "test(/^snapshots::/)"]
+# Unused-dependency sweep (regex pass).
+mc = "machete"
+# Unused-dependency sweep, AST-based (complementary to machete).
+sh = "shear"
+# Supply-chain audit: advisories + bans + licenses + sources, per this
+# workspace's own deny.toml (cargo-deny finds it from the workspace root).
+dn = "deny check"

--- a/crates/bdinfo-rs-wasm/.cargo/config.toml
+++ b/crates/bdinfo-rs-wasm/.cargo/config.toml
@@ -1,0 +1,26 @@
+# Cargo aliases for the INDEPENDENT in-browser wasm workspace. Cargo merges
+# config files from the invocation directory upward, so running inside this
+# directory also picks up the repo-root .cargo/config.toml; the aliases below
+# shadow the root ones of the same name, which are spelled for the root
+# workspace (`--workspace`, core coverage floors) and are wrong for this crate.
+#
+# These spellings are the SINGLE home for what the wasm gate runs — the tracked
+# .github/workflows/wasm.yml invokes them, so a flag added here reaches CI. They
+# only apply when cargo runs with this directory as its working directory.
+
+[alias]
+# Lint on the SHIPPED wasm32 target with warnings promoted to errors.
+ltw = "clippy --target wasm32-unknown-unknown --all-targets --release --locked -- -D warnings"
+# Lint the NATIVE build: the rlib the parity test links must be warning-clean,
+# which catches the dead_code / unused-import a cfg gate would orphan.
+lt = "clippy --all-targets --locked -- -D warnings"
+# rustdoc with warnings = errors (RUSTDOCFLAGS is set by the caller) on wasm32:
+# doc comments intra-doc-link to items that are cfg'd out on native.
+dc = "doc --target wasm32-unknown-unknown --no-deps --document-private-items --locked"
+# Unused-dependency sweep (regex pass).
+mc = "machete"
+# Unused-dependency sweep, AST-based (complementary to machete).
+sh = "shear"
+# Supply-chain audit: advisories + bans + licenses + sources, per this
+# workspace's own deny.toml (cargo-deny finds it from the workspace root).
+dn = "deny check"


### PR DESCRIPTION
The sibling workspaces had no `.cargo/config.toml`, so every gate command was
spelled out twice — once in the workflow YAML, once in the local gate script —
with no shareable home. The root workspace already solves this with aliases.

Adds `crates/bdinfo-rs-gui/.cargo/config.toml` and
`crates/bdinfo-rs-wasm/.cargo/config.toml` covering clippy, doc, nextest,
machete, shear and deny, and switches those steps in `gui.yml` and `wasm.yml`
to the aliases. Every alias reproduces the current spelling exactly; where a
step adds a flag (`--release`, `--no-fail-fast`) it is appended to the alias.

Wiring: nearly every sibling-workspace step already sets
`working-directory: crates/bdinfo-rs-<x>`, which is where a per-directory
`.cargo/config.toml` applies. The two `cargo deny` steps ran from the repo root
with `--manifest-path`; they now set `working-directory` too, which resolves the
same manifest and the same crate-local `deny.toml`.

The two nextest aliases are named `nx`/`snap` rather than `nt`: they need array
form for their `-E` filterset, and cargo refuses to merge an array alias over
the string alias of the same name in the repo-root config it also reads.

`classify-diff.ps1` maps both new paths to their crate areas (verified by
invocation); its self-test passes.