### PR TITLE
ci: re-pin the m2ts mutant exclusions and refresh the stale tool pins

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -139,7 +139,7 @@ exclude_re = [
     # is a u32 that the mutant only ever decrements from the wrapped u32::MAX, so
     # the acting arms (1, 0) are ~4 GiB of PID-0 bytes away, and the corrupted
     # pat_section_length is only read under those arms.
-    "m2ts\\.rs:1223:\\d+: replace > with >= in TsStreamFile::parse_pat",
+    "m2ts\\.rs:1277:\\d+: replace > with >= in TsStreamFile::parse_pat",
 
     # `parse_pmt` program-info guard `pmt_program_info_length > 0` vs `>=`: the dead
     # branch decrements pmt_section_length and the program-info countdown in
@@ -148,7 +148,7 @@ exclude_re = [
     # transfer is zero-length and the stale section re-walk is idempotent
     # (create_stream is keyed on contains_key). Traced and verified empirically
     # with a 357-padding-packet stream.
-    "m2ts\\.rs:1377:\\d+: replace > with >= in TsStreamFile::parse_pmt",
+    "m2ts\\.rs:1433:\\d+: replace > with >= in TsStreamFile::parse_pmt",
 
     # ── environment/platform probes no test process can observe ──────────────
 

--- a/.github/workflows/gui-publish.yml
+++ b/.github/workflows/gui-publish.yml
@@ -105,7 +105,7 @@ env:
   # Tool pins, hand-bumped (invisible to Dependabot; version-freshness.yml
   # watches them and asserts they agree with packages.yml's copies).
   KOMAC_VERSION: 2.16.0
-  CLOUDSMITH_CLI_VERSION: 1.20.2
+  CLOUDSMITH_CLI_VERSION: 1.21.0
 
 jobs:
   # Resolve tag/channels/mode from either trigger (the packages.yml gate

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -55,7 +55,7 @@ jobs:
       # nags (files an issue) when Homebrew master moves past this SHA, and the bump
       # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
       # releases, and this repo has none).
-      - uses: Homebrew/actions/setup-homebrew@726029484f4d6a3cc19c735a5fb22595f8655a9a # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@f5448d3709dc32011524a9e0819671e08d21661c # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its
@@ -118,7 +118,7 @@ jobs:
     steps:
       # A SHA-frozen Homebrew/actions pin — the full rationale sits on the
       # homebrew job's identical line above.
-      - uses: Homebrew/actions/setup-homebrew@726029484f4d6a3cc19c735a5fb22595f8655a9a # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@f5448d3709dc32011524a9e0819671e08d21661c # zizmor: ignore[ref-version-mismatch]
 
       # The same tap-trust story as the homebrew job above, for its reasons.
       - name: Trust the taps (ours + the runner's pre-tapped ones)


### PR DESCRIPTION
The daily core-mutants sweep reported two MISSED mutants in `m2ts.rs`. Both guards are already adjudicated as equivalent; their exclusions are pinned by line because their operator column is ambiguous within the function, and the lines shifted when #249 added code above them.

- `parse_pat` `pat_section_parse > 0`: 1223 -> 1277
- `parse_pmt` `pmt_program_info_length > 0`: 1377 -> 1433

Both proofs were re-derived against the current code and still hold, so this is a re-pin only.

Also resolves the version-freshness report:

- `Homebrew/actions/setup-homebrew` re-pinned to master HEAD `f5448d3709dc32011524a9e0819671e08d21661c` (both uses in install-smoke-test.yml)
- `CLOUDSMITH_CLI_VERSION` in gui-publish.yml aligned to `1.21.0`, matching the two pins in packages.yml

Closes #256