### PR TITLE
feat(core): export the shared projection, formatting, and selection helpers

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -226,7 +226,7 @@ exclude_re = [
     # mounted physical UDF disc, so every mutant is indistinguishable from the
     # original in any test environment. The returned label is validated end-to-end
     # against real hardware; the pure machinery it drives (AlignedReader,
-    # UdfSource::read_label, resolve_with, drive_root_letter, safe_report_stem) is
+    # UdfSource::read_label, resolve_with, drive_root_letter) is
     # unit-tested AND mutation-covered. cargo-mutants ignores `cfg`, so it also
     # mutates the cfg'd-out non-Windows stub; both are matched here by the fn name.
     "volume\\.rs:\\d+:\\d+:.*real_volume_label",

--- a/crates/bdinfo-rs-core/src/bdrom.rs
+++ b/crates/bdinfo-rs-core/src/bdrom.rs
@@ -8,7 +8,10 @@
 //!
 //! The disc-level orchestration that wires these together — the [`disc`] scan
 //! plus the cross-clip resolution that feeds the [`m2ts`] demux — builds on
-//! these standalone parsers.
+//! these standalone parsers. Two presentation modules sit beside them, over
+//! the scanned model rather than the bytes: [`order`] (which playlists a
+//! surface lists, and in what order) and [`progress`] (how far along a running
+//! scan is).
 
 use crate::bytes;
 use crate::error::BdError;
@@ -20,6 +23,7 @@ pub mod interleaved;
 pub mod m2ts;
 pub mod mpls;
 pub mod order;
+pub mod progress;
 
 // Shared fallible reads: every byte access in the parsers goes through these
 // bounds-checked helpers, mapping an out-of-bounds read (a short/truncated

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -151,9 +151,11 @@ impl PlaylistSummary {
         self.streams.iter().any(|stream| stream.is_hidden)
     }
 
-    /// The playlist's *estimated* (on-disk, unmeasured) size in bytes: the
-    /// interleaved `*.ssif` total when the playlist has one, else the `*.m2ts`
-    /// total, else `None` — neither file is present, or none has a size.
+    /// The playlist's *estimated* (on-disk, unmeasured) size in bytes.
+    ///
+    /// The interleaved `*.ssif` total when the playlist has one, else the
+    /// `*.m2ts` total, else `None` — neither file is present, or none has a
+    /// size.
     ///
     /// The interleaved total wins because an `*.ssif` already contains its
     /// playlist's `*.m2ts` bytes; adding the two would double-count. How an
@@ -213,8 +215,10 @@ impl PlaylistSummary {
 }
 
 /// The footnote a playlist listing prints when any listed playlist reports
-/// [`PlaylistSummary::has_hidden_streams`] — the classic `BDInfo` wording,
-/// explaining the `*` those playlists are marked with.
+/// [`PlaylistSummary::has_hidden_streams`].
+///
+/// The classic `BDInfo` wording, explaining the `*` those playlists are marked
+/// with.
 ///
 /// A surface with no room for a footnote need not show it, but one that does
 /// must show this text: the mark and its explanation are one contract.
@@ -282,9 +286,10 @@ impl ClipSummary {
         rate_over(self.packet_size(), self.packet_seconds)
     }
 
-    /// The clip's *estimated* (on-disk, unmeasured) size in bytes — the
-    /// interleaved `*.ssif` size when the clip has one, else the `*.m2ts` size,
-    /// else `None` (the file is absent). The per-clip form of
+    /// The clip's *estimated* (on-disk, unmeasured) size in bytes.
+    ///
+    /// The interleaved `*.ssif` size when the clip has one, else the `*.m2ts`
+    /// size, else `None` (the file is absent) — the per-clip form of
     /// [`PlaylistSummary::estimated_bytes`], with the same preference and the
     /// same reason for it.
     #[must_use]

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -151,6 +151,25 @@ impl PlaylistSummary {
         self.streams.iter().any(|stream| stream.is_hidden)
     }
 
+    /// The playlist's *estimated* (on-disk, unmeasured) size in bytes: the
+    /// interleaved `*.ssif` total when the playlist has one, else the `*.m2ts`
+    /// total, else `None` — neither file is present, or none has a size.
+    ///
+    /// The interleaved total wins because an `*.ssif` already contains its
+    /// playlist's `*.m2ts` bytes; adding the two would double-count. How an
+    /// absent size renders is the caller's choice (the classic table prints
+    /// `-`).
+    #[must_use]
+    pub const fn estimated_bytes(&self) -> Option<u64> {
+        if self.interleaved_file_size > 0 {
+            Some(self.interleaved_file_size)
+        } else if self.file_size > 0 {
+            Some(self.file_size)
+        } else {
+            None
+        }
+    }
+
     /// Per-angle measurement totals, one entry per extra camera angle (angle 1
     /// first; empty for a single-angle playlist).
     ///
@@ -192,6 +211,15 @@ impl PlaylistSummary {
         totals
     }
 }
+
+/// The footnote a playlist listing prints when any listed playlist reports
+/// [`PlaylistSummary::has_hidden_streams`] — the classic `BDInfo` wording,
+/// explaining the `*` those playlists are marked with.
+///
+/// A surface with no room for a footnote need not show it, but one that does
+/// must show this text: the mark and its explanation are one contract.
+pub const HIDDEN_STREAMS_NOTE: &str =
+    "(*) Some playlists on this disc have hidden tracks. These tracks are marked with an asterisk.";
 
 /// `size * 8 / seconds` rounded half-to-even as a bit rate, or `0` for a
 /// non-positive duration.
@@ -252,6 +280,22 @@ impl ClipSummary {
     #[must_use]
     pub fn packet_bit_rate(&self) -> u64 {
         rate_over(self.packet_size(), self.packet_seconds)
+    }
+
+    /// The clip's *estimated* (on-disk, unmeasured) size in bytes — the
+    /// interleaved `*.ssif` size when the clip has one, else the `*.m2ts` size,
+    /// else `None` (the file is absent). The per-clip form of
+    /// [`PlaylistSummary::estimated_bytes`], with the same preference and the
+    /// same reason for it.
+    #[must_use]
+    pub const fn estimated_bytes(&self) -> Option<u64> {
+        if self.interleaved_file_size > 0 {
+            Some(self.interleaved_file_size)
+        } else if self.file_size > 0 {
+            Some(self.file_size)
+        } else {
+            None
+        }
     }
 }
 
@@ -3605,6 +3649,28 @@ mod tests {
             clips,
             chapters: Vec::new(),
         }
+    }
+
+    #[test]
+    fn estimated_bytes_prefer_the_interleaved_size_then_the_m2ts_size() {
+        // Both sizes known: the interleaved total wins (it already contains the
+        // m2ts bytes). Only the m2ts: that. Neither: absent.
+        let sizes = |interleaved, m2ts| {
+            let clip = ClipSummary {
+                file_size: m2ts,
+                interleaved_file_size: interleaved,
+                ..clip_summary(0, 0.0, 0.0, 0)
+            };
+            let playlist = PlaylistSummary {
+                file_size: m2ts,
+                interleaved_file_size: interleaved,
+                ..playlist_summary(0.0, 0, Vec::new())
+            };
+            (playlist.estimated_bytes(), clip.estimated_bytes())
+        };
+        assert_eq!(sizes(2000, 500), (Some(2000), Some(2000)));
+        assert_eq!(sizes(0, 500), (Some(500), Some(500)));
+        assert_eq!(sizes(0, 0), (None, None));
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/bdrom/order.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/order.rs
@@ -18,10 +18,11 @@
 //! apply the presentation order on top.
 //!
 //! The projections every surface builds on that order live here too:
-//! [`table_rows`] (the grouped rows a selection table prints),
-//! [`selection_order`] and [`selection_stream_files`] (what a by-name
-//! selection renders and reads), and the [`HiddenRule`] classification behind
-//! the filter switches.
+//! [`table_rows`] (the grouped rows a selection table prints), the by-name
+//! selection family — [`normalize_playlist_name`] and [`named_selection`]
+//! (which names a request resolves to), [`selection_order`] and
+//! [`selection_stream_files`] (what that selection renders and reads) — and
+//! the [`HiddenRule`] classification behind the filter switches.
 
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
@@ -127,7 +128,12 @@ impl PlaylistFilter {
 /// then name ascending (ordinal byte order). A non-comparable length pair
 /// (NaN, impossible for parsed playlists) falls through to the name, mirroring
 /// a `>`-based three-way comparison.
-fn presentation_cmp(a: &PlaylistSummary, b: &PlaylistSummary) -> Ordering {
+///
+/// Public because a surface that lists playlists *outside* the presentation
+/// order — the hidden-playlist lines, which name what the filter withheld —
+/// must still list them in the order the table would have used.
+#[must_use]
+pub fn presentation_cmp(a: &PlaylistSummary, b: &PlaylistSummary) -> Ordering {
     b.total_length
         .partial_cmp(&a.total_length)
         .unwrap_or(Ordering::Equal)
@@ -229,13 +235,50 @@ pub fn selection_order(playlists: &[PlaylistSummary], selection: &[String]) -> V
         .collect()
 }
 
+/// Normalizes a user-typed playlist name to the spelling
+/// [`PlaylistSummary::name`] carries: upper-cased, with `.MPLS` appended when
+/// the name holds no `.` at all.
+///
+/// So `00800`, `00800.mpls` and `00800.MPLS` all name the same playlist. A name
+/// that already has *some* extension is only upper-cased, never re-suffixed —
+/// `feature.m2ts` normalizes to `FEATURE.M2TS` and then matches no playlist,
+/// which is the intended outcome for a name that is not a playlist file.
+#[must_use]
+pub fn normalize_playlist_name(name: &str) -> String {
+    let upper = name.to_ascii_uppercase();
+    if upper.contains('.') { upper } else { format!("{upper}.MPLS") }
+}
+
+/// A by-name playlist selection: each requested name
+/// [normalized](normalize_playlist_name) and matched against `playlists`, in
+/// the given order, first occurrence winning.
+///
+/// A name that matches no playlist is skipped and a repeat is dropped, so the
+/// result is a duplicate-free subset of the disc's names — the classic
+/// selection behaviour, and unfiltered (any parsed playlist is addressable by
+/// name, whatever a [`PlaylistFilter`] would withhold).
+#[must_use]
+pub fn named_selection(playlists: &[PlaylistSummary], requested: &[String]) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+    for raw in requested {
+        let name = normalize_playlist_name(raw);
+        if playlists.iter().any(|playlist| playlist.name == name) && !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    names
+}
+
 #[cfg(test)]
 mod tests {
+    use std::cmp::Ordering;
+
     use proptest::prelude::{prop_assert, prop_assert_eq, proptest};
 
     use super::{
-        HiddenRule, PlaylistFilter, presentation_groups, presentation_order, selection_order,
-        selection_stream_files, table_rows,
+        HiddenRule, PlaylistFilter, named_selection, normalize_playlist_name, presentation_cmp,
+        presentation_groups, presentation_order, selection_order, selection_stream_files,
+        table_rows,
     };
     use crate::bdrom::disc::{ClipSummary, PlaylistSummary};
 
@@ -425,6 +468,44 @@ mod tests {
         let selection = ["00002.MPLS".to_owned(), "00000.MPLS".to_owned(), "00002.MPLS".to_owned()];
         assert_eq!(selection_order(&selection_disc(), &selection), [2, 0, 2]);
         assert_eq!(selection_order(&selection_disc(), &["99999.MPLS".to_owned()]), [0_usize; 0]);
+    }
+
+    #[test]
+    fn playlist_names_normalize_to_the_model_spelling() {
+        // Bare number, lower-cased and upper-cased `.mpls` all name one playlist.
+        assert_eq!(normalize_playlist_name("00800"), "00800.MPLS");
+        assert_eq!(normalize_playlist_name("00800.mpls"), "00800.MPLS");
+        assert_eq!(normalize_playlist_name("00800.MPLS"), "00800.MPLS");
+        // Some other extension is upper-cased, never re-suffixed.
+        assert_eq!(normalize_playlist_name("feature.m2ts"), "FEATURE.M2TS");
+    }
+
+    #[test]
+    fn named_selection_normalizes_dedupes_and_keeps_order() {
+        let disc = selection_disc();
+        let requested =
+            ["00002".to_owned(), "00000.mpls".to_owned(), "99999".to_owned(), "00002".to_owned()];
+        // Normalized, unknown skipped, repeat dropped, request order kept.
+        assert_eq!(named_selection(&disc, &requested), ["00002.MPLS", "00000.MPLS"]);
+        // A request naming nothing on the disc, and an empty request, select nothing.
+        assert!(named_selection(&disc, &["X".to_owned()]).is_empty());
+        assert!(named_selection(&disc, &[]).is_empty());
+    }
+
+    #[test]
+    fn presentation_cmp_orders_longest_first_then_by_name() {
+        let long = playlist("00010.MPLS", 100.0, false, &[]);
+        let short = playlist("00001.MPLS", 50.0, false, &[]);
+        let tie = playlist("00020.MPLS", 100.0, false, &[]);
+        assert_eq!(presentation_cmp(&long, &short), Ordering::Less);
+        assert_eq!(presentation_cmp(&short, &long), Ordering::Greater);
+        // Equal lengths fall through to the ordinal name…
+        assert_eq!(presentation_cmp(&long, &tie), Ordering::Less);
+        // …as does a non-comparable pair, which no parsed playlist produces:
+        // `00005` sorts ahead of `00010` however their lengths compare.
+        let nan = playlist("00005.MPLS", f64::NAN, false, &[]);
+        assert_eq!(presentation_cmp(&nan, &long), Ordering::Less);
+        assert_eq!(presentation_cmp(&nan, &nan), Ordering::Equal);
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/bdrom/order.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/order.rs
@@ -125,9 +125,10 @@ impl PlaylistFilter {
 }
 
 /// Compares two playlists in presentation order: total length descending,
-/// then name ascending (ordinal byte order). A non-comparable length pair
-/// (NaN, impossible for parsed playlists) falls through to the name, mirroring
-/// a `>`-based three-way comparison.
+/// then name ascending (ordinal byte order).
+///
+/// A non-comparable length pair (NaN, impossible for parsed playlists) falls
+/// through to the name, mirroring a `>`-based three-way comparison.
 ///
 /// Public because a surface that lists playlists *outside* the presentation
 /// order — the hidden-playlist lines, which name what the filter withheld —

--- a/crates/bdinfo-rs-core/src/bdrom/progress.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/progress.rs
@@ -15,7 +15,9 @@
 use std::time::Duration;
 
 /// The `(percent, elapsed seconds, remaining seconds)` triple a progress line
-/// draws, from the bytes read so far, the bytes the pass will read, and the
+/// draws.
+///
+/// Derived from the bytes read so far, the bytes the pass will read, and the
 /// wall time since it started.
 ///
 /// The percent is the byte ratio; a scan with nothing to read (`total == 0`)

--- a/crates/bdinfo-rs-core/src/bdrom/progress.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/progress.rs
@@ -1,0 +1,175 @@
+//! The scan-progress line's arithmetic.
+//!
+//! A surface that draws live progress over a packet scan — a terminal line, a
+//! progress bar — turns each [`ScanProgress`](super::disc::ScanProgress)
+//! observation plus the wall time since the scan started into the same three
+//! numbers ([`progress_stats`]) and spells the two times the same way
+//! ([`hms`]). The line format and the redraw throttle are the surface's own;
+//! only the arithmetic is shared, so two surfaces watching one scan cannot
+//! disagree about how far along it is.
+//!
+//! The functions take plain counts rather than a `ScanProgress`, so a caller
+//! whose progress events carry `(done, total)` in some other shape uses them
+//! unchanged.
+
+use std::time::Duration;
+
+/// The `(percent, elapsed seconds, remaining seconds)` triple a progress line
+/// draws, from the bytes read so far, the bytes the pass will read, and the
+/// wall time since it started.
+///
+/// The percent is the byte ratio; a scan with nothing to read (`total == 0`)
+/// reads 100%, not a division by zero. The remaining estimate scales the
+/// elapsed time by the bytes still to read, and is `0` before the first byte
+/// arrives (`done == 0` gives it nothing to extrapolate from).
+///
+/// The estimate works in **milliseconds**: whole-second math would read zero
+/// for the entire first second, exactly when the first plausible estimate
+/// should already show.
+#[must_use]
+pub fn progress_stats(done: u64, total: u64, elapsed: Duration) -> (u64, u64, u64) {
+    let percent =
+        if total == 0 { 100 } else { done.saturating_mul(100).checked_div(total).unwrap_or(100) };
+    let elapsed_seconds = elapsed.as_secs();
+    let remaining = total.saturating_sub(done);
+    let remaining_seconds = elapsed
+        .as_millis()
+        .saturating_mul(u128::from(remaining))
+        .checked_div(u128::from(done).saturating_mul(1000))
+        .map_or(0, |seconds| u64::try_from(seconds).unwrap_or(u64::MAX));
+    (percent, elapsed_seconds, remaining_seconds)
+}
+
+/// `hh:mm:ss` from whole seconds — the elapsed and remaining spellings.
+///
+/// Hours **accumulate**: a scan past a day reads `25:01:01`, not `01:01:01`.
+/// That is deliberately unlike the report's own
+/// [`time_hh_short`](crate::report::text::time_hh_short), which wraps at 24
+/// because a playlist runtime never legitimately exceeds a day and a wall-clock
+/// estimate can.
+#[must_use]
+pub fn hms(seconds: u64) -> String {
+    let h = seconds.checked_div(3600).unwrap_or(0);
+    let m = seconds.checked_div(60).and_then(|minutes| minutes.checked_rem(60)).unwrap_or(0);
+    let s = seconds.checked_rem(60).unwrap_or(0);
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{hms, progress_stats};
+
+    #[test]
+    fn an_empty_scan_reads_one_hundred_percent() {
+        // total == 0 (a disc with no measurable bytes) is complete, not a
+        // divide-by-zero.
+        let (percent, _, remaining) = progress_stats(0, 0, Duration::from_secs(5));
+        assert_eq!(percent, 100);
+        assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn percent_is_the_byte_ratio() {
+        assert_eq!(progress_stats(0, 200, Duration::ZERO).0, 0);
+        assert_eq!(progress_stats(50, 200, Duration::ZERO).0, 25);
+        assert_eq!(progress_stats(200, 200, Duration::ZERO).0, 100);
+    }
+
+    #[test]
+    fn the_first_second_already_estimates() {
+        // Half-read after 500 ms: the ms-based math estimates ~500 ms remaining
+        // (reads 0 s), where whole-second math would have shown nothing yet. The
+        // point is it does not panic and rounds down to 0 s, not that it is
+        // non-zero — the next event past 1 s is the first whole-second estimate.
+        let (_, elapsed, remaining) = progress_stats(100, 200, Duration::from_millis(500));
+        assert_eq!(elapsed, 0);
+        assert_eq!(remaining, 0);
+        // Half-read after 4 s → ~4 s remaining.
+        assert_eq!(progress_stats(100, 200, Duration::from_secs(4)).2, 4);
+    }
+
+    #[test]
+    fn remaining_is_zero_before_any_bytes() {
+        // done == 0 → the estimate would divide by zero; it reads 0 instead.
+        assert_eq!(progress_stats(0, 200, Duration::from_secs(3)).2, 0);
+    }
+
+    #[test]
+    fn an_estimate_past_a_u64_of_seconds_saturates() {
+        // One byte read of u64::MAX after a very long wait: the u128 estimate
+        // exceeds u64, and saturates rather than wrapping to a small time.
+        let (_, _, remaining) =
+            progress_stats(1, u64::MAX, Duration::from_secs(u64::from(u32::MAX)));
+        assert_eq!(remaining, u64::MAX);
+    }
+
+    #[test]
+    fn hms_formats_hours_minutes_seconds() {
+        assert_eq!(hms(0), "00:00:00");
+        assert_eq!(hms(61), "00:01:01");
+        assert_eq!(hms(3661), "01:01:01");
+        // Hours accumulate past a day (no wrap) — a long scan estimate stays legible.
+        assert_eq!(hms(90_061), "25:01:01");
+    }
+
+    // The estimate math runs over hostile-shaped byte counts and durations, so
+    // amplify the unit cases with property tests.
+    mod prop {
+        use std::time::Duration;
+
+        use proptest::prelude::{Just, Strategy, any, prop_assert, prop_assert_eq, proptest};
+
+        use super::super::{hms, progress_stats};
+
+        /// A `(done, total)` pair with `done <= total` — the real scan invariant
+        /// (a packet scan never reports more bytes read than the disc holds).
+        fn done_and_total() -> impl Strategy<Value = (u64, u64)> {
+            (0_u64..1_000_000).prop_flat_map(|total| (0..=total, Just(total)))
+        }
+
+        proptest! {
+            #[test]
+            fn percent_is_bounded_and_monotone(
+                (done, total) in done_and_total(),
+                millis in 0_u64..10_000,
+            ) {
+                let (percent, _, _) = progress_stats(done, total, Duration::from_millis(millis));
+                prop_assert!(percent <= 100);
+                // Reading one more byte (still within total) never lowers the percent.
+                let more = progress_stats(done.saturating_add(1), total, Duration::ZERO).0;
+                prop_assert!(more >= percent || done >= total);
+            }
+
+            // Total over any counts and any duration, including the shapes a
+            // real scan cannot produce (done past total, a huge elapsed).
+            #[test]
+            fn the_triple_is_total_over_any_counts(
+                done in any::<u64>(),
+                total in any::<u64>(),
+                millis in any::<u64>(),
+            ) {
+                let (percent, elapsed, remaining) =
+                    progress_stats(done, total, Duration::from_millis(millis));
+                prop_assert!(percent <= 100 || total < done);
+                let _ = (elapsed, remaining);
+            }
+
+            // The spelling is always three colon-separated fields, the minutes
+            // and seconds two digits under 60.
+            #[test]
+            fn hms_is_well_formed(seconds in any::<u64>()) {
+                let formatted = hms(seconds);
+                let mut parts = formatted.split(':');
+                let hours = parts.next().and_then(|part| part.parse::<u64>().ok());
+                let minutes = parts.next().and_then(|part| part.parse::<u64>().ok());
+                let secs = parts.next().and_then(|part| part.parse::<u64>().ok());
+                prop_assert!(parts.next().is_none(), "exactly three segments");
+                prop_assert_eq!(hours, seconds.checked_div(3600));
+                prop_assert!(minutes.is_some_and(|value| value < 60));
+                prop_assert!(secs.is_some_and(|value| value < 60));
+            }
+        }
+    }
+}

--- a/crates/bdinfo-rs-core/src/report.rs
+++ b/crates/bdinfo-rs-core/src/report.rs
@@ -15,10 +15,11 @@ pub mod text;
 /// identical everywhere.
 const ILLEGAL: &[char] = &['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
 
-/// The report's save-file name for a disc labelled `label`: `BDINFO.<stem>.txt`,
-/// the stem being `label` with each illegal or control character replaced by
-/// `_`. A clean label — a folder name, a `.iso` volume identifier, a resolved
-/// drive label — passes through unchanged.
+/// The report's save-file name for a disc labelled `label`: `BDINFO.<stem>.txt`.
+///
+/// The stem is `label` with each illegal or control character replaced by `_`.
+/// A clean label — a folder name, a `.iso` volume identifier, a resolved drive
+/// label — passes through unchanged.
 ///
 /// The disc controls its own label bytes and a caller may save without a user in
 /// the loop, so the result is always **one flat path component**: a label

--- a/crates/bdinfo-rs-core/src/report.rs
+++ b/crates/bdinfo-rs-core/src/report.rs
@@ -73,7 +73,11 @@ mod tests {
                 // `.txt` must match exactly, never case-insensitively).
                 let stem = name.strip_prefix("BDINFO.").and_then(|rest| rest.strip_suffix(".txt"));
                 prop_assert!(stem.is_some(), "the name keeps its fixed shape: {name}");
-                prop_assert!(!name.chars().any(|c| c.is_control() || ILLEGAL.contains(&c)));
+                // Two assertions, not one `||` predicate: the combined form's
+                // second operand is unreachable by the very property being
+                // asserted, so it would read as a permanently uncovered branch.
+                prop_assert!(!name.chars().any(char::is_control));
+                prop_assert!(!name.chars().any(|c| ILLEGAL.contains(&c)));
                 // Joining it onto a directory can never re-root the path.
                 prop_assert_eq!(std::path::Path::new(&name).components().count(), 1);
             }

--- a/crates/bdinfo-rs-core/src/report.rs
+++ b/crates/bdinfo-rs-core/src/report.rs
@@ -3,5 +3,79 @@
 //! The library composes reports as `String`s — printing or saving them is the
 //! caller's job (the library never writes to stdout). The one report format is
 //! the classic human-readable disc report in [`text`].
+//!
+//! The file a caller saves it as is part of the same contract, so the name is
+//! composed here too: [`file_name`].
 
 pub mod text;
+
+/// Characters illegal in a Windows filename component, plus the separators that
+/// would re-root the report path. Replaced so [`file_name`] is always one
+/// writable file; applied uniformly on every platform so the report filename is
+/// identical everywhere.
+const ILLEGAL: &[char] = &['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
+
+/// The report's save-file name for a disc labelled `label`: `BDINFO.<stem>.txt`,
+/// the stem being `label` with each illegal or control character replaced by
+/// `_`. A clean label — a folder name, a `.iso` volume identifier, a resolved
+/// drive label — passes through unchanged.
+///
+/// The disc controls its own label bytes and a caller may save without a user in
+/// the loop, so the result is always **one flat path component**: a label
+/// carrying separators, `..\`, or control characters can neither re-root the
+/// path nor break the write.
+#[must_use]
+pub fn file_name(label: &str) -> String {
+    let stem: String = label
+        .chars()
+        .map(|c| if c.is_control() || ILLEGAL.contains(&c) { '_' } else { c })
+        .collect();
+    format!("BDINFO.{stem}.txt")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::file_name;
+
+    #[test]
+    fn a_clean_label_passes_through() {
+        assert_eq!(file_name("MY_DISC"), "BDINFO.MY_DISC.txt");
+        assert_eq!(file_name("BigBuckBunny"), "BDINFO.BigBuckBunny.txt");
+        assert_eq!(file_name("Blu-Ray"), "BDINFO.Blu-Ray.txt");
+        assert_eq!(file_name(""), "BDINFO..txt");
+    }
+
+    #[test]
+    fn illegal_and_control_characters_become_underscores() {
+        assert_eq!(file_name(r"J:\"), "BDINFO.J__.txt");
+        assert_eq!(file_name("a/b"), "BDINFO.a_b.txt");
+        assert_eq!(file_name("x<y>z|?*\""), "BDINFO.x_y_z____.txt");
+        assert_eq!(file_name("tab\there"), "BDINFO.tab_here.txt");
+        // The disc-controlled relative-write shape: a label that would
+        // lexically escape the chosen directory stays one flat component.
+        assert_eq!(file_name(r"..\..\x"), "BDINFO..._.._x.txt");
+    }
+
+    mod prop {
+        use proptest::prelude::{any, prop_assert, prop_assert_eq, proptest};
+
+        use super::super::{ILLEGAL, file_name};
+
+        proptest! {
+            // The write-safety contract: whatever bytes a disc puts in its
+            // label, the report filename is one flat component — no
+            // separators, no control characters, no illegal-on-Windows chars.
+            #[test]
+            fn the_name_is_always_one_safe_component(label in any::<String>()) {
+                let name = file_name(&label);
+                // Byte-exact prefix and suffix (strip, not ends_with — the
+                // `.txt` must match exactly, never case-insensitively).
+                let stem = name.strip_prefix("BDINFO.").and_then(|rest| rest.strip_suffix(".txt"));
+                prop_assert!(stem.is_some(), "the name keeps its fixed shape: {name}");
+                prop_assert!(!name.chars().any(|c| c.is_control() || ILLEGAL.contains(&c)));
+                // Joining it onto a directory can never re-root the path.
+                prop_assert_eq!(std::path::Path::new(&name).components().count(), 1);
+            }
+        }
+    }
+}

--- a/crates/bdinfo-rs-core/src/report/text.rs
+++ b/crates/bdinfo-rs-core/src/report/text.rs
@@ -772,7 +772,12 @@ fn cents(hundredths: i64) -> String {
 
 /// Groups a non-negative integer with `,` thousands separators (the `N0`
 /// spelling).
-fn group(value: u128) -> String {
+///
+/// Public because the byte-count cells a surface prints beside the report —
+/// the playlist table's estimated/measured columns, a disc-size read-out —
+/// must group exactly as the report does.
+#[must_use]
+pub fn group(value: u128) -> String {
     let digits = value.to_string();
     let mut parts: Vec<&[u8]> = digits.as_bytes().rchunks(3).collect();
     parts.reverse();
@@ -840,8 +845,15 @@ fn time_hh(ticks: i64) -> String {
     format!("{h:02}:{m:02}:{s:02}.{ms:03}")
 }
 
-/// `hh:mm:ss` — two-digit hours, the seconds-resolution spelling.
-fn time_hh_short(ticks: i64) -> String {
+/// `hh:mm:ss` — two-digit hours, the seconds-resolution spelling. Hours wrap at
+/// 24 and negative ticks clamp to zero (see [`time_parts`]).
+///
+/// Public because the playlist-length cell a surface prints beside the report
+/// is this spelling; feed it
+/// [`seconds_to_ticks`](crate::bdrom::chapters::seconds_to_ticks) of a
+/// [`PlaylistSummary::total_length`](crate::bdrom::disc::PlaylistSummary::total_length).
+#[must_use]
+pub fn time_hh_short(ticks: i64) -> String {
     let (h, m, s, _) = time_parts(ticks);
     format!("{h:02}:{m:02}:{s:02}")
 }
@@ -852,7 +864,7 @@ mod tests {
         RenderOptions, bytes_cell, cents, fixed_even, group, group_signed, kbps, render,
         render_with, secondary_audio, time_h, time_hh, time_hh_short, time_parts,
     };
-    use crate::bdrom::chapters::ChapterSummary;
+    use crate::bdrom::chapters::{ChapterSummary, seconds_to_ticks};
     use crate::bdrom::disc::{BdRom, ClipStreamTally, ClipSummary, PlaylistSummary, StreamSummary};
     use crate::error::{BdError, ScanError, ScanStage};
     use crate::primitives::Pid;
@@ -1499,7 +1511,11 @@ Subtitle:       English / 19.12 kbps
     fn formatting_helpers_pin_their_edge_rules() {
         // `N0` grouping, signed and unsigned.
         assert_eq!(group(0), "0");
+        assert_eq!(group(7), "7");
+        assert_eq!(group(1_000), "1,000");
         assert_eq!(group(1_234_567), "1,234,567");
+        // The widest byte count a disc field can carry still groups.
+        assert_eq!(group(u128::from(u64::MAX)), "18,446,744,073,709,551,615");
         assert_eq!(group_signed(-1_234), "-1,234");
         // The two-decimal hundredths spelling clamps negatives to zero.
         assert_eq!(cents(637), "6.37");
@@ -1529,5 +1545,58 @@ Subtitle:       English / 19.12 kbps
         assert_eq!(time_hh(ticks), "02:03:24.567");
         assert_eq!(time_hh_short(ticks), "02:03:24");
         assert_eq!(time_parts(-1), (0, 0, 0, 0));
+    }
+
+    #[test]
+    fn the_seconds_resolution_spelling_reads_a_playlist_length() {
+        // The playlist-length cell: seconds through `seconds_to_ticks`, the
+        // form every surface's table column takes.
+        let cell = |seconds: f64| time_hh_short(seconds_to_ticks(seconds));
+        assert_eq!(cell(0.0), "00:00:00");
+        assert_eq!(cell(100.0), "00:01:40");
+        assert_eq!(cell(3661.0), "01:01:01");
+        assert_eq!(cell(93_600.0 + 65.0), "02:01:05");
+        // A negative length clamps to zero; 25 h 01 min 01 s wraps the day.
+        assert_eq!(cell(-5.0), "00:00:00");
+        assert_eq!(cell(90_061.0), "01:01:01");
+    }
+
+    // Both spellings render values a disc controls, so amplify the unit cases
+    // with property tests.
+    mod prop {
+        use proptest::prelude::{any, prop_assert, prop_assert_eq, proptest};
+
+        use super::super::{group, time_hh_short};
+        use crate::bdrom::chapters::seconds_to_ticks;
+
+        proptest! {
+            #[test]
+            fn grouping_round_trips_and_commas_every_three(value in any::<u128>()) {
+                let grouped = group(value);
+                // Stripping the commas yields the plain decimal.
+                let plain: String = grouped.chars().filter(|&c| c != ',').collect();
+                prop_assert_eq!(&plain, &value.to_string());
+                // One comma for every full group of three past the first digit.
+                let digits = value.to_string().chars().count();
+                let commas = grouped.chars().filter(|&c| c == ',').count();
+                prop_assert_eq!(commas, digits.saturating_sub(1).checked_div(3).unwrap_or(0));
+            }
+
+            #[test]
+            fn the_seconds_resolution_spelling_is_well_formed(
+                seconds in 0.0_f64..1_000_000.0,
+            ) {
+                let formatted = time_hh_short(seconds_to_ticks(seconds));
+                let mut parts = formatted.split(':');
+                let hours = parts.next().and_then(|part| part.parse::<u64>().ok());
+                let minutes = parts.next().and_then(|part| part.parse::<u64>().ok());
+                let secs = parts.next().and_then(|part| part.parse::<u64>().ok());
+                prop_assert!(parts.next().is_none(), "exactly three segments");
+                prop_assert_eq!(formatted.chars().count(), 8); // NN:NN:NN
+                prop_assert!(hours.is_some_and(|value| value < 24));
+                prop_assert!(minutes.is_some_and(|value| value < 60));
+                prop_assert!(secs.is_some_and(|value| value < 60));
+            }
+        }
     }
 }

--- a/crates/bdinfo-rs-core/src/vfs.rs
+++ b/crates/bdinfo-rs-core/src/vfs.rs
@@ -100,7 +100,9 @@ pub trait BdDir {
     /// Files matching `pattern`, optionally recursing into subdirectories.
     ///
     /// Matching is ASCII case-insensitive — one pass finds `*.mpls` and
-    /// `*.MPLS` spellings alike, no per-case retries needed.
+    /// `*.MPLS` spellings alike, no per-case retries needed. [`fs::glob_ci`] is
+    /// the rule both built-in backends apply; an implementor outside this crate
+    /// should call it rather than write a second matcher.
     ///
     /// # Errors
     /// Propagates the underlying IO error if the directory cannot be read.

--- a/crates/bdinfo-rs-core/src/vfs/fs.rs
+++ b/crates/bdinfo-rs-core/src/vfs/fs.rs
@@ -346,8 +346,12 @@ fn extension_of(path: &Path) -> String {
 /// case-folded pass finds `*.mpls` and `*.MPLS` spellings alike.
 ///
 /// Shared with the UDF backend ([`super::udf`]) so `.iso` and folder input
-/// match patterns identically.
-pub(crate) fn glob_ci(pattern: &[u8], name: &[u8]) -> bool {
+/// match patterns identically, and public so an out-of-crate
+/// [`BdDir`](crate::vfs::BdDir) backend — a browser file list, an in-memory
+/// tree — resolves [`get_files_pattern`](crate::vfs::BdDir::get_files_pattern)
+/// by the same rule rather than a lookalike of its own.
+#[must_use]
+pub fn glob_ci(pattern: &[u8], name: &[u8]) -> bool {
     match pattern.split_first() {
         None => name.is_empty(),
         Some((&b'*', rest)) => {

--- a/crates/bdinfo-rs-core/src/vfs/fs.rs
+++ b/crates/bdinfo-rs-core/src/vfs/fs.rs
@@ -341,8 +341,9 @@ fn extension_of(path: &Path) -> String {
     }
 }
 
-/// ASCII case-insensitive glob match of `name` against `pattern`, where `*`
-/// matches any run (including empty) and `?` matches exactly one byte. One
+/// ASCII case-insensitive glob match of `name` against `pattern`.
+///
+/// `*` matches any run (including empty) and `?` matches exactly one byte. One
 /// case-folded pass finds `*.mpls` and `*.MPLS` spellings alike.
 ///
 /// Shared with the UDF backend ([`super::udf`]) so `.iso` and folder input

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -33,13 +33,12 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use bdinfo_rs_core::bdrom::disc::{PlaylistSummary, ScanProgress};
+use bdinfo_rs_core::bdrom::disc::{HIDDEN_STREAMS_NOTE, PlaylistSummary, ScanProgress};
 use bdinfo_rs_core::error::ScanError;
+use bdinfo_rs_core::report;
 use bdinfo_rs_gui::diagnostics::{self, LogErr as _};
 use bdinfo_rs_gui::flow::{self, Flow, ScanRequest, Stage};
-use bdinfo_rs_gui::model::{
-    SelectableRow, Sort, SortColumn, ViewSettings, format_file_size, group_n0,
-};
+use bdinfo_rs_gui::model::{SelectableRow, Sort, SortColumn, ViewSettings, format_file_size};
 use bdinfo_rs_gui::panes::{CodecRow, StreamFileRow};
 use bdinfo_rs_gui::progress::{self, ProgressModel};
 use bdinfo_rs_gui::scan::{self, Input, Structural};
@@ -1863,14 +1862,14 @@ impl App {
 
     /// Writes the rendered report into `dir` as `BDINFO.{label}.txt`, bytes
     /// verbatim (the locked CRLF / UTF-8 no-BOM contract — never re-encode).
-    /// The label is disc-controlled, so the filename goes through the
-    /// sanitizer ([`paths::report_file_name`]) — the same name the CLI writes.
+    /// The label is disc-controlled, so the filename goes through the core's
+    /// sanitizer ([`report::file_name`]) — the same name the CLI writes.
     fn save_report(&mut self, dir: &std::path::Path) {
-        let (Some(report), Some(label)) = (self.flow.report(), self.flow.label()) else {
+        let (Some(rendered), Some(label)) = (self.flow.report(), self.flow.label()) else {
             return;
         };
-        let target = dir.join(paths::report_file_name(label));
-        self.status = match std::fs::write(&target, report.as_bytes()) {
+        let target = dir.join(report::file_name(label));
+        self.status = match std::fs::write(&target, rendered.as_bytes()) {
             Ok(()) => Some(format!("Report saved to: {}", target.display())),
             Err(err) => {
                 // The status line is transient; autosave in particular runs
@@ -2375,12 +2374,13 @@ impl App {
         }
 
         if let Some(size) = self.flow.disc_size() {
-            let value = format!("{} bytes ({})", group_n0(size), format_file_size(size));
+            let value =
+                format!("{} bytes ({})", report::text::group(u128::from(size)), format_file_size(size));
             lines = lines.push(info_line(p, "Disc Size:", value, true));
         }
 
         if self.flow.show_hidden_note() {
-            lines = lines.push(text(HIDDEN_NOTE).size(ui::TEXT_XS).color(p.text_muted));
+            lines = lines.push(text(HIDDEN_STREAMS_NOTE).size(ui::TEXT_XS).color(p.text_muted));
         }
 
         // The indicator takes the slack the strip already has to the right of
@@ -2593,11 +2593,6 @@ impl App {
             .into()
     }
 }
-
-/// The CLI's hidden-tracks footer note, shown verbatim below the table when any
-/// listed playlist hides a stream.
-const HIDDEN_NOTE: &str =
-    "(*) Some playlists on this disc have hidden tracks. These tracks are marked with an asterisk.";
 
 /// The encrypted-disc indicator in the info box: a warning sign and the
 /// condition, spelled out rather than left to the glyph alone — the glyph is

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -2374,8 +2374,11 @@ impl App {
         }
 
         if let Some(size) = self.flow.disc_size() {
-            let value =
-                format!("{} bytes ({})", report::text::group(u128::from(size)), format_file_size(size));
+            let value = format!(
+                "{} bytes ({})",
+                report::text::group(u128::from(size)),
+                format_file_size(size)
+            );
             lines = lines.push(info_line(p, "Disc Size:", value, true));
         }
 

--- a/crates/bdinfo-rs-gui/src/model.rs
+++ b/crates/bdinfo-rs-gui/src/model.rs
@@ -10,8 +10,8 @@ use std::cmp::Ordering;
 
 use bdinfo_rs_core::bdrom::chapters::seconds_to_ticks;
 use bdinfo_rs_core::bdrom::disc::PlaylistSummary;
-use bdinfo_rs_core::bdrom::order::{HiddenRule, PlaylistFilter, table_rows};
-use bdinfo_rs_core::report::text::RenderOptions;
+use bdinfo_rs_core::bdrom::order::{HiddenRule, PlaylistFilter, presentation_cmp, table_rows};
+use bdinfo_rs_core::report::text::{self, RenderOptions};
 
 use crate::settings::Settings;
 
@@ -114,8 +114,8 @@ pub(crate) struct PlaylistRow {
     /// key behind the formatted `length` cell (hours wrap in the cell, ticks
     /// don't).
     pub(crate) length_ticks: i64,
-    /// Estimated bytes — interleaved `*.ssif` size, else `*.m2ts` size, else
-    /// `None` (the `-` cell).
+    /// Estimated bytes per [`PlaylistSummary::estimated_bytes`]; `None` is the
+    /// `-` cell.
     pub(crate) estimated_bytes: Option<u64>,
     /// Measured (packet-derived) bytes over all angle clips — `0` until the
     /// measured scan fills it.
@@ -167,49 +167,11 @@ pub struct SelectableRow {
     pub cells: TableRow,
 }
 
-/// `hh:mm:ss` from playlist seconds, truncated to the tick like the CLI table
-/// (hours wrap at 24; no day component).
-pub(crate) fn table_length(seconds: f64) -> String {
-    let total = seconds_to_ticks(seconds).max(0).checked_div(10_000_000).unwrap_or(0);
-    let h = total.checked_div(3600).and_then(|h| h.checked_rem(24)).unwrap_or(0);
-    let m = total.checked_div(60).and_then(|m| m.checked_rem(60)).unwrap_or(0);
-    let s = total.checked_rem(60).unwrap_or(0);
-    format!("{h:02}:{m:02}:{s:02}")
-}
-
-/// The estimated byte size shown for a playlist: the interleaved `*.ssif` size
-/// when known, else the `*.m2ts` size, else `None` (the `-` cell).
-const fn estimated_bytes(playlist: &PlaylistSummary) -> Option<u64> {
-    if playlist.interleaved_file_size > 0 {
-        Some(playlist.interleaved_file_size)
-    } else if playlist.file_size > 0 {
-        Some(playlist.file_size)
-    } else {
-        None
-    }
-}
-
-/// `N0` thousands grouping for a byte count (`1234567` → `1,234,567`) — the
-/// CLI table's byte-cell format.
-///
-/// Public so the binary's info box can group the exact disc-size byte count
-/// alongside its [`format_file_size`] short form.
-#[must_use]
-pub fn group_n0(value: u64) -> String {
-    let mut grouped = Vec::new();
-    for (position, digit) in value.to_string().chars().rev().enumerate() {
-        if position > 0 && position.checked_rem(3) == Some(0) {
-            grouped.push(',');
-        }
-        grouped.push(digit);
-    }
-    grouped.into_iter().rev().collect()
-}
-
 /// One byte-count cell body: the human-readable short form when the toggle is
-/// on (`BDInfo`'s `SizeFormatHR`), else the thousands-grouped exact count.
+/// on (`BDInfo`'s `SizeFormatHR`), else the report's thousands-grouped exact
+/// count.
 pub(crate) fn byte_cell(bytes: u64, human: bool) -> String {
-    if human { format_file_size(bytes) } else { group_n0(bytes) }
+    if human { format_file_size(bytes) } else { text::group(u128::from(bytes)) }
 }
 
 /// The `Estimated Bytes` cell: a [`byte_cell`] when known, else `-`.
@@ -249,7 +211,7 @@ pub fn format_file_size(bytes: u64) -> String {
     let whole = u64::try_from(hundredths.checked_div(100).unwrap_or(0)).unwrap_or(u64::MAX);
     let frac = hundredths.checked_rem(100).unwrap_or(0);
     let label = UNITS.get(unit).copied().unwrap_or("B");
-    format!("{}.{frac:02} {label}", group_n0(whole))
+    format!("{}.{frac:02} {label}", text::group(u128::from(whole)))
 }
 
 /// Builds the structured selection-table rows over the `filter`-kept set.
@@ -267,9 +229,9 @@ pub(crate) fn playlist_rows(
                 group,
                 name: playlist.name.clone(),
                 chapter_count: playlist.chapter_count,
-                length: table_length(playlist.total_length),
+                length: text::time_hh_short(seconds_to_ticks(playlist.total_length)),
                 length_ticks: seconds_to_ticks(playlist.total_length),
-                estimated_bytes: estimated_bytes(playlist),
+                estimated_bytes: playlist.estimated_bytes(),
                 measured_bytes: playlist.total_angle_packet_size(),
                 has_hidden_streams: playlist.has_hidden_streams(),
             })
@@ -486,12 +448,7 @@ pub fn hidden_playlists(
     if hidden.is_empty() {
         return None;
     }
-    hidden.sort_by(|a, b| {
-        b.total_length
-            .partial_cmp(&a.total_length)
-            .unwrap_or(Ordering::Equal)
-            .then_with(|| a.name.cmp(&b.name))
-    });
+    hidden.sort_by(|a, b| presentation_cmp(a, b));
     let short = filter.filter_short_playlists
         && hidden.iter().any(|playlist| filter.classify(playlist).contains(&HiddenRule::Short));
     let looping = filter.filter_looping_playlists
@@ -510,8 +467,8 @@ mod tests {
 
     use super::{
         PlaylistRow, Sort, SortColumn, TableRow, ViewSettings, any_hidden, byte_cell, compare,
-        display_rows, estimated_bytes, estimated_cell, format_file_size, group_n0,
-        hidden_playlists, playlist_display_name, playlist_rows, sort_rows, table_length,
+        display_rows, estimated_cell, format_file_size, hidden_playlists, playlist_display_name,
+        playlist_rows, sort_rows,
     };
     use crate::settings::Settings;
 
@@ -697,30 +654,6 @@ mod tests {
                 },
             ]
         );
-    }
-
-    #[test]
-    fn table_length_truncates_and_wraps_the_day() {
-        assert_eq!(table_length(0.0), "00:00:00");
-        assert_eq!(table_length(3661.0), "01:01:01");
-        assert_eq!(table_length(-5.0), "00:00:00"); // a negative length clamps to zero
-        assert_eq!(table_length(90_061.0), "01:01:01"); // 25h01m01s wraps the day
-    }
-
-    #[test]
-    fn estimated_bytes_prefers_interleaved_then_m2ts_then_none() {
-        assert_eq!(estimated_bytes(&sample_playlist("X", 1.0, 500, 2000, &[])), Some(2000));
-        assert_eq!(estimated_bytes(&sample_playlist("X", 1.0, 500, 0, &[])), Some(500));
-        assert_eq!(estimated_bytes(&sample_playlist("X", 1.0, 0, 0, &[])), None);
-    }
-
-    #[test]
-    fn group_n0_groups_every_three_digits_from_the_right() {
-        assert_eq!(group_n0(0), "0");
-        assert_eq!(group_n0(7), "7");
-        assert_eq!(group_n0(1000), "1,000");
-        assert_eq!(group_n0(1_234_567), "1,234,567");
-        assert_eq!(group_n0(u64::MAX), "18,446,744,073,709,551,615");
     }
 
     #[test]
@@ -1029,38 +962,11 @@ mod tests {
         use proptest::prelude::*;
 
         use super::super::{
-            Sort, SortColumn, ViewSettings, display_rows, group_n0, playlist_rows, sort_rows,
-            table_length,
+            Sort, SortColumn, ViewSettings, display_rows, playlist_rows, sort_rows,
         };
         use super::sample_playlist;
 
         proptest! {
-            #[test]
-            fn group_n0_round_trips_and_commas_every_three(value: u64) {
-                let grouped = group_n0(value);
-                // Stripping the commas yields the plain decimal.
-                let plain: String = grouped.chars().filter(|&c| c != ',').collect();
-                prop_assert_eq!(&plain, &value.to_string());
-                // One comma for every full group of three past the first digit.
-                let digits = value.to_string().chars().count();
-                let commas = grouped.chars().filter(|&c| c == ',').count();
-                prop_assert_eq!(commas, digits.saturating_sub(1).checked_div(3).unwrap_or(0));
-            }
-
-            #[test]
-            fn table_length_is_well_formed_hms(seconds in 0.0_f64..1_000_000.0) {
-                let formatted = table_length(seconds);
-                let mut parts = formatted.split(':');
-                let hours = parts.next().and_then(|p| p.parse::<u64>().ok());
-                let minutes = parts.next().and_then(|p| p.parse::<u64>().ok());
-                let secs = parts.next().and_then(|p| p.parse::<u64>().ok());
-                prop_assert!(parts.next().is_none(), "exactly three segments");
-                prop_assert_eq!(formatted.chars().count(), 8); // NN:NN:NN
-                prop_assert!(hours.is_some_and(|h| h < 24));
-                prop_assert!(minutes.is_some_and(|m| m < 60));
-                prop_assert!(secs.is_some_and(|s| s < 60));
-            }
-
             // The whole table pipeline — build, format, sort — is total over
             // arbitrary disc shapes: it never panics, positions stay 1-based
             // and dense, every cell renders non-empty, and a sort is a true

--- a/crates/bdinfo-rs-gui/src/panes.rs
+++ b/crates/bdinfo-rs-gui/src/panes.rs
@@ -8,17 +8,19 @@
 //! `description` is the same string the locked report prints — built by the core,
 //! reused verbatim here.
 
+use bdinfo_rs_core::bdrom::chapters::seconds_to_ticks;
 use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary, StreamSummary};
+use bdinfo_rs_core::report::text;
 
-use crate::model::{byte_cell, group_n0, table_length};
+use crate::model::byte_cell;
 
 /// One "Stream File" pane row: a clip of the selected playlist, pre-formatted.
 ///
 /// Columns: Stream File / Index / Length / Estimated Size / Measured Size — the
-/// same five `BDInfo` shows. `estimated` is the clip's on-disk size (the
-/// interleaved `*.ssif` when it has one, else the `*.m2ts`); `measured` is the
-/// packet-derived size the demux attributed to the clip. Either is `-` until it
-/// is known (no file on disk / nothing demuxed yet).
+/// same five `BDInfo` shows. `estimated` is the clip's on-disk size
+/// ([`ClipSummary::estimated_bytes`]); `measured` is the packet-derived size the
+/// demux attributed to the clip. Either is `-` until it is known (no file on
+/// disk / nothing demuxed yet).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StreamFileRow {
     /// The clip's display name (the interleaved `*.ssif`, else the `*.m2ts`),
@@ -73,9 +75,8 @@ pub fn stream_file_rows(playlist: &PlaylistSummary, human_sizes: bool) -> Vec<St
 }
 
 /// Formats one clip into its stream-file row, mirroring `BDInfo`: an extra-angle
-/// clip gets a ` (N)` suffix; the estimated size prefers the interleaved
-/// `*.ssif` and falls back to the plain `*.m2ts`; a size that is not yet known
-/// (no file / nothing demuxed) shows as `-`.
+/// clip gets a ` (N)` suffix, and a size that is not yet known (no file /
+/// nothing demuxed) shows as `-`.
 fn stream_file_row(clip: &ClipSummary, index: usize, human_sizes: bool) -> StreamFileRow {
     let file = if clip.angle_index > 0 {
         format!("{} ({})", clip.display_name, clip.angle_index)
@@ -85,16 +86,10 @@ fn stream_file_row(clip: &ClipSummary, index: usize, human_sizes: bool) -> Strea
     StreamFileRow {
         file,
         index: index.to_string(),
-        length: table_length(clip.length),
-        estimated: size_cell(estimated_size(clip), human_sizes),
+        length: text::time_hh_short(seconds_to_ticks(clip.length)),
+        estimated: size_cell(clip.estimated_bytes().unwrap_or(0), human_sizes),
         measured: size_cell(clip.packet_size(), human_sizes),
     }
-}
-
-/// The clip's on-disk (estimated) size — the interleaved `*.ssif` when it has
-/// one, else the plain `*.m2ts` (`0` when neither is present).
-const fn estimated_size(clip: &ClipSummary) -> u64 {
-    if clip.interleaved_file_size > 0 { clip.interleaved_file_size } else { clip.file_size }
 }
 
 /// A byte-size cell — grouped or human-readable per the toggle — or `-` when
@@ -130,7 +125,7 @@ fn bitrate_cell(bits_per_second: i64) -> String {
     if kbps <= 0 {
         "-".to_owned()
     } else {
-        format!("{} kbps", group_n0(u64::try_from(kbps).unwrap_or(0)))
+        format!("{} kbps", text::group(u128::try_from(kbps).unwrap_or(0)))
     }
 }
 

--- a/crates/bdinfo-rs-gui/src/paths.rs
+++ b/crates/bdinfo-rs-gui/src/paths.rs
@@ -162,5 +162,4 @@ mod tests {
         // A bare relative file name has no usable parent — no destination.
         assert_eq!(super::autosave_dir(&Input::Iso(PathBuf::from("disc.iso"))), None);
     }
-
 }

--- a/crates/bdinfo-rs-gui/src/paths.rs
+++ b/crates/bdinfo-rs-gui/src/paths.rs
@@ -10,9 +10,9 @@
 //! image's OS path, a literal `::` separator, then the in-image path with `/`
 //! separators — unambiguous, and greppable back to the image.
 //!
-//! The report's save paths live here too: the autosave destination implied
-//! by the input ([`autosave_dir`]) and the disc-label-safe report filename
-//! ([`report_file_name`]).
+//! The autosave destination implied by the input ([`autosave_dir`]) lives here
+//! too; the report's file name itself comes from
+//! [`bdinfo_rs_core::report::file_name`].
 
 use std::path::{Path, PathBuf};
 
@@ -67,32 +67,6 @@ pub fn autosave_dir(input: &Input) -> Option<PathBuf> {
     // A bare relative name yields an empty parent — no destination, never an
     // accidental write into the current directory.
     dir.filter(|parent| !parent.as_os_str().is_empty())
-}
-
-/// Characters illegal in a Windows filename component, plus the separators
-/// that would re-root the report path. Replaced so `BDINFO.<stem>.txt` is
-/// always one writable file; applied uniformly on every platform so the
-/// report filename is identical everywhere. Replicates the CLI's
-/// `volume::ILLEGAL` (`crates/bdinfo-rs/src/volume.rs`) — keep in lock-step.
-const ILLEGAL: &[char] = &['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
-
-/// The report's save-file name for a disc labelled `label`:
-/// `BDINFO.<stem>.txt`, the stem being `label` with each illegal or control
-/// character replaced by `_`.
-///
-/// The same name the CLI writes for the same disc (its
-/// `volume::safe_report_stem`, replicated here because the crates share no
-/// code; keep the two in lock-step). A disc controls its label bytes and
-/// autosave writes with no user in the loop, so a hostile label (separators,
-/// `..\`, control chars) must never re-root the path or break the write; a
-/// clean label passes through unchanged.
-#[must_use]
-pub fn report_file_name(label: &str) -> String {
-    let stem: String = label
-        .chars()
-        .map(|c| if c.is_control() || ILLEGAL.contains(&c) { '_' } else { c })
-        .collect();
-    format!("BDINFO.{stem}.txt")
 }
 
 /// Builds the copy target for the `BDMV/<dir>/<name>` disc entry.
@@ -189,46 +163,4 @@ mod tests {
         assert_eq!(super::autosave_dir(&Input::Iso(PathBuf::from("disc.iso"))), None);
     }
 
-    #[test]
-    fn report_file_name_passes_a_clean_label_through() {
-        // The same fixtures the CLI's `safe_report_stem` tests pin.
-        assert_eq!(super::report_file_name("MY_DISC"), "BDINFO.MY_DISC.txt");
-        assert_eq!(super::report_file_name("BigBuckBunny"), "BDINFO.BigBuckBunny.txt");
-        assert_eq!(super::report_file_name("Blu-Ray"), "BDINFO.Blu-Ray.txt");
-        assert_eq!(super::report_file_name(""), "BDINFO..txt");
-    }
-
-    #[test]
-    fn report_file_name_replaces_illegal_and_control_characters() {
-        assert_eq!(super::report_file_name(r"J:\"), "BDINFO.J__.txt");
-        assert_eq!(super::report_file_name("a/b"), "BDINFO.a_b.txt");
-        assert_eq!(super::report_file_name("x<y>z|?*\""), "BDINFO.x_y_z____.txt");
-        assert_eq!(super::report_file_name("tab\there"), "BDINFO.tab_here.txt");
-        // The disc-controlled relative-write shape: a label that would
-        // lexically escape the chosen directory stays one flat component.
-        assert_eq!(super::report_file_name(r"..\..\x"), "BDINFO..._.._x.txt");
-    }
-
-    mod prop {
-        use proptest::prelude::*;
-
-        proptest! {
-            // The write-safety contract: whatever bytes a disc puts in its
-            // label, the report filename is one flat component — no
-            // separators, no control characters, no illegal-on-Windows chars.
-            #[test]
-            fn report_file_name_is_always_one_safe_component(label in any::<String>()) {
-                let name = super::super::report_file_name(&label);
-                // Byte-exact prefix and suffix (strip, not ends_with — the
-                // `.txt` must match exactly, never case-insensitively).
-                let stem = name.strip_prefix("BDINFO.").and_then(|rest| rest.strip_suffix(".txt"));
-                prop_assert!(stem.is_some(), "the name keeps its fixed shape: {name}");
-                prop_assert!(
-                    !name.chars().any(|c| c.is_control() || super::super::ILLEGAL.contains(&c))
-                );
-                // Joining it onto a directory can never re-root the path.
-                prop_assert_eq!(std::path::Path::new(&name).components().count(), 1);
-            }
-        }
-    }
 }

--- a/crates/bdinfo-rs-gui/src/progress.rs
+++ b/crates/bdinfo-rs-gui/src/progress.rs
@@ -1,17 +1,16 @@
 //! The pure live-progress model.
 //!
-//! Ports the CLI's (`main.rs`) `progress_stats` + `hms` math: from a scan's
-//! `done` / `total` byte counts and the elapsed wall time it derives the
-//! percent, the elapsed seconds, and a remaining-time estimate. The model is
-//! pure — `(file, done, total, elapsed) -> ProgressModel` — so the iced progress
-//! bar + text line are a thin projection of it, and the boundary cases the CLI
-//! pins (an empty scan reads 100%, the first-second estimate already shows) are
-//! unit-testable here without a window. The two other pieces of progress-line
-//! decision logic live here for the same reason: the indeterminate bar's
-//! triangle wave ([`pulse_fraction`] / [`pulse_advance`]) and the worker's
-//! event-coalescing rule ([`emit_due`]).
+//! Wraps the core's [`progress_stats`] + [`hms`] math — percent, elapsed
+//! seconds, remaining estimate — in a pure
+//! `(file, done, total, elapsed) -> ProgressModel` projection, so the iced
+//! progress bar + text line are a thin read of it and are unit-testable without
+//! a window. The two other pieces of progress-line decision logic live here for
+//! the same reason: the indeterminate bar's triangle wave ([`pulse_fraction`] /
+//! [`pulse_advance`]) and the worker's event-coalescing rule ([`emit_due`]).
 
 use std::time::Duration;
+
+use bdinfo_rs_core::bdrom::progress::{hms, progress_stats};
 
 /// The indeterminate-bar animation period (one full 0→1→0 breath).
 pub const PULSE_PERIOD: u16 = 1000;
@@ -51,35 +50,6 @@ const EMIT_EVERY: Duration = Duration::from_millis(100);
 #[must_use]
 pub fn emit_due(file_changed: bool, done: u64, total: u64, since_last: Option<Duration>) -> bool {
     file_changed || done == total || since_last.is_none_or(|elapsed| elapsed >= EMIT_EVERY)
-}
-
-/// The percent / elapsed-seconds / remaining-seconds triple the progress line
-/// draws.
-///
-/// The percent comes from the byte counts (an empty scan — `total == 0` — reads
-/// 100%); the remaining estimate scales the elapsed time by the bytes still to
-/// read. The estimate works in **milliseconds**: whole-second math would read
-/// zero for the entire first second, exactly when the first plausible estimate
-/// should already show.
-fn progress_stats(done: u64, total: u64, elapsed: Duration) -> (u64, u64, u64) {
-    let percent =
-        if total == 0 { 100 } else { done.saturating_mul(100).checked_div(total).unwrap_or(100) };
-    let elapsed_seconds = elapsed.as_secs();
-    let remaining = total.saturating_sub(done);
-    let remaining_seconds = elapsed
-        .as_millis()
-        .saturating_mul(u128::from(remaining))
-        .checked_div(u128::from(done).saturating_mul(1000))
-        .map_or(0, |seconds| u64::try_from(seconds).unwrap_or(u64::MAX));
-    (percent, elapsed_seconds, remaining_seconds)
-}
-
-/// `hh:mm:ss` from whole seconds (no day component — hours accumulate).
-fn hms(seconds: u64) -> String {
-    let h = seconds.checked_div(3600).unwrap_or(0);
-    let m = seconds.checked_div(60).and_then(|m| m.checked_rem(60)).unwrap_or(0);
-    let s = seconds.checked_rem(60).unwrap_or(0);
-    format!("{h:02}:{m:02}:{s:02}")
 }
 
 /// A live-progress snapshot: the current file, the percent, and the estimates.
@@ -154,51 +124,7 @@ impl ProgressModel {
 mod tests {
     use std::time::Duration;
 
-    use super::{ProgressModel, hms, progress_stats};
-
-    #[test]
-    fn an_empty_scan_reads_one_hundred_percent() {
-        // total == 0 (a disc with no measurable bytes) is complete, not a
-        // divide-by-zero.
-        let (percent, _, remaining) = progress_stats(0, 0, Duration::from_secs(5));
-        assert_eq!(percent, 100);
-        assert_eq!(remaining, 0);
-    }
-
-    #[test]
-    fn percent_is_the_byte_ratio() {
-        assert_eq!(progress_stats(0, 200, Duration::ZERO).0, 0);
-        assert_eq!(progress_stats(50, 200, Duration::ZERO).0, 25);
-        assert_eq!(progress_stats(200, 200, Duration::ZERO).0, 100);
-    }
-
-    #[test]
-    fn the_first_second_already_estimates() {
-        // Half-read after 500 ms: the ms-based math estimates ~500 ms remaining
-        // (reads 0 s), where whole-second math would have shown nothing yet. The
-        // point is it does not panic and rounds down to 0 s, not that it is
-        // non-zero — the next event past 1 s is the first whole-second estimate.
-        let (_, elapsed, remaining) = progress_stats(100, 200, Duration::from_millis(500));
-        assert_eq!(elapsed, 0);
-        assert_eq!(remaining, 0);
-        // Half-read after 4 s → ~4 s remaining.
-        assert_eq!(progress_stats(100, 200, Duration::from_secs(4)).2, 4);
-    }
-
-    #[test]
-    fn remaining_is_zero_before_any_bytes() {
-        // done == 0 → the estimate would divide by zero; it reads 0 instead.
-        assert_eq!(progress_stats(0, 200, Duration::from_secs(3)).2, 0);
-    }
-
-    #[test]
-    fn hms_formats_hours_minutes_seconds() {
-        assert_eq!(hms(0), "00:00:00");
-        assert_eq!(hms(61), "00:01:01");
-        assert_eq!(hms(3661), "01:01:01");
-        // Hours accumulate past a day (no wrap) — a long scan estimate stays legible.
-        assert_eq!(hms(90_061), "25:01:01");
-    }
+    use super::ProgressModel;
 
     #[test]
     fn model_projects_fraction_and_line() {
@@ -263,34 +189,16 @@ mod tests {
         assert!(super::emit_due(false, 100, 100, Some(Duration::ZERO)));
     }
 
-    // The estimate math runs over hostile-shaped byte counts and durations, so
+    // The projection runs over hostile-shaped byte counts and durations, so
     // amplify the unit cases with property tests.
     mod prop {
         use std::time::Duration;
 
         use proptest::prelude::*;
 
-        use super::super::{ProgressModel, progress_stats};
-
-        /// A `(done, total)` pair with `done <= total` — the real scan invariant
-        /// (a packet scan never reports more bytes read than the disc holds).
-        fn done_and_total() -> impl Strategy<Value = (u64, u64)> {
-            (0_u64..1_000_000).prop_flat_map(|total| (0..=total, Just(total)))
-        }
+        use super::super::ProgressModel;
 
         proptest! {
-            #[test]
-            fn percent_is_bounded_and_monotone(
-                (done, total) in done_and_total(),
-                millis in 0_u64..10_000,
-            ) {
-                let (percent, _, _) = progress_stats(done, total, Duration::from_millis(millis));
-                prop_assert!(percent <= 100);
-                // Reading one more byte (still within total) never lowers the percent.
-                let more = progress_stats(done.saturating_add(1), total, Duration::ZERO).0;
-                prop_assert!(more >= percent || done >= total);
-            }
-
             #[test]
             fn fraction_stays_in_unit_range(
                 done in 0_u64..1_000_000,

--- a/crates/bdinfo-rs-gui/src/volume.rs
+++ b/crates/bdinfo-rs-gui/src/volume.rs
@@ -9,8 +9,8 @@
 //! the drive root, whose path carries no final component, so the label degrades
 //! to the drive-root string itself (`"J:\"`). That is wrong in the report's
 //! `Disc Label:` line, the info box, and the `BDINFO.<label>.txt` save name
-//! (whose *characters* `paths::report_file_name` already sanitizes — this
-//! module fixes the label's SOURCE).
+//! (whose *characters* [`bdinfo_rs_core::report::file_name`] already sanitizes
+//! — this module fixes the label's SOURCE).
 //!
 //! [`resolve_folder_label`] replaces a nameless-drive-root label with the real
 //! UDF volume label — read off the raw volume device (`\\.\J:`) through the

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -53,16 +53,15 @@ use std::io::{Read, Seek};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-#[cfg(any(target_arch = "wasm32", test))]
-use bdinfo_rs_core::bdrom::disc::PlaylistSummary;
 use bdinfo_rs_core::bdrom::disc::{BdRom, ScanMode, ScanProgress, ScanReport};
 use bdinfo_rs_core::bdrom::order::PlaylistFilter;
 #[cfg(any(target_arch = "wasm32", test))]
-use bdinfo_rs_core::bdrom::order::{selection_order, selection_stream_files};
+use bdinfo_rs_core::bdrom::order::{named_selection, selection_order, selection_stream_files};
 #[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::discovery::BdmvDir;
 use bdinfo_rs_core::error::BdError;
 use bdinfo_rs_core::report::text::{self, RenderOptions};
+use bdinfo_rs_core::vfs::fs::glob_ci;
 use bdinfo_rs_core::vfs::udf::source::{IsoReader, UdfSource};
 use bdinfo_rs_core::vfs::{BdDir, BdFile, ReadSeek, SearchOption};
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -106,31 +105,10 @@ impl<F> Node<F> {
     }
 }
 
-/// ASCII case-insensitive glob: `*` = any run, `?` = any one byte. Mirrors
-/// `glob_ci` in the core's `vfs::fs` (crate-private there, so it cannot be
-/// reused or linked) so file-backed input matches patterns exactly like
-/// folder input does — the two implementations must agree.
-fn glob_match(pattern: &[u8], name: &[u8]) -> bool {
-    match pattern.split_first() {
-        None => name.is_empty(),
-        Some((b'*', rest)) => {
-            (0..=name.len()).any(|skip| name.get(skip..).is_some_and(|tail| glob_match(rest, tail)))
-        }
-        Some((b'?', rest)) => match name.split_first() {
-            Some((_, tail)) => glob_match(rest, tail),
-            None => false,
-        },
-        Some((c, rest)) => match name.split_first() {
-            Some((n, tail)) => c.eq_ignore_ascii_case(n) && glob_match(rest, tail),
-            None => false,
-        },
-    }
-}
-
 impl<F: BdFile + Clone + 'static> Node<F> {
     fn collect_pattern(&self, pattern: &str, recurse: bool, out: &mut Vec<Box<dyn BdFile>>) {
         for f in &self.files {
-            if glob_match(pattern.as_bytes(), f.name().as_bytes()) {
+            if glob_ci(pattern.as_bytes(), f.name().as_bytes()) {
                 out.push(Box::new(f.clone()));
             }
         }
@@ -731,28 +709,6 @@ fn classification_filter(short_seconds: Option<f64>) -> PlaylistFilter {
     }
 }
 
-/// Normalizes a requested playlist name to the model's spelling: upper-cased,
-/// with `.MPLS` appended when no extension was given. Mirrors the CLI.
-#[cfg(any(target_arch = "wasm32", test))]
-fn normalize_playlist_name(name: &str) -> String {
-    let upper = name.to_ascii_uppercase();
-    if upper.contains('.') { upper } else { format!("{upper}.MPLS") }
-}
-
-/// Resolves the requested names against the disc, in the given order, first
-/// occurrence wins, unknown names skipped — the CLI's `--mpls` selection.
-#[cfg(any(target_arch = "wasm32", test))]
-fn named_selection(playlists: &[PlaylistSummary], requested: &[String]) -> Vec<String> {
-    let mut names: Vec<String> = Vec::new();
-    for raw in requested {
-        let name = normalize_playlist_name(raw);
-        if playlists.iter().any(|playlist| playlist.name == name) && !names.contains(&name) {
-            names.push(name);
-        }
-    }
-    names
-}
-
 /// Why a by-name [`scan_selection`] could not produce a report.
 #[cfg(any(target_arch = "wasm32", test))]
 #[derive(Debug)]
@@ -1185,8 +1141,8 @@ mod tests {
     use std::io::{self, SeekFrom};
 
     use super::{
-        MAX_TREE_DEPTH, RenderOptions, TreeError, assemble_tree, extension_of, glob_match,
-        path_components, read_window, seek_target, split_sections,
+        MAX_TREE_DEPTH, RenderOptions, TreeError, assemble_tree, extension_of, path_components,
+        read_window, seek_target, split_sections,
     };
 
     /// Parses path strings into the `(components, id)` entries `assemble_tree`
@@ -1217,18 +1173,6 @@ mod tests {
             blob.extend_from_slice(section);
         }
         blob
-    }
-
-    #[test]
-    fn glob_match_is_literal_anchored_and_case_insensitive() {
-        assert!(glob_match(b"00000.MPLS", b"00000.mpls"));
-        assert!(glob_match(b"*.mpls", b"00000.MPLS"));
-        assert!(glob_match(b"00???.clpi", b"00012.clpi"));
-        assert!(glob_match(b"*", b""));
-        assert!(glob_match(b"", b""));
-        assert!(!glob_match(b"*.mpls", b"00000.m2ts"));
-        assert!(!glob_match(b"?", b""));
-        assert!(!glob_match(b"a", b""));
     }
 
     #[test]
@@ -1673,7 +1617,7 @@ mod tests {
         use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary};
         use bdinfo_rs_core::bdrom::order::PlaylistFilter;
 
-        use crate::{classification_filter, named_selection, normalize_playlist_name};
+        use crate::classification_filter;
 
         /// A `ClipSummary` carrying just a name + length (the fields the
         /// selection helpers read); the measured tallies stay zero.
@@ -1782,35 +1726,6 @@ mod tests {
                 classification_filter(Some(0.0)).classify(&looping),
                 [bdinfo_rs_core::bdrom::order::HiddenRule::Looping]
             );
-        }
-
-        #[test]
-        fn normalize_playlist_name_uppercases_and_appends_mpls() {
-            assert_eq!(normalize_playlist_name("00000"), "00000.MPLS");
-            assert_eq!(normalize_playlist_name("00000.mpls"), "00000.MPLS");
-            assert_eq!(normalize_playlist_name("feature.m2ts"), "FEATURE.M2TS");
-        }
-
-        #[test]
-        fn named_selection_normalizes_dedupes_and_keeps_order() {
-            let playlists = [
-                sample_playlist("00000.MPLS", 1.0, 0, 0, &[]),
-                sample_playlist("00002.MPLS", 1.0, 0, 0, &[]),
-            ];
-            // unknown skipped, duplicate skipped, order preserved, name normalized.
-            assert_eq!(
-                named_selection(
-                    &playlists,
-                    &[
-                        "00002".to_owned(),
-                        "00000.mpls".to_owned(),
-                        "99999".to_owned(),
-                        "00002".to_owned(),
-                    ],
-                ),
-                ["00002.MPLS", "00000.MPLS"]
-            );
-            assert!(named_selection(&playlists, &[]).is_empty());
         }
 
         #[test]

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -77,11 +77,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use bdinfo_rs_core::bdrom::chapters::seconds_to_ticks;
-use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, ScanMode, ScanProgress};
-use bdinfo_rs_core::bdrom::order::{
-    HiddenRule, PlaylistFilter, selection_order, selection_stream_files, table_rows,
+use bdinfo_rs_core::bdrom::disc::{
+    BdRom, HIDDEN_STREAMS_NOTE, PlaylistSummary, ScanMode, ScanProgress,
 };
+use bdinfo_rs_core::bdrom::order::{
+    HiddenRule, PlaylistFilter, named_selection, presentation_cmp, selection_order,
+    selection_stream_files, table_rows,
+};
+use bdinfo_rs_core::bdrom::progress::{hms, progress_stats};
 use bdinfo_rs_core::error::{BdError, ScanError};
+use bdinfo_rs_core::report;
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 use bdinfo_rs_core::vfs::fs::FsDir;
 use bdinfo_rs_core::vfs::udf::source::{PathIso, UdfSource};
@@ -317,10 +322,7 @@ fn run(cli: &Cli) -> u8 {
             .iter()
             .any(|&(_, i)| bdrom.playlists.get(i).is_some_and(PlaylistSummary::has_hidden_streams))
         {
-            println!(
-                "(*) Some playlists on this disc have hidden tracks. These tracks are marked \
-                 with an asterisk."
-            );
+            println!("{HIDDEN_STREAMS_NOTE}");
         }
         print!("{}", hidden_hint(&bdrom.playlists, &filter));
         if cli.whole || cli.list {
@@ -625,27 +627,6 @@ fn resolve_dest(cli: &Cli, bd_path: &Path) -> Result<PathBuf, u8> {
     Ok(dest)
 }
 
-/// Normalizes a `--mpls` value to the playlist-file spelling the model uses:
-/// upper-cased, with `.MPLS` appended when no extension was given.
-fn normalize_playlist_name(name: &str) -> String {
-    let upper = name.to_ascii_uppercase();
-    if upper.contains('.') { upper } else { format!("{upper}.MPLS") }
-}
-
-/// The `--mpls` selection: each requested name normalized and matched against
-/// the disc, in the given order, first occurrence wins; an unknown name is
-/// skipped, the classic selection behaviour.
-fn named_selection(playlists: &[PlaylistSummary], requested: &[String]) -> Vec<String> {
-    let mut names: Vec<String> = Vec::new();
-    for raw in requested {
-        let name = normalize_playlist_name(raw);
-        if playlists.iter().any(|p| p.name == name) && !names.contains(&name) {
-            names.push(name);
-        }
-    }
-    names
-}
-
 /// How many playlist names a hint line spells out before it counts the rest —
 /// enough to recognize the disc's numbering, short enough to stay on one line
 /// on an 80-column console.
@@ -697,12 +678,7 @@ fn hint_line(
     if hidden.is_empty() {
         return String::new();
     }
-    hidden.sort_by(|a, b| {
-        b.total_length
-            .partial_cmp(&a.total_length)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.name.cmp(&b.name))
-    });
+    hidden.sort_by(|a, b| presentation_cmp(a, b));
     let named: Vec<&str> =
         hidden.iter().take(HINT_NAMES).map(|playlist| playlist.name.as_str()).collect();
     let rest = hidden.len().saturating_sub(HINT_NAMES);
@@ -731,10 +707,10 @@ fn row_names(
 
 /// Composes the playlist selection table: the `#`/Group/Playlist
 /// File/Length/Estimated Bytes/Measured Bytes header (followed by a blank
-/// line) and one row per listed playlist. Estimated bytes prefer the
-/// interleaved `*.ssif` size, fall back to the `*.m2ts` size, and read `-`
-/// when neither is known; measured bytes read `-` until a packet scan has
-/// measured the playlist.
+/// line) and one row per listed playlist. Both byte columns read `-` when the
+/// size is not known — estimated per
+/// [`PlaylistSummary::estimated_bytes`](bdinfo_rs_core::bdrom::disc::PlaylistSummary::estimated_bytes),
+/// measured until a packet scan has measured the playlist.
 fn selection_table(playlists: &[PlaylistSummary], rows: &[(usize, usize)]) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
@@ -747,17 +723,11 @@ fn selection_table(playlists: &[PlaylistSummary], rows: &[(usize, usize)]) -> St
         let Some(playlist) = playlists.get(index) else {
             continue;
         };
-        let estimated = if playlist.interleaved_file_size > 0 {
-            group_n0(playlist.interleaved_file_size)
-        } else if playlist.file_size > 0 {
-            group_n0(playlist.file_size)
-        } else {
-            "-".to_owned()
-        };
-        let measured = if playlist.total_packet_size() > 0 {
-            group_n0(playlist.total_packet_size())
-        } else {
-            "-".to_owned()
+        let cell = |bytes: u64| text::group(u128::from(bytes));
+        let estimated = playlist.estimated_bytes().map_or_else(|| "-".to_owned(), cell);
+        let measured = match playlist.total_packet_size() {
+            0 => "-".to_owned(),
+            bytes => cell(bytes),
         };
         let _ = writeln!(
             out,
@@ -765,34 +735,12 @@ fn selection_table(playlists: &[PlaylistSummary], rows: &[(usize, usize)]) -> St
             position.saturating_add(1),
             group,
             playlist.name,
-            table_length(playlist.total_length),
+            text::time_hh_short(seconds_to_ticks(playlist.total_length)),
             estimated,
             measured
         );
     }
     out
-}
-
-/// `hh:mm:ss` from playlist seconds, truncated to the tick like the classic
-/// table (hours wrap at 24; the day component is not shown).
-fn table_length(seconds: f64) -> String {
-    let total = seconds_to_ticks(seconds).max(0).checked_div(10_000_000).unwrap_or(0);
-    let h = total.checked_div(3600).and_then(|h| h.checked_rem(24)).unwrap_or(0);
-    let m = total.checked_div(60).and_then(|m| m.checked_rem(60)).unwrap_or(0);
-    let s = total.checked_rem(60).unwrap_or(0);
-    format!("{h:02}:{m:02}:{s:02}")
-}
-
-/// `N0` thousands grouping for a byte count (`1234567` → `1,234,567`).
-fn group_n0(value: u64) -> String {
-    let mut grouped = Vec::new();
-    for (position, digit) in value.to_string().chars().rev().enumerate() {
-        if position > 0 && position.checked_rem(3) == Some(0) {
-            grouped.push(',');
-        }
-        grouped.push(digit);
-    }
-    grouped.into_iter().rev().collect()
 }
 
 /// The interactive playlist picker: prompts `Select (q when finished): `
@@ -858,7 +806,7 @@ fn analyze_preamble(playlists: &[PlaylistSummary], selection: &[String]) -> Stri
 /// Writes `rendered` into `dest` as `BDINFO.{volume label}.txt` (CRLF, UTF-8,
 /// no BOM). Returns the exit code on a failed write (`2`).
 fn save_report(dest: &Path, bdrom: &BdRom, rendered: &str) -> Result<(), u8> {
-    let target = dest.join(format!("BDINFO.{}.txt", volume::safe_report_stem(&bdrom.volume_label)));
+    let target = dest.join(report::file_name(&bdrom.volume_label));
     std::fs::write(&target, rendered.as_bytes()).map_err(|err| {
         eprintln!("error: cannot write {}: {err}", target.display());
         2
@@ -1053,7 +1001,8 @@ fn compose_styled_progress(
     elapsed: Duration,
     columns: usize,
 ) -> String {
-    let (percent, elapsed_seconds, remaining_seconds) = progress_stats(progress, elapsed);
+    let (percent, elapsed_seconds, remaining_seconds) =
+        progress_stats(progress.done, progress.total, elapsed);
     let tail = format!(
         "{percent:>3}% - {} | Elapsed: {} | Remaining: {}",
         progress.file,
@@ -1088,40 +1037,14 @@ fn compose_styled_progress(
 /// Composes the plain progress line: percent, current file, elapsed, and the
 /// remaining-time estimate.
 fn compose_progress(progress: &ScanProgress<'_>, elapsed: Duration) -> String {
-    let (percent, elapsed_seconds, remaining_seconds) = progress_stats(progress, elapsed);
+    let (percent, elapsed_seconds, remaining_seconds) =
+        progress_stats(progress.done, progress.total, elapsed);
     format!(
         "Scanning {percent:>3}% - {} | Elapsed: {} | Remaining: {}",
         progress.file,
         hms(elapsed_seconds),
         hms(remaining_seconds)
     )
-}
-
-/// The percent / elapsed-seconds / remaining-seconds triple both progress
-/// spellings draw: the percent from the byte counts (an empty scan reads
-/// 100%), the remaining estimate the elapsed time scaled by the bytes still
-/// to read. The estimate works in milliseconds — whole-second math would
-/// read zero for the entire first second, exactly when the first plausible
-/// estimate should already show.
-fn progress_stats(progress: &ScanProgress<'_>, elapsed: Duration) -> (u64, u64, u64) {
-    let percent = if progress.total == 0 {
-        100
-    } else {
-        progress.done.saturating_mul(100).checked_div(progress.total).unwrap_or(100)
-    };
-    let elapsed_seconds = elapsed.as_secs();
-    let remaining = progress.total.saturating_sub(progress.done);
-    let remaining_seconds = elapsed
-        .as_millis()
-        .saturating_mul(u128::from(remaining))
-        .checked_div(u128::from(progress.done).saturating_mul(1000))
-        .map_or(0, |seconds| u64::try_from(seconds).unwrap_or(u64::MAX));
-    (percent, elapsed_seconds, remaining_seconds)
-}
-
-/// `hh:mm:ss` from whole seconds.
-fn hms(seconds: u64) -> String {
-    format!("{:02}:{:02}:{:02}", seconds / 3600, (seconds % 3600) / 60, seconds % 60)
 }
 
 #[cfg(test)]
@@ -1140,9 +1063,8 @@ mod tests {
 
     use super::{
         BAR_MAX_CELLS, Cli, ProgressDisplay, analyze_preamble, banner, compose_progress,
-        compose_styled_progress, erase_sequence, finish_early, group_n0, help_page, hidden_hint,
-        hms, named_selection, normalize_playlist_name, pick_playlists, redraw_sequence,
-        report_parse_failure, row_names, run, selection_table, table_length,
+        compose_styled_progress, erase_sequence, finish_early, help_page, hidden_hint,
+        pick_playlists, redraw_sequence, report_parse_failure, row_names, run, selection_table,
     };
 
     /// A throwaway minimal BD folder (`BDMV/PLAYLIST` + `BDMV/CLIPINF`, both empty)
@@ -1703,12 +1625,8 @@ mod tests {
     }
 
     #[test]
-    fn playlist_names_normalize_to_the_model_spelling() {
-        assert_eq!(normalize_playlist_name("00800"), "00800.MPLS");
-        assert_eq!(normalize_playlist_name("00800.mpls"), "00800.MPLS");
-        assert_eq!(normalize_playlist_name("00800.MPLS"), "00800.MPLS");
-        // The shared no-op observer observes nothing (it backs the scan paths
-        // that never run the packet scan).
+    fn the_no_op_progress_observer_observes_nothing() {
+        // It backs the scan paths that never run the packet scan.
         super::no_progress(ScanProgress { file: "00000.M2TS", done: 0, total: 0 });
     }
 
@@ -1876,8 +1794,6 @@ Options:
             Duration::ZERO,
         );
         assert!(line.starts_with("Scanning 100% - 00000.M2TS"));
-        assert_eq!(hms(3661), "01:01:01");
-        assert_eq!(hms(0), "00:00:00");
     }
 
     /// A playlist summary carrying only what the selection flow reads.
@@ -2114,19 +2030,6 @@ Options:
     }
 
     #[test]
-    fn table_cells_group_digits_and_wrap_hours() {
-        assert_eq!(group_n0(0), "0");
-        assert_eq!(group_n0(123), "123");
-        assert_eq!(group_n0(1_000), "1,000");
-        assert_eq!(group_n0(1_234_567), "1,234,567");
-        assert_eq!(table_length(0.0), "00:00:00");
-        assert_eq!(table_length(100.0), "00:01:40");
-        // 26 h wraps at 24, like the classic table's TimeSpan hours.
-        assert_eq!(table_length(93_600.0 + 65.0), "02:01:05");
-        assert_eq!(table_length(-5.0), "00:00:00");
-    }
-
-    #[test]
     fn the_picker_collects_indices_until_q() {
         // An invalid word, an out-of-range number, two picks (one repeated),
         // then `q` — picks keep their order and the duplicate.
@@ -2169,16 +2072,6 @@ Options:
         }
 
         fn consume(&mut self, _: usize) {}
-    }
-
-    #[test]
-    fn named_selection_keeps_the_given_order_and_dedups() {
-        let playlists =
-            [summary("00001.MPLS", 60.0, &["A.M2TS"]), summary("00002.MPLS", 60.0, &["B.M2TS"])];
-        let requested =
-            ["00002".to_owned(), "00001.mpls".to_owned(), "00002".to_owned(), "X".to_owned()];
-        assert_eq!(named_selection(&playlists, &requested), ["00002.MPLS", "00001.MPLS"]);
-        assert!(named_selection(&playlists, &["X".to_owned()]).is_empty());
     }
 
     #[test]

--- a/crates/bdinfo-rs/src/volume.rs
+++ b/crates/bdinfo-rs/src/volume.rs
@@ -1,5 +1,5 @@
-//! Naming the disc report: a filesystem-safe file stem, and recovering the real
-//! disc label when a folder scan lands on a nameless drive root.
+//! Recovering the real disc label when a folder scan lands on a nameless drive
+//! root.
 //!
 //! A folder scan labels the disc after its root directory's name. That works
 //! everywhere a disc is mounted at a *named* path — an extracted folder, or the
@@ -8,16 +8,16 @@
 //! Windows drive root (`J:\`) has no such name: the disc root resolves to the
 //! drive root, whose path carries no final component, so the label degrades to
 //! the drive-root string itself (`"J:\"`). That is wrong in the report and, with
-//! its `:` and separator, an illegal `BDINFO.<label>.txt` filename — the write
-//! fails outright (issue: "Cannot save report from physical disc").
+//! its `:` and separator, would be an illegal `BDINFO.<label>.txt` filename
+//! (issue: "Cannot save report from physical disc"). The filename half of that
+//! is handled for every label by
+//! [`bdinfo_rs_core::report::file_name`]; the label itself is repaired here.
 //!
-//! Two repairs live here:
-//! - [`resolve_folder_label`] replaces a nameless-drive-root label with the real UDF volume label —
-//!   read off the raw volume device (`\\.\J:`) through the same [`UdfSource`] core the `.iso` path
-//!   uses, the identical string Windows Explorer and classic `BDInfo` show — falling back to the
-//!   drive letter when that read is unavailable.
-//! - [`safe_report_stem`] reduces any label to a safe single filename component, a defensive net
-//!   that also covers a hostile `.iso` volume identifier.
+//! [`resolve_folder_label`] replaces a nameless-drive-root label with the real
+//! UDF volume label — read off the raw volume device (`\\.\J:`) through the same
+//! [`UdfSource`] core the `.iso` path uses, the identical string Windows
+//! Explorer and classic `BDInfo` show — falling back to the drive letter when
+//! that read is unavailable.
 //!
 //! The label recovery is replicated by the GUI's `volume` module
 //! (`crates/bdinfo-rs-gui/src/volume.rs`), which must resolve the same label
@@ -35,23 +35,6 @@ use std::io::{self, Read, Seek, SeekFrom};
 use bdinfo_rs_core::vfs::ReadSeek;
 #[cfg(windows)]
 use bdinfo_rs_core::vfs::udf::source::{IsoReader, UdfSource};
-
-/// Characters illegal in a Windows filename component, plus the separators that
-/// would re-root the report path. Replaced so `BDINFO.<stem>.txt` is always one
-/// writable file; applied uniformly on every platform so the report filename is
-/// identical everywhere.
-const ILLEGAL: &[char] = &['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
-
-/// `label` reduced to a filesystem-safe report-file stem: each illegal or
-/// control character becomes `_`. A clean label — a folder name, a `.iso` volume
-/// identifier, a resolved drive label — passes through unchanged.
-///
-/// Replicated by the GUI's `paths::report_file_name`
-/// (`crates/bdinfo-rs-gui/src/paths.rs`), which must produce the same
-/// filename for the same disc — keep the two in lock-step.
-pub(crate) fn safe_report_stem(label: &str) -> String {
-    label.chars().map(|c| if c.is_control() || ILLEGAL.contains(&c) { '_' } else { c }).collect()
-}
 
 /// The uppercase drive letter of a bare Windows drive-root label — `"J:\"`,
 /// `"k:/"`, or `"k:"` all yield `'J'`/`'K'` — or `None` for any real name.
@@ -288,24 +271,7 @@ mod tests {
 
     use super::{
         AlignedReader, SECTOR, add_signed, drive_root_letter, resolve_folder_label, resolve_with,
-        safe_report_stem,
     };
-
-    #[test]
-    fn safe_report_stem_passes_clean_labels_through() {
-        assert_eq!(safe_report_stem("MY_DISC"), "MY_DISC");
-        assert_eq!(safe_report_stem("BigBuckBunny"), "BigBuckBunny");
-        assert_eq!(safe_report_stem("Blu-Ray"), "Blu-Ray");
-        assert_eq!(safe_report_stem(""), "");
-    }
-
-    #[test]
-    fn safe_report_stem_replaces_illegal_and_control_characters() {
-        assert_eq!(safe_report_stem(r"J:\"), "J__");
-        assert_eq!(safe_report_stem("a/b"), "a_b");
-        assert_eq!(safe_report_stem("x<y>z|?*\""), "x_y_z____");
-        assert_eq!(safe_report_stem("tab\there"), "tab_here");
-    }
 
     #[test]
     fn drive_root_letter_matches_every_bare_drive_root_spelling() {

--- a/fuzz/fuzz_targets/parse_report.rs
+++ b/fuzz/fuzz_targets/parse_report.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 
 use bdinfo_rs_core::bdrom::disc::{BdRom, ScanMode};
 use bdinfo_rs_core::report::text;
+use bdinfo_rs_core::vfs::fs::glob_ci;
 use bdinfo_rs_core::vfs::{BdDir, BdFile, ReadSeek, SearchOption};
 use libfuzzer_sys::fuzz_target;
 
@@ -82,28 +83,10 @@ struct MemDir {
     files: Vec<MemFile>,
 }
 
-/// ASCII case-insensitive glob: `*` = any run, `?` = any one byte.
-fn glob_match(pattern: &[u8], name: &[u8]) -> bool {
-    match pattern.split_first() {
-        None => name.is_empty(),
-        Some((b'*', rest)) => {
-            (0..=name.len()).any(|skip| glob_match(rest, &name[skip..]))
-        }
-        Some((b'?', rest)) => match name.split_first() {
-            Some((_, tail)) => glob_match(rest, tail),
-            None => false,
-        },
-        Some((c, rest)) => match name.split_first() {
-            Some((n, tail)) => c.eq_ignore_ascii_case(n) && glob_match(rest, tail),
-            None => false,
-        },
-    }
-}
-
 impl MemDir {
     fn collect_pattern(&self, pattern: &str, recurse: bool, out: &mut Vec<Box<dyn BdFile>>) {
         for f in &self.files {
-            if glob_match(pattern.as_bytes(), f.name.as_bytes()) {
+            if glob_ci(pattern.as_bytes(), f.name.as_bytes()) {
                 out.push(Box::new(f.clone()));
             }
         }


### PR DESCRIPTION
Nine presentation and selection facts each lived in two or three surfaces and had to agree byte-for-byte with the locked report. Each now has one public, documented home in the library, and every copy is deleted.

Widened in place (the code was already in core, just private):

- `bdrom::order::presentation_cmp` — the CLI hidden-playlist hint and the GUI hidden-playlist model drop their identical inline comparators.
- `vfs::fs::glob_ci` — the wasm crate and the `parse_report` fuzz target drop theirs. The `BdDir::get_files_pattern_option` contract now names it, so an out-of-crate backend resolves patterns by the same rule.
- `report::text::group` and `report::text::time_hh_short` — the CLI and GUI `group_n0` / `table_length` copies are deleted.

Lifted into core (additive API):

- `bdrom::order::normalize_playlist_name` and `named_selection`, beside the selection family they serve.
- `report::file_name` composes the whole `BDINFO.<label>.txt` name, replacing the CLI `volume::safe_report_stem` plus its call-site shape and the GUI `paths::report_file_name`.
- `PlaylistSummary::estimated_bytes` and `ClipSummary::estimated_bytes` return the interleaved-then-m2ts preference the three surfaces spelled three ways; each surface keeps its own absent-encoding at the call site.
- `bdrom::disc::HIDDEN_STREAMS_NOTE`, the hidden-tracks footnote both surfaces printed verbatim.
- `bdrom::progress::progress_stats` and `hms`, in the general `(done, total, elapsed)` form; each surface keeps its own line format and throttle.

Behaviour is unchanged throughout: report bytes, CLI table output, GUI strings, and wasm classifications are identical. The union of the CLI, GUI and wasm test suites moved with the code, including the filename traversal proptest and the non-`.mpls` extension case.

Verified: `scripts/compliance.ps1` (100% lines/regions/functions, branches 97.77%, 51 mutants found and 51 caught), `scripts/wasm-compliance.ps1`, and `scripts/gui-compliance.ps1` all pass on the committed branch. `cargo-semver-checks` reports no update required against the unreleased 3.0.0.