### PR TITLE
feat(core): open discs and classify hidden playlists through shared helpers

### DIFF
--- a/crates/bdinfo-rs-core/src/bdrom/order.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/order.rs
@@ -22,7 +22,8 @@
 //! selection family — [`normalize_playlist_name`] and [`named_selection`]
 //! (which names a request resolves to), [`selection_order`] and
 //! [`selection_stream_files`] (what that selection renders and reads) — and
-//! the [`HiddenRule`] classification behind the filter switches.
+//! the [`HiddenRule`] classification behind the filter switches, with
+//! [`hidden_by`] naming what a filter withheld and why.
 
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
@@ -122,6 +123,34 @@ impl PlaylistFilter {
             HiddenRule::Looping => self.filter_looping_playlists,
         }
     }
+}
+
+/// What `filter` withholds from `playlists`: every playlist it drops, paired
+/// with the rules that dropped it, in presentation order (length descending,
+/// then name ascending).
+///
+/// A rule appears only when its switch is on, so the pairing is exactly "why
+/// this playlist is missing from the table". A playlist failing both rules
+/// appears once, naming both — a surface that reports per rule reads the list
+/// twice, one rule each; a surface that reports per playlist reads it once.
+/// Both then see the same set and the same order as [`table_rows`]'s
+/// complement.
+#[must_use]
+pub fn hidden_by<'a>(
+    playlists: &'a [PlaylistSummary],
+    filter: &PlaylistFilter,
+) -> Vec<(&'a PlaylistSummary, Vec<HiddenRule>)> {
+    let mut hidden: Vec<(&PlaylistSummary, Vec<HiddenRule>)> = playlists
+        .iter()
+        .map(|playlist| {
+            let rules =
+                filter.classify(playlist).into_iter().filter(|&rule| filter.drops(rule)).collect();
+            (playlist, rules)
+        })
+        .filter(|(_, rules): &(_, Vec<HiddenRule>)| !rules.is_empty())
+        .collect();
+    hidden.sort_by(|(a, _), (b, _)| presentation_cmp(a, b));
+    hidden
 }
 
 /// Compares two playlists in presentation order: total length descending,
@@ -277,9 +306,9 @@ mod tests {
     use proptest::prelude::{prop_assert, prop_assert_eq, proptest};
 
     use super::{
-        HiddenRule, PlaylistFilter, named_selection, normalize_playlist_name, presentation_cmp,
-        presentation_groups, presentation_order, selection_order, selection_stream_files,
-        table_rows,
+        HiddenRule, PlaylistFilter, hidden_by, named_selection, normalize_playlist_name,
+        presentation_cmp, presentation_groups, presentation_order, selection_order,
+        selection_stream_files, table_rows,
     };
     use crate::bdrom::disc::{ClipSummary, PlaylistSummary};
 
@@ -548,6 +577,74 @@ mod tests {
         assert_eq!(HiddenRule::Looping.label(), "looping");
     }
 
+    /// The names `hidden_by` reports, in the order it reports them.
+    fn hidden_names(
+        hidden: &[(&PlaylistSummary, Vec<HiddenRule>)],
+    ) -> Vec<(String, Vec<HiddenRule>)> {
+        hidden.iter().map(|(playlist, rules)| (playlist.name.clone(), rules.clone())).collect()
+    }
+
+    #[test]
+    fn hidden_by_pairs_each_withheld_playlist_with_the_rules_that_dropped_it() {
+        // 00001 loops, 00090 is short AND loops, 00091 is short, 00013 passes.
+        // 00091 (10 s) precedes 00090 (5 s): length descending, as the table
+        // would have listed them.
+        let playlists = [
+            playlist("00001.MPLS", 5765.0, true, &["A.M2TS"]),
+            playlist("00013.MPLS", 3600.0, false, &["B.M2TS"]),
+            playlist("00090.MPLS", 5.0, true, &["C.M2TS"]),
+            playlist("00091.MPLS", 10.0, false, &["D.M2TS"]),
+        ];
+        assert_eq!(
+            hidden_names(&hidden_by(&playlists, &PlaylistFilter::default())),
+            [
+                ("00001.MPLS".to_owned(), vec![HiddenRule::Looping]),
+                ("00091.MPLS".to_owned(), vec![HiddenRule::Short]),
+                ("00090.MPLS".to_owned(), vec![HiddenRule::Short, HiddenRule::Looping]),
+            ]
+        );
+        // The withheld set is exactly the table's complement.
+        let listed: Vec<usize> = table_rows(&playlists, &PlaylistFilter::default())
+            .into_iter()
+            .map(|(_, i)| i)
+            .collect();
+        assert_eq!(listed, [1]);
+    }
+
+    #[test]
+    fn hidden_by_names_only_the_rules_whose_switch_is_on() {
+        // The threshold keeps its value while the short switch is off, so a
+        // looping playlist under it must not be reported as short.
+        let playlists = [playlist("00090.MPLS", 5.0, true, &["C.M2TS"])];
+        let looping_only =
+            PlaylistFilter { filter_short_playlists: false, ..PlaylistFilter::default() };
+        assert_eq!(
+            hidden_names(&hidden_by(&playlists, &looping_only)),
+            [("00090.MPLS".to_owned(), vec![HiddenRule::Looping])]
+        );
+        let short_only =
+            PlaylistFilter { filter_looping_playlists: false, ..PlaylistFilter::default() };
+        assert_eq!(
+            hidden_names(&hidden_by(&playlists, &short_only)),
+            [("00090.MPLS".to_owned(), vec![HiddenRule::Short])]
+        );
+    }
+
+    #[test]
+    fn hidden_by_withholds_nothing_when_no_rule_matches_or_is_on() {
+        let playlists = [
+            playlist("00001.MPLS", 5765.0, true, &["A.M2TS"]),
+            playlist("00090.MPLS", 5.0, false, &["C.M2TS"]),
+        ];
+        // Every switch off — nothing is withheld, whatever the classification.
+        assert!(hidden_by(&playlists, &PlaylistFilter::everything()).is_empty());
+        // A playlist of exactly the threshold length is not short, and a disc
+        // with nothing to hide hides nothing.
+        let edge = [playlist("00014.MPLS", 20.0, false, &["E.M2TS"])];
+        assert!(hidden_by(&edge, &PlaylistFilter::default()).is_empty());
+        assert!(hidden_by(&[], &PlaylistFilter::default()).is_empty());
+    }
+
     #[test]
     fn presentation_groups_exposes_the_group_boundaries() {
         // Same disc as the first-appearance test: A+B share a clip and form
@@ -635,6 +732,37 @@ mod tests {
             let dropped_short = filter_short && length < threshold;
             let dropped_looping = filter_looping && has_loops;
             prop_assert_eq!(filter.keeps(&subject), !(dropped_short || dropped_looping));
+        }
+
+        /// `hidden_by` and `presentation_order` partition the disc: every
+        /// playlist is either listed or withheld, never both and never neither.
+        #[test]
+        fn hidden_and_listed_partition_the_disc(
+            lengths in proptest::collection::vec(0.0_f64..40.0, 0..12),
+            loops in proptest::collection::vec(proptest::bool::ANY, 0..12),
+            filter_short in proptest::bool::ANY,
+            filter_looping in proptest::bool::ANY,
+        ) {
+            let playlists: Vec<PlaylistSummary> = lengths
+                .iter()
+                .zip(loops.iter().chain(std::iter::repeat(&false)))
+                .enumerate()
+                .map(|(i, (&len, &lp))| playlist(&format!("{i:05}.MPLS"), len, lp, &[]))
+                .collect();
+            let filter = PlaylistFilter {
+                filter_short_playlists: filter_short,
+                filter_looping_playlists: filter_looping,
+                ..PlaylistFilter::default()
+            };
+            let hidden = hidden_by(&playlists, &filter);
+            let listed = presentation_order(&playlists, &filter);
+            prop_assert_eq!(hidden.len().checked_add(listed.len()), Some(playlists.len()));
+            let withheld: Vec<&str> =
+                hidden.iter().map(|(playlist, _)| playlist.name.as_str()).collect();
+            for &index in &listed {
+                let name = playlists.get(index).map(|p| p.name.as_str());
+                prop_assert!(name.is_some_and(|name| !withheld.contains(&name)));
+            }
         }
 
         /// Deterministic: the same input always yields the same order.

--- a/crates/bdinfo-rs-core/src/lib.rs
+++ b/crates/bdinfo-rs-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod index;
 pub mod language_codes;
 pub mod primitives;
 pub mod report;
+pub mod scan;
 pub mod stream;
 pub mod vfs;
 

--- a/crates/bdinfo-rs-core/src/scan.rs
+++ b/crates/bdinfo-rs-core/src/scan.rs
@@ -1,0 +1,216 @@
+//! Opening a disc from a path — the one place folder and `.iso` input diverge.
+//!
+//! [`BdRom::open_resilient_with`] reads through the [`crate::vfs`] seam and
+//! knows nothing about paths. A caller holding one must pick the backend, open
+//! it, and merge that backend's own recorded failures into the scan's — and for
+//! a folder repair the label the scan derived. These two functions are that
+//! composition, so every path-driven surface shares one implementation of it.
+//! A browser caller has no paths and builds its [`BdDir`](crate::vfs::BdDir)
+//! itself, so it uses neither.
+//!
+//! How deep to read stays the caller's choice: `mode` is passed through
+//! untouched.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+
+use crate::bdrom::disc::{BdRom, ScanMode, ScanProgress, ScanReport};
+use crate::error::BdError;
+use crate::vfs::fs::FsDir;
+use crate::vfs::udf::source::{PathIso, UdfSource};
+use crate::vfs::volume;
+
+/// Opens the Blu-ray folder at `path` through `std::fs`, resiliently.
+///
+/// `path` is the disc root, its `BDMV` directory, or any directory inside it
+/// (the scan walks up). [`ScanReport::errors`] carries the scan's own recorded
+/// failures **plus** the enumeration's per-entry ones
+/// ([`FsDir::take_errors`]) — a directory that could not be read is damage the
+/// scan itself never sees.
+///
+/// The label is [`volume::resolve_folder_label`]'s: a folder scan names the
+/// disc after its root directory, which a bare Windows drive root (`J:\`) does
+/// not have.
+///
+/// `mode`, `scan_files`, `progress` and `cancel` are
+/// [`BdRom::open_resilient_with`]'s, passed through unchanged.
+///
+/// # Errors
+/// As [`BdRom::open_resilient_with`]: only the failures with no readable rest
+/// to degrade to.
+pub fn open_folder(
+    path: &Path,
+    mode: ScanMode,
+    scan_files: Option<&BTreeSet<String>>,
+    progress: &mut dyn FnMut(ScanProgress<'_>),
+    cancel: &AtomicBool,
+) -> Result<ScanReport, BdError> {
+    let root = FsDir::new(path);
+    let mut report = BdRom::open_resilient_with(&root, mode, scan_files, progress, cancel)?;
+    report.errors.extend(root.take_errors());
+    report.bdrom.volume_label = volume::resolve_folder_label(&report.bdrom.volume_label);
+    Ok(report)
+}
+
+/// Opens the Blu-ray `.iso` image at `path` through the UDF reader,
+/// resiliently.
+///
+/// Yields the same [`BdRom`] the folder scan would over the same disc — only
+/// the IO backend differs — except for the label: an `.iso` carries the genuine
+/// UDF volume label, so it needs no repair. [`ScanReport::errors`] carries the
+/// scan's own recorded failures **plus** the reader's bad-sector recordings
+/// ([`UdfSource::take_errors`]).
+///
+/// `mode`, `scan_files`, `progress` and `cancel` are
+/// [`BdRom::open_resilient_with`]'s, passed through unchanged.
+///
+/// # Errors
+/// [`BdError::StructureNotFound`] or [`BdError::Io`] when `path` holds no
+/// readable UDF volume, else as [`BdRom::open_resilient_with`].
+pub fn open_iso(
+    path: &Path,
+    mode: ScanMode,
+    scan_files: Option<&BTreeSet<String>>,
+    progress: &mut dyn FnMut(ScanProgress<'_>),
+    cancel: &AtomicBool,
+) -> Result<ScanReport, BdError> {
+    let source = UdfSource::open_resilient(Box::new(PathIso::new(path)))?;
+    let mut report =
+        BdRom::open_resilient_with(&source.root(), mode, scan_files, progress, cancel)?;
+    report.errors.extend(source.take_errors());
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+    use super::{BdError, ScanMode, ScanReport, open_folder, open_iso};
+
+    /// The committed real-disc fixtures, one crate over: `BigBuckBunny` (a BDMV
+    /// folder) and `BigBuckBunny.iso` (the same disc as a UDF image, whose UDF
+    /// volume label is `Blu-Ray`).
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../bdinfo-rs/tests/fixtures").join(name)
+    }
+
+    /// A throwaway directory under the system temp dir, removed on drop.
+    struct Scratch {
+        root: PathBuf,
+    }
+
+    impl Scratch {
+        fn new() -> Self {
+            static COUNTER: AtomicU32 = AtomicU32::new(0);
+            let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let root = std::env::temp_dir()
+                .join(format!("bdinfo-rs-scan-{}-{unique}", std::process::id()));
+            std::fs::create_dir_all(&root).expect("create the scratch dir");
+            Self { root }
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            // Best-effort: a stray temp directory is harmless if removal races.
+            let _ = std::fs::remove_dir_all(&self.root).is_ok();
+        }
+    }
+
+    /// Opens `path` as a folder at `mode`, with no selection and no
+    /// cancellation, asserting that the progress sink fires exactly when a
+    /// packet scan ran — the pass-through arguments have to reach the demux,
+    /// and only [`ScanMode::Full`] reports (the quick codec pass does not).
+    fn folder(path: &Path, mode: ScanMode) -> Result<ScanReport, BdError> {
+        let mut reported = 0_usize;
+        let report = open_folder(
+            path,
+            mode,
+            None,
+            &mut |_| reported = reported.saturating_add(1),
+            &AtomicBool::new(false),
+        );
+        assert_eq!(reported != 0, report.is_ok() && mode == ScanMode::Full);
+        report
+    }
+
+    /// [`folder`]'s `.iso` twin.
+    fn iso(path: &Path, mode: ScanMode) -> Result<ScanReport, BdError> {
+        let mut reported = 0_usize;
+        let report = open_iso(
+            path,
+            mode,
+            None,
+            &mut |_| reported = reported.saturating_add(1),
+            &AtomicBool::new(false),
+        );
+        assert_eq!(reported != 0, report.is_ok() && mode == ScanMode::Full);
+        report
+    }
+
+    #[test]
+    fn a_folder_scan_names_the_disc_after_its_root_directory() {
+        let report =
+            folder(&fixture("BigBuckBunny"), ScanMode::Full).expect("the fixture folder opens");
+        // The label repair is identity for a named directory, so this pins both
+        // that it runs and that an ordinary folder keeps its own name.
+        assert_eq!(report.bdrom.volume_label, "BigBuckBunny");
+        assert!(!report.bdrom.playlists.is_empty(), "the structure lists");
+        assert!(report.errors.is_empty(), "healthy media records no failure");
+    }
+
+    #[test]
+    fn an_iso_scan_reads_the_real_udf_volume_label() {
+        // The same disc as the folder above, whose label is a directory name;
+        // this one's is the UDF volume's. (The two reports are compared
+        // byte-for-byte against their goldens by the CLI's end-to-end test.)
+        let report =
+            iso(&fixture("BigBuckBunny.iso"), ScanMode::Full).expect("the fixture image opens");
+        assert_eq!(report.bdrom.volume_label, "Blu-Ray");
+        assert!(!report.bdrom.playlists.is_empty(), "the structure lists");
+        assert!(report.errors.is_empty(), "healthy media records no failure");
+    }
+
+    #[test]
+    fn a_folder_without_a_bd_structure_fails() {
+        let scratch = Scratch::new();
+        let err = folder(&scratch.root, ScanMode::Metadata).expect_err("no BDMV to locate");
+        assert_eq!(err.to_string(), "unable to locate BD structure");
+    }
+
+    #[test]
+    fn a_file_that_is_no_udf_volume_fails() {
+        let scratch = Scratch::new();
+        let path = scratch.root.join("garbage.iso");
+        std::fs::write(&path, b"not a udf volume at all").expect("the scratch image writes");
+        let err = iso(&path, ScanMode::Metadata).expect_err("no UDF volume to open");
+        assert!(!err.to_string().is_empty(), "the failure carries a message");
+    }
+
+    #[test]
+    fn a_udf_volume_without_a_bd_structure_fails() {
+        // A VALID UDF image whose BDMV tree is unfindable: rename every `BDMV`
+        // byte run in a copy of the fixture image. The volume still opens (the
+        // anchor and descriptors are untouched), so this reaches the structure
+        // walk — the `.iso` failure road garbage bytes never get to.
+        let scratch = Scratch::new();
+        let path = scratch.root.join("renamed.iso");
+        let mut bytes = std::fs::read(fixture("BigBuckBunny.iso")).expect("the fixture reads");
+        let needle = b"BDMV";
+        let mut at = 0;
+        while let Some(hit) =
+            bytes.get(at..).and_then(|tail| tail.windows(needle.len()).position(|w| w == needle))
+        {
+            let start = at.checked_add(hit).expect("the offset fits");
+            let end = start.checked_add(needle.len()).expect("the offset fits");
+            bytes.get_mut(start..end).expect("the window is in range").copy_from_slice(b"XDMV");
+            at = start.checked_add(1).expect("the offset fits");
+        }
+        std::fs::write(&path, bytes).expect("the scratch image writes");
+        let err =
+            iso(&path, ScanMode::Metadata).expect_err("a volume with no BDMV cannot be scanned");
+        assert_eq!(err.to_string(), "unable to locate BD structure");
+    }
+}

--- a/crates/bdinfo-rs-gui/src/model.rs
+++ b/crates/bdinfo-rs-gui/src/model.rs
@@ -10,7 +10,7 @@ use std::cmp::Ordering;
 
 use bdinfo_rs_core::bdrom::chapters::seconds_to_ticks;
 use bdinfo_rs_core::bdrom::disc::PlaylistSummary;
-use bdinfo_rs_core::bdrom::order::{HiddenRule, PlaylistFilter, presentation_cmp, table_rows};
+use bdinfo_rs_core::bdrom::order::{HiddenRule, PlaylistFilter, hidden_by, table_rows};
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 
 use crate::settings::Settings;
@@ -361,10 +361,9 @@ pub(crate) fn any_hidden(rows: &[PlaylistRow]) -> bool {
 /// What a [`PlaylistFilter`] withholds from the playlist table — the count,
 /// the rules that withheld it, and the withheld names.
 ///
-/// The two rules are judged **independently**, each against the whole disc
-/// ([`PlaylistFilter::classify`]): a playlist that is both short and looping
-/// is counted once and names both rules, and revealing it takes switching
-/// both off.
+/// The two rules are judged **independently**, each against the whole disc: a
+/// playlist that is both short and looping is counted once and names both
+/// rules, and revealing it takes switching both off.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HiddenPlaylists {
     /// The withheld playlists' names, in the order the table would have listed
@@ -435,28 +434,24 @@ impl HiddenPlaylists {
 /// The playlists `filter` withholds from `playlists` — `None` when it
 /// withholds none (there is then no line to draw).
 ///
-/// A rule that is switched OFF never names itself: the short threshold keeps
-/// its configured value while its switch is off, so a looping playlist under
-/// that threshold must not be reported as short.
+/// One aggregate view of [`hidden_by`]: every withheld playlist counted once,
+/// and each rule named if it withheld anything. A rule that is switched OFF
+/// never names itself — the short threshold keeps its configured value while
+/// its switch is off, so a looping playlist under that threshold must not be
+/// reported as short.
 #[must_use]
 pub fn hidden_playlists(
     playlists: &[PlaylistSummary],
     filter: &PlaylistFilter,
 ) -> Option<HiddenPlaylists> {
-    let mut hidden: Vec<&PlaylistSummary> =
-        playlists.iter().filter(|playlist| !filter.keeps(playlist)).collect();
+    let hidden = hidden_by(playlists, filter);
     if hidden.is_empty() {
         return None;
     }
-    hidden.sort_by(|a, b| presentation_cmp(a, b));
-    let short = filter.filter_short_playlists
-        && hidden.iter().any(|playlist| filter.classify(playlist).contains(&HiddenRule::Short));
-    let looping = filter.filter_looping_playlists
-        && hidden.iter().any(|playlist| filter.classify(playlist).contains(&HiddenRule::Looping));
     Some(HiddenPlaylists {
-        names: hidden.iter().map(|playlist| playlist.name.clone()).collect(),
-        short,
-        looping,
+        names: hidden.iter().map(|(playlist, _)| playlist.name.clone()).collect(),
+        short: hidden.iter().any(|(_, rules)| rules.contains(&HiddenRule::Short)),
+        looping: hidden.iter().any(|(_, rules)| rules.contains(&HiddenRule::Looping)),
     })
 }
 

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -1,9 +1,8 @@
 //! The scan seam — a picked folder or `.iso` → the structural playlist list and,
 //! after a selection, the measured report.
 //!
-//! Drives the identical `bdinfo-rs-core` API the CLI (`main.rs`) and the wasm
-//! crate use, dispatching folder vs `.iso` input exactly like the CLI's
-//! `scan_disc` (`FsDir` / `UdfSource` → [`BdRom::open_resilient_with`] →
+//! Drives the identical `bdinfo-rs-core` API the CLI and the wasm crate use
+//! ([`core_scan::open_folder`] / [`core_scan::open_iso`] →
 //! [`text::render_with`]). The pure formatting / selection / progress math is the
 //! Tier-A [`crate::model`] / `selection` / [`crate::progress`]; this
 //! module is the thin IO glue, verified by the golden-tie parity test (byte-exact
@@ -22,9 +21,7 @@ use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, ScanMode, ScanProgress
 use bdinfo_rs_core::bdrom::order::selection_order;
 use bdinfo_rs_core::error::{BdError, ScanError};
 use bdinfo_rs_core::report::text::{self, RenderOptions};
-use bdinfo_rs_core::vfs::fs::FsDir;
-use bdinfo_rs_core::vfs::udf::source::{PathIso, UdfSource};
-use bdinfo_rs_core::vfs::volume;
+use bdinfo_rs_core::scan as core_scan;
 
 /// The disc the user picked: a Blu-ray **folder** or a single `.iso` image.
 ///
@@ -36,7 +33,8 @@ pub enum Input {
     /// A disc folder: the disc root, its `BDMV` directory, or any directory
     /// inside it (the scan walks up to the disc root). The label is the
     /// directory name — or, when the disc root is a nameless Windows drive
-    /// root, the real UDF label recovered by [`volume::resolve_folder_label`].
+    /// root, the real UDF label
+    /// [`bdinfo_rs_core::vfs::volume::resolve_folder_label`] recovers.
     Folder(PathBuf),
     /// A single `.iso` image. The label is the real UDF volume label.
     Iso(PathBuf),
@@ -122,10 +120,11 @@ pub struct Measured {
     pub playlists: Vec<PlaylistSummary>,
 }
 
-/// Opens `input` at the given scan depth, merging the backend's recorded
-/// failures (filesystem enumeration, or `.iso` bad-sector recordings) into the
-/// scan's own. The shared body behind both entry points — the one place folder
-/// vs `.iso` input diverges, mirroring the CLI's `scan_disc`.
+/// Opens `input` at the given scan depth through the core's path-based scan,
+/// which merges the backend's own recorded failures (filesystem enumeration,
+/// or `.iso` bad-sector recordings) into the scan's and repairs a folder's
+/// label. This dispatch is the whole of what the two input kinds do
+/// differently here.
 fn open(
     input: &Input,
     mode: ScanMode,
@@ -133,28 +132,11 @@ fn open(
     progress: &mut dyn FnMut(ScanProgress<'_>),
     cancel: &AtomicBool,
 ) -> Result<(BdRom, Vec<ScanError>), BdError> {
-    match input {
-        Input::Folder(path) => {
-            let root = FsDir::new(path);
-            let report = BdRom::open_resilient_with(&root, mode, scan_files, progress, cancel)?;
-            let mut errors = report.errors;
-            errors.extend(root.take_errors());
-            let mut bdrom = report.bdrom;
-            // A folder scan labels the disc after its root directory; a disc
-            // at a bare Windows drive root (`J:\`) has no such name — recover
-            // the real UDF label, exactly like the CLI's `scan_folder`.
-            bdrom.volume_label = volume::resolve_folder_label(&bdrom.volume_label);
-            Ok((bdrom, errors))
-        }
-        Input::Iso(path) => {
-            let source = UdfSource::open_resilient(Box::new(PathIso::new(path)))?;
-            let report =
-                BdRom::open_resilient_with(&source.root(), mode, scan_files, progress, cancel)?;
-            let mut errors = report.errors;
-            errors.extend(source.take_errors());
-            Ok((report.bdrom, errors))
-        }
-    }
+    let report = match input {
+        Input::Folder(path) => core_scan::open_folder(path, mode, scan_files, progress, cancel),
+        Input::Iso(path) => core_scan::open_iso(path, mode, scan_files, progress, cancel),
+    }?;
+    Ok((report.bdrom, report.errors))
 }
 
 /// What one open of the disc yields: the scanned disc paired with the per-file
@@ -314,7 +296,9 @@ mod tests {
     use std::cell::RefCell;
     use std::path::{Path, PathBuf};
 
-    use super::{BdRom, FsDir, Input, ScanMode};
+    use bdinfo_rs_core::vfs::fs::FsDir;
+
+    use super::{BdRom, Input, ScanMode};
 
     /// A scratch directory under the crate's target dir (unique per test).
     fn scratch(name: &str) -> PathBuf {

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -82,16 +82,13 @@ use bdinfo_rs_core::bdrom::disc::{
     BdRom, HIDDEN_STREAMS_NOTE, PlaylistSummary, ScanMode, ScanProgress,
 };
 use bdinfo_rs_core::bdrom::order::{
-    HiddenRule, PlaylistFilter, named_selection, presentation_cmp, selection_order,
+    HiddenRule, PlaylistFilter, hidden_by, named_selection, selection_order,
     selection_stream_files, table_rows,
 };
 use bdinfo_rs_core::bdrom::progress::{hms, progress_stats};
 use bdinfo_rs_core::error::{BdError, ScanError};
-use bdinfo_rs_core::report;
 use bdinfo_rs_core::report::text::{self, RenderOptions};
-use bdinfo_rs_core::vfs::fs::FsDir;
-use bdinfo_rs_core::vfs::udf::source::{PathIso, UdfSource};
-use bdinfo_rs_core::vfs::volume;
+use bdinfo_rs_core::{report, scan};
 use clap::error::ErrorKind;
 use crossterm::style::Stylize as _;
 use crossterm::{Command as _, cursor, terminal};
@@ -173,58 +170,6 @@ type ScanOutcome = (BdRom, Vec<ScanError>);
 type ScanFn<'a> =
     dyn FnMut(&mut dyn FnMut(ScanProgress<'_>), &AtomicBool) -> Result<ScanOutcome, BdError> + 'a;
 
-/// Scans the Blu-ray `.iso` at `path` through the UDF reader, returning the same
-/// `BdRom` the folder path would (only the IO backend differs). The resilient
-/// scan merges its per-file failures with the reader's bad-sector recordings.
-/// `scan_files` narrows the packet scan, `progress` observes it, and `cancel`
-/// aborts it (the library's `open_with` extras).
-fn scan_iso(
-    path: &str,
-    run_packet_scan: bool,
-    scan_files: Option<&BTreeSet<String>>,
-    progress: &mut dyn FnMut(ScanProgress<'_>),
-    cancel: &AtomicBool,
-) -> Result<ScanOutcome, BdError> {
-    let source = UdfSource::open_resilient(Box::new(PathIso::new(path)))?;
-    let report = BdRom::open_resilient_with(
-        &source.root(),
-        scan_mode(run_packet_scan),
-        scan_files,
-        progress,
-        cancel,
-    )?;
-    let mut errors = report.errors;
-    errors.extend(source.take_errors());
-    Ok((report.bdrom, errors))
-}
-
-/// Scans the Blu-ray folder at `location` through `std::fs`. The resilient
-/// scan merges its per-file failures with the enumeration's recorded
-/// per-entry failures.
-fn scan_folder(
-    location: &Path,
-    run_packet_scan: bool,
-    scan_files: Option<&BTreeSet<String>>,
-    progress: &mut dyn FnMut(ScanProgress<'_>),
-    cancel: &AtomicBool,
-) -> Result<ScanOutcome, BdError> {
-    let root = FsDir::new(location);
-    let report = BdRom::open_resilient_with(
-        &root,
-        scan_mode(run_packet_scan),
-        scan_files,
-        progress,
-        cancel,
-    )?;
-    let mut errors = report.errors;
-    errors.extend(root.take_errors());
-    let mut bdrom = report.bdrom;
-    // A disc mounted at a nameless drive root (`J:\`) leaves the folder-derived
-    // label unusable; recover the real UDF volume label (or the drive letter).
-    bdrom.volume_label = volume::resolve_folder_label(&bdrom.volume_label);
-    Ok((bdrom, errors))
-}
-
 /// The CLI's scan depth: it only ever wants the metadata list or the full
 /// measured report, so `run_packet_scan` maps to [`ScanMode::Full`] or
 /// [`ScanMode::Metadata`] (the bounded [`ScanMode::Codecs`] is a GUI affordance).
@@ -236,7 +181,9 @@ const fn scan_mode(run_packet_scan: bool) -> ScanMode {
 /// packet scan, so no display fires.
 const fn no_progress(_: ScanProgress<'_>) {}
 
-/// Dispatches `path` to the `.iso` or folder scan.
+/// Dispatches `path` to the `.iso` or folder scan. `scan_files` narrows the
+/// packet scan, `progress` observes it, and `cancel` aborts it (the library's
+/// `open_with` extras).
 fn scan_disc(
     path: &str,
     run_packet_scan: bool,
@@ -245,11 +192,13 @@ fn scan_disc(
     cancel: &AtomicBool,
 ) -> Result<ScanOutcome, BdError> {
     let location = Path::new(path);
-    if is_iso(location) {
-        scan_iso(path, run_packet_scan, scan_files, progress, cancel)
+    let mode = scan_mode(run_packet_scan);
+    let report = if is_iso(location) {
+        scan::open_iso(location, mode, scan_files, progress, cancel)
     } else {
-        scan_folder(location, run_packet_scan, scan_files, progress, cancel)
-    }
+        scan::open_folder(location, mode, scan_files, progress, cancel)
+    }?;
+    Ok((report.bdrom, report.errors))
 }
 
 /// Prints the "scan completed with errors" stderr summary — one line per recorded
@@ -637,8 +586,7 @@ const HINT_NAMES: usize = 3;
 /// on *and* withheld at least one playlist, looping first, then short. Empty
 /// (so the flow's bytes are unchanged) when every rule is off or hid nothing.
 ///
-/// Each rule is judged on its own against the whole disc
-/// ([`PlaylistFilter::classify`]), not against what the table dropped, so a
+/// Each rule is judged on its own, not against what the table dropped, so a
 /// playlist that is both short and looping is named on both lines and is only
 /// revealed when both switches are passed.
 ///
@@ -661,10 +609,10 @@ fn hidden_hint(playlists: &[PlaylistSummary], filter: &PlaylistFilter) -> String
 }
 
 /// One `Hidden by filters (KIND): NAMES - rerun with FLAG` line for the
-/// playlists `rule` matches under `filter`'s threshold, empty when it matches
-/// none. The names come in the order the table would have listed them (length
-/// descending, then name ascending), the first [`HINT_NAMES`] spelled out and
-/// the rest counted as ` and N more`.
+/// playlists [`hidden_by`] reports under `rule`, empty when it withheld none.
+/// The names keep that function's table order (length descending, then name
+/// ascending), the first [`HINT_NAMES`] spelled out and the rest counted as
+/// ` and N more`.
 ///
 /// ASCII only — the console flow must survive a legacy OEM codepage, so a
 /// plain hyphen stands where prose would take a dash.
@@ -674,14 +622,15 @@ fn hint_line(
     rule: HiddenRule,
     flag: &str,
 ) -> String {
-    let mut hidden: Vec<&PlaylistSummary> =
-        playlists.iter().filter(|playlist| filter.classify(playlist).contains(&rule)).collect();
+    let hidden: Vec<&str> = hidden_by(playlists, filter)
+        .into_iter()
+        .filter(|(_, rules)| rules.contains(&rule))
+        .map(|(playlist, _)| playlist.name.as_str())
+        .collect();
     if hidden.is_empty() {
         return String::new();
     }
-    hidden.sort_by(|a, b| presentation_cmp(a, b));
-    let named: Vec<&str> =
-        hidden.iter().take(HINT_NAMES).map(|playlist| playlist.name.as_str()).collect();
+    let named: Vec<&str> = hidden.iter().take(HINT_NAMES).copied().collect();
     let rest = hidden.len().saturating_sub(HINT_NAMES);
     let more = if rest == 0 { String::new() } else { format!(" and {rest} more") };
     format!(


### PR DESCRIPTION
The CLI and the desktop GUI each held their own folder-vs-.iso open (build the
root, resilient-scan it, merge the backend's recorded failures, repair a
folder-derived label) and their own selection of what a playlist filter
withheld. Both now live once in the library.

## Core

- New `bdinfo_rs_core::scan` with `open_folder` and `open_iso`: path in,
  `ScanReport` out, backend errors merged, and for a folder the label passed
  through `vfs::volume::resolve_folder_label`. `mode`, `scan_files`, `progress`
  and `cancel` are `BdRom::open_resilient_with`'s, threaded unchanged, so how
  deep to read stays the caller's choice.
- New `bdrom::order::hidden_by`: every playlist the filter drops, paired with
  the rules whose switch dropped it, in presentation order.

Both are additive.

## Surfaces

`bdinfo-rs`: `scan_iso` and `scan_folder` are gone; `scan_disc` is the path
sniff plus a call. `hint_line` derives its per-rule list from `hidden_by`.

`bdinfo-rs-gui`: `scan::open` is the two-arm dispatch and nothing more;
`model::hidden_playlists` aggregates `hidden_by`.

The two renderings differ on purpose and are unchanged to the byte: the CLI
emits one line per rule, spelling three names then counting the rest, and lists
a short-and-looping playlist under both rules; the GUI emits one aggregate line
counting each playlist once. Input classification stays per surface -- the CLI
sniffs the path, the GUI pre-classifies with its own "exists but is not a disc"
message. wasm is untouched: a browser caller has no paths.

## Verification

Root, GUI and wasm gates all pass on the committed branch. Core coverage 100%
lines/regions/functions (23061/23061, 43667/43667, 2225/2225), branches 97.77%;
GUI 100% (4127/4127, 7656/7656, 595/595). Mutants over the branch diff: root 9
found, 4 caught, 5 unviable; GUI 4 found, 1 caught, 3 unviable; none missed.
Report fixtures byte-identical.
