### PR TITLE
refactor(core): drive stream construction from one type table

### DIFF
--- a/crates/bdinfo-rs-core/src/bdrom.rs
+++ b/crates/bdinfo-rs-core/src/bdrom.rs
@@ -6,6 +6,10 @@
 //! the [`crate::stream`] data model, returning [`crate::error::BdError`] on
 //! malformed input.
 //!
+//! Both file kinds describe a stream entry with the same coding-info layout at
+//! their own offset, so both decode it through the one `build_coded_stream`
+//! here, beside the shared bounds-checked byte reads.
+//!
 //! The disc-level orchestration that wires these together — the [`disc`] scan
 //! plus the cross-clip resolution that feeds the [`m2ts`] demux — builds on
 //! these standalone parsers. Two presentation modules sit beside them, over
@@ -15,6 +19,10 @@
 
 use crate::bytes;
 use crate::error::BdError;
+use crate::stream::{
+    StreamKind, TsAspectRatio, TsAudioStream, TsChannelLayout, TsFrameRate, TsGraphicsStream,
+    TsSampleRate, TsStream, TsStreamType, TsTextStream, TsVideoFormat, TsVideoStream,
+};
 
 pub mod chapters;
 pub mod clpi;
@@ -60,6 +68,70 @@ pub(crate) fn u32_off(buf: &[u8], off: usize) -> Result<usize, BdError> {
 /// [`BdError::UnexpectedEof`].
 pub(crate) fn ascii(buf: &[u8], off: usize, count: usize) -> Result<String, BdError> {
     bytes::read_ascii(buf, off, count).ok_or(BdError::UnexpectedEof)
+}
+
+/// Builds the [`TsStream`] a `stream_coding_type` of `stream_type` describes,
+/// reading its coding info from `data` starting at `coding`, or `None` for a
+/// [`StreamKind::Unknown`] type.
+///
+/// The clip-information (`*.clpi`) and playlist (`*.mpls`) stream entries carry
+/// the same coding-info layout at their own offset — a format byte for video and
+/// audio, then a 3-byte ISO-639 language code for audio (at `coding + 1`),
+/// graphics (at `coding`) and text (at `coding + 1`, past a 1-byte unused code
+/// field). `aspect` names the byte holding the display aspect-ratio nibble of a
+/// video stream, which only the clip information carries; `None` leaves
+/// [`TsVideoStream::aspect_ratio`] at its default.
+///
+/// `MvcVideo` is *not* refused here — it is [`StreamKind::Video`] like every
+/// other video coding type, and both callers return `None` for it before
+/// dispatching. [`TsStreamType::default_stream`] documents why.
+pub(crate) fn build_coded_stream(
+    data: &[u8],
+    coding: usize,
+    stream_type: TsStreamType,
+    aspect: Option<usize>,
+) -> Result<Option<TsStream>, BdError> {
+    Ok(match stream_type.kind() {
+        StreamKind::Video => {
+            // The setters (deriving height/scan + the frame-rate ratio) run
+            // first, so the later `aspect_ratio` field write isn't a
+            // default-reassign.
+            let format = byte(data, coding)?;
+            let mut stream = TsVideoStream::default();
+            stream.set_video_format(TsVideoFormat::from_u8(format.wrapping_shr(4)));
+            stream.set_frame_rate(TsFrameRate::from_u8(format & 0x0F));
+            if let Some(aspect) = aspect {
+                stream.aspect_ratio = TsAspectRatio::from_u8(byte(data, aspect)?.wrapping_shr(4));
+            }
+            Some(TsStream::Video(stream))
+        }
+        StreamKind::Audio => {
+            let format = byte(data, coding)?;
+            let language = ascii(data, coding.saturating_add(1), 3)?;
+            let mut stream = TsAudioStream {
+                channel_layout: TsChannelLayout::from_u8(format.wrapping_shr(4)),
+                sample_rate: TsAudioStream::convert_sample_rate(TsSampleRate::from_u8(
+                    format & 0x0F,
+                )),
+                ..TsAudioStream::default()
+            };
+            stream.base.set_language_code(&language);
+            Some(TsStream::Audio(stream))
+        }
+        StreamKind::Graphics => {
+            let language = ascii(data, coding, 3)?;
+            let mut stream = TsGraphicsStream::default();
+            stream.base.set_language_code(&language);
+            Some(TsStream::Graphics(stream))
+        }
+        StreamKind::Text => {
+            let language = ascii(data, coding.saturating_add(1), 3)?;
+            let mut stream = TsTextStream::default();
+            stream.base.set_language_code(&language);
+            Some(TsStream::Text(stream))
+        }
+        StreamKind::Unknown => None,
+    })
 }
 
 #[cfg(test)]

--- a/crates/bdinfo-rs-core/src/bdrom/clpi.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/clpi.rs
@@ -14,18 +14,15 @@
 //! short or truncated file surfaces as [`BdError`] rather than a panic (disc
 //! bytes are never indexed raw; malformed input → `Result`). Disc offsets
 //! advance with `saturating_add` (an out-of-range offset then fails the next
-//! bounds-checked read as [`BdError::UnexpectedEof`]); the small coding-info
-//! nibble math uses fixed-width `wrapping_*` arithmetic.
+//! bounds-checked read as [`BdError::UnexpectedEof`]); the entry-length math
+//! uses fixed-width `wrapping_*` arithmetic.
 
 use std::collections::BTreeMap;
 
-use super::{ascii, byte, u16_be, u32_off};
+use super::{ascii, build_coded_stream, byte, u16_be, u32_off};
 use crate::error::BdError;
 use crate::primitives::Pid;
-use crate::stream::{
-    TsAspectRatio, TsAudioStream, TsChannelLayout, TsFrameRate, TsGraphicsStream, TsSampleRate,
-    TsStream, TsStreamType, TsTextStream, TsVideoFormat, TsVideoStream,
-};
+use crate::stream::{TsStream, TsStreamType};
 
 /// One playlist clip.
 ///
@@ -151,69 +148,17 @@ fn build_clip_stream(
     info: usize,
     stream_type: TsStreamType,
 ) -> Result<Option<TsStream>, BdError> {
-    Ok(match stream_type {
-        // MVC is a recognised coding type that carries no decoded fields, so it
-        // stays a distinct arm (the place dependent-view handling would slot in)
-        // rather than being folded into the Unknown default.
-        #[expect(
-            clippy::match_same_arms,
-            reason = "MVC is a recognised coding type, deliberately not the Unknown default"
-        )]
-        TsStreamType::MvcVideo => None,
-        TsStreamType::HevcVideo
-        | TsStreamType::AvcVideo
-        | TsStreamType::Mpeg1Video
-        | TsStreamType::Mpeg2Video
-        | TsStreamType::Vc1Video => {
-            let format = byte(clip_data, info.saturating_add(2))?;
-            let aspect = byte(clip_data, info.saturating_add(3))?;
-            // The setters (deriving height/scan + the frame-rate ratio) run first,
-            // so the trailing `aspect_ratio` field write isn't a default-reassign.
-            let mut stream = TsVideoStream::default();
-            stream.set_video_format(TsVideoFormat::from_u8(format.wrapping_shr(4)));
-            stream.set_frame_rate(TsFrameRate::from_u8(format & 0x0F));
-            stream.aspect_ratio = TsAspectRatio::from_u8(aspect.wrapping_shr(4));
-            Some(TsStream::Video(stream))
-        }
-        TsStreamType::Ac3Audio
-        | TsStreamType::Ac3PlusAudio
-        | TsStreamType::Ac3PlusSecondaryAudio
-        | TsStreamType::Ac3TrueHdAudio
-        | TsStreamType::DtsAudio
-        | TsStreamType::DtsHdAudio
-        | TsStreamType::DtsHdMasterAudio
-        | TsStreamType::DtsHdSecondaryAudio
-        | TsStreamType::LpcmAudio
-        | TsStreamType::Mpeg1Audio
-        | TsStreamType::Mpeg2Audio
-        | TsStreamType::Mpeg2AacAudio
-        | TsStreamType::Mpeg4AacAudio => {
-            let format = byte(clip_data, info.saturating_add(2))?;
-            let language = ascii(clip_data, info.saturating_add(3), 3)?;
-            let mut stream = TsAudioStream {
-                channel_layout: TsChannelLayout::from_u8(format.wrapping_shr(4)),
-                sample_rate: TsAudioStream::convert_sample_rate(TsSampleRate::from_u8(
-                    format & 0x0F,
-                )),
-                ..TsAudioStream::default()
-            };
-            stream.base.set_language_code(&language);
-            Some(TsStream::Audio(stream))
-        }
-        TsStreamType::InteractiveGraphics | TsStreamType::PresentationGraphics => {
-            let language = ascii(clip_data, info.saturating_add(2), 3)?;
-            let mut stream = TsGraphicsStream::default();
-            stream.base.set_language_code(&language);
-            Some(TsStream::Graphics(stream))
-        }
-        TsStreamType::Subtitle => {
-            let language = ascii(clip_data, info.saturating_add(3), 3)?;
-            let mut stream = TsTextStream::default();
-            stream.base.set_language_code(&language);
-            Some(TsStream::Text(stream))
-        }
-        TsStreamType::Unknown => None,
-    })
+    // MVC is a recognised coding type that yields no clip stream — deliberately
+    // not folded into the Unknown default, and the place dependent-view handling
+    // would slot in. `TsStreamType::default_stream` documents why the demux
+    // accepts what this parser refuses.
+    if stream_type == TsStreamType::MvcVideo {
+        return Ok(None);
+    }
+    // `info` points at the coding-info length byte and the coding type follows
+    // it, so the coding info itself starts two bytes on. Its video attributes
+    // are the format byte then the aspect byte.
+    build_coded_stream(clip_data, info.saturating_add(2), stream_type, Some(info.saturating_add(3)))
 }
 
 #[cfg(test)]

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -1898,26 +1898,7 @@ fn merge_stream(dst: &mut TsStream, src: &TsStream) {
 /// description values the `streams` diff level emits, plus the report-table
 /// columns (alternate codec name, language code, audio channel detail).
 fn stream_summary(stream: &TsStream) -> StreamSummary {
-    let (codec_short_name, codec_name, description) = match stream {
-        TsStream::Video(video) => (
-            video.codec_short_name().to_owned(),
-            video.codec_name().to_owned(),
-            video.description(),
-        ),
-        TsStream::Audio(audio) => (
-            audio.codec_short_name().to_owned(),
-            audio.codec_name().to_owned(),
-            audio.description(),
-        ),
-        TsStream::Graphics(graphics) => (
-            graphics.codec_short_name().to_owned(),
-            graphics.codec_name().to_owned(),
-            graphics.description(),
-        ),
-        TsStream::Text(text) => {
-            (text.codec_short_name().to_owned(), text.codec_name().to_owned(), text.description())
-        }
-    };
+    let description = stream.description();
     let (channel_description, sample_rate, bit_depth, channel_count) = match stream {
         TsStream::Audio(audio) => {
             (audio.channel_description(), audio.sample_rate, audio.bit_depth, audio.channel_count)
@@ -1931,8 +1912,8 @@ fn stream_summary(stream: &TsStream) -> StreamSummary {
     StreamSummary {
         pid: stream.pid(),
         stream_type: stream.stream_type(),
-        codec_short_name,
-        codec_name,
+        codec_short_name: stream.codec_short_name().to_owned(),
+        codec_name: stream.codec_name().to_owned(),
         codec_alt_name: stream.codec_alt_name(),
         bitrate: 0,
         active_bitrate: 0,

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -53,9 +53,7 @@ use super::mpls::TsPlaylistFile;
 use crate::bitstream::TsStreamBuffer;
 use crate::error::BdError;
 use crate::primitives::Pid;
-use crate::stream::{
-    TsAudioStream, TsGraphicsStream, TsStream, TsStreamType, TsTextStream, TsVideoStream,
-};
+use crate::stream::{StreamKind, TsStream, TsStreamType};
 
 /// Read-chunk size (5 MiB) for each underlying read. The packet state machine
 /// is chunk-boundary-agnostic, so the value affects only read granularity
@@ -232,22 +230,9 @@ struct TsStreamState {
     /// seam) so the per-byte loop needs no `streams` lookup.
     stream_initialized: bool,
     /// Mirror of the stream's kind (set at registration), for the same reason.
+    /// A PID with no registered stream keeps the [`StreamKind`] default, which
+    /// matches none of the three kinds the per-byte loop dispatches on.
     stream_kind: StreamKind,
-}
-
-/// The stream-kind mirror held in [`TsStreamState`] — the per-byte demux loop
-/// branches on the kind without a `streams` map lookup.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-enum StreamKind {
-    /// No registered stream, or one that is neither video, audio nor graphics.
-    #[default]
-    Other,
-    /// A video stream.
-    Video,
-    /// An audio stream.
-    Audio,
-    /// A graphics (PGS/IGS) stream.
-    Graphics,
 }
 
 /// The whole-file packet parser — the fields the core demux reads (write-only
@@ -1676,33 +1661,7 @@ impl TsStreamFile {
     /// list.
     fn create_stream(&mut self, stream_pid: u16, stream_type_byte: u8) {
         let stream_type = TsStreamType::from_u8(stream_type_byte);
-        let stream: Option<TsStream> = match stream_type {
-            TsStreamType::MvcVideo
-            | TsStreamType::AvcVideo
-            | TsStreamType::HevcVideo
-            | TsStreamType::Mpeg1Video
-            | TsStreamType::Mpeg2Video
-            | TsStreamType::Vc1Video => Some(TsStream::Video(TsVideoStream::default())),
-            TsStreamType::Ac3Audio
-            | TsStreamType::Ac3PlusAudio
-            | TsStreamType::Ac3PlusSecondaryAudio
-            | TsStreamType::Ac3TrueHdAudio
-            | TsStreamType::DtsAudio
-            | TsStreamType::DtsHdAudio
-            | TsStreamType::DtsHdMasterAudio
-            | TsStreamType::DtsHdSecondaryAudio
-            | TsStreamType::LpcmAudio
-            | TsStreamType::Mpeg1Audio
-            | TsStreamType::Mpeg2Audio
-            | TsStreamType::Mpeg2AacAudio
-            | TsStreamType::Mpeg4AacAudio => Some(TsStream::Audio(TsAudioStream::default())),
-            TsStreamType::InteractiveGraphics | TsStreamType::PresentationGraphics => {
-                Some(TsStream::Graphics(TsGraphicsStream::default()))
-            }
-            TsStreamType::Subtitle => Some(TsStream::Text(TsTextStream::default())),
-            TsStreamType::Unknown => None,
-        };
-        if let Some(mut stream) = stream {
+        if let Some(mut stream) = stream_type.default_stream() {
             // The caller registers a PID only once (`streams` is checked before
             // the call), so the order list records each PID exactly once;
             // `or_insert` keeps any existing entry and drops the duplicate.
@@ -1713,15 +1672,7 @@ impl TsStreamFile {
             let registered = self.streams.entry(stream_pid).or_insert(stream);
             // Mirror the kind/init flags into the per-PID state so the
             // per-byte demux loop reads them without a `streams` lookup.
-            let kind = if registered.base().is_video_stream() {
-                StreamKind::Video
-            } else if registered.base().is_audio_stream() {
-                StreamKind::Audio
-            } else if registered.base().is_graphics_stream() {
-                StreamKind::Graphics
-            } else {
-                StreamKind::Other
-            };
+            let kind = registered.stream_type().kind();
             let initialized = registered.base().is_initialized;
             let state = self.stream_states.entry(stream_pid).or_default();
             state.stream_kind = kind;

--- a/crates/bdinfo-rs-core/src/bdrom/mpls.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/mpls.rs
@@ -26,13 +26,10 @@
 use std::collections::BTreeMap;
 
 use super::clpi::TsStreamClip;
-use super::{ascii, byte, u16_be, u32_be};
+use super::{ascii, build_coded_stream, byte, u16_be, u32_be};
 use crate::error::BdError;
 use crate::primitives::Pid;
-use crate::stream::{
-    TsAudioStream, TsChannelLayout, TsFrameRate, TsGraphicsStream, TsSampleRate, TsStream,
-    TsStreamType, TsTextStream, TsVideoFormat, TsVideoStream,
-};
+use crate::stream::{TsStream, TsStreamType};
 
 /// A parsed playlist file.
 ///
@@ -369,69 +366,17 @@ fn build_playlist_stream(
     coding: usize,
     stream_type: TsStreamType,
 ) -> Result<Option<TsStream>, BdError> {
-    Ok(match stream_type {
-        // MVC is a recognised coding type that yields no stream, kept as a
-        // distinct arm rather than folded into the Unknown default.
-        #[expect(
-            clippy::match_same_arms,
-            reason = "MVC is a recognised coding type, deliberately not the Unknown default"
-        )]
-        TsStreamType::MvcVideo => None,
-        TsStreamType::HevcVideo
-        | TsStreamType::AvcVideo
-        | TsStreamType::Mpeg1Video
-        | TsStreamType::Mpeg2Video
-        | TsStreamType::Vc1Video => {
-            // MPLS video attributes carry only format + rate; the next byte is
-            // dynamic_range_type/color_space on HEVC, not an aspect field
-            // (aspect lives in the CLPI stream-coding info), so it is not read.
-            let format = byte(data, coding)?;
-            let mut stream = TsVideoStream::default();
-            stream.set_video_format(TsVideoFormat::from_u8(format.wrapping_shr(4)));
-            stream.set_frame_rate(TsFrameRate::from_u8(format & 0x0F));
-            Some(TsStream::Video(stream))
-        }
-        TsStreamType::Ac3Audio
-        | TsStreamType::Ac3PlusAudio
-        | TsStreamType::Ac3PlusSecondaryAudio
-        | TsStreamType::Ac3TrueHdAudio
-        | TsStreamType::DtsAudio
-        | TsStreamType::DtsHdAudio
-        | TsStreamType::DtsHdMasterAudio
-        | TsStreamType::DtsHdSecondaryAudio
-        | TsStreamType::LpcmAudio
-        | TsStreamType::Mpeg1Audio
-        | TsStreamType::Mpeg2Audio
-        | TsStreamType::Mpeg2AacAudio
-        | TsStreamType::Mpeg4AacAudio => {
-            let format = byte(data, coding)?;
-            let language = ascii(data, coding.saturating_add(1), 3)?;
-            let mut stream = TsAudioStream {
-                channel_layout: TsChannelLayout::from_u8(format.wrapping_shr(4)),
-                sample_rate: TsAudioStream::convert_sample_rate(TsSampleRate::from_u8(
-                    format & 0x0F,
-                )),
-                ..TsAudioStream::default()
-            };
-            stream.base.set_language_code(&language);
-            Some(TsStream::Audio(stream))
-        }
-        TsStreamType::InteractiveGraphics | TsStreamType::PresentationGraphics => {
-            let language = ascii(data, coding, 3)?;
-            let mut stream = TsGraphicsStream::default();
-            stream.base.set_language_code(&language);
-            Some(TsStream::Graphics(stream))
-        }
-        TsStreamType::Subtitle => {
-            // A 1-byte code field (unused) precedes the language, so the
-            // language sits one byte past `coding`.
-            let language = ascii(data, coding.saturating_add(1), 3)?;
-            let mut stream = TsTextStream::default();
-            stream.base.set_language_code(&language);
-            Some(TsStream::Text(stream))
-        }
-        TsStreamType::Unknown => None,
-    })
+    // MVC is a recognised coding type that yields no playlist stream —
+    // deliberately not folded into the Unknown default.
+    // `TsStreamType::default_stream` documents why the demux accepts what this
+    // parser refuses.
+    if stream_type == TsStreamType::MvcVideo {
+        return Ok(None);
+    }
+    // No aspect byte: MPLS video attributes carry only format + rate, and the
+    // byte after the format is dynamic_range_type/color_space on HEVC, not an
+    // aspect field (aspect lives in the CLPI stream-coding info).
+    build_coded_stream(data, coding, stream_type, None)
 }
 
 #[cfg(test)]

--- a/crates/bdinfo-rs-core/src/stream.rs
+++ b/crates/bdinfo-rs-core/src/stream.rs
@@ -2,7 +2,8 @@
 //!
 //! The model covers the enums, [`TsDescriptor`], and the
 //! `TsStream`/`TsVideoStream`/`TsAudioStream`/`TsGraphicsStream`/`TsTextStream`
-//! stream family.
+//! stream family. Which of those four a coding type maps to is [`StreamKind`],
+//! decided once by [`TsStreamType::kind`].
 //!
 //! The enum discriminants are fixed **verbatim** (`#[repr(u8)]`, the on-disc
 //! numeric values) because the parsers cast on-disc bytes straight into
@@ -95,6 +96,28 @@ pub enum TsStreamType {
     InteractiveGraphics = 0x91,
     /// Text subtitle (`TextST`).
     Subtitle = 0x92,
+}
+
+/// The family a [`TsStreamType`] belongs to — the four concrete [`TsStream`]
+/// variants plus the catch-all for a coding type the analyzer does not model.
+///
+/// [`TsStreamType::kind`] is the only partition of the coding types in this
+/// crate: the classifiers, both BDMV parsers, the demux registration and the
+/// demux's per-PID kind mirror all read it, so a new coding type is classified
+/// once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StreamKind {
+    /// A coding type with no modelled stream (`Unknown`).
+    #[default]
+    Unknown,
+    /// A video stream ([`TsVideoStream`]).
+    Video,
+    /// An audio stream ([`TsAudioStream`]).
+    Audio,
+    /// A graphics (PGS/IGS) stream ([`TsGraphicsStream`]).
+    Graphics,
+    /// A text-subtitle stream ([`TsTextStream`]).
+    Text,
 }
 
 /// Video resolution + scan code.
@@ -347,51 +370,81 @@ impl TsStreamBase {
 }
 
 impl TsStreamType {
+    /// The [`StreamKind`] this coding type belongs to — the authoritative
+    /// partition every other classifier in the crate defers to.
+    #[must_use]
+    pub const fn kind(self) -> StreamKind {
+        match self {
+            Self::Mpeg1Video
+            | Self::Mpeg2Video
+            | Self::AvcVideo
+            | Self::MvcVideo
+            | Self::Vc1Video
+            | Self::HevcVideo => StreamKind::Video,
+            Self::Mpeg1Audio
+            | Self::Mpeg2Audio
+            | Self::Mpeg2AacAudio
+            | Self::Mpeg4AacAudio
+            | Self::LpcmAudio
+            | Self::Ac3Audio
+            | Self::Ac3PlusAudio
+            | Self::Ac3PlusSecondaryAudio
+            | Self::Ac3TrueHdAudio
+            | Self::DtsAudio
+            | Self::DtsHdAudio
+            | Self::DtsHdSecondaryAudio
+            | Self::DtsHdMasterAudio => StreamKind::Audio,
+            Self::PresentationGraphics | Self::InteractiveGraphics => StreamKind::Graphics,
+            Self::Subtitle => StreamKind::Text,
+            Self::Unknown => StreamKind::Unknown,
+        }
+    }
+
+    /// A default-valued [`TsStream`] of this type's [`kind`](Self::kind), or
+    /// `None` for a kind with no modelled stream — the shape the M2TS demux
+    /// registers for a PID the PMT declares, with every field left for the
+    /// packet scan to fill.
+    ///
+    /// `MvcVideo` yields the video variant here while both BDMV parsers refuse
+    /// it, so a 3D disc's dependent view reaches the model only through the
+    /// demux, which `bdrom::disc`'s `resolve_playlist_streams` then presents
+    /// from the scanned file. The asymmetry follows classic `BDInfo`, whose
+    /// `TSStreamFile.CreateStream` groups MVC with the other video coding types
+    /// while its `TSStreamClipFile` and `TSPlaylistFile` leave their MVC case
+    /// unimplemented.
+    #[must_use]
+    pub fn default_stream(self) -> Option<TsStream> {
+        match self.kind() {
+            StreamKind::Video => Some(TsStream::Video(TsVideoStream::default())),
+            StreamKind::Audio => Some(TsStream::Audio(TsAudioStream::default())),
+            StreamKind::Graphics => Some(TsStream::Graphics(TsGraphicsStream::default())),
+            StreamKind::Text => Some(TsStream::Text(TsTextStream::default())),
+            StreamKind::Unknown => None,
+        }
+    }
+
     /// Whether this type is a video type.
     #[must_use]
     pub const fn is_video(self) -> bool {
-        matches!(
-            self,
-            Self::Mpeg1Video
-                | Self::Mpeg2Video
-                | Self::AvcVideo
-                | Self::MvcVideo
-                | Self::Vc1Video
-                | Self::HevcVideo
-        )
+        matches!(self.kind(), StreamKind::Video)
     }
 
     /// Whether this type is an audio type.
     #[must_use]
     pub const fn is_audio(self) -> bool {
-        matches!(
-            self,
-            Self::Mpeg1Audio
-                | Self::Mpeg2Audio
-                | Self::Mpeg2AacAudio
-                | Self::Mpeg4AacAudio
-                | Self::LpcmAudio
-                | Self::Ac3Audio
-                | Self::Ac3PlusAudio
-                | Self::Ac3PlusSecondaryAudio
-                | Self::Ac3TrueHdAudio
-                | Self::DtsAudio
-                | Self::DtsHdAudio
-                | Self::DtsHdSecondaryAudio
-                | Self::DtsHdMasterAudio
-        )
+        matches!(self.kind(), StreamKind::Audio)
     }
 
     /// Whether this type is a graphics (PGS/IGS) type.
     #[must_use]
     pub const fn is_graphics(self) -> bool {
-        matches!(self, Self::PresentationGraphics | Self::InteractiveGraphics)
+        matches!(self.kind(), StreamKind::Graphics)
     }
 
     /// Whether this type is a text-subtitle type.
     #[must_use]
     pub const fn is_text(self) -> bool {
-        matches!(self, Self::Subtitle)
+        matches!(self.kind(), StreamKind::Text)
     }
 }
 
@@ -1154,6 +1207,32 @@ impl TsStream {
         }
     }
 
+    /// The long codec label of the concrete kind (the per-kind `codec_name`).
+    ///
+    /// Borrowed rather than `'static`: an MPEG-1/2 or AAC audio stream returns
+    /// the codec-supplied [`ext_data`](TsAudioStream::ext_data) string it owns.
+    #[must_use]
+    pub fn codec_name(&self) -> &str {
+        match self {
+            Self::Video(s) => s.codec_name(),
+            Self::Audio(s) => s.codec_name(),
+            Self::Graphics(s) => s.codec_name(),
+            Self::Text(s) => s.codec_name(),
+        }
+    }
+
+    /// The per-stream description of the concrete kind (the per-kind
+    /// `description`).
+    #[must_use]
+    pub fn description(&self) -> String {
+        match self {
+            Self::Video(s) => s.description(),
+            Self::Audio(s) => s.description(),
+            Self::Graphics(s) => s.description(),
+            Self::Text(s) => s.description(),
+        }
+    }
+
     /// The alternate codec label some report tables print (e.g. the summary
     /// table's `AVC` / `DD AC3` / `DTS-HD Master` cells) — keyed by the stream
     /// type, with the Dolby/DTS extension upgrades (`Dolby Atmos`,
@@ -1416,9 +1495,9 @@ mod tests {
     use proptest::prelude::{any, prop_assert, prop_assert_eq, proptest};
 
     use super::{
-        Pid, TsAspectRatio, TsAudioMode, TsAudioStream, TsChannelLayout, TsDescriptor, TsFrameRate,
-        TsGraphicsStream, TsSampleRate, TsStream, TsStreamBase, TsStreamType, TsTextStream,
-        TsVideoFormat, TsVideoStream,
+        Pid, StreamKind, TsAspectRatio, TsAudioMode, TsAudioStream, TsChannelLayout, TsDescriptor,
+        TsFrameRate, TsGraphicsStream, TsSampleRate, TsStream, TsStreamBase, TsStreamType,
+        TsTextStream, TsVideoFormat, TsVideoStream,
     };
 
     #[test]
@@ -1435,6 +1514,58 @@ mod tests {
         let mut text = TsTextStream::default();
         text.base.stream_type = TsStreamType::Subtitle;
         assert_eq!(TsStream::Text(text).codec_short_name(), "SUB");
+    }
+
+    #[test]
+    fn codec_name_and_description_delegate_to_every_concrete_kind() {
+        // One populated detail field per kind, so a delegation crossed between
+        // two kinds shows up in the description as well as the codec name.
+        let mut video = TsVideoStream::default();
+        video.base.stream_type = TsStreamType::AvcVideo;
+        video.set_video_format(TsVideoFormat::Videoformat1080p);
+        let video = TsStream::Video(video);
+        assert_eq!(video.codec_name(), "MPEG-4 AVC Video");
+        assert_eq!(video.description(), "1080p");
+
+        let mut audio = TsAudioStream::default();
+        audio.base.stream_type = TsStreamType::LpcmAudio;
+        audio.channel_count = 2;
+        let audio = TsStream::Audio(audio);
+        assert_eq!(audio.codec_name(), "LPCM Audio");
+        assert_eq!(audio.description(), "2.0");
+
+        let mut graphics = TsGraphicsStream::default();
+        graphics.base.stream_type = TsStreamType::PresentationGraphics;
+        graphics.captions = 3;
+        let graphics = TsStream::Graphics(graphics);
+        assert_eq!(graphics.codec_name(), "Presentation Graphics");
+        assert_eq!(graphics.description(), " / 3 Captions");
+
+        let mut text = TsTextStream::default();
+        text.base.stream_type = TsStreamType::Subtitle;
+        let text = TsStream::Text(text);
+        assert_eq!(text.codec_name(), "Subtitle");
+        assert_eq!(text.description(), "");
+    }
+
+    #[test]
+    fn default_stream_builds_the_variant_of_each_kind() {
+        // MVC gets the video variant here while both BDMV parsers return no
+        // stream for it — the asymmetry `default_stream`'s doc records.
+        let cases = [
+            (TsStreamType::AvcVideo, Some(TsStream::Video(TsVideoStream::default()))),
+            (TsStreamType::MvcVideo, Some(TsStream::Video(TsVideoStream::default()))),
+            (TsStreamType::Ac3Audio, Some(TsStream::Audio(TsAudioStream::default()))),
+            (
+                TsStreamType::PresentationGraphics,
+                Some(TsStream::Graphics(TsGraphicsStream::default())),
+            ),
+            (TsStreamType::Subtitle, Some(TsStream::Text(TsTextStream::default()))),
+            (TsStreamType::Unknown, None),
+        ];
+        for (ty, expected) in cases {
+            assert_eq!(ty.default_stream(), expected, "default stream for {ty:?}");
+        }
     }
 
     #[test]
@@ -1594,8 +1725,11 @@ mod tests {
         let graphics = [TsStreamType::PresentationGraphics, TsStreamType::InteractiveGraphics];
         let text = [TsStreamType::Subtitle];
 
+        // The lists above are the whole enum bar `Unknown`, so this pins every
+        // arm of the one kind table the predicates read.
         for &t in &video {
             let b = base_of(t);
+            assert_eq!(t.kind(), StreamKind::Video, "kind of {t:?}");
             assert!(b.is_video_stream(), "{t:?} should be video");
             assert!(!b.is_audio_stream());
             assert!(!b.is_graphics_stream());
@@ -1603,6 +1737,7 @@ mod tests {
         }
         for &t in &audio {
             let b = base_of(t);
+            assert_eq!(t.kind(), StreamKind::Audio, "kind of {t:?}");
             assert!(b.is_audio_stream(), "{t:?} should be audio");
             assert!(!b.is_video_stream());
             assert!(!b.is_graphics_stream());
@@ -1610,6 +1745,7 @@ mod tests {
         }
         for &t in &graphics {
             let b = base_of(t);
+            assert_eq!(t.kind(), StreamKind::Graphics, "kind of {t:?}");
             assert!(b.is_graphics_stream(), "{t:?} should be graphics");
             assert!(!b.is_video_stream());
             assert!(!b.is_audio_stream());
@@ -1617,12 +1753,16 @@ mod tests {
         }
         for &t in &text {
             let b = base_of(t);
+            assert_eq!(t.kind(), StreamKind::Text, "kind of {t:?}");
             assert!(b.is_text_stream(), "{t:?} should be text");
             assert!(!b.is_video_stream());
             assert!(!b.is_audio_stream());
             assert!(!b.is_graphics_stream());
         }
-        // Unknown is none of the four.
+        // Unknown is none of the four, and is the kind a default `StreamKind`
+        // carries.
+        assert_eq!(TsStreamType::Unknown.kind(), StreamKind::Unknown);
+        assert_eq!(StreamKind::default(), StreamKind::Unknown);
         let u = base_of(TsStreamType::Unknown);
         assert!(!u.is_video_stream());
         assert!(!u.is_audio_stream());


### PR DESCRIPTION
The video/audio/graphics/text partition of `TsStreamType` was hand-spelled in seven places: the four `is_video`/`is_audio`/`is_graphics`/`is_text` predicates, the clip-information and playlist stream builders, and the M2TS demux registration. Adding a coding type meant seven list edits, and every list ended in a `_`/`Unknown` arm that swallowed a missed one.

`TsStreamType::kind` now holds the partition once, as a `StreamKind`, and the four predicates are `matches!` over it.

The two BDMV builders were the same function at a fixed offset shift: every clip-information offset is exactly +2 from its playlist twin, because the clip-information pointer sits on the coding-info length byte. Both now call one `bdrom::build_coded_stream`; only the clip information passes an aspect-byte offset, and the playlist site records why it has none (its next byte is dynamic-range/colour-space on HEVC). `m2ts::create_stream` becomes `TsStreamType::default_stream`, and the demux's per-PID kind mirror reads `kind()` instead of a private four-variant enum plus an if/else chain.

`TsStream` gains `codec_name` and `description` delegators beside the existing `codec_short_name`; the disc scan's `stream_summary` collapses its four-arm match onto them.

Both BDMV builders keep returning no stream for MVC, ahead of the shared dispatch. That asymmetry with the demux, which does build a video stream for it, is now explained once in `TsStreamType::default_stream` and cited from the two parser sites.

Grep proof: no coding-type list survives outside `stream.rs` -- `grep -rn "Mpeg1Video\|Mpeg2AacAudio\|InteractiveGraphics" crates/ fuzz/ --include=*.rs` returns only test data and `codec.rs`'s scanner dispatch, which selects a codec scanner rather than a stream family. Adding a coding type is now a one-file edit: a variant plus its `from_u8`/`as_u8`/`name` code and one `kind()` arm, all in `stream.rs`.

Behaviour-preserving: the same inputs construct the same streams, and every report fixture is byte-identical.

Verified locally on the committed branch: `pwsh scripts/compliance.ps1` PASS -- 1014 tests, 100% lines/regions/functions (23099/23099, 43704/43704, 2232/2232), branches 97.77%, `mt` 31 mutants found / 24 caught / 7 unviable / 0 missed. `pwsh scripts/wasm-compliance.ps1` and `pwsh scripts/gui-compliance.ps1` both PASS.