### PR TITLE
refactor(core): consolidate the parser-side helper idioms

### DIFF
--- a/crates/bdinfo-rs-core/src/bitstream.rs
+++ b/crates/bdinfo-rs-core/src/bitstream.rs
@@ -27,12 +27,24 @@
 //! read whose `skip_bits + bits` exceeds that span yields the in-window bits
 //! followed by **zero** tail bits: all three carry an explicit in-window index
 //! guard, and none of them reads further into the stream, so the true
-//! downstream bits are never returned. The rule is latent in-tree — every
-//! *full-width* call site is byte-aligned, and the unaligned callers are all
-//! sub-width (`hevc` reads a 6-bit `nal_unit_type` one bit into the NAL header;
-//! `ac3`'s EMDF sync search reads 16 bits per iteration while advancing one bit
-//! at a time), so no current read reaches its tail. A new unaligned full-width
-//! caller would get zeros where it expects stream bits.
+//! downstream bits are never returned. The condition is
+//! `skip_bits + bits > window width`, not `bits < width`: a 12-bit
+//! [`read_bits2`](TsStreamBuffer::read_bits2) at bit offset 5 reaches its tail.
+//!
+//! Two in-tree paths do reach it, neither observably.
+//! [`bs_skip_bits`](TsStreamBuffer::bs_skip_bits) reaches it routinely on
+//! well-formed streams — it chops a skip into 16-bit `read_bits2` calls from
+//! whatever bit offset it starts at — but discards every value, and the cursor
+//! advance is computed from the requested `bits` alone.
+//! [`read_exp`](TsStreamBuffer::read_exp) reaches it with a *used* value when an
+//! Exp-Golomb code carries 33 or more leading zeros, which it passes straight to
+//! [`read_bits4`](TsStreamBuffer::read_bits4); no conforming H.264/H.265 stream
+//! can, since such a code encodes a value around 2^33 — far outside every field
+//! these parsers decode. (Verified 2026-08-05 by computing the pre-guard wrapping
+//! result alongside the zero-filled one in both readers and asserting they agree,
+//! `bs_skip_bits` excluded: the whole test suite's only disagreement came from
+//! `hevc`'s malformed-SPS fixture, through `read_exp`.) A new unaligned
+//! full-width caller would get zeros where it expects stream bits.
 
 /// Fixed capacity of the backing byte buffer — the 5 MiB logical window.
 /// [`add`]
@@ -285,19 +297,20 @@ impl TsStreamBuffer {
         value
     }
 
-    /// Loads up to four bytes from the cursor, big-endian, into the low-to-high
-    /// bytes of a `u32` (`b0 << 24 | b1 << 16 | b2 << 8 | b3`) — the four-byte
-    /// shift-accumulate window shared by [`read_bits4`](Self::read_bits4)
-    /// and [`read_bits8`](Self::read_bits8).
+    /// Loads up to `bytes` bytes from the cursor, big-endian, into the top-down
+    /// bytes of a `u32` (for `bytes = 4`, `b0 << 24 | b1 << 16 | b2 << 8 | b3`;
+    /// for `bytes = 2`, `b0 << 8 | b1`) — the shift-accumulate window every
+    /// `read_bits*` reader loads. A byte the buffer does not reach is not read at
+    /// all, so its place in the window stays zero.
     ///
     /// The in-bounds test deliberately uses the *original* `pos` (`pos + i`) —
     /// so the loop count is governed by `pos` while the reads
     /// continue from the advancing cursor; [`read_bits8`](Self::read_bits8) relies
     /// on that quirk by passing the same `pos` to both of its loads.
-    fn load_be_word(&mut self, pos: usize, skip_h26x_emulation_byte: bool) -> u32 {
-        let mut shift: u32 = 24;
+    fn load_be_bytes(&mut self, pos: usize, bytes: usize, skip_h26x_emulation_byte: bool) -> u32 {
+        let mut shift = u32::try_from(bytes).unwrap_or(0).saturating_sub(1).wrapping_mul(8);
         let mut data: u32 = 0;
-        for i in 0..4_usize {
+        for i in 0..bytes {
             if pos.saturating_add(i) >= self.buffer.len() {
                 break;
             }
@@ -306,6 +319,26 @@ impl TsStreamBuffer {
             shift = shift.wrapping_sub(8);
         }
         data
+    }
+
+    /// Reads bytes from the cursor until the last four form `sync`, and reports
+    /// whether they did.
+    ///
+    /// The rolling 32-bit window advances one byte per step over at most
+    /// [`length`](Self::length) bytes, so the hunt is bounded and leaves the
+    /// cursor just past the sync word it found (at the end of the content
+    /// otherwise). Emulation-prevention is not honoured — the audio codecs that
+    /// hunt for a sync word carry no RBSP.
+    #[must_use]
+    pub fn find_sync32(&mut self, sync: u32) -> bool {
+        let mut window: u32 = 0;
+        for _ in 0..self.length() {
+            window = window.wrapping_shl(8).wrapping_add(u32::from(self.read_byte(false)));
+            if window == sync {
+                return true;
+            }
+        }
+        false
     }
 
     /// Reads up to 16 bits MSB-first into a `u16`.
@@ -318,16 +351,7 @@ impl TsStreamBuffer {
     pub fn read_bits2(&mut self, bits: usize, skip_h26x_emulation_byte: bool) -> u16 {
         let pos = self.position;
         self.skipped_bytes = 0;
-        let mut shift: u32 = 8;
-        let mut data: u32 = 0;
-        for i in 0..2_usize {
-            if pos.saturating_add(i) >= self.buffer.len() {
-                break;
-            }
-            let byte = u32::from(self.read_byte(skip_h26x_emulation_byte));
-            data = data.wrapping_add(byte.wrapping_shl(shift));
-            shift = shift.wrapping_sub(8);
-        }
+        let data = self.load_be_bytes(pos, 2, skip_h26x_emulation_byte);
         let count = i32::try_from(bits).unwrap_or(i32::MAX);
         let end = self.skip_bits.wrapping_add(count);
         let mut value: u16 = 0;
@@ -356,7 +380,7 @@ impl TsStreamBuffer {
     pub fn read_bits4(&mut self, bits: usize, skip_h26x_emulation_byte: bool) -> u32 {
         let pos = self.position;
         self.skipped_bytes = 0;
-        let data = self.load_be_word(pos, skip_h26x_emulation_byte);
+        let data = self.load_be_bytes(pos, 4, skip_h26x_emulation_byte);
         let count = i32::try_from(bits).unwrap_or(i32::MAX);
         let end = self.skip_bits.wrapping_add(count);
         let mut value: u32 = 0;
@@ -383,8 +407,8 @@ impl TsStreamBuffer {
     pub fn read_bits8(&mut self, bits: usize, skip_h26x_emulation_byte: bool) -> u64 {
         let pos = self.position;
         self.skipped_bytes = 0;
-        let data = self.load_be_word(pos, skip_h26x_emulation_byte);
-        let data2 = self.load_be_word(pos, skip_h26x_emulation_byte);
+        let data = self.load_be_bytes(pos, 4, skip_h26x_emulation_byte);
+        let data2 = self.load_be_bytes(pos, 4, skip_h26x_emulation_byte);
         let window = u64::from(data).wrapping_shl(32).wrapping_add(u64::from(data2));
         let count = i32::try_from(bits).unwrap_or(i32::MAX);
         let end = self.skip_bits.wrapping_add(count);
@@ -863,6 +887,24 @@ mod tests {
         assert_eq!(b.read_bits2(8, false), 0xAC);
         let mut b = buf(&[0x12, 0x34]);
         assert_eq!(b.read_bits2(16, false), 0x1234);
+    }
+
+    #[test]
+    fn find_sync32_stops_just_past_the_word_it_finds() {
+        // The sync word starts at byte 2, so the cursor lands on byte 6.
+        let mut b = buf(&[0x11, 0x22, 0xDE, 0xAD, 0xBE, 0xEF, 0x99]);
+        assert!(b.find_sync32(0xDEAD_BEEF));
+        assert_eq!(b.position(), 6);
+        assert_eq!(b.read_byte(false), 0x99);
+
+        // A buffer holding only the first three bytes of the word never matches,
+        // and the hunt stops at the end of the content.
+        let mut b = buf(&[0xDE, 0xAD, 0xBE]);
+        assert!(!b.find_sync32(0xDEAD_BEEF));
+        assert_eq!(b.position(), 3);
+
+        // An empty buffer runs the loop zero times.
+        assert!(!buf(&[]).find_sync32(0xDEAD_BEEF));
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/codec.rs
+++ b/crates/bdinfo-rs-core/src/codec.rs
@@ -42,7 +42,36 @@ pub mod truehd;
 pub mod vc1;
 
 use crate::bitstream::TsStreamBuffer;
-use crate::stream::{TsStream, TsStreamType};
+use crate::stream::{TsAudioStream, TsStream, TsStreamType};
+
+/// Scans the access unit in `buffer` as `stream`'s embedded legacy core,
+/// creating that core stream (of type `core_type`) on first sight and handing it
+/// to `scan_core`.
+///
+/// The two HD audio codecs that wrap a backward-compatible core ([`truehd`] over
+/// AC-3, [`dts_hd`] over DTS) call this for an access unit that carries no HD
+/// sync word. `buffer` is rewound first, and that rewind is what makes the
+/// delegation correct: the caller has already consumed the access unit hunting
+/// for its sync word, and the core scanner expects the buffer from offset 0.
+/// A core already initialized is left alone — one decoded core frame is enough.
+pub(crate) fn scan_embedded_core(
+    stream: &mut TsAudioStream,
+    buffer: &mut TsStreamBuffer,
+    core_type: TsStreamType,
+    scan_core: impl FnOnce(&mut TsAudioStream, &mut TsStreamBuffer),
+) {
+    if stream.core_stream.is_none() {
+        let mut core = TsAudioStream::default();
+        core.base.stream_type = core_type;
+        stream.core_stream = Some(Box::new(core));
+    }
+    if let Some(core) = stream.core_stream.as_mut()
+        && !core.base.is_initialized
+    {
+        buffer.begin_read();
+        scan_core(core, buffer);
+    }
+}
 
 /// Decodes one assembled access-unit `buffer` into `stream`, dispatching by stream
 /// type to the matching codec scanner.

--- a/crates/bdinfo-rs-core/src/codec/ac3.rs
+++ b/crates/bdinfo-rs-core/src/codec/ac3.rs
@@ -11,6 +11,14 @@
 //!
 //! The `f64`→`i64` bit-rate conversion truncates toward zero. A buffer too short
 //! for a header read returns early and leaves the stream untouched.
+//!
+//! Alone among the audio scanners, this one requires its `0x0B77` sync word at
+//! the **head** of the access unit — it compares the first two bytes rather than
+//! hunting for the word the way [`crate::codec::dts`], [`crate::codec::dts_hd`]
+//! and [`crate::codec::truehd`] do. The likeliest reason is BDAV frame
+//! alignment — an AC-3 access unit assembled from a PES payload begins at a
+//! frame boundary — and it is why `truehd` rewinds the buffer before
+//! delegating here.
 
 use crate::bitstream::{SeekOrigin, TsStreamBuffer};
 use crate::stream::{TsAudioMode, TsAudioStream, TsStreamType};

--- a/crates/bdinfo-rs-core/src/codec/dts.rs
+++ b/crates/bdinfo-rs-core/src/codec/dts.rs
@@ -63,17 +63,7 @@ pub fn scan(
         return;
     }
 
-    let mut sync_found = false;
-    let mut sync: u32 = 0;
-    // A bounded byte-at-a-time scan for the sync over the whole buffer.
-    for _ in 0..buffer.length() {
-        sync = sync.wrapping_shl(8).wrapping_add(u32::from(buffer.read_byte(false)));
-        if sync == DTS_SYNC {
-            sync_found = true;
-            break;
-        }
-    }
-    if !sync_found {
+    if !buffer.find_sync32(DTS_SYNC) {
         return;
     }
 

--- a/crates/bdinfo-rs-core/src/codec/dts_hd.rs
+++ b/crates/bdinfo-rs-core/src/codec/dts_hd.rs
@@ -22,7 +22,7 @@
 //! contributes one mask byte.
 
 use crate::bitstream::TsStreamBuffer;
-use crate::codec::dts;
+use crate::codec::{self, dts};
 use crate::stream::{TsAudioMode, TsAudioStream, TsStreamType};
 
 /// The DTS-HD extension-substream sync word scanned for in the access unit
@@ -76,31 +76,13 @@ pub fn scan(
         return;
     }
 
-    let mut sync_found = false;
-    let mut sync: u32 = 0;
-    // A bounded byte-at-a-time scan for the sync over the whole buffer.
-    for _ in 0..buffer.length() {
-        sync = sync.wrapping_shl(8).wrapping_add(u32::from(buffer.read_byte(false)));
-        if sync == DTS_HD_SYNC {
-            sync_found = true;
-            break;
-        }
-    }
-
-    if !sync_found {
+    if !buffer.find_sync32(DTS_HD_SYNC) {
         *tag = Some("CORE".to_owned());
-        if stream.core_stream.is_none() {
-            // Seed the embedded DTS core stream on first sight.
-            let mut core = TsAudioStream::default();
-            core.base.stream_type = TsStreamType::DtsAudio;
-            stream.core_stream = Some(Box::new(core));
-        }
-        if let Some(core) = stream.core_stream.as_mut()
-            && !core.base.is_initialized
-        {
-            buffer.begin_read();
-            dts::scan(core, buffer, bitrate, tag);
-        }
+        // The DTS core hunts for its own sync word, so it must see the access
+        // unit from the start — the rewind inside this call restores it.
+        codec::scan_embedded_core(stream, buffer, TsStreamType::DtsAudio, |core, buf| {
+            dts::scan(core, buf, bitrate, tag);
+        });
         return;
     }
 

--- a/crates/bdinfo-rs-core/src/codec/truehd.rs
+++ b/crates/bdinfo-rs-core/src/codec/truehd.rs
@@ -16,7 +16,7 @@
 //! non-finite value that simply fails the `> 14` test).
 
 use crate::bitstream::TsStreamBuffer;
-use crate::codec::ac3;
+use crate::codec::{self, ac3};
 use crate::stream::{TsAudioStream, TsStreamType};
 
 /// The MLP major-sync signature scanned for in the access unit (`0xF8726FBA`).
@@ -41,10 +41,9 @@ fn scale_peak_bitrate(peak_bitrate: u32, sample_rate: i32) -> u32 {
 /// With no MLP major sync the embedded AC-3 core is scanned (and `tag` set to
 /// `"CORE"`); with one, the `TrueHD` header is read (`tag` set to `"HD"`).
 /// `stream` is marked initialized only when its core also is.
-#[expect(
-    clippy::too_many_lines,
-    reason = "one linear major-sync header parse; the 13 channel-assignment reads are clearest inline"
-)]
+// The 13 channel-assignment reads stay spelled out one per line: the header
+// transcribes a fixed field order, and a table would hide which bit contributes
+// which channel count.
 pub fn scan(stream: &mut TsAudioStream, buffer: &mut TsStreamBuffer, tag: &mut Option<String>) {
     if stream.base.is_initialized
         && stream.core_stream.as_ref().is_some_and(|c| c.base.is_initialized)
@@ -52,31 +51,13 @@ pub fn scan(stream: &mut TsAudioStream, buffer: &mut TsStreamBuffer, tag: &mut O
         return;
     }
 
-    let mut sync_found = false;
-    let mut sync: u32 = 0;
-    // A bounded byte-at-a-time scan for the sync over the whole buffer.
-    for _ in 0..buffer.length() {
-        sync = sync.wrapping_shl(8).wrapping_add(u32::from(buffer.read_byte(false)));
-        if sync == TRUEHD_MAJOR_SYNC {
-            sync_found = true;
-            break;
-        }
-    }
-
-    if !sync_found {
+    if !buffer.find_sync32(TRUEHD_MAJOR_SYNC) {
         *tag = Some("CORE".to_owned());
-        if stream.core_stream.is_none() {
-            // Seed the embedded AC-3 core stream on first sight.
-            let mut core = TsAudioStream::default();
-            core.base.stream_type = TsStreamType::Ac3Audio;
-            stream.core_stream = Some(Box::new(core));
-        }
-        if let Some(core) = stream.core_stream.as_mut()
-            && !core.base.is_initialized
-        {
-            buffer.begin_read();
-            ac3::scan(core, buffer, tag);
-        }
+        // The AC-3 core requires its sync word at the head of the access unit
+        // (see [`crate::codec::ac3`]), which the rewind inside this call restores.
+        codec::scan_embedded_core(stream, buffer, TsStreamType::Ac3Audio, |core, buf| {
+            ac3::scan(core, buf, tag);
+        });
         return;
     }
 

--- a/crates/bdinfo-rs-core/src/vfs.rs
+++ b/crates/bdinfo-rs-core/src/vfs.rs
@@ -159,9 +159,36 @@ pub fn find_files(dir: &dyn BdDir, kind: BdFileKind) -> io::Result<Vec<Box<dyn B
     Ok(out)
 }
 
+/// The extension of `name` *including* the leading dot (e.g. `.SSIF`), or the
+/// empty string when `name` holds no `.`. The text after the last `.` is
+/// returned verbatim (a lone `.` for a trailing-dot name like `00000.`); no
+/// further normalization is applied.
+///
+/// Both backends derive [`BdFile::extension`] through this one function, and
+/// that agreement is load-bearing: the disc-size total skips an interleaved
+/// stream by matching this string against `.ssif`
+/// ([`crate::bdrom::disc`]), so a folder and the same disc as an `.iso` would
+/// report different sizes if two lookalike derivations disagreed on a name.
+#[must_use]
+pub(crate) fn extension_of_name(name: &str) -> String {
+    match name.rsplit_once('.') {
+        Some((_, ext)) => format!(".{ext}"),
+        None => String::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::SearchOption;
+    use super::{SearchOption, extension_of_name};
+
+    #[test]
+    fn extension_of_name_handles_dotted_and_bare_names() {
+        assert_eq!(extension_of_name("00000.MPLS"), ".MPLS");
+        assert_eq!(extension_of_name("a.b.ssif"), ".ssif");
+        assert_eq!(extension_of_name("README"), "");
+        assert_eq!(extension_of_name("trailing."), ".");
+        assert_eq!(extension_of_name(".hidden"), ".hidden");
+    }
 
     #[test]
     fn search_option_is_debug_and_eq() {

--- a/crates/bdinfo-rs-core/src/vfs/fs.rs
+++ b/crates/bdinfo-rs-core/src/vfs/fs.rs
@@ -11,8 +11,8 @@
 //!   top-level read error still propagates as `Err`. Directory-ness comes from the listing's own
 //!   [`file_type`](std::fs::DirEntry::file_type) (no extra follow-stat per entry — one fewer
 //!   failure point on flaky media).
-//! - The extension ([`extension_of`]) is the text after the last `.` verbatim (a lone `.` for a
-//!   trailing-dot name); no further path normalization is applied.
+//! - The extension ([`extension_of`]) is derived from the final path component by the
+//!   backend-shared [`extension_of_name`]; no further path normalization is applied.
 //! - The full name ([`full_name_of`]) is the path as opened, not canonicalized to a rooted absolute
 //!   path.
 
@@ -21,7 +21,7 @@ use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, PoisonError};
 
-use super::{BdDir, BdFile, ReadSeek, SearchOption};
+use super::{BdDir, BdFile, ReadSeek, SearchOption, extension_of_name};
 use crate::error::{BdError, ScanError, ScanStage};
 
 /// A file backed by [`std::fs`] — the [`BdFile`] implementation for folder
@@ -328,17 +328,13 @@ fn full_name_of(path: &Path) -> String {
 }
 
 /// The extension *including* the leading dot, e.g. `.mpls`; the empty string
-/// when there is no name or no `.` in it. The text after the last `.` is
-/// returned verbatim (a lone `.` for a trailing-dot name like `00000.`); no
-/// further path normalization is applied.
+/// when the path has no final component. The name itself is handed to
+/// [`extension_of_name`], the rule both backends share.
 fn extension_of(path: &Path) -> String {
     let Some(name) = path.file_name() else {
         return String::new();
     };
-    match name.to_string_lossy().rsplit_once('.') {
-        Some((_, ext)) => format!(".{ext}"),
-        None => String::new(),
-    }
+    extension_of_name(&name.to_string_lossy())
 }
 
 /// ASCII case-insensitive glob match of `name` against `pattern`.

--- a/crates/bdinfo-rs-core/src/vfs/udf.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf.rs
@@ -159,6 +159,22 @@ impl Tag {
         }
         Some(Self { identifier })
     }
+
+    /// Parses the tag at the **start** of `buf` and requires it to be
+    /// `identifier`, yielding `None` otherwise — the preamble of every
+    /// fixed-identifier descriptor parser (see [`descriptor`]), each of which
+    /// reads a whole descriptor from a buffer beginning at its tag.
+    ///
+    /// A caller walking descriptors at running offsets (a File Identifier
+    /// sequence) calls [`parse`](Self::parse) with its own offset instead.
+    #[must_use]
+    pub fn expect(buf: &[u8], identifier: u16) -> Option<Self> {
+        let tag = Self::parse(buf, 0)?;
+        if tag.identifier != identifier {
+            return None;
+        }
+        Some(tag)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -411,6 +427,18 @@ mod tests {
         // Corrupt a non-checksum byte so the stored checksum no longer matches.
         tag[0] = tag[0].wrapping_add(1);
         assert_eq!(Tag::parse(&tag, 0), None);
+    }
+
+    #[test]
+    fn tag_expect_requires_the_named_identifier() {
+        let tag = fix_tag_checksum([2, 0, 3, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 1, 0, 0]);
+        assert_eq!(
+            Tag::expect(&tag, TAG_ANCHOR_VOLUME_POINTER),
+            Some(Tag { identifier: TAG_ANCHOR_VOLUME_POINTER })
+        );
+        assert_eq!(Tag::expect(&tag, super::TAG_LOGICAL_VOLUME), None);
+        // A buffer that is not a tag at all fails before the identifier test.
+        assert_eq!(Tag::expect(&[], TAG_ANCHOR_VOLUME_POINTER), None);
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/vfs/udf/descriptor.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/descriptor.rs
@@ -48,10 +48,7 @@ impl Avdp {
     /// AVDP (id 2) or the bytes are too short.
     #[must_use]
     pub fn parse(buf: &[u8]) -> Option<Self> {
-        let tag = Tag::parse(buf, 0)?;
-        if tag.identifier != TAG_ANCHOR_VOLUME_POINTER {
-            return None;
-        }
+        Tag::expect(buf, TAG_ANCHOR_VOLUME_POINTER)?;
         let main_vds = ExtentAd::parse(buf, 16)?;
         let reserve_vds = ExtentAd::parse(buf, 24)?;
         Some(Self { main_vds, reserve_vds })
@@ -78,10 +75,7 @@ impl Pvd {
     /// Descriptor (id 1) or the identifier field is out of range.
     #[must_use]
     pub fn parse(buf: &[u8]) -> Option<Self> {
-        let tag = Tag::parse(buf, 0)?;
-        if tag.identifier != TAG_PRIMARY_VOLUME {
-            return None;
-        }
+        Tag::expect(buf, TAG_PRIMARY_VOLUME)?;
         let volume_identifier = cs0::decode_dstring(buf.get(24..56)?);
         Some(Self { volume_identifier })
     }
@@ -101,10 +95,7 @@ impl Vdp {
     /// Volume Descriptor Pointer (id 3) or the extent is out of range.
     #[must_use]
     pub fn parse(buf: &[u8]) -> Option<Self> {
-        let tag = Tag::parse(buf, 0)?;
-        if tag.identifier != TAG_VOLUME_DESCRIPTOR_POINTER {
-            return None;
-        }
+        Tag::expect(buf, TAG_VOLUME_DESCRIPTOR_POINTER)?;
         let next = ExtentAd::parse(buf, 20)?;
         Some(Self { next })
     }
@@ -224,10 +215,7 @@ impl Lvd {
     /// out of range.
     #[must_use]
     pub fn parse(buf: &[u8]) -> Option<Self> {
-        let tag = Tag::parse(buf, 0)?;
-        if tag.identifier != TAG_LOGICAL_VOLUME {
-            return None;
-        }
+        Tag::expect(buf, TAG_LOGICAL_VOLUME)?;
         let logical_volume_identifier = cs0::decode_dstring(buf.get(84..212)?);
         let logical_block_size = u32_le(buf, 212)?;
         // LogicalVolumeContentsUse (offset 248) is a long_ad to the FSD.
@@ -267,10 +255,7 @@ impl PartitionDescriptor {
     /// Descriptor (id 5) or a field is out of range.
     #[must_use]
     pub fn parse(buf: &[u8]) -> Option<Self> {
-        let tag = Tag::parse(buf, 0)?;
-        if tag.identifier != TAG_PARTITION {
-            return None;
-        }
+        Tag::expect(buf, TAG_PARTITION)?;
         let partition_number = u16_le(buf, 22)?;
         let starting_location = u32_le(buf, 188)?;
         let length = u32_le(buf, 192)?;
@@ -293,10 +278,7 @@ impl Fsd {
     /// (id 256) or the root-directory ICB is out of range.
     #[must_use]
     pub fn parse(buf: &[u8]) -> Option<Self> {
-        let tag = Tag::parse(buf, 0)?;
-        if tag.identifier != TAG_FILE_SET {
-            return None;
-        }
+        Tag::expect(buf, TAG_FILE_SET)?;
         let root_directory_icb = LongAd::parse(buf, 400)?;
         Some(Self { root_directory_icb })
     }

--- a/crates/bdinfo-rs-core/src/vfs/udf/source.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/source.rs
@@ -57,7 +57,7 @@ use super::{
 };
 use crate::error::{BdError, ScanError, ScanStage};
 use crate::vfs::fs::glob_ci;
-use crate::vfs::{BdDir, BdFile, ReadSeek, SearchOption};
+use crate::vfs::{BdDir, BdFile, ReadSeek, SearchOption, extension_of_name};
 
 /// The Anchor Volume Descriptor Pointer's fixed logical sector (ECMA-167 §3/10.2).
 const ANCHOR_SECTOR: u64 = 256;
@@ -418,7 +418,7 @@ impl UdfDir {
                 inner: Arc::clone(&self.inner),
                 name: node.name.clone(),
                 full_name: node.full_name.clone(),
-                extension: extension_of(&node.name),
+                extension: extension_of_name(&node.name),
                 body: Arc::clone(body),
             }),
             NodeKind::Dir => None,
@@ -524,9 +524,8 @@ pub struct UdfFile {
     name: String,
     /// The synthesized full path.
     full_name: String,
-    /// The extension including the leading dot, or empty (derived from the name
-    /// exactly as the folder backend derives it, so the `.SSIF` disc-size skip
-    /// is identical).
+    /// The extension including the leading dot, or empty — derived by the
+    /// backend-shared [`extension_of_name`].
     extension: String,
     /// The shared size + content.
     body: Arc<FileBody>,
@@ -747,16 +746,6 @@ impl Seek for EmbeddedReader {
     fn seek(&mut self, from: SeekFrom) -> io::Result<u64> {
         self.pos = seek_within(self.pos, self.length, from)?;
         Ok(self.pos)
-    }
-}
-
-/// The extension *including* the leading dot (e.g. `.SSIF`), or the empty string
-/// when `name` has no `.` — derived exactly as the folder backend derives it, so
-/// the disc-size `.SSIF` skip behaves identically over either input.
-fn extension_of(name: &str) -> String {
-    match name.rsplit_once('.') {
-        Some((_, ext)) => format!(".{ext}"),
-        None => String::new(),
     }
 }
 
@@ -1200,10 +1189,7 @@ const AED_AD_START: usize = 24;
 /// descriptors. The declared `L_AD` bounds the descriptors (slack bytes past it
 /// are not descriptors), clamped to the block.
 fn aed_allocation_area(area: &[u8]) -> Option<&[u8]> {
-    let tag = Tag::parse(area, 0)?;
-    if tag.identifier != TAG_ALLOCATION_EXTENT {
-        return None;
-    }
+    Tag::expect(area, TAG_ALLOCATION_EXTENT)?;
     let l_ad = as_offset(u32_le(area, AED_L_AD_OFFSET)?);
     let end = AED_AD_START.saturating_add(l_ad).min(area.len());
     area.get(AED_AD_START..end)
@@ -1673,9 +1659,9 @@ mod tests {
     use super::{
         BdDir, BdFile, Content, EmbeddedReader, ExtentKind, FileEntry, IsoReader, Limits, Node,
         NodeKind, PartitionLoc, PathIso, Run, UdfDir, UdfFileReader, UdfInner, UdfSource, Volume,
-        build_tree, collect_extents, directory_bytes, expand_directory, extension_of, extent_runs,
-        file_body, metadata_runs, metadata_sector, offset_by, parse_volume, read_runs,
-        resolve_partitions, resolve_sector,
+        build_tree, collect_extents, directory_bytes, expand_directory, extent_runs, file_body,
+        metadata_runs, metadata_sector, offset_by, parse_volume, read_runs, resolve_partitions,
+        resolve_sector,
     };
     use crate::error::ScanStage;
     use crate::vfs::SearchOption;
@@ -3382,14 +3368,6 @@ mod tests {
     }
 
     // ── Pure helpers ─────────────────────────────────────────────────────────
-
-    #[test]
-    fn extension_of_handles_dotted_and_bare_names() {
-        assert_eq!(extension_of("00000.MPLS"), ".MPLS");
-        assert_eq!(extension_of("a.b.ssif"), ".ssif");
-        assert_eq!(extension_of("README"), "");
-        assert_eq!(extension_of("trailing."), ".");
-    }
 
     #[test]
     fn offset_by_clamps_and_overflows() {


### PR DESCRIPTION
Five parser-side idioms each had more than one home; each now has exactly one.

- `Tag::expect(buf, identifier)` replaces the parse-tag-then-require-identifier preamble in the six `descriptor.rs` parsers and in `source.rs`'s AED header check. `fid.rs` keeps `Tag::parse`: it walks a File Identifier sequence at running offsets.
- `TsStreamBuffer::load_be_bytes(pos, bytes, skip)` generalizes `load_be_word`; `read_bits2` no longer carries its own copy of the shift-accumulate loop. The `pos`-based in-bounds test that `read_bits8` depends on is unchanged.
- `vfs::extension_of_name` is the one derivation behind both backends' `BdFile::extension`. Their agreement is load-bearing for the disc-size `.SSIF` skip, and that sentence now lives with the function.
- `TsStreamBuffer::find_sync32(sync)` replaces the identical rolling-window sync hunt in `dts`, `dts_hd` and `truehd`. The inner scans in `dts_hd` and the `avc` state machine are untouched.
- `codec::scan_embedded_core` holds the seed-once-rewind-delegate sequence `truehd` and `dts_hd` shared, taking a closure for the inner scan.

Docs: the bitstream module's tail-rule section closed with a false claim that no in-tree read reaches the tail. Two do. `bs_skip_bits` reaches it routinely and discards every value; `read_exp` reaches it with a used value only for an Exp-Golomb code of 33 or more leading zeros, which no conforming H.264/H.265 stream carries. The condition is `skip_bits + bits` over the window width, not `bits` under the width. Also recorded: AC-3 requires its sync word at the head of the access unit while the three other scanners hunt for theirs, which is what the delegation rewind exists for.

No behavior change; every report fixture is byte-identical.