### PR TITLE
test(core): share the bit-packing and disc-structure builders

### DIFF
--- a/crates/bdinfo-rs-core/src/bdrom/clpi.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/clpi.rs
@@ -161,24 +161,18 @@ fn build_clip_stream(
     build_coded_stream(clip_data, info.saturating_add(2), stream_type, Some(info.saturating_add(3)))
 }
 
+/// Synthetic `*.clpi` builders shared by this module's and the disc
+/// orchestration's tests.
+///
+/// The per-program header, one stream entry, and the envelope that wraps them.
+/// The on-disc layout is encoded here and nowhere else.
 #[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-
-    use proptest::prelude::{any, proptest};
-
-    use super::{TsStreamClip, TsStreamClipFile};
-    use crate::primitives::Pid;
-    use crate::stream::{
-        TsAspectRatio, TsAudioStream, TsChannelLayout, TsFrameRate, TsGraphicsStream, TsStream,
-        TsStreamType, TsTextStream, TsVideoFormat, TsVideoStream,
-    };
-
+pub mod clips {
     /// One per-program 8-byte header: `spn_program_sequence_start` +
     /// `program_map_pid` + the stream count + `num_groups`. The fields around
     /// the count are non-zero filler, so an offset slip lands on visibly
     /// different bytes.
-    fn program_header(stream_count: usize) -> Vec<u8> {
+    pub(crate) fn program_header(stream_count: usize) -> Vec<u8> {
         let mut header = 0x0102_0304_u32.to_be_bytes().to_vec(); // spn start
         header.extend_from_slice(&0x0100_u16.to_be_bytes()); // program_map_pid
         header.push(u8::try_from(stream_count).unwrap());
@@ -188,7 +182,7 @@ mod tests {
 
     /// One stream entry: `[PID:2][len=5][coding_type][payload:4]`, where
     /// `payload` is the four bytes after the coding-type byte.
-    fn entry_bytes(pid: u16, coding_type: u8, payload: [u8; 4]) -> Vec<u8> {
+    pub(crate) fn entry_bytes(pid: u16, coding_type: u8, payload: [u8; 4]) -> Vec<u8> {
         let mut entry = pid.to_be_bytes().to_vec();
         entry.push(5); // coding-info length (coding_type + 4 payload bytes)
         entry.push(coding_type);
@@ -198,7 +192,7 @@ mod tests {
 
     /// Builds a minimal valid `*.clpi`: header → `ProgramInfo` at offset 16 →
     /// one program sequence carrying `entries`.
-    fn build_clpi(magic: [u8; 8], entries: &[(u16, u8, [u8; 4])]) -> Vec<u8> {
+    pub(crate) fn build_clpi(magic: [u8; 8], entries: &[(u16, u8, [u8; 4])]) -> Vec<u8> {
         let mut clip_data = vec![0_u8]; // index 0: reserved byte
         clip_data.push(1); // index 1: num_prog
         clip_data.extend(program_header(entries.len())); // 2..10; entries at 10
@@ -213,6 +207,21 @@ mod tests {
         buf.extend_from_slice(&clip_data); // 20..
         buf
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use proptest::prelude::{any, proptest};
+
+    use super::clips::{build_clpi, entry_bytes, program_header};
+    use super::{TsStreamClip, TsStreamClipFile};
+    use crate::primitives::Pid;
+    use crate::stream::{
+        TsAspectRatio, TsAudioStream, TsChannelLayout, TsFrameRate, TsGraphicsStream, TsStream,
+        TsStreamType, TsTextStream, TsVideoFormat, TsVideoStream,
+    };
 
     #[test]
     fn scan_parses_every_stream_kind() {

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -2223,8 +2223,10 @@ mod tests {
         unit_shows_encryption, walked_disc_root,
     };
     use crate::bdrom::clpi::TsStreamClip;
+    use crate::bdrom::clpi::clips::build_clpi;
     use crate::bdrom::interleaved::{MemBdFile, TsInterleavedFile};
     use crate::bdrom::m2ts::packets::{packet, pat_payload, pes_dts, pes_pts, pmt_payload};
+    use crate::bdrom::mpls::playlists::{build_item_codec, build_mpls, chapter_entry, pl_stream};
     use crate::discovery::BdmvDir;
     use crate::primitives::Pid;
     use crate::stream::{
@@ -2235,26 +2237,14 @@ mod tests {
     use crate::vfs::{BdDir, BdFile, ReadSeek, SearchOption};
 
     // ── synthetic metadata builders (minimal valid `*.clpi` / `*.mpls`) ──────
+    //
+    // Convenience wrappers only: the on-disc byte layouts live once, in the
+    // parsers' own `clpi::clips` and `mpls::playlists` builders.
 
     /// A valid `*.clpi`: `HDMV0300`, `ProgramInfo` at offset 16, one program
     /// sequence, one entry per `(pid, coding_type, 4-byte payload)`.
     fn clpi(entries: &[(u16, u8, [u8; 4])]) -> Vec<u8> {
-        let mut clip_data = vec![0_u8, 1]; // reserved + num_prog = 1
-        clip_data.extend_from_slice(&[0_u8; 6]); // spn start + program_map_pid
-        clip_data.push(u8::try_from(entries.len()).unwrap()); // stream count at 8
-        clip_data.push(0); // 9: num_groups; stream entries start at 10
-        for &(pid, coding_type, payload) in entries {
-            clip_data.extend_from_slice(&pid.to_be_bytes());
-            clip_data.push(5); // coding-info length (type + 4 payload)
-            clip_data.push(coding_type);
-            clip_data.extend_from_slice(&payload);
-        }
-        let mut buf = b"HDMV0300".to_vec();
-        buf.extend_from_slice(&[0_u8; 4]); // 8..12
-        buf.extend_from_slice(&16_u32.to_be_bytes()); // 12..16 ProgramInfo addr
-        buf.extend_from_slice(&u32::try_from(clip_data.len()).unwrap().to_be_bytes());
-        buf.extend_from_slice(&clip_data);
-        buf
+        build_clpi(*b"HDMV0300", entries)
     }
 
     /// A valid single-item `*.mpls` with no extra camera angles (the common case).
@@ -2262,8 +2252,8 @@ mod tests {
         mpls_angles(item_name, in_t, out_t, &[], chapters)
     }
 
-    /// A valid single-item `*.mpls` like [`mpls_full`], with an empty
-    /// Stream-Number table.
+    /// A valid single-item `*.mpls` with `angle_names` extra camera angles and an
+    /// empty Stream-Number table.
     fn mpls_angles(
         item_name: &str,
         in_t: u32,
@@ -2315,106 +2305,31 @@ mod tests {
         declared_audio: &[u16],
         chapters: &[(u8, u16, u32)],
     ) -> Vec<u8> {
-        let mut items = Vec::new();
-        for item_name in item_names {
-            let mut body = Vec::new();
-            let mut name = item_name.as_bytes().to_vec();
-            name.resize(5, 0);
-            body.extend_from_slice(&name); // +2..7
-            body.extend_from_slice(&codec); // +7..11
-            body.push(0); // +11
-            body.push(if angle_names.is_empty() { 0 } else { 0x10 }); // +12 multiangle flag
-            body.push(0); // +13
-            body.extend_from_slice(&in_t.to_be_bytes()); // +14..18
-            body.extend_from_slice(&out_t.to_be_bytes()); // +18..22
-            body.extend_from_slice(&[0_u8; 12]); // +22..34
-            if !angle_names.is_empty() {
-                body.push(u8::try_from(angle_names.len().wrapping_add(1)).unwrap()); // angle count
-                body.push(0); // reserved
-                for angle in angle_names {
-                    let mut angle_bytes = angle.as_bytes().to_vec();
-                    angle_bytes.resize(5, 0);
-                    body.extend_from_slice(&angle_bytes); // angle name (5)
-                    body.extend_from_slice(&codec); // angle type (4)
-                    body.push(0); // reserved (1)
-                }
-            }
-            body.extend_from_slice(&[0_u8; 2]); // stream-info length
-            body.extend_from_slice(&[0_u8; 2]); // reserved
-            body.push(0); // video count
-            body.push(u8::try_from(declared_audio.len()).unwrap()); // audio count
-            body.extend_from_slice(&[0_u8; 5]); // remaining 5 stream counts (all zero)
-            body.extend_from_slice(&[0_u8; 5]); // reserved
-            for pid in declared_audio {
-                body.push(3); // header length (type + PID)
-                body.push(1); // header type 1: the PID follows directly
-                body.extend_from_slice(&pid.to_be_bytes());
-                body.push(5); // stream length (type byte + format + language)
-                body.push(0x81); // AC3 audio
-                body.push(0x61); // 5.1 / 48 kHz
-                body.extend_from_slice(b"eng");
-            }
-            items.extend_from_slice(&u16::try_from(body.len()).unwrap().to_be_bytes());
-            items.extend_from_slice(&body);
+        // Each declared PID becomes one AC3 5.1 / 48 kHz English entry, so the
+        // counts array names audio alone.
+        let mut stream_bytes = Vec::new();
+        for &pid in declared_audio {
+            stream_bytes.extend(pl_stream(1, pid, 0x81, [0x61, b'e', b'n', b'g']));
         }
-
-        let playlist_offset: usize = 0x3C;
-        let mut playlist = Vec::new();
-        playlist.extend_from_slice(&[0_u8; 4]); // PlayList length
-        playlist.extend_from_slice(&[0_u8; 2]); // reserved
-        playlist.extend_from_slice(&u16::try_from(item_names.len()).unwrap().to_be_bytes());
-        playlist.extend_from_slice(&[0_u8; 2]); // sub-item count
-        playlist.extend_from_slice(&items);
-        let chapters_offset = playlist_offset.wrapping_add(playlist.len());
-
-        let mut mark = Vec::new();
-        mark.extend_from_slice(&[0_u8; 4]); // PlayListMark length
-        mark.extend_from_slice(&u16::try_from(chapters.len()).unwrap().to_be_bytes());
-        for &(chapter_type, file_index, tick) in chapters {
-            let mut entry = vec![0_u8, chapter_type];
-            entry.extend_from_slice(&file_index.to_be_bytes());
-            entry.extend_from_slice(&tick.to_be_bytes());
-            entry.resize(14, 0);
-            mark.extend_from_slice(&entry);
-        }
-
-        let mut buf = b"MPLS0300".to_vec();
-        buf.extend_from_slice(&u32::try_from(playlist_offset).unwrap().to_be_bytes());
-        buf.extend_from_slice(&u32::try_from(chapters_offset).unwrap().to_be_bytes());
-        buf.extend_from_slice(&[0_u8; 4]); // extensions offset
-        buf.resize(0x38, 0);
-        buf.push(0); // misc flags at 0x38
-        buf.resize(playlist_offset, 0);
-        buf.extend_from_slice(&playlist);
-        buf.extend_from_slice(&mark);
-        buf
+        let counts = [0, u8::try_from(declared_audio.len()).unwrap(), 0, 0, 0, 0, 0];
+        // An empty angle list is a single-angle item, not a multi-angle one with
+        // no extra angles — the two differ in the item's multiangle flag.
+        let angles = (!angle_names.is_empty()).then_some(angle_names);
+        let items: Vec<Vec<u8>> = item_names
+            .iter()
+            .map(|name| build_item_codec(name, codec, in_t, out_t, angles, counts, &stream_bytes))
+            .collect();
+        let marks: Vec<Vec<u8>> = chapters
+            .iter()
+            .map(|&(chapter_type, file_index, tick)| chapter_entry(chapter_type, file_index, tick))
+            .collect();
+        build_mpls(0, &items, &marks)
     }
 
     /// A valid `*.mpls` with zero play items — its `stream_clips` are empty, so
     /// the reference-clip selection finds nothing.
     fn empty_mpls() -> Vec<u8> {
-        let playlist_offset: usize = 0x3C;
-        let mut playlist = Vec::new();
-        playlist.extend_from_slice(&[0_u8; 4]); // PlayList length
-        playlist.extend_from_slice(&[0_u8; 2]); // reserved
-        playlist.extend_from_slice(&0_u16.to_be_bytes()); // item count = 0
-        playlist.extend_from_slice(&[0_u8; 2]); // sub-item count
-        let chapters_offset = playlist_offset.wrapping_add(playlist.len());
-
-        let mut mark = Vec::new();
-        mark.extend_from_slice(&[0_u8; 4]); // PlayListMark length
-        mark.extend_from_slice(&0_u16.to_be_bytes()); // zero marks
-
-        let mut buf = b"MPLS0300".to_vec();
-        buf.extend_from_slice(&u32::try_from(playlist_offset).unwrap().to_be_bytes());
-        buf.extend_from_slice(&u32::try_from(chapters_offset).unwrap().to_be_bytes());
-        buf.extend_from_slice(&[0_u8; 4]); // extensions offset
-        buf.resize(0x38, 0);
-        buf.push(0); // misc flags at 0x38
-        buf.resize(playlist_offset, 0);
-        buf.extend_from_slice(&playlist);
-        buf.extend_from_slice(&mark);
-        buf
+        build_mpls(0, &[], &[])
     }
 
     /// `bdmt_eng.xml` with the given title in the `discinfo` namespace.

--- a/crates/bdinfo-rs-core/src/bdrom/mpls.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/mpls.rs
@@ -379,20 +379,23 @@ fn build_playlist_stream(
     build_coded_stream(data, coding, stream_type, None)
 }
 
+/// Synthetic `*.mpls` builders shared by this module's and the disc
+/// orchestration's tests.
+///
+/// Stream-Number-table entries, `PlayItem`s with or without extra camera angles,
+/// `PlayListMark` entries, and the envelope that wraps them. Parametric
+/// throughout — a caller spells out the counts and bytes it needs, so the
+/// on-disc layout is encoded here and nowhere else.
 #[cfg(test)]
-mod tests {
-    use proptest::prelude::{any, proptest};
-
-    use super::TsPlaylistFile;
-    use crate::primitives::Pid;
-    use crate::stream::{
-        TsAspectRatio, TsAudioStream, TsChannelLayout, TsFrameRate, TsStream, TsStreamType,
-        TsVideoFormat, TsVideoStream,
-    };
-
+pub mod playlists {
     /// One Stream-Number-table entry: a 9-byte header block (PID placed per
     /// `header_type`) + the stream length (5) + the coding type + 4 coding bytes.
-    fn pl_stream(header_type: u8, pid: u16, stream_type: u8, coding: [u8; 4]) -> Vec<u8> {
+    pub(crate) fn pl_stream(
+        header_type: u8,
+        pid: u16,
+        stream_type: u8,
+        coding: [u8; 4],
+    ) -> Vec<u8> {
         let [ph, pl] = pid.to_be_bytes();
         let mut header = vec![header_type];
         match header_type {
@@ -413,7 +416,7 @@ mod tests {
 
     /// One secondary-stream comb-info block: the ref count, a reserved byte,
     /// the 1-byte refs, and a pad byte when the count is odd.
-    fn comb_info(refs: &[u8]) -> Vec<u8> {
+    pub(crate) fn comb_info(refs: &[u8]) -> Vec<u8> {
         let mut block = vec![u8::try_from(refs.len()).unwrap(), 0];
         block.extend_from_slice(refs);
         if refs.len() % 2 == 1 {
@@ -425,7 +428,7 @@ mod tests {
     /// One `PlayItem`. `angles` is `None` for a single-angle item or `Some(names)`
     /// for a multi-angle one (`names.len()` extra angles). `counts` are the seven
     /// SN-table stream counts; `stream_bytes` is the concatenated entries.
-    fn build_item(
+    pub(crate) fn build_item(
         name: &str,
         in_time: u32,
         out_time: u32,
@@ -439,7 +442,7 @@ mod tests {
     /// [`build_item`] with the 4-byte codec id chosen by the caller — `*b"M2TS"`
     /// for an ordinary clip, `*b"FMTS"` for one whose stream file is `*.FMTS`.
     /// The codec id is written for both the item and each angle entry.
-    fn build_item_codec(
+    pub(crate) fn build_item_codec(
         name: &str,
         codec: [u8; 4],
         in_time: u32,
@@ -482,7 +485,7 @@ mod tests {
 
     /// A 14-byte `PlayListMark` entry: `chapter_type` at +1, `file_index` at +2,
     /// `chapter_time` at +4.
-    fn chapter_entry(chapter_type: u8, file_index: u16, chapter_time: u32) -> Vec<u8> {
+    pub(crate) fn chapter_entry(chapter_type: u8, file_index: u16, chapter_time: u32) -> Vec<u8> {
         let mut entry = vec![0, chapter_type];
         entry.extend_from_slice(&file_index.to_be_bytes());
         entry.extend_from_slice(&chapter_time.to_be_bytes());
@@ -492,7 +495,7 @@ mod tests {
 
     /// Wraps items + chapter entries in a valid MPLS envelope (`PlayList` at
     /// `0x3C`, then `PlayListMark`).
-    fn build_mpls(misc_flags: u8, items: &[Vec<u8>], chapters: &[Vec<u8>]) -> Vec<u8> {
+    pub(crate) fn build_mpls(misc_flags: u8, items: &[Vec<u8>], chapters: &[Vec<u8>]) -> Vec<u8> {
         let playlist_offset: usize = 0x3C;
         let mut playlist = Vec::new();
         playlist.extend_from_slice(&[0_u8; 4]); // PlayList length
@@ -521,6 +524,21 @@ mod tests {
         buf.extend_from_slice(&mark);
         buf
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::{any, proptest};
+
+    use super::TsPlaylistFile;
+    use super::playlists::{
+        build_item, build_item_codec, build_mpls, chapter_entry, comb_info, pl_stream,
+    };
+    use crate::primitives::Pid;
+    use crate::stream::{
+        TsAspectRatio, TsAudioStream, TsChannelLayout, TsFrameRate, TsStream, TsStreamType,
+        TsVideoFormat, TsVideoStream,
+    };
 
     /// The comprehensive two-item playlist exercised by several tests.
     fn comprehensive_mpls() -> Vec<u8> {

--- a/crates/bdinfo-rs-core/src/bitstream.rs
+++ b/crates/bdinfo-rs-core/src/bitstream.rs
@@ -513,19 +513,74 @@ impl TsStreamBuffer {
     }
 }
 
+/// Bit-level builders shared by this module's, [`crate::codec`]'s and the
+/// thirteen codec scanners' tests.
+///
+/// A readable [`TsStreamBuffer`] over a byte slice, and a field-by-field bit
+/// packer for spelling out synthetic frames.
 #[cfg(test)]
-mod tests {
-    use proptest::prelude::{any, prop_assert, prop_assert_eq, proptest};
-
-    use super::{BUFFER_SIZE, SeekOrigin, TsStreamBuffer};
+pub mod bits {
+    use super::TsStreamBuffer;
 
     /// Builds a buffer holding `data`, rewound for reading.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
+    pub(crate) fn buf(data: &[u8]) -> TsStreamBuffer {
         let mut b = TsStreamBuffer::new();
         b.add(data, 0, data.len());
         b.begin_read();
         b
     }
+
+    /// Packs `(value, bit_width)` fields MSB-first into bytes; a trailing partial
+    /// byte is left-aligned (low bits zero), matching how the bit reader consumes
+    /// them. Lets each scanner test spell its frame out field-by-field.
+    pub(crate) fn pack(fields: &[(u64, u32)]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut cur: u8 = 0;
+        let mut nbits: u32 = 0;
+        for &(val, width) in fields {
+            let mut b = width;
+            while b > 0 {
+                b = b.wrapping_sub(1);
+                let bit = u8::try_from(val.wrapping_shr(b) & 1).unwrap_or(0);
+                cur = cur.wrapping_shl(1).wrapping_add(bit);
+                nbits = nbits.wrapping_add(1);
+                if nbits == 8 {
+                    bytes.push(cur);
+                    cur = 0;
+                    nbits = 0;
+                }
+            }
+        }
+        if nbits > 0 {
+            bytes.push(cur.wrapping_shl(8_u32.wrapping_sub(nbits)));
+        }
+        bytes
+    }
+
+    #[test]
+    fn pack_handles_aligned_and_partial_inputs() {
+        // 16 bits → exactly two whole bytes (the trailing-partial push is skipped).
+        assert_eq!(pack(&[(0xABCD, 16)]), vec![0xAB, 0xCD]);
+        // 12 bits → one whole byte plus a left-aligned partial byte.
+        assert_eq!(pack(&[(0xABC, 12)]), vec![0xAB, 0xC0]);
+    }
+
+    #[test]
+    fn buf_is_readable_from_its_first_byte() {
+        // `begin_read` is what makes the difference: without it the buffer's read
+        // cursor sits past the data every caller wants to parse.
+        let mut b = buf(&[0xAB, 0xCD]);
+        assert_eq!(b.length(), 2);
+        assert_eq!(b.read_bits4(16, false), 0xABCD);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::{any, prop_assert, prop_assert_eq, proptest};
+
+    use super::bits::buf;
+    use super::{BUFFER_SIZE, SeekOrigin, TsStreamBuffer};
 
     /// Packs `bits` MSB-first into bytes; a trailing partial byte is left-aligned
     /// (low bits padded with zero), matching how the readers consume them.

--- a/crates/bdinfo-rs-core/src/codec.rs
+++ b/crates/bdinfo-rs-core/src/codec.rs
@@ -131,44 +131,10 @@ pub(crate) fn scan_access_unit(
 #[cfg(test)]
 mod tests {
     use super::scan_access_unit;
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::{buf, pack};
     use crate::stream::{
         TsAudioStream, TsGraphicsStream, TsStream, TsStreamType, TsTextStream, TsVideoStream,
     };
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
-
-    /// Packs `(value, bit_width)` fields MSB-first into bytes (trailing partial byte
-    /// left-aligned) — the same field-spelling helper the codec modules' tests use.
-    fn pack(fields: &[(u64, u32)]) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        let mut cur: u8 = 0;
-        let mut nbits: u32 = 0;
-        for &(val, width) in fields {
-            let mut b = width;
-            while b > 0 {
-                b = b.wrapping_sub(1);
-                let bit = u8::try_from(val.wrapping_shr(b) & 1).unwrap_or(0);
-                cur = cur.wrapping_shl(1).wrapping_add(bit);
-                nbits = nbits.wrapping_add(1);
-                if nbits == 8 {
-                    bytes.push(cur);
-                    cur = 0;
-                    nbits = 0;
-                }
-            }
-        }
-        if nbits > 0 {
-            bytes.push(cur.wrapping_shl(8_u32.wrapping_sub(nbits)));
-        }
-        bytes
-    }
 
     /// A legacy AC-3 5.1 / 48 kHz / 640 kbps core frame (also the `TrueHD`/`DTS-HD`
     /// embedded-core access unit, which carries no HD major-sync).
@@ -313,14 +279,6 @@ mod tests {
     /// dispatch arm falling through to the default (channels stay 0).
     fn audio_channels(stream: &TsStream) -> i32 {
         if let TsStream::Audio(audio) = stream { audio.channel_count } else { -1 }
-    }
-
-    #[test]
-    fn pack_handles_aligned_and_partial_inputs() {
-        // 16 bits → exactly two whole bytes (the trailing-partial push is skipped).
-        assert_eq!(pack(&[(0xABCD, 16)]), vec![0xAB, 0xCD]);
-        // 12 bits → one whole byte plus a left-aligned partial byte.
-        assert_eq!(pack(&[(0xABC, 12)]), vec![0xAB, 0xC0]);
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/codec/aac.rs
+++ b/crates/bdinfo-rs-core/src/codec/aac.rs
@@ -117,42 +117,8 @@ mod tests {
     use proptest::prelude::{any, proptest};
 
     use super::{get_aac_profile, scan};
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::{buf, pack};
     use crate::stream::{TsAudioMode, TsAudioStream, TsStreamType};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
-
-    /// Packs `(value, bit_width)` fields MSB-first into bytes; a trailing partial
-    /// byte is left-aligned, matching how the bit reader consumes them.
-    fn pack(fields: &[(u64, u32)]) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        let mut cur: u8 = 0;
-        let mut nbits: u32 = 0;
-        for &(val, width) in fields {
-            let mut b = width;
-            while b > 0 {
-                b = b.wrapping_sub(1);
-                let bit = u8::try_from(val.wrapping_shr(b) & 1).unwrap_or(0);
-                cur = cur.wrapping_shl(1).wrapping_add(bit);
-                nbits = nbits.wrapping_add(1);
-                if nbits == 8 {
-                    bytes.push(cur);
-                    cur = 0;
-                    nbits = 0;
-                }
-            }
-        }
-        if nbits > 0 {
-            bytes.push(cur.wrapping_shl(8_u32.wrapping_sub(nbits)));
-        }
-        bytes
-    }
 
     /// The ADTS fixed-header field sequence for the given `version`/`profile`/
     /// `sr_idx`/`chan` (sync, then the fixed header up through `home`), padded.

--- a/crates/bdinfo-rs-core/src/codec/ac3.rs
+++ b/crates/bdinfo-rs-core/src/codec/ac3.rs
@@ -377,49 +377,14 @@ mod tests {
     use proptest::prelude::{any, proptest};
 
     use super::{ac3_chan_map, scan};
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::{buf, pack};
     use crate::stream::{TsAudioMode, TsAudioStream, TsStreamType};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
 
     /// A fresh audio stream of `stream_type`.
     fn stream(stream_type: TsStreamType) -> TsAudioStream {
         let mut s = TsAudioStream::default();
         s.base.stream_type = stream_type;
         s
-    }
-
-    /// Packs `(value, bit_width)` fields MSB-first into bytes; a trailing partial
-    /// byte is left-aligned (low bits zero), matching how the bit reader consumes
-    /// them. Lets each test spell its AC-3 frame out field-by-field.
-    fn pack(fields: &[(u64, u32)]) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        let mut cur: u8 = 0;
-        let mut nbits: u32 = 0;
-        for &(val, width) in fields {
-            let mut b = width;
-            while b > 0 {
-                b = b.wrapping_sub(1);
-                let bit = u8::try_from(val.wrapping_shr(b) & 1).unwrap_or(0);
-                cur = cur.wrapping_shl(1).wrapping_add(bit);
-                nbits = nbits.wrapping_add(1);
-                if nbits == 8 {
-                    bytes.push(cur);
-                    cur = 0;
-                    nbits = 0;
-                }
-            }
-        }
-        if nbits > 0 {
-            bytes.push(cur.wrapping_shl(8_u32.wrapping_sub(nbits)));
-        }
-        bytes
     }
 
     /// Runs [`scan`] over a packed frame and returns the mutated stream.

--- a/crates/bdinfo-rs-core/src/codec/avc.rs
+++ b/crates/bdinfo-rs-core/src/codec/avc.rs
@@ -118,16 +118,8 @@ mod tests {
     use proptest::prelude::{any, proptest};
 
     use super::scan;
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::buf;
     use crate::stream::{TsAspectRatio, TsFrameRate, TsStreamType, TsVideoFormat, TsVideoStream};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
 
     /// A fresh AVC video stream.
     fn stream() -> TsVideoStream {

--- a/crates/bdinfo-rs-core/src/codec/dts.rs
+++ b/crates/bdinfo-rs-core/src/codec/dts.rs
@@ -142,49 +142,14 @@ mod tests {
     use proptest::prelude::{any, proptest};
 
     use super::scan;
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::{buf, pack};
     use crate::stream::{TsAudioMode, TsAudioStream, TsStreamType};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
 
     /// A fresh DTS audio stream.
     fn stream() -> TsAudioStream {
         let mut s = TsAudioStream::default();
         s.base.stream_type = TsStreamType::DtsAudio;
         s
-    }
-
-    /// Packs `(value, bit_width)` fields MSB-first into bytes; a trailing partial
-    /// byte is left-aligned (low bits zero), matching how the bit reader consumes
-    /// them.
-    fn pack(fields: &[(u64, u32)]) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        let mut cur: u8 = 0;
-        let mut nbits: u32 = 0;
-        for &(val, width) in fields {
-            let mut b = width;
-            while b > 0 {
-                b = b.wrapping_sub(1);
-                let bit = u8::try_from(val.wrapping_shr(b) & 1).unwrap_or(0);
-                cur = cur.wrapping_shl(1).wrapping_add(bit);
-                nbits = nbits.wrapping_add(1);
-                if nbits == 8 {
-                    bytes.push(cur);
-                    cur = 0;
-                    nbits = 0;
-                }
-            }
-        }
-        if nbits > 0 {
-            bytes.push(cur.wrapping_shl(8_u32.wrapping_sub(nbits)));
-        }
-        bytes
     }
 
     /// One DTS core frame: the `0x7FFE8001` sync followed by the header fields up to
@@ -238,14 +203,6 @@ mod tests {
         scan(&mut s, &mut b, bitrate, &mut tag);
         assert_eq!(tag, None, "the DTS core never sets the tag");
         s
-    }
-
-    #[test]
-    fn pack_handles_byte_aligned_and_partial_inputs() {
-        // 16 bits → exactly two whole bytes (the trailing-partial path is skipped).
-        assert_eq!(pack(&[(0xABCD, 16)]), vec![0xAB, 0xCD]);
-        // 12 bits → one whole byte plus a left-aligned partial byte.
-        assert_eq!(pack(&[(0xABC, 12)]), vec![0xAB, 0xC0]);
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/codec/dts_hd.rs
+++ b/crates/bdinfo-rs-core/src/codec/dts_hd.rs
@@ -238,48 +238,14 @@ mod tests {
     use proptest::prelude::{any, proptest};
 
     use super::scan;
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::{buf, pack};
     use crate::stream::{TsAudioMode, TsAudioStream, TsStreamType};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
 
     /// A fresh audio stream of `stream_type`.
     fn stream(stream_type: TsStreamType) -> TsAudioStream {
         let mut s = TsAudioStream::default();
         s.base.stream_type = stream_type;
         s
-    }
-
-    /// Packs `(value, bit_width)` fields MSB-first into bytes (trailing partial byte
-    /// left-aligned).
-    fn pack(fields: &[(u64, u32)]) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        let mut cur: u8 = 0;
-        let mut nbits: u32 = 0;
-        for &(val, width) in fields {
-            let mut b = width;
-            while b > 0 {
-                b = b.wrapping_sub(1);
-                let bit = u8::try_from(val.wrapping_shr(b) & 1).unwrap_or(0);
-                cur = cur.wrapping_shl(1).wrapping_add(bit);
-                nbits = nbits.wrapping_add(1);
-                if nbits == 8 {
-                    bytes.push(cur);
-                    cur = 0;
-                    nbits = 0;
-                }
-            }
-        }
-        if nbits > 0 {
-            bytes.push(cur.wrapping_shl(8_u32.wrapping_sub(nbits)));
-        }
-        bytes
     }
 
     /// A DTS-HD "HD" substream-header configuration, with a valid 5.1 / 48 kHz /
@@ -499,14 +465,6 @@ mod tests {
             (4, 3), // channel base → 5
             (0, 64),
         ])
-    }
-
-    #[test]
-    fn pack_handles_byte_aligned_and_partial_inputs() {
-        // 16 bits → exactly two whole bytes (the trailing-partial path is skipped).
-        assert_eq!(pack(&[(0xABCD, 16)]), vec![0xAB, 0xCD]);
-        // 12 bits → one whole byte plus a left-aligned partial byte.
-        assert_eq!(pack(&[(0xABC, 12)]), vec![0xAB, 0xC0]);
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/codec/lpcm.rs
+++ b/crates/bdinfo-rs-core/src/codec/lpcm.rs
@@ -128,16 +128,8 @@ mod tests {
     use proptest::prelude::{any, proptest};
 
     use super::scan;
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::buf;
     use crate::stream::{TsAudioStream, TsStreamType};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
 
     /// Builds a ≥5-byte LPCM access unit whose `flags` word packs the channel,
     /// sample-rate, and bit-depth fields (the third/fourth header bytes). The

--- a/crates/bdinfo-rs-core/src/codec/mpa.rs
+++ b/crates/bdinfo-rs-core/src/codec/mpa.rs
@@ -129,42 +129,8 @@ mod tests {
     use proptest::prelude::{any, proptest};
 
     use super::scan;
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::{buf, pack};
     use crate::stream::{TsAudioMode, TsAudioStream, TsStreamType};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
-
-    /// Packs `(value, bit_width)` fields MSB-first into bytes; a trailing partial
-    /// byte is left-aligned, matching how the bit reader consumes them.
-    fn pack(fields: &[(u64, u32)]) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        let mut cur: u8 = 0;
-        let mut nbits: u32 = 0;
-        for &(val, width) in fields {
-            let mut b = width;
-            while b > 0 {
-                b = b.wrapping_sub(1);
-                let bit = u8::try_from(val.wrapping_shr(b) & 1).unwrap_or(0);
-                cur = cur.wrapping_shl(1).wrapping_add(bit);
-                nbits = nbits.wrapping_add(1);
-                if nbits == 8 {
-                    bytes.push(cur);
-                    cur = 0;
-                    nbits = 0;
-                }
-            }
-        }
-        if nbits > 0 {
-            bytes.push(cur.wrapping_shl(8_u32.wrapping_sub(nbits)));
-        }
-        bytes
-    }
 
     /// The MPEG-audio frame header field sequence (sync, then version/layer/…/
     /// emphasis), padded.

--- a/crates/bdinfo-rs-core/src/codec/mpeg2.rs
+++ b/crates/bdinfo-rs-core/src/codec/mpeg2.rs
@@ -69,16 +69,8 @@ mod tests {
     use proptest::prelude::{any, proptest};
 
     use super::scan;
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::buf;
     use crate::stream::{TsAspectRatio, TsFrameRate, TsStreamType, TsVideoFormat, TsVideoStream};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
 
     /// A fresh MPEG-2 video stream.
     fn stream() -> TsVideoStream {

--- a/crates/bdinfo-rs-core/src/codec/mvc.rs
+++ b/crates/bdinfo-rs-core/src/codec/mvc.rs
@@ -32,16 +32,8 @@ mod tests {
     use proptest::prelude::{any, prop_assert, proptest};
 
     use super::scan;
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::buf;
     use crate::stream::{TsStreamType, TsVideoFormat, TsVideoStream};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
 
     /// A fresh MVC video stream.
     fn stream() -> TsVideoStream {

--- a/crates/bdinfo-rs-core/src/codec/pgs.rs
+++ b/crates/bdinfo-rs-core/src/codec/pgs.rs
@@ -137,16 +137,8 @@ mod tests {
     use proptest::prelude::{any, prop_assert, proptest};
 
     use super::{Frame, read_ods, read_pcs, scan};
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::buf;
     use crate::stream::{TsGraphicsStream, TsStreamType};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
 
     /// Runs [`scan`] over `data` against `stream`, returning the resulting tag.
     fn run(stream: &mut TsGraphicsStream, data: &[u8]) -> Option<String> {

--- a/crates/bdinfo-rs-core/src/codec/truehd.rs
+++ b/crates/bdinfo-rs-core/src/codec/truehd.rs
@@ -148,48 +148,14 @@ mod tests {
     use proptest::prelude::{any, proptest};
 
     use super::scan;
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::{buf, pack};
     use crate::stream::{TsAudioStream, TsStreamType};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
 
     /// A fresh audio stream of `stream_type`.
     fn stream(stream_type: TsStreamType) -> TsAudioStream {
         let mut s = TsAudioStream::default();
         s.base.stream_type = stream_type;
         s
-    }
-
-    /// Packs `(value, bit_width)` fields MSB-first into bytes (trailing partial byte
-    /// left-aligned).
-    fn pack(fields: &[(u64, u32)]) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        let mut cur: u8 = 0;
-        let mut nbits: u32 = 0;
-        for &(val, width) in fields {
-            let mut b = width;
-            while b > 0 {
-                b = b.wrapping_sub(1);
-                let bit = u8::try_from(val.wrapping_shr(b) & 1).unwrap_or(0);
-                cur = cur.wrapping_shl(1).wrapping_add(bit);
-                nbits = nbits.wrapping_add(1);
-                if nbits == 8 {
-                    bytes.push(cur);
-                    cur = 0;
-                    nbits = 0;
-                }
-            }
-        }
-        if nbits > 0 {
-            bytes.push(cur.wrapping_shl(8_u32.wrapping_sub(nbits)));
-        }
-        bytes
     }
 
     /// The legacy AC-3 5.1 / 48 kHz / 640 kbps / DN -31 core frame the demux feeds

--- a/crates/bdinfo-rs-core/src/codec/vc1.rs
+++ b/crates/bdinfo-rs-core/src/codec/vc1.rs
@@ -120,16 +120,8 @@ mod tests {
     use proptest::prelude::{any, proptest};
 
     use super::scan;
-    use crate::bitstream::TsStreamBuffer;
+    use crate::bitstream::bits::buf;
     use crate::stream::{TsAspectRatio, TsFrameRate, TsStreamType, TsVideoFormat, TsVideoStream};
-
-    /// A rewound buffer holding `data`.
-    fn buf(data: &[u8]) -> TsStreamBuffer {
-        let mut b = TsStreamBuffer::new();
-        b.add(data, 0, data.len());
-        b.begin_read();
-        b
-    }
 
     /// A fresh VC-1 video stream.
     fn stream() -> TsVideoStream {


### PR DESCRIPTION
Test code only; no production diff.

Three duplicated test utilities collapse to one home each, following the
`m2ts::packets` precedent — a `#[cfg(test)] pub mod` sitting beside the code
whose bytes it builds, rather than a separate fixtures module. Colocation keeps
a byte layout in the same file as the parser that reads it, and the crate
already reads that way.

- `bitstream::bits` — `buf` (14 byte-identical copies) and `pack` (7), plus the
  one `pack_handles_aligned_and_partial_inputs` test that existed three times.
  A new `buf_is_readable_from_its_first_byte` test pins the `begin_read` step
  that made the helper worth sharing.
- `mpls::playlists` — the parametric `PlayItem` / Stream-Number-table /
  `PlayListMark` / envelope builders, promoted unchanged.
- `clpi::clips` — `program_header`, `entry_bytes`, `build_clpi`, promoted
  unchanged.

`disc.rs` keeps its convenience wrappers (`mpls`, `mpls_angles`,
`mpls_declared`, `mpls_items`, `mpls_items_codec`, `empty_mpls`, `clpi`) as thin
calls on the shared builders; its second hand-written copy of both on-disc
layouts is gone. The per-module `stream()` / `dts_frame` / `Hd` / `pcs` fixtures
stay local — they carry per-codec intent.

Gate: 1016 tests, coverage 100% lines/regions/functions, branches 97.71%.