### PR TITLE
test(core): expose summary constructors behind a test-fixtures feature

### DIFF
--- a/crates/bdinfo-rs-core/Cargo.toml
+++ b/crates/bdinfo-rs-core/Cargo.toml
@@ -28,6 +28,13 @@ doctest = false
 [lints]
 workspace = true
 
+# Off by default: a normal build compiles none of it. `test-fixtures` exposes
+# `bdrom::disc::fixtures`, the constructors that build a `PlaylistSummary` or
+# `ClipSummary` from the few fields a test varies — the only way the crates that
+# consume this one (which cannot see its `#[cfg(test)]` code) can share them.
+[features]
+test-fixtures = []
+
 [dependencies]
 roxmltree = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -304,6 +304,66 @@ impl ClipSummary {
     }
 }
 
+/// Test constructors for [`PlaylistSummary`] and [`ClipSummary`].
+///
+/// Both are wide plain-data structs — 11 and 12 public fields — while a test
+/// usually cares about two or three. Each function takes those few and zeroes
+/// the rest, so a test spells only its own intent and a field added to either
+/// struct changes one body here instead of every construction site.
+///
+/// Other crates reach these through the off-by-default `test-fixtures` feature;
+/// inside this crate `cfg(test)` alone brings them in.
+#[cfg(any(test, feature = "test-fixtures"))]
+pub mod fixtures {
+    use super::{ClipSummary, PlaylistSummary};
+
+    /// A clip named `name` — its display name too — `length` seconds long,
+    /// with no sizes and nothing measured.
+    #[must_use]
+    pub fn clip(name: &str, length: f64) -> ClipSummary {
+        ClipSummary {
+            name: name.to_owned(),
+            display_name: name.to_owned(),
+            file_size: 0,
+            interleaved_file_size: 0,
+            angle_index: 0,
+            relative_time_in: 0.0,
+            length,
+            payload_bytes: 0,
+            packet_count: 0,
+            packet_seconds: 0.0,
+            file_seconds: 0.0,
+            streams: Vec::new(),
+        }
+    }
+
+    /// One [`clip`] per name in `names`, each `length` seconds long — the clip
+    /// sequence of a playlist that plays those files.
+    #[must_use]
+    pub fn clips(names: &[&str], length: f64) -> Vec<ClipSummary> {
+        names.iter().map(|name| clip(name, length)).collect()
+    }
+
+    /// A single-angle, non-looping playlist named `name`, `total_length`
+    /// seconds long, presenting `clips` and no streams, chapters or sizes.
+    #[must_use]
+    pub fn playlist(name: &str, total_length: f64, clips: Vec<ClipSummary>) -> PlaylistSummary {
+        PlaylistSummary {
+            name: name.to_owned(),
+            total_length,
+            file_size: 0,
+            interleaved_file_size: 0,
+            chapter_count: 0,
+            stream_count: 0,
+            angle_count: 0,
+            has_loops: false,
+            streams: Vec::new(),
+            clips,
+            chapters: Vec::new(),
+        }
+    }
+}
+
 /// One stream's whole-file measured tallies within one clip's stream file.
 ///
 /// Carries the demuxed payload byte and transport packet counts for that PID,
@@ -2217,7 +2277,7 @@ mod tests {
         PlaylistFilter, PlaylistSummary, Progress, SOURCE_PACKET_BYTES, ScanMode, ScanProgress,
         ScanStage, Sink, TsPlaylistFile, TsStreamFile, backup_subdir_files,
         build_chapter_summaries, build_clip_summaries, build_sorted_streams, clear_measurements,
-        clip_has_50hz_video, clip_stem, collect_backups, has_aacs_key_file, merge_stream,
+        clip_has_50hz_video, clip_stem, collect_backups, fixtures, has_aacs_key_file, merge_stream,
         rate_over, read_disc_title, read_file, read_file_capped, resolve_playlist_streams,
         scan_stream_files, scan_total, select_reference, stream_content_encrypted, stream_summary,
         unit_shows_encryption, walked_disc_root,
@@ -3530,18 +3590,10 @@ mod tests {
     /// per-stream tallies.
     fn clip_summary(angle_index: i32, time_in: f64, length: f64, packets: u64) -> ClipSummary {
         ClipSummary {
-            name: "00000.M2TS".to_owned(),
-            display_name: "00000.M2TS".to_owned(),
-            file_size: 0,
-            interleaved_file_size: 0,
             angle_index,
             relative_time_in: time_in,
-            length,
-            payload_bytes: 0,
             packet_count: packets,
-            packet_seconds: 0.0,
-            file_seconds: 0.0,
-            streams: Vec::new(),
+            ..fixtures::clip("00000.M2TS", length)
         }
     }
 
@@ -3551,19 +3603,7 @@ mod tests {
         angle_count: usize,
         clips: Vec<ClipSummary>,
     ) -> PlaylistSummary {
-        PlaylistSummary {
-            name: "00000.MPLS".to_owned(),
-            total_length,
-            file_size: 0,
-            interleaved_file_size: 0,
-            chapter_count: 0,
-            stream_count: 0,
-            angle_count,
-            has_loops: false,
-            streams: Vec::new(),
-            clips,
-            chapters: Vec::new(),
-        }
+        PlaylistSummary { angle_count, ..fixtures::playlist("00000.MPLS", total_length, clips) }
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -2415,6 +2415,12 @@ mod tests {
             let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
             let mut root = std::env::temp_dir();
             root.push(format!("bdinfo-rs-disc-{}-{unique}", std::process::id()));
+            // The name repeats across runs — the operating system reuses process
+            // ids — and a run killed before `Drop` leaves its directory behind, so
+            // clear any leftover first. `create_dir_all` would adopt it silently,
+            // and a disc built to lack a directory would then be handed the files
+            // of whichever test held this name last.
+            let _ = std::fs::remove_dir_all(&root).is_ok();
             std::fs::create_dir_all(&root).expect("create root");
             for dir in dirs {
                 std::fs::create_dir_all(root.join(dir)).expect("create dir");

--- a/crates/bdinfo-rs-core/src/bdrom/order.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/order.rs
@@ -310,39 +310,14 @@ mod tests {
         presentation_cmp, presentation_groups, presentation_order, selection_order,
         selection_stream_files, table_rows,
     };
-    use crate::bdrom::disc::{ClipSummary, PlaylistSummary};
+    use crate::bdrom::disc::{PlaylistSummary, fixtures};
 
     /// A playlist summary carrying only what the presentation order reads:
     /// name, total length, loop flag, and its clip names.
     fn playlist(name: &str, total_length: f64, has_loops: bool, clips: &[&str]) -> PlaylistSummary {
         PlaylistSummary {
-            name: name.to_owned(),
-            total_length,
-            file_size: 0,
-            interleaved_file_size: 0,
-            chapter_count: 0,
-            stream_count: 0,
-            angle_count: 0,
             has_loops,
-            streams: Vec::new(),
-            clips: clips
-                .iter()
-                .map(|clip| ClipSummary {
-                    name: (*clip).to_owned(),
-                    display_name: (*clip).to_owned(),
-                    file_size: 0,
-                    interleaved_file_size: 0,
-                    angle_index: 0,
-                    relative_time_in: 0.0,
-                    length: total_length,
-                    payload_bytes: 0,
-                    packet_count: 0,
-                    packet_seconds: 0.0,
-                    file_seconds: 0.0,
-                    streams: Vec::new(),
-                })
-                .collect(),
-            chapters: Vec::new(),
+            ..fixtures::playlist(name, total_length, fixtures::clips(clips, total_length))
         }
     }
 

--- a/crates/bdinfo-rs-core/src/report/text.rs
+++ b/crates/bdinfo-rs-core/src/report/text.rs
@@ -864,7 +864,9 @@ mod tests {
         render_with, secondary_audio, time_h, time_hh, time_hh_short, time_parts,
     };
     use crate::bdrom::chapters::{ChapterSummary, seconds_to_ticks};
-    use crate::bdrom::disc::{BdRom, ClipStreamTally, ClipSummary, PlaylistSummary, StreamSummary};
+    use crate::bdrom::disc::{
+        BdRom, ClipStreamTally, ClipSummary, PlaylistSummary, StreamSummary, fixtures,
+    };
     use crate::error::{BdError, ScanError, ScanStage};
     use crate::primitives::Pid;
     use crate::stream::TsStreamType;
@@ -910,39 +912,20 @@ mod tests {
         assert_eq!(super::forums_audio_cell(&s), "DTS-HD MA 5.1 768 kbps");
     }
 
-    /// A measured clip row.
+    /// A measured clip row: the demux attributed `packet_count` packets to it
+    /// and its whole file is the clip's own length.
     fn clip(name: &str, length: f64, packet_count: u64) -> ClipSummary {
         ClipSummary {
-            name: name.to_owned(),
-            display_name: name.to_owned(),
-            file_size: 0,
-            interleaved_file_size: 0,
-            angle_index: 0,
-            relative_time_in: 0.0,
-            length,
-            payload_bytes: 0,
             packet_count,
             packet_seconds: length,
             file_seconds: length,
-            streams: Vec::new(),
+            ..fixtures::clip(name, length)
         }
     }
 
     /// A playlist with no streams, clips, or chapters.
     fn playlist(name: &str, total_length: f64) -> PlaylistSummary {
-        PlaylistSummary {
-            name: name.to_owned(),
-            total_length,
-            file_size: 0,
-            interleaved_file_size: 0,
-            chapter_count: 0,
-            stream_count: 0,
-            angle_count: 0,
-            has_loops: false,
-            streams: Vec::new(),
-            clips: Vec::new(),
-            chapters: Vec::new(),
-        }
+        fixtures::playlist(name, total_length, Vec::new())
     }
 
     /// A bare disc carrying `playlists` and no feature flags.

--- a/crates/bdinfo-rs-core/src/vfs/fs.rs
+++ b/crates/bdinfo-rs-core/src/vfs/fs.rs
@@ -394,6 +394,11 @@ mod tests {
             let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
             let mut root = std::env::temp_dir();
             root.push(format!("bdinfo-rs-vfs-{}-{unique}", std::process::id()));
+            // The name repeats across runs (reused process ids) and a run killed
+            // before `Drop` leaves its directory behind, so clear any leftover:
+            // the listing assertions below count entries, and adopted files add to
+            // them.
+            let _ = std::fs::remove_dir_all(&root).is_ok();
 
             let bdmv = root.join("bdmv"); // lowercase on purpose
             let playlist = bdmv.join("PlayList"); // mixed case on purpose

--- a/crates/bdinfo-rs-gui/Cargo.toml
+++ b/crates/bdinfo-rs-gui/Cargo.toml
@@ -80,6 +80,12 @@ rfd = { version = "0.16", default-features = false, features = ["xdg-portal", "t
 log = "0.4"
 
 [dev-dependencies]
+# The analyzer library again, with the feature that exposes its summary
+# constructors (`bdinfo_rs_core::bdrom::disc::fixtures`) to the tests here.
+# Deliberately PATH-ONLY, unlike the [dependencies] entry above: cargo drops a
+# dev-dependency that carries no version when it packages the crate, so this one
+# never becomes a published requirement.
+bdinfo-rs-core = { path = "../bdinfo-rs-core", features = ["test-fixtures"] }
 # Drive the real `view()` headlessly — click by text, drain the messages back
 # through `update` — and pin key states as tiny-skia RGBA snapshot hashes: the
 # Tier-B verification layer (Posture C's analogue of the wasm crate's

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -942,46 +942,22 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use bdinfo_rs_core::bdrom::disc::{BdRom, ClipSummary, PlaylistSummary};
+    use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, fixtures};
 
     use super::{Flow, Stage};
     use crate::model::{Sort, SortColumn, ViewSettings};
     use crate::scan::{Input, Structural};
 
-    fn clip(name: &str) -> ClipSummary {
-        ClipSummary {
-            name: name.to_owned(),
-            display_name: name.to_owned(),
-            file_size: 0,
-            interleaved_file_size: 0,
-            angle_index: 0,
-            relative_time_in: 0.0,
-            length: 0.0,
-            payload_bytes: 0,
-            packet_count: 0,
-            packet_seconds: 0.0,
-            file_seconds: 0.0,
-            streams: Vec::new(),
-        }
-    }
-
     fn playlist(name: &str, length: f64, clips: &[&str]) -> PlaylistSummary {
         playlist_sized(name, length, 1000, clips)
     }
 
+    /// A playlist with a name, a length, an estimated `*.m2ts` size, and clips
+    /// carrying a name only — nothing here reads their lengths.
     fn playlist_sized(name: &str, length: f64, file_size: u64, clips: &[&str]) -> PlaylistSummary {
         PlaylistSummary {
-            name: name.to_owned(),
-            total_length: length,
             file_size,
-            interleaved_file_size: 0,
-            chapter_count: 0,
-            stream_count: 0,
-            angle_count: 0,
-            has_loops: false,
-            streams: Vec::new(),
-            clips: clips.iter().map(|c| clip(c)).collect(),
-            chapters: Vec::new(),
+            ..fixtures::playlist(name, length, fixtures::clips(clips, 0.0))
         }
     }
 

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -3424,7 +3424,7 @@ async fn pick_iso() -> Option<PathBuf> {
 mod harness {
     use std::path::PathBuf;
 
-    use bdinfo_rs_core::bdrom::disc::{BdRom, ClipSummary, PlaylistSummary};
+    use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, fixtures};
     use bdinfo_rs_gui::flow::Flow;
     use bdinfo_rs_gui::model::ViewSettings;
     use bdinfo_rs_gui::scan::{Input, Structural};
@@ -3432,38 +3432,12 @@ mod harness {
 
     use super::{App, Message};
 
-    /// A `ClipSummary` carrying just a name (what the panes read here).
-    fn clip(name: &str) -> ClipSummary {
-        ClipSummary {
-            name: name.to_owned(),
-            display_name: name.to_owned(),
-            file_size: 0,
-            interleaved_file_size: 0,
-            angle_index: 0,
-            relative_time_in: 0.0,
-            length: 0.0,
-            payload_bytes: 0,
-            packet_count: 0,
-            packet_seconds: 0.0,
-            file_seconds: 0.0,
-            streams: Vec::new(),
-        }
-    }
-
-    /// A `PlaylistSummary` with a name, length, estimated size, and clips.
+    /// A `PlaylistSummary` with a name, length, estimated size, and clips
+    /// carrying a name only (what the panes read here).
     fn playlist(name: &str, length: f64, file_size: u64, clips: &[&str]) -> PlaylistSummary {
         PlaylistSummary {
-            name: name.to_owned(),
-            total_length: length,
             file_size,
-            interleaved_file_size: 0,
-            chapter_count: 0,
-            stream_count: 0,
-            angle_count: 0,
-            has_loops: false,
-            streams: Vec::new(),
-            clips: clips.iter().map(|c| clip(c)).collect(),
-            chapters: Vec::new(),
+            ..fixtures::playlist(name, length, fixtures::clips(clips, 0.0))
         }
     }
 

--- a/crates/bdinfo-rs-gui/src/model.rs
+++ b/crates/bdinfo-rs-gui/src/model.rs
@@ -457,7 +457,7 @@ pub fn hidden_playlists(
 
 #[cfg(test)]
 mod tests {
-    use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary};
+    use bdinfo_rs_core::bdrom::disc::{PlaylistSummary, fixtures};
     use bdinfo_rs_core::bdrom::order::{PlaylistFilter, table_rows};
 
     use super::{
@@ -467,27 +467,9 @@ mod tests {
     };
     use crate::settings::Settings;
 
-    /// A `ClipSummary` carrying just a name + length (the fields the view-model
-    /// reads); the measured tallies stay zero.
-    fn sample_clip(name: &str, length: f64) -> ClipSummary {
-        ClipSummary {
-            name: name.to_owned(),
-            display_name: name.to_owned(),
-            file_size: 0,
-            interleaved_file_size: 0,
-            angle_index: 0,
-            relative_time_in: 0.0,
-            length,
-            payload_bytes: 0,
-            packet_count: 0,
-            packet_seconds: 0.0,
-            file_seconds: 0.0,
-            streams: Vec::new(),
-        }
-    }
-
     /// A `PlaylistSummary` carrying just what the view-model reads: name, length,
-    /// the two file sizes, and its clip names.
+    /// the two file sizes, and its clip names (each clip as long as the
+    /// playlist).
     fn sample_playlist(
         name: &str,
         total_length: f64,
@@ -496,17 +478,9 @@ mod tests {
         clips: &[&str],
     ) -> PlaylistSummary {
         PlaylistSummary {
-            name: name.to_owned(),
-            total_length,
             file_size,
             interleaved_file_size,
-            chapter_count: 0,
-            stream_count: 0,
-            angle_count: 0,
-            has_loops: false,
-            streams: Vec::new(),
-            clips: clips.iter().map(|clip| sample_clip(clip, total_length)).collect(),
-            chapters: Vec::new(),
+            ..fixtures::playlist(name, total_length, fixtures::clips(clips, total_length))
         }
     }
 

--- a/crates/bdinfo-rs-gui/src/panes.rs
+++ b/crates/bdinfo-rs-gui/src/panes.rs
@@ -131,7 +131,7 @@ fn bitrate_cell(bits_per_second: i64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary, StreamSummary};
+    use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary, StreamSummary, fixtures};
     use bdinfo_rs_core::primitives::Pid;
     use bdinfo_rs_core::stream::TsStreamType;
 
@@ -152,18 +152,11 @@ mod tests {
         interleaved_file_size: u64,
     ) -> ClipSummary {
         ClipSummary {
-            name: name.to_owned(),
-            display_name: name.to_owned(),
             file_size,
             interleaved_file_size,
             angle_index,
-            relative_time_in: 0.0,
-            length,
-            payload_bytes: 0,
             packet_count,
-            packet_seconds: 0.0,
-            file_seconds: 0.0,
-            streams: Vec::new(),
+            ..fixtures::clip(name, length)
         }
     }
 
@@ -195,25 +188,21 @@ mod tests {
     /// A two-clip, two-stream playlist (the fields the panes read).
     fn playlist() -> PlaylistSummary {
         PlaylistSummary {
-            name: "00000.MPLS".to_owned(),
-            total_length: 130.0,
-            file_size: 0,
-            interleaved_file_size: 0,
-            chapter_count: 0,
             stream_count: 2,
-            angle_count: 0,
-            has_loops: false,
             streams: vec![
                 stream("MPEG-4 AVC Video", "", 0, "1080p / 23.976 fps / 16:9"),
                 stream("DTS-HD Master Audio", "English", 3_948_000, "5.1 / 48 kHz / 24-bit"),
             ],
-            clips: vec![
-                // A plain clip: a 500 KB `*.m2ts`, 1000 packets demuxed.
-                sized_clip("00000.M2TS", 0, 100.0, 1000, 500_000, 0),
-                // No file on disk, nothing demuxed yet: both sizes unknown.
-                clip("00001.M2TS", 0, 30.0, 0),
-            ],
-            chapters: Vec::new(),
+            ..fixtures::playlist(
+                "00000.MPLS",
+                130.0,
+                vec![
+                    // A plain clip: a 500 KB `*.m2ts`, 1000 packets demuxed.
+                    sized_clip("00000.M2TS", 0, 100.0, 1000, 500_000, 0),
+                    // No file on disk, nothing demuxed yet: both sizes unknown.
+                    clip("00001.M2TS", 0, 30.0, 0),
+                ],
+            )
         }
     }
 

--- a/crates/bdinfo-rs-gui/src/selection.rs
+++ b/crates/bdinfo-rs-gui/src/selection.rs
@@ -106,31 +106,14 @@ impl Selection {
 
 #[cfg(test)]
 mod tests {
-    use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary};
+    use bdinfo_rs_core::bdrom::disc::{PlaylistSummary, fixtures};
 
     use super::Selection;
     use crate::model::playlist_rows;
 
-    /// A `ClipSummary` carrying just a name (the field the selection reads).
-    fn sample_clip(name: &str) -> ClipSummary {
-        ClipSummary {
-            name: name.to_owned(),
-            display_name: name.to_owned(),
-            file_size: 0,
-            interleaved_file_size: 0,
-            angle_index: 0,
-            relative_time_in: 0.0,
-            length: 0.0,
-            payload_bytes: 0,
-            packet_count: 0,
-            packet_seconds: 0.0,
-            file_seconds: 0.0,
-            streams: Vec::new(),
-        }
-    }
-
-    /// A `PlaylistSummary` carrying just a name, length, the two file sizes, and
-    /// its clip names — what the view-model + selection read.
+    /// A `PlaylistSummary` carrying just a name, length, its `*.m2ts` size, and
+    /// its clip names — what the view-model + selection read. The clips carry a
+    /// name only; nothing here reads their lengths.
     fn sample_playlist(
         name: &str,
         total_length: f64,
@@ -138,17 +121,8 @@ mod tests {
         clips: &[&str],
     ) -> PlaylistSummary {
         PlaylistSummary {
-            name: name.to_owned(),
-            total_length,
             file_size,
-            interleaved_file_size: 0,
-            chapter_count: 0,
-            stream_count: 0,
-            angle_count: 0,
-            has_loops: false,
-            streams: Vec::new(),
-            clips: clips.iter().map(|clip| sample_clip(clip)).collect(),
-            chapters: Vec::new(),
+            ..fixtures::playlist(name, total_length, fixtures::clips(clips, 0.0))
         }
     }
 

--- a/crates/bdinfo-rs-wasm/Cargo.toml
+++ b/crates/bdinfo-rs-wasm/Cargo.toml
@@ -44,6 +44,9 @@ js-sys = "0.3"
 web-sys = { version = "0.3", features = ["Blob", "File", "FileReaderSync"] }
 
 [dev-dependencies]
+# The analyzer library again, with the feature that exposes its summary
+# constructors (`bdinfo_rs_core::bdrom::disc::fixtures`) to the tests here.
+bdinfo-rs-core = { path = "../bdinfo-rs-core", features = ["test-fixtures"] }
 wasm-bindgen-test = "0.3"
 # The native stand-in for the browser serializer: the mirror wire-format tests
 # assert property names and value shapes, which are the same whichever

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -1614,32 +1614,14 @@ mod tests {
     /// CLI-parity selection helpers: the classification threshold and the
     /// by-name measured scan, native-tested.
     mod selection {
-        use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary};
+        use bdinfo_rs_core::bdrom::disc::{PlaylistSummary, fixtures};
         use bdinfo_rs_core::bdrom::order::PlaylistFilter;
 
         use crate::classification_filter;
 
-        /// A `ClipSummary` carrying just a name + length (the fields the
-        /// selection helpers read); the measured tallies stay zero.
-        fn sample_clip(name: &str, length: f64) -> ClipSummary {
-            ClipSummary {
-                name: name.to_owned(),
-                display_name: name.to_owned(),
-                file_size: 0,
-                interleaved_file_size: 0,
-                angle_index: 0,
-                relative_time_in: 0.0,
-                length,
-                payload_bytes: 0,
-                packet_count: 0,
-                packet_seconds: 0.0,
-                file_seconds: 0.0,
-                streams: Vec::new(),
-            }
-        }
-
         /// A `PlaylistSummary` carrying just what the selection/table helpers
-        /// read: name, length, the two file sizes, and its clip names.
+        /// read: name, length, the two file sizes, and its clip names (each
+        /// clip as long as the playlist).
         fn sample_playlist(
             name: &str,
             total_length: f64,
@@ -1648,17 +1630,9 @@ mod tests {
             clips: &[&str],
         ) -> PlaylistSummary {
             PlaylistSummary {
-                name: name.to_owned(),
-                total_length,
                 file_size,
                 interleaved_file_size,
-                chapter_count: 0,
-                stream_count: 0,
-                angle_count: 0,
-                has_loops: false,
-                streams: Vec::new(),
-                clips: clips.iter().map(|clip| sample_clip(clip, total_length)).collect(),
-                chapters: Vec::new(),
+                ..fixtures::playlist(name, total_length, fixtures::clips(clips, total_length))
             }
         }
 

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -988,7 +988,7 @@ mod tests {
 
     use bdinfo_rs_core::bdrom::chapters::ChapterSummary;
     use bdinfo_rs_core::bdrom::disc::{
-        BdRom, ClipStreamTally, ClipSummary, PlaylistSummary, ScanMode, StreamSummary,
+        BdRom, ClipStreamTally, ClipSummary, PlaylistSummary, ScanMode, StreamSummary, fixtures,
     };
     use bdinfo_rs_core::bdrom::order::PlaylistFilter;
     use bdinfo_rs_core::error;
@@ -1399,20 +1399,24 @@ mod tests {
     }
 
     /// The [`ClipSummary`] whose mirror is [`a_clip`].
+    ///
+    /// Every field is spelled with a value distinct from every other field's,
+    /// including the two the constructor already sets to them: the round-trip
+    /// test rebuilds this value through the mirror, so a field wired to the
+    /// wrong counterpart surfaces as an inequality rather than as a coincidence.
     fn a_core_clip() -> ClipSummary {
         ClipSummary {
-            name: "00001.M2TS".to_owned(),
             display_name: "00001.SSIF".to_owned(),
             file_size: 12,
             interleaved_file_size: 13,
             angle_index: 14,
             relative_time_in: 15.5,
-            length: 16.25,
             payload_bytes: 17,
             packet_count: 18,
             packet_seconds: 19.5,
             file_seconds: 20.5,
             streams: vec![a_core_clip_stream()],
+            ..fixtures::clip("00001.M2TS", 16.25)
         }
     }
 
@@ -1434,11 +1438,10 @@ mod tests {
         }
     }
 
-    /// The [`PlaylistSummary`] whose mirror is [`a_playlist`].
+    /// The [`PlaylistSummary`] whose mirror is [`a_playlist`] — every field
+    /// distinctly valued, for the reason [`a_core_clip`] records.
     fn a_core_playlist() -> PlaylistSummary {
         PlaylistSummary {
-            name: "00000.MPLS".to_owned(),
-            total_length: 3.5,
             file_size: 4,
             interleaved_file_size: 5,
             chapter_count: 6,
@@ -1446,8 +1449,8 @@ mod tests {
             angle_count: 8,
             has_loops: true,
             streams: vec![a_core_stream()],
-            clips: vec![a_core_clip()],
             chapters: vec![a_core_chapter()],
+            ..fixtures::playlist("00000.MPLS", 3.5, vec![a_core_clip()])
         }
     }
 

--- a/crates/bdinfo-rs/Cargo.toml
+++ b/crates/bdinfo-rs/Cargo.toml
@@ -110,6 +110,13 @@ clap = { workspace = true }
 # only — no C compiled), keeping the static-binary + no-C-deps guarantees.
 crossterm = { version = "0.29.0", default-features = false, features = ["windows", "events"] }
 
+# The same library again, with the feature that exposes its summary
+# constructors (`bdinfo_rs_core::bdrom::disc::fixtures`) to this crate's tests.
+# Cargo unifies this with the [dependencies] entry above only when a test target
+# is built, so the shipped binary still compiles the library without it.
+[dev-dependencies]
+bdinfo-rs-core = { workspace = true, features = ["test-fixtures"] }
+
 # Build-time ONLY — these never link into the shipped binary (they generate the
 # shell completions + man page in build.rs from the same `src/cli.rs` the binary
 # uses). All pure Rust (no C / FFI), so the single-static-binary guarantee and

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -1004,7 +1004,7 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::time::{Duration, Instant};
 
-    use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary, ScanProgress};
+    use bdinfo_rs_core::bdrom::disc::{PlaylistSummary, ScanProgress, fixtures};
     use bdinfo_rs_core::bdrom::order::{PlaylistFilter, table_rows};
     use bdinfo_rs_core::error::{BdError, ScanError, ScanStage};
     use bdinfo_rs_core::report::text::RenderOptions;
@@ -1746,37 +1746,10 @@ Options:
         assert!(line.starts_with("Scanning 100% - 00000.M2TS"));
     }
 
-    /// A playlist summary carrying only what the selection flow reads.
+    /// A playlist summary carrying only what the selection flow reads: name,
+    /// total length, and its clip names (each clip as long as the playlist).
     fn summary(name: &str, total_length: f64, clips: &[&str]) -> PlaylistSummary {
-        PlaylistSummary {
-            name: name.to_owned(),
-            total_length,
-            file_size: 0,
-            interleaved_file_size: 0,
-            chapter_count: 0,
-            stream_count: 0,
-            angle_count: 0,
-            has_loops: false,
-            streams: Vec::new(),
-            clips: clips
-                .iter()
-                .map(|clip| ClipSummary {
-                    name: (*clip).to_owned(),
-                    display_name: (*clip).to_owned(),
-                    file_size: 0,
-                    interleaved_file_size: 0,
-                    angle_index: 0,
-                    relative_time_in: 0.0,
-                    length: total_length,
-                    payload_bytes: 0,
-                    packet_count: 0,
-                    packet_seconds: 0.0,
-                    file_seconds: 0.0,
-                    streams: Vec::new(),
-                })
-                .collect(),
-            chapters: Vec::new(),
-        }
+        fixtures::playlist(name, total_length, fixtures::clips(clips, total_length))
     }
 
     #[test]


### PR DESCRIPTION
Eleven test sites across the four crates hand-wrote every field of ClipSummary
(12 fields) or PlaylistSummary (11): core order.rs, report/text.rs and disc.rs;
the CLI; the GUI's model.rs, selection.rs, flow.rs, main.rs and panes.rs; the
wasm crate's lib.rs and mirror.rs. A field added to either struct forced an edit
at each one, across workspace boundaries that cfg(test) support cannot cross.

## What changed

bdrom::disc::fixtures holds three constructors -- clip, clips, playlist --
taking the few fields a test varies and zeroing the rest. Every site now keeps
only its own intent, expressed through struct update syntax, which a later field
addition does not break. The wasm mirror fixtures still spell each field with a
distinct value, because their round-trip test is what proves the mirror maps
each field to the right counterpart; they are simply no longer exhaustive.

The module is off by default and adds nothing to a normal build. It reaches the
other crates through the core library's first cargo feature, test-fixtures:

- CLI: a dev-dependency on the library with the feature. Cargo unifies it with
  the existing dependency only when a test target is built.
- wasm and GUI (independent workspaces): a path-only dev-dependency, with no
  version key, so cargo drops it when the crate is packaged. Verified against
  this cargo: a path-only dev-dependency is absent from the generated manifest
  in the produced .crate, so the GUI's crates.io publish is unaffected.

The hack gate step (feature-powerset clippy) does real work now that a features
table exists; it passes.

## Also fixed

Both TempDisc test helpers (core disc.rs and vfs/fs.rs) named their temp
directory after the process id, which the operating system reuses, and a run
killed before Drop leaves the directory behind. create_dir_all then adopted it,
so a disc built to lack CLIPINF was handed the files of whichever test held that
name in an earlier run and opened successfully. This turned up as two red gate
runs on this branch, from 21 stale directories left by earlier runs. Both
helpers now clear a leftover before creating. Proven with a seeded collision:
the affected test fails against it without the change and passes with it.

## Verification

All three gates pass on the committed branch. Core: 1016 tests, 100% lines /
regions / functions (22739, 43005, 2233), branches 97.71%, mutants 4 found, 1
caught, 3 unviable. wasm: 100% (1648, 2499, 190), every Node and Chrome parity
and demo check green. GUI: 263 tests, 100% (4059, 7612, 589). Report fixtures
are byte-identical -- the golden cross-product test passes.

Grep proof: no exhaustive ClipSummary or PlaylistSummary literal remains in test
code. Every remaining literal is either a struct-update form or production code
(the mirror's From impls and the two build sites in disc.rs).
