### PR TITLE
ci: evaluate coverage floors and parity checks through shared scripts

### DIFF
--- a/.github/scripts/classify-diff.ps1
+++ b/.github/scripts/classify-diff.ps1
@@ -309,6 +309,20 @@ begin {
             Match      = { param($f) (Test-Match $f @('.github/scripts/gui-*.ps1')) }
         },
         @{
+            Name       = 'wasm gate script'
+            Areas      = @('wasm')
+            Structural = $true
+            Why        = 'The wasm workflow runs it directly, twice: the LICENSE/NOTICE parity check and the unsafe-token tripwire.'
+            Match      = { param($f) (Test-Match $f @('.github/scripts/wasm-*.ps1')) }
+        },
+        @{
+            Name       = 'coverage floor script'
+            Areas      = @('gui', 'wasm')
+            Structural = $true
+            Why        = 'Both sibling-crate workflows hand it their llvm-cov export, so it decides both coverage verdicts. The root workspace enforces its floors through cargo-llvm-cov''s own --fail-under flags and never reads this script.'
+            Match      = { param($f) $f -eq '.github/scripts/cov-floor.ps1' }
+        },
+        @{
             Name       = 'linux package script'
             Areas      = @('pkg')
             Structural = $true
@@ -489,6 +503,8 @@ end {
             @{ Path = '.github/workflows/gui.yml'; Areas = 'gui links typos workflows yaml' }
             @{ Path = '.github/workflows/docker.yml'; Areas = 'links typos workflows yaml' }
             @{ Path = '.github/scripts/gui-package-windows.ps1'; Areas = 'gui links typos' }
+            @{ Path = '.github/scripts/wasm-rules.ps1'; Areas = 'links typos wasm' }
+            @{ Path = '.github/scripts/cov-floor.ps1'; Areas = 'gui links typos wasm' }
             @{ Path = '.github/scripts/publish-gui-aur.ps1'; Areas = 'links typos' }
             @{ Path = 'packaging/aur/PKGBUILD.template'; Areas = 'links typos' }
             @{ Path = 'Dockerfile'; Areas = 'links typos' }

--- a/.github/scripts/cov-floor.ps1
+++ b/.github/scripts/cov-floor.ps1
@@ -1,0 +1,127 @@
+#!/usr/bin/env pwsh
+# Coverage-floor evaluator over a cargo-llvm-cov JSON export, enforced
+# IDENTICALLY by the local gates (scripts/compliance.ps1,
+# scripts/wasm-compliance.ps1, scripts/gui-compliance.ps1) and CI (the coverage
+# steps in wasm.yml and gui.yml). This script is the single source of truth for
+# all five, exactly like .github/scripts/source-rules.ps1 and gui-rules.ps1.
+#
+# The line/region/function floor is exact — covered == count, never a rounded
+# percentage — so a single uncovered line cannot round its way to 100.00%.
+# -Include/-Exclude select the measured denominator: a crate whose coverage
+# report also carries a path dependency's files filters by crate directory, and
+# a crate that verifies part of its surface by other means (rendered pixels,
+# byte-exact parity) excludes those files by name.
+#
+# The BRANCH floors are percentages rather than covered == count, and they are
+# PLATFORM-VARIANT: a library with #[cfg(windows)] arms has a different branch
+# count on each host, so the same source clears a floor on one OS and misses it
+# on another. Only a caller that knows it runs on one developer's machine may
+# pass them; a CI caller enforces the platform-invariant three and leaves
+# -BranchFloor / -FileBranchFloor unset.
+#
+# Prints one line per metric, and on failure the per-file breakdown naming every
+# file with a gap — the totals alone never say WHICH file is short. Exits 1 on
+# any shortfall (or when the filters select no file at all), 0 when clean.
+
+[CmdletBinding()]
+param(
+    # The --json --output-path export of `cargo llvm-cov`.
+    [Parameter(Mandatory)]
+    [string] $JsonPath,
+
+    # Regex a file's path must match to enter the denominator. Empty = every
+    # file in the report.
+    [string] $Include = '',
+
+    # Regex a file's path must NOT match to enter the denominator. Empty = no
+    # exclusions.
+    [string] $Exclude = '',
+
+    # Names the measured surface in the pass/fail lines.
+    [string] $Label = 'coverage',
+
+    # Minimum branch percentage over the whole denominator. 0 = not enforced.
+    [int] $BranchFloor = 0,
+
+    # Minimum branch percentage for each individual file. 0 = not enforced.
+    [int] $FileBranchFloor = 0,
+
+    # Files with fewer branches than this are exempt from -FileBranchFloor: a
+    # file with two branches reads as 50% the moment one arm is unreachable by
+    # construction, which says nothing about how well it is tested.
+    [int] $FileBranchMinCount = 5
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$data = (Get-Content -LiteralPath $JsonPath -Raw | ConvertFrom-Json).data[0]
+
+$files = @($data.files)
+if ($Include) { $files = @($files | Where-Object { $_.filename -match $Include }) }
+if ($Exclude) { $files = @($files | Where-Object { $_.filename -notmatch $Exclude }) }
+
+if (-not $files.Count) {
+    Write-Host "FAILED: $Label — the coverage report holds no file matching the measured surface." -ForegroundColor Red
+    if ($Include) { Write-Host "    include: $Include" -ForegroundColor DarkGray }
+    if ($Exclude) { Write-Host "    exclude: $Exclude" -ForegroundColor DarkGray }
+    exit 1
+}
+
+# Summed from the selected files rather than read from the report's own totals,
+# which describe every file it measured — including the ones the filters drop.
+function Get-MetricTotal {
+    param([object[]] $File, [string] $Metric)
+    $covered = (@($File | ForEach-Object { $_.summary.$Metric.covered }) | Measure-Object -Sum).Sum
+    $count = (@($File | ForEach-Object { $_.summary.$Metric.count }) | Measure-Object -Sum).Sum
+    return [pscustomobject]@{
+        Covered = $covered
+        Count   = $count
+        Percent = if ($count) { 100.0 * $covered / $count } else { 100.0 }
+    }
+}
+
+$failures = @()
+
+foreach ($metric in @('lines', 'regions', 'functions')) {
+    $t = Get-MetricTotal -File $files -Metric $metric
+    Write-Host ("    {0,-10}{1,7:N2}%  ({2}/{3})" -f $metric, $t.Percent, $t.Covered, $t.Count) -ForegroundColor DarkGray
+    if ($t.Covered -lt $t.Count) {
+        $failures += "$metric $([math]::Round($t.Percent, 2))% < 100% ($($t.Covered)/$($t.Count))"
+    }
+}
+
+if ($BranchFloor -gt 0) {
+    $b = Get-MetricTotal -File $files -Metric 'branches'
+    Write-Host ("    {0,-10}{1,7:N2}%  ({2}/{3})  floor {4}%" -f 'branches', $b.Percent, $b.Covered, $b.Count, $BranchFloor) -ForegroundColor DarkGray
+    if ($b.Percent -lt $BranchFloor) {
+        $failures += "branches $([math]::Round($b.Percent, 2))% < $BranchFloor% floor"
+    }
+}
+
+if ($FileBranchFloor -gt 0) {
+    foreach ($f in $files) {
+        $fb = $f.summary.branches
+        if ($fb.count -ge $FileBranchMinCount -and $fb.percent -lt $FileBranchFloor) {
+            $leaf = Split-Path $f.filename -Leaf
+            $failures += "branches[$leaf] $([math]::Round($fb.percent, 2))% < $FileBranchFloor% per-file floor ($($fb.covered)/$($fb.count))"
+        }
+    }
+}
+
+if (-not $failures.Count) { exit 0 }
+
+Write-Host "FAILED: $Label below floor (ratchets only go UP):" -ForegroundColor Red
+$failures | ForEach-Object { Write-Host "    $_" -ForegroundColor DarkGray }
+
+Write-Host '    files with an uncovered line/region/function:' -ForegroundColor DarkGray
+foreach ($f in $files) {
+    $gaps = @()
+    foreach ($metric in @('functions', 'lines', 'regions')) {
+        $s = $f.summary.$metric
+        if ($s.covered -lt $s.count) { $gaps += ("{0} {1}/{2}" -f $metric, $s.covered, $s.count) }
+    }
+    if ($gaps.Count) { Write-Host "      $(Split-Path $f.filename -Leaf):  $($gaps -join '  ')" -ForegroundColor DarkGray }
+}
+
+exit 1

--- a/.github/scripts/wasm-rules.ps1
+++ b/.github/scripts/wasm-rules.ps1
@@ -1,0 +1,66 @@
+#!/usr/bin/env pwsh
+# Tripwire guards for the BROWSER package (crates/bdinfo-rs-wasm) — the two
+# rules no clippy lint covers, enforced IDENTICALLY by the local gate
+# (scripts/wasm-compliance.ps1) and CI (the `gate` job in wasm.yml). This script
+# is the single source of truth for both, exactly like
+# .github/scripts/gui-rules.ps1 and source-rules.ps1.
+#
+#   -Check licenses
+#       The npm tarball ships web/ copies of the repo-root LICENSE and NOTICE:
+#       under the LGPL the license text and the use-notice must travel with the
+#       statically-linked code. They are MANUAL copies, so assert each still
+#       matches its root original byte for byte (re-copy on drift). Cheap and
+#       toolchain-free, so a caller can run it before installing anything.
+#   -Check unsafe
+#       Exactly three `unsafe` tokens in src/lib.rs, all of them cfg-gated
+#       marker impls: `unsafe impl Send for WebFile` (the folder backend) plus
+#       `unsafe impl Send` and `unsafe impl Sync for WebIso` (the .iso backend —
+#       IsoReader requires Send + Sync, so that marker needs both impls). Any
+#       other count is a new unsafe block or a deleted marker, and either is a
+#       deliberate decision that this count records. Unlike the GUI crate, which
+#       carries #![forbid(unsafe_code)], these three are the memory-safety
+#       exception the browser bindings need, so the guard is a fixed count
+#       rather than zero.
+#
+# Exits 1 naming the offender on any violation, 0 when clean.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('licenses', 'unsafe')]
+    [string] $Check,
+
+    # Default: crates/bdinfo-rs-wasm relative to this script (.github/scripts/).
+    [string] $Crate = [System.IO.Path]::Combine($PSScriptRoot, '..', '..', 'crates', 'bdinfo-rs-wasm')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$crate = (Resolve-Path -LiteralPath $Crate).Path
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $crate '..' '..')).Path
+
+if ($Check -eq 'licenses') {
+    foreach ($name in @('LICENSE', 'NOTICE')) {
+        $rootHash = (Get-FileHash -LiteralPath (Join-Path $repoRoot $name) -Algorithm SHA256).Hash
+        $webHash = (Get-FileHash -LiteralPath (Join-Path $crate 'web' $name) -Algorithm SHA256).Hash
+        if ($rootHash -ne $webHash) {
+            Write-Host "FAILED: crates/bdinfo-rs-wasm/web/$name does not match the repo-root $name (re-copy it)." -ForegroundColor Red
+            exit 1
+        }
+        Write-Host "    ok: web/$name matches root" -ForegroundColor DarkGray
+    }
+    exit 0
+}
+
+# Strip // comments before counting: the module and SAFETY docs say "unsafe" in
+# prose, so a bare match would count those too. `\bunsafe\b` also leaves
+# `unsafe_code` alone.
+$code = ((Get-Content -LiteralPath (Join-Path $crate 'src/lib.rs')) -replace '//.*$', '') -join "`n"
+$found = ([regex]::Matches($code, '\bunsafe\b')).Count
+if ($found -ne 3) {
+    Write-Host "FAILED: expected exactly 3 unsafe tokens in src/lib.rs (cfg-gated WebFile Send + WebIso Send/Sync), found $found" -ForegroundColor Red
+    exit 1
+}
+Write-Host '    ok: 3 unsafe tokens (cfg-gated WebFile Send + WebIso Send/Sync)' -ForegroundColor DarkGray
+exit 0

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -365,23 +365,14 @@ jobs:
       - name: Coverage (llvm-cov nextest — Tier A 100% lines/regions/functions)
         working-directory: crates/bdinfo-rs-gui
         shell: pwsh
+        # The floor itself lives in the single-source .github/scripts/cov-floor.ps1
+        # the local gate runs too. No branch floor is passed — branch counts are
+        # platform-variant (see cov-floor.ps1).
         run: |
           $json = Join-Path $env:RUNNER_TEMP 'gui-cov.json'
           cargo "+$env:NIGHTLY" llvm-cov nextest --locked --no-tests=fail --json --output-path $json
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $files = @((Get-Content -Raw $json | ConvertFrom-Json).data[0].files |
-              Where-Object { $_.filename -match 'bdinfo-rs-gui[\\/]src[\\/]' -and
-                  $_.filename -notmatch '[\\/]src[\\/](main|ui)\.rs$' })
-          if (-not $files.Count) { Write-Host 'no Tier-A src files in the coverage report'; exit 1 }
-          $fail = @()
-          foreach ($m in 'lines', 'regions', 'functions') {
-            $covered = (@($files | ForEach-Object { $_.summary.$m.covered }) | Measure-Object -Sum).Sum
-            $count = (@($files | ForEach-Object { $_.summary.$m.count }) | Measure-Object -Sum).Sum
-            $pct = if ($count) { 100.0 * $covered / $count } else { 100.0 }
-            Write-Host ("{0,-10}{1,7:N2}%  ({2}/{3})" -f $m, $pct, $covered, $count)
-            if ($covered -lt $count) { $fail += "$m $covered/$count" }
-          }
-          if ($fail.Count) { Write-Host "coverage below 100%: $($fail -join ', ')"; exit 1 }
+          ../../.github/scripts/cov-floor.ps1 -JsonPath $json -Label 'GUI coverage' -Include 'bdinfo-rs-gui[\\/]src[\\/]' -Exclude '[\\/]src[\\/](main|ui)\.rs$'
 
   # The declared MSRV is enforced, not decorative: build with exactly the
   # rust-version toolchain from Cargo.toml, read from the manifest at run time

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -4,11 +4,13 @@ name: link-check
 # relative/file link across the repo (README, CHANGELOG, DIFFERENCES,
 # CONTRIBUTING, the issue templates, the Cargo/audit metadata, and the
 # doc-comment URLs in src), daily — external pages move without touching our
-# code, so links rot after merge. The PR/push leg is the identically-named job
-# in repo.yml, plan-gated on the `links` area. Cheap: lychee caches its results
-# and only re-checks day-old links; a residual rate-limit
-# (429) is accepted rather than failed, so an external host can't red-X an
-# unrelated run.
+# code, so links rot after merge.
+#
+# The job itself is repo.yml's `links`, invoked here with only the `links` area
+# asserted so the other four scanners in that reusable report `skipped`. The
+# PR/push leg is the same job, invoked by ci.yml with the areas its plan
+# computed; the daily sweep re-runs that leg ungated. One definition, three
+# callers — the exclusion list and the accepted 429 cannot drift between them.
 
 on:
   schedule:
@@ -24,42 +26,10 @@ concurrency:
 
 jobs:
   links:
-    name: Check links
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # Persist lychee's response cache so reruns only re-check day-old links.
-      - name: Restore the lychee cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .lycheecache
-          key: lychee-${{ github.run_id }}
-          restore-keys: lychee-
-
-      - name: Check links
-        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
-        with:
-          # Whole repo; skip the generated lockfile and the binary fuzz seed
-          # corpus (the binary disc fixtures are skipped automatically by their
-          # non-text extensions). The golden disc reports are byte-exact BDInfo
-          # output: the two URLs they carry (cinemasquid/avsforum) are part of
-          # the locked format and reproduce a defunct tool's text verbatim, so
-          # they're pinned, not maintainable link surface — exclude them.
-          # Accept 429 so an external host's rate-limit can't fail the gate;
-          # fail:true turns any broken link into a failure.
-          args: >-
-            --cache
-            --max-cache-age 1d
-            --no-progress
-            --accept 200..=299,429
-            --exclude-path Cargo.lock
-            --exclude-path fuzz/corpus
-            --exclude-path crates/bdinfo-rs/tests/fixtures/golden
-            --exclude-path crates/bdinfo-rs-wasm/tests/golden_report.txt
-            .
-          fail: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/repo.yml
+    with:
+      yaml: "false"
+      toml: "false"
+      workflows: "false"
+      typos: "false"
+      links: "true"

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -14,6 +14,11 @@ name: repo
 # are the caller's — so it can never fire on its own and never needs a paths
 # filter.
 #
+# Two further callers assert ONE area each on a daily schedule, because the two
+# scanners they name have verdicts that change without the repository changing:
+# zizmor.yml (a newly-disclosed vulnerable action) and link-check.yml (an
+# external page that moved). They reach the identical job definitions here.
+#
 # Every job here scans the tree rather than producing an artifact from it, so
 # every verdict is arch-invariant and each job runs on `ubuntu-24.04-arm`
 # (rationale in core.yml).
@@ -151,9 +156,9 @@ jobs:
   # finding, like the other quality gates. The only accepted residuals live in
   # .github/zizmor.yml (the cargo-dist-generated v-release.yml, which cannot be
   # hand-edited) and inline (the two architecturally-required workflow_run triggers);
-  # every hand-maintained workflow is fixed in place, not suppressed. This is the
-  # PR/push leg; the daily cron leg (newly-disclosed action vulns surface between
-  # pushes) stays in zizmor.yml.
+  # every hand-maintained workflow is fixed in place, not suppressed. zizmor.yml
+  # calls this job daily as well, since a newly-disclosed action vulnerability
+  # surfaces between pushes.
   zizmor:
     name: zizmor (workflow security)
     if: inputs.workflows == 'true'
@@ -179,9 +184,9 @@ jobs:
   # Cargo/audit metadata, and the doc-comment URLs in src). Cheap: lychee caches
   # its results and only re-checks day-old links; a residual rate-limit (429) is
   # accepted rather than failed, so an external host can't red-X an unrelated
-  # push. This is the PR/push leg (`docs` = any .md or .rs, since doc-comments
-  # carry links); the daily cron leg (links rot after merge without touching our
-  # code) stays in link-check.yml.
+  # push. The `links` area is any .md or .rs, since doc-comments carry links.
+  # link-check.yml calls this job daily as well, since links rot after merge
+  # without touching our code.
   # typos reads the whole working tree (minus files.extend-exclude in
   # typos.toml), so prose changes reach it while changing no Rust source. It is
   # its own job rather than a step of `lint` for that reason: the rest of that

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -54,21 +54,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # The npm tarball ships web/ copies of the repo-root LICENSE + NOTICE (LGPL:
-      # the license text + use-notice must travel with the statically-linked
-      # code). They are MANUAL copies, so assert they still match root byte-for-byte
-      # and fail on drift (re-copy them). Cheap + dependency-free, so it runs first.
+      # The LGPL hygiene rule that the npm tarball's web/ LICENSE + NOTICE copies
+      # still match their repo-root originals — the single-source script the
+      # local gate runs too. Cheap + dependency-free, so it runs first.
       - name: LICENSE/NOTICE parity (web copies match the repo root)
         shell: pwsh
-        run: |
-          foreach ($name in 'LICENSE', 'NOTICE') {
-            $root = (Get-FileHash -LiteralPath $name -Algorithm SHA256).Hash
-            $web = (Get-FileHash -LiteralPath "crates/bdinfo-rs-wasm/web/$name" -Algorithm SHA256).Hash
-            if ($root -ne $web) {
-              throw "$name drift: crates/bdinfo-rs-wasm/web/$name does not match the repo-root $name (re-copy it)."
-            }
-            Write-Host "ok: web/$name matches root"
-          }
+        run: ./.github/scripts/wasm-rules.ps1 -Check licenses
 
       - name: Install pinned nightly rustfmt + llvm-tools (for llvm-cov)
         run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component rustfmt --component llvm-tools-preview
@@ -124,17 +115,12 @@ jobs:
         working-directory: crates/bdinfo-rs-wasm/web
         run: npm ci
 
+      # The fixed unsafe-token count in src/lib.rs (the cfg-gated marker impls the
+      # browser bindings need) — the same single-source script, which carries the
+      # count and what each token is.
       - name: Unsafe tripwire (exactly three unsafe tokens in lib.rs)
-        working-directory: crates/bdinfo-rs-wasm
         shell: pwsh
-        # Three cfg-gated marker impls: `unsafe impl Send for WebFile` (folder
-        # backend) + `unsafe impl Send`/`Sync for WebIso` (the .iso backend —
-        # IsoReader requires Send + Sync, so the marker needs both impls).
-        run: |
-          $code = (Get-Content -LiteralPath src/lib.rs) -replace '//.*$', ''
-          $n = ([regex]::Matches(($code -join "`n"), '\bunsafe\b')).Count
-          if ($n -ne 3) { Write-Host "expected exactly 3 unsafe tokens (cfg-gated WebFile Send + WebIso Send/Sync), found $n"; exit 1 }
-          Write-Host "ok: $n unsafe tokens (cfg-gated WebFile Send + WebIso Send/Sync)"
+        run: ./.github/scripts/wasm-rules.ps1 -Check unsafe
 
       - name: Format (nightly rustfmt)
         working-directory: crates/bdinfo-rs-wasm
@@ -186,22 +172,17 @@ jobs:
         shell: pwsh
         env:
           NIGHTLY: ${{ env.NIGHTLY }}
+        # The floor itself lives in the single-source .github/scripts/cov-floor.ps1
+        # the local gate runs too. The crate's own src/ is the denominator: the
+        # bdinfo-rs-core path dependency is measured by the root workspace, and
+        # the browser glue is #[cfg(target_arch = "wasm32")]-gated out of this
+        # native build. No branch floor is passed — branch counts are
+        # platform-variant (see cov-floor.ps1).
         run: |
           $json = Join-Path $env:RUNNER_TEMP 'wasm-cov.json'
           cargo "+$env:NIGHTLY" llvm-cov nextest --locked --no-tests=fail --json --output-path $json
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $files = @((Get-Content -Raw $json | ConvertFrom-Json).data[0].files |
-              Where-Object { $_.filename -match 'bdinfo-rs-wasm[\\/]src[\\/]' })
-          if (-not $files.Count) { Write-Host 'no wasm src files in the coverage report'; exit 1 }
-          $fail = @()
-          foreach ($m in 'lines', 'regions', 'functions') {
-            $covered = (@($files | ForEach-Object { $_.summary.$m.covered }) | Measure-Object -Sum).Sum
-            $count = (@($files | ForEach-Object { $_.summary.$m.count }) | Measure-Object -Sum).Sum
-            $pct = if ($count) { 100.0 * $covered / $count } else { 100.0 }
-            Write-Host ("{0,-10}{1,7:N2}%  ({2}/{3})" -f $m, $pct, $covered, $count)
-            if ($covered -lt $count) { $fail += "$m $covered/$count" }
-          }
-          if ($fail.Count) { Write-Host "coverage below 100%: $($fail -join ', ')"; exit 1 }
+          ../../.github/scripts/cov-floor.ps1 -JsonPath $json -Label 'wasm coverage' -Include 'bdinfo-rs-wasm[\\/]src[\\/]'
 
       - name: Build the browser artifact (wasm-bindgen + wasm-opt -Oz + tsc)
         working-directory: crates/bdinfo-rs-wasm/web

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,13 +5,14 @@ name: zizmor
 # unpinned/impostor actions, cache poisoning, dangerous triggers, credential
 # persistence, and more), daily — zizmor floats at latest and the audits are
 # partly ONLINE (impostor-commit / known-vulnerable-actions via the GitHub
-# API), so a newly-disclosed vulnerable action surfaces between pushes. The
-# PR/push leg is the identically-named job in repo.yml, plan-gated on the
-# `workflows` area; the daily sweep re-runs that leg ungated too. The only accepted
-# residuals live in .github/zizmor.yml (the cargo-dist-generated v-release.yml,
-# which cannot be hand-edited) and inline (the two architecturally-required
-# workflow_run triggers); every hand-maintained workflow is fixed in place, not
-# suppressed.
+# API), so a newly-disclosed vulnerable action surfaces between pushes.
+#
+# The job itself is repo.yml's `zizmor`, invoked here with only the `workflows`
+# area asserted so the other four scanners in that reusable report `skipped`.
+# The PR/push leg is the same job, invoked by ci.yml with the areas its plan
+# computed; the daily sweep re-runs that leg ungated. One definition, three
+# callers — the audit set, the pinned action digests and the accepted residuals
+# cannot drift between them.
 
 on:
   schedule:
@@ -27,26 +28,10 @@ concurrency:
 
 jobs:
   zizmor:
-    name: zizmor (workflow security)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # `fallback: none`: install only from install-action's checksummed manifest,
-      # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
-      - name: Install zizmor (prebuilt, no from-source compile)
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
-        with:
-          tool: zizmor
-          fallback: none
-
-      # Audit every workflow at full strength. The token enables the online audits
-      # (impostor-commit, known-vulnerable-actions); .github/zizmor.yml is
-      # auto-discovered for the accepted v-release.yml residuals. zizmor exits
-      # non-zero when any finding remains, which fails the gate.
-      - name: Audit the workflows
-        run: zizmor .github/workflows
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/repo.yml
+    with:
+      yaml: "false"
+      toml: "false"
+      workflows: "true"
+      typos: "false"
+      links: "false"


### PR DESCRIPTION
The llvm-cov floor evaluator existed in four copies: the coverage steps in
`gui.yml` and `wasm.yml`, and the `cov` steps of the two local gate scripts. The
two CI copies had dropped the per-file gap breakdown, so a CI coverage failure
named no file. The wasm unsafe-token tripwire and the LICENSE/NOTICE parity
check each had two homes as well.

All three now live in tracked scripts that both sides call, as
`source-rules.ps1` and `gui-rules.ps1` already do:

- `.github/scripts/cov-floor.ps1` filters the llvm-cov JSON by crate (with an
  exclude regex for the GUI exemption), enforces covered == count on
  lines/regions/functions, and always prints the per-file gap breakdown on
  failure. Its optional branch-percentage floors are passed by the root local
  gate alone: branch counts are platform-variant, so CI keeps enforcing only the
  platform-invariant three.
- `.github/scripts/wasm-rules.ps1 -Check licenses|unsafe` holds the two wasm
  tripwires, so the token count of 3 and its justification have one home.

`zizmor.yml` and `link-check.yml` were byte-copies of jobs inside `repo.yml`,
which is already a `workflow_call` reusable with per-area inputs. Each now calls
it with one area asserted, which deletes the duplicated 20-line lychee argument
list and moves both onto the same arm runner the rest of that file uses. Their
check runs render prefixed; no required check name changes.

No floor, filter or allowance changes. Verified: the root gate cov step judges
the same export identically before and after (lines/regions/functions 100%,
branches 97.71%, no per-file miss); both sibling gates pass through the shared
scripts; the classifier self-test passes with rules for the three new paths.