### PR TITLE
ci: consolidate the publish-lane scripts and package jobs

### DIFF
--- a/.github/scripts/_common.ps1
+++ b/.github/scripts/_common.ps1
@@ -1,0 +1,121 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Helpers shared by the publish lanes.
+
+.DESCRIPTION
+    Dot-source this file; every function below then runs in the caller's scope:
+
+        . "$PSScriptRoot/_common.ps1"                        # from a script
+        . ./.github/scripts/_common.ps1                      # from a workflow step
+
+    Callers keep their own three-line preamble
+
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $false
+
+    ahead of the dot-source: it has to be in force before this file is read, and
+    the third line is what makes the `if ($LASTEXITCODE -ne 0)` checks these
+    scripts are built on reachable at all — with it left at $true a non-zero exit
+    from a native command throws instead.
+
+    Consumers: the publish-gui-*.ps1 channel legs, cloudsmith-push.ps1, and the
+    inline pwsh steps of publish-crates.yml and publish-npm.yml.
+#>
+
+# Fail a publishing leg. Never a `throw`: these run as the whole body of a
+# workflow step, where the exit code is the verdict and a bare error record
+# buries the reason in a stack trace.
+function Stop-Leg {
+    param([Parameter(Mandatory)] [string] $Why)
+
+    Write-Host "FAILED: $Why" -ForegroundColor Red
+    exit 1
+}
+
+# Parse a SHA256SUMS file into a filename -> lower-case hex hash map, accepting
+# both the plain and the binary-marker (`*name`) coreutils spellings.
+#
+# -Strict rejects a line that matches neither, for the caller that is proving
+# the file itself well-formed rather than looking a known name up in it.
+#
+# The parameter is -Path, not -Sums, and the local is $shaByName: PowerShell
+# variable names are case-insensitive, so a `$sums` local inside a function
+# taking `$Sums` overwrites the path before the loop reads it.
+function Get-Sha256Sums {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [switch] $Strict
+    )
+
+    $shaByName = @{}
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if ($line -match '^([0-9a-f]{64})\s+\*?(.+)$') { $shaByName[$Matches[2].Trim()] = $Matches[1] }
+        elseif ($Strict) { Stop-Leg "unparseable SHA256SUMS line: $line" }
+    }
+    return $shaByName
+}
+
+# The X.Y.Z of a stable `gui-v*` tag. Stable only — a prerelease suffix never
+# reaches a package manager (the packages.yml gate's rule).
+function Get-GuiTagVersion {
+    param([Parameter(Mandatory)] [string] $Tag)
+
+    if ($Tag -notmatch '^gui-v(\d+\.\d+\.\d+)$') { Stop-Leg "tag '$Tag' is not a stable gui-vX.Y.Z tag" }
+    return $Matches[1]
+}
+
+# The X.Y.Z base of a `v*` release tag, with any prerelease suffix stripped.
+# The CLI lanes publish prereleases (npm under the `next` dist-tag, crates.io as
+# a prerelease version), so unlike the GUI tag above the suffix is accepted, not
+# rejected; what the callers compare against a manifest is the base.
+function Get-ReleaseTagBase {
+    param([Parameter(Mandatory)] [string] $Tag)
+
+    if ($Tag -notmatch '^v(?<base>\d+\.\d+\.\d+)(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$') {
+        Stop-Leg "tag '$Tag' is not vMAJOR.MINOR.PATCH[-prerelease]"
+    }
+    return $Matches['base']
+}
+
+# The version cargo would publish for a package, read from cargo itself rather
+# than from the manifest text: a crate inheriting `version.workspace = true`
+# carries no version line of its own, and a hand-rolled line parser has to know
+# which table it is in to avoid reading a dependency's version instead.
+#
+# -ManifestPath selects a workspace other than the one the working directory
+# resolves to; the sibling crates are excluded workspaces and need it.
+function Get-CrateVersion {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [string] $ManifestPath
+    )
+
+    $cargoArgs = @('metadata', '--no-deps', '--format-version', '1')
+    if ($ManifestPath) { $cargoArgs += @('--manifest-path', $ManifestPath) }
+    $json = & cargo @cargoArgs | Out-String
+    if ($LASTEXITCODE -ne 0) { Stop-Leg "cargo metadata failed while reading the version of $Name" }
+
+    $found = @(($json | ConvertFrom-Json).packages | Where-Object { $_.name -eq $Name })
+    if ($found.Count -ne 1) { Stop-Leg "cargo metadata names $($found.Count) packages called $Name, expected exactly one" }
+    return $found[0].version
+}
+
+# Render a packaging template by literal placeholder substitution and prove the
+# render complete. The assertion is the point: a template gaining a placeholder
+# that its caller does not fill would otherwise ship the literal `__NAME__` to a
+# package manager.
+function Expand-Template {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [System.Collections.IDictionary] $Values
+    )
+
+    $text = Get-Content -LiteralPath $Path -Raw
+    foreach ($placeholder in $Values.Keys) { $text = $text.Replace($placeholder, $Values[$placeholder]) }
+    if ($text -match '__[A-Z0-9_]+__') { Stop-Leg "an unreplaced placeholder survived the render: $($Matches[0])" }
+    return $text
+}

--- a/.github/scripts/classify-diff.ps1
+++ b/.github/scripts/classify-diff.ps1
@@ -379,8 +379,8 @@ begin {
             Name       = 'publishing helpers'
             Areas      = @()
             Structural = $true
-            Why        = 'Run only by the tag and dispatch publishing lanes, which the orchestrator never calls; their dry runs verify them.'
-            Match      = { param($f) Test-Match $f @('.github/scripts/publish-*.ps1') }
+            Why        = 'Run only by the tag and dispatch publishing lanes, which the orchestrator never calls; their dry runs verify them. _common.ps1 carries what those legs share and cloudsmith-push.ps1 the package push both the CLI and the GUI lane call, so the two are named here as well as the publish-* legs.'
+            Match      = { param($f) Test-Match $f @('.github/scripts/publish-*.ps1', '.github/scripts/_common.ps1', '.github/scripts/cloudsmith-push.ps1') }
         },
         @{
             Name       = 'banned-word and classifier scripts'
@@ -506,6 +506,8 @@ end {
             @{ Path = '.github/scripts/wasm-rules.ps1'; Areas = 'links typos wasm' }
             @{ Path = '.github/scripts/cov-floor.ps1'; Areas = 'gui links typos wasm' }
             @{ Path = '.github/scripts/publish-gui-aur.ps1'; Areas = 'links typos' }
+            @{ Path = '.github/scripts/_common.ps1'; Areas = 'links typos' }
+            @{ Path = '.github/scripts/cloudsmith-push.ps1'; Areas = 'links typos' }
             @{ Path = 'packaging/aur/PKGBUILD.template'; Areas = 'links typos' }
             @{ Path = 'Dockerfile'; Areas = 'links typos' }
             @{ Path = 'fuzz/fuzz_targets/mpls.rs'; Areas = 'fuzz links typos' }

--- a/.github/scripts/cloudsmith-push.ps1
+++ b/.github/scripts/cloudsmith-push.ps1
@@ -1,0 +1,100 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Push already-built .deb/.rpm packages to the Cloudsmith repository, idempotently.
+
+.DESCRIPTION
+    The one push implementation for every lane that ships a Linux package: the
+    CLI's packages.yml and the GUI's publish-gui-cloudsmith.ps1 both call it, so
+    both get the same idempotency.
+
+    Idempotent by PREFLIGHT rather than by unconditional `--republish`. A
+    dispatch re-run or a backfill must not re-upload a version that is already
+    there: a plain re-push of an existing version uploads and then fails
+    mid-sync ("...already exists...This package should be deleted"), leaving a
+    broken entry, while `--republish` avoids that but needlessly re-uploads and
+    is discouraged by Cloudsmith. So query the public API by exact filename and
+    SKIP when the version is present; push cleanly when it is absent.
+    `--republish` survives solely as the safe fallback for the two cases where a
+    plain push would otherwise strand a broken entry: the preflight could not
+    determine the state, or the push raced another run into "already exists".
+
+    The query matches the version BASE. Cloudsmith stores the
+    packaging-revisioned version (1.2.0-1), so a bare `version:X.Y.Z` query
+    matches nothing.
+
+    Every file is attempted before the script fails, so one channel's bad
+    package does not hide the state of the others.
+
+    Env: CLOUDSMITH_API_KEY (the push credential), CLOUDSMITH_CLI_VERSION (the
+    pipx pin; version-freshness.yml asserts every lane pins the same value).
+
+.PARAMETER Version
+    The bare X.Y.Z version the packages are expected to carry.
+
+.PARAMETER Path
+    The package files to push. The format is taken from each file's extension.
+
+.PARAMETER Repo
+    The Cloudsmith `owner/repo` to push into.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $Version,
+    [Parameter(Mandatory)] [string[]] $Path,
+    [string] $Repo = 'bdinfo-rs/bdinfo-rs'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+. "$PSScriptRoot/_common.ps1"
+
+if (-not $env:CLOUDSMITH_API_KEY) { Stop-Leg 'CLOUDSMITH_API_KEY is not set' }
+if (-not $env:CLOUDSMITH_CLI_VERSION) { Stop-Leg 'CLOUDSMITH_CLI_VERSION is not set (the workflow pins it)' }
+pipx install "cloudsmith-cli==$env:CLOUDSMITH_CLI_VERSION" | Out-Null
+if ($LASTEXITCODE -ne 0) { Stop-Leg 'pipx install cloudsmith-cli failed' }
+
+# One `any-distro/any-version` upload serves every distro in the family, so
+# users can install by name from a single entry.
+$distro = "$Repo/any-distro/any-version"
+
+$failed = @()
+foreach ($file in $Path) {
+    if (-not (Test-Path -LiteralPath $file)) { Stop-Leg "no package at $file" }
+    $name = Split-Path -Leaf $file
+    $format = if ($name.EndsWith('.deb')) { 'deb' } elseif ($name.EndsWith('.rpm')) { 'rpm' } else { $null }
+    if (-not $format) { Stop-Leg "$name is neither a .deb nor a .rpm" }
+
+    # An empty $count means the state could not be determined -> --republish.
+    $count = ''
+    try {
+        $query = [uri]::EscapeDataString("filename:$name")
+        $json = Invoke-RestMethod -Uri "https://api.cloudsmith.io/v1/packages/$Repo/?query=$query&page_size=100"
+        $count = @($json | Where-Object { ($_.version -replace '-\d+$', '') -eq $Version }).Count
+    }
+    catch { $count = '' }
+
+    if ($count -is [int] -and $count -gt 0) {
+        Write-Host "$name $Version is already in Cloudsmith ($count) - skipping"
+        continue
+    }
+    if ($count -is [int]) {
+        cloudsmith push $format $distro $file
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host 'plain push failed - retrying idempotently with --republish'
+            cloudsmith push $format --republish $distro $file
+        }
+    }
+    else {
+        Write-Host 'could not query the Cloudsmith state - pushing with --republish (safe)'
+        cloudsmith push $format --republish $distro $file
+    }
+    if ($LASTEXITCODE -ne 0) { $failed += $name }
+}
+if ($failed.Count) { Stop-Leg "Cloudsmith push failed for: $($failed -join ', ')" }
+Write-Host "pushed $($Path.Count) package(s) to Cloudsmith ($Version)"

--- a/.github/scripts/publish-gui-aur.ps1
+++ b/.github/scripts/publish-gui-aur.ps1
@@ -30,29 +30,20 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 
-function Stop-Leg([string] $why) {
-    Write-Host "FAILED: $why" -ForegroundColor Red
-    exit 1
-}
+. "$PSScriptRoot/_common.ps1"
 
 $repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..' '..')).Path
 
-# Not `$sums`: PowerShell variable names are case-insensitive, so that would
-# overwrite the $Sums path parameter before the loop reads it.
-$shaByName = @{}
-foreach ($line in Get-Content -LiteralPath $Sums) {
-    if ($line -match '^([0-9a-f]{64})\s+\*?(.+)$') { $shaByName[$Matches[2].Trim()] = $Matches[1] }
-}
+$shaByName = Get-Sha256Sums -Path $Sums
 $shaX64 = $shaByName['bdinfo-rs-gui-x86_64-unknown-linux-gnu.deb']
 $shaArm64 = $shaByName['bdinfo-rs-gui-aarch64-unknown-linux-gnu.deb']
 if (-not $shaX64 -or -not $shaArm64) { Stop-Leg 'SHA256SUMS carries no entry for one of the two .deb assets' }
 
-$template = Join-Path $repoRoot 'packaging/aur/PKGBUILD-gui.template'
-$pkgbuild = (Get-Content -LiteralPath $template -Raw).
-Replace('__PKGVER__', $Version).
-Replace('__SHA256_X86_64__', $shaX64).
-Replace('__SHA256_AARCH64__', $shaArm64)
-if ($pkgbuild -match '__[A-Z0-9_]+__') { Stop-Leg "an unreplaced placeholder survived the render: $($Matches[0])" }
+$pkgbuild = Expand-Template -Path (Join-Path $repoRoot 'packaging/aur/PKGBUILD-gui.template') -Values @{
+    '__PKGVER__'          = $Version
+    '__SHA256_X86_64__'   = $shaX64
+    '__SHA256_AARCH64__'  = $shaArm64
+}
 
 New-Item -ItemType Directory -Force $Payload | Out-Null
 $payloadDir = (Resolve-Path -LiteralPath $Payload).Path

--- a/.github/scripts/publish-gui-cloudsmith.ps1
+++ b/.github/scripts/publish-gui-cloudsmith.ps1
@@ -9,16 +9,11 @@
 #                  package metadata (name, version, architecture) via
 #                  dpkg-deb / rpm, and stage the bytes in -Payload — the
 #                  exact files the publish leg pushes.
-#   -Mode publish  for each file: query the public Cloudsmith API by filename
-#                  and SKIP if the version is already there (Cloudsmith
-#                  stores the packaging-revisioned version, e.g. 2.0.0-1, so
-#                  the match strips the trailing revision); push cleanly when
-#                  absent; fall back to --republish only when the state could
-#                  not be determined or a plain push raced another run — the
-#                  packages.yml deb/rpm idiom, unchanged.
+#   -Mode publish  hand the four staged files to cloudsmith-push.ps1, the same
+#                  idempotent preflight-and-push the CLI's packages.yml uses.
 #
-# Env: GH_TOKEN (prepare: gh release download), CLOUDSMITH_API_KEY (publish),
-# CLOUDSMITH_CLI_VERSION (the pipx pin; watched by version-freshness.yml).
+# Env: GH_TOKEN (prepare: gh release download); publish additionally needs what
+# cloudsmith-push.ps1 documents.
 
 [CmdletBinding()]
 param(
@@ -37,7 +32,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 
-$cloudsmithRepo = 'bdinfo-rs/bdinfo-rs'
+. "$PSScriptRoot/_common.ps1"
+
 $files = @(
     'bdinfo-rs-gui-x86_64-unknown-linux-gnu.deb'
     'bdinfo-rs-gui-aarch64-unknown-linux-gnu.deb'
@@ -45,19 +41,9 @@ $files = @(
     'bdinfo-rs-gui-aarch64-unknown-linux-gnu.rpm'
 )
 
-function Stop-Leg([string] $why) {
-    Write-Host "FAILED: $why" -ForegroundColor Red
-    exit 1
-}
-
 if ($Mode -eq 'prepare') {
     if (-not $Sums) { Stop-Leg 'prepare needs -Sums' }
-    # Not `$sums`: PowerShell variable names are case-insensitive, so that
-    # would overwrite the $Sums path parameter before the loop reads it.
-    $shaByName = @{}
-    foreach ($line in Get-Content -LiteralPath $Sums) {
-        if ($line -match '^([0-9a-f]{64})\s+\*?(.+)$') { $shaByName[$Matches[2].Trim()] = $Matches[1] }
-    }
+    $shaByName = Get-Sha256Sums -Path $Sums
 
     New-Item -ItemType Directory -Force $Payload | Out-Null
     foreach ($name in $files) {
@@ -104,45 +90,6 @@ if ($Mode -eq 'prepare') {
 }
 
 # ── publish ──────────────────────────────────────────────────────────────────
-if (-not $env:CLOUDSMITH_API_KEY) { Stop-Leg 'CLOUDSMITH_API_KEY is not set' }
-if (-not $env:CLOUDSMITH_CLI_VERSION) { Stop-Leg 'CLOUDSMITH_CLI_VERSION is not set (the workflow pins it)' }
-pipx install "cloudsmith-cli==$env:CLOUDSMITH_CLI_VERSION" | Out-Null
-if ($LASTEXITCODE -ne 0) { Stop-Leg 'pipx install cloudsmith-cli failed' }
-
-$failed = @()
-foreach ($name in $files) {
-    $path = Join-Path $Payload $name
-    if (-not (Test-Path -LiteralPath $path)) { Stop-Leg "no prepared package at $path" }
-    $format = if ($name.EndsWith('.deb')) { 'deb' } else { 'rpm' }
-
-    # Preflight by exact filename via the anonymous public API, matching the
-    # version BASE (Cloudsmith stores the packaging-revisioned version, so a
-    # bare version:X.Y.Z query matches nothing). An empty count means the
-    # state could not be determined -> --republish, the safe fallback.
-    $count = ''
-    try {
-        $q = [uri]::EscapeDataString("filename:$name")
-        $json = Invoke-RestMethod -Uri "https://api.cloudsmith.io/v1/packages/$cloudsmithRepo/?query=$q&page_size=100"
-        $count = @($json | Where-Object { ($_.version -replace '-\d+$', '') -eq $Version }).Count
-    }
-    catch { $count = '' }
-
-    if ($count -is [int] -and $count -gt 0) {
-        Write-Host "$name $Version is already in Cloudsmith ($count) - skipping"
-        continue
-    }
-    if ($count -is [int]) {
-        cloudsmith push $format "$cloudsmithRepo/any-distro/any-version" $path
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host 'plain push failed - retrying idempotently with --republish'
-            cloudsmith push $format --republish "$cloudsmithRepo/any-distro/any-version" $path
-        }
-    }
-    else {
-        Write-Host 'could not query the Cloudsmith state - pushing with --republish (safe)'
-        cloudsmith push $format --republish "$cloudsmithRepo/any-distro/any-version" $path
-    }
-    if ($LASTEXITCODE -ne 0) { $failed += $name }
-}
-if ($failed.Count) { Stop-Leg "Cloudsmith push failed for: $($failed -join ', ')" }
+& "$PSScriptRoot/cloudsmith-push.ps1" -Version $Version -Path @($files | ForEach-Object { Join-Path $Payload $_ })
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 Write-Host "published the 4 packages to Cloudsmith ($Version)"

--- a/.github/scripts/publish-gui-crates.ps1
+++ b/.github/scripts/publish-gui-crates.ps1
@@ -40,29 +40,17 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 
-function Stop-Leg([string] $why) {
-    Write-Host "FAILED: $why" -ForegroundColor Red
-    exit 1
-}
+. "$PSScriptRoot/_common.ps1"
 
-if ($Tag -notmatch '^gui-v(\d+\.\d+\.\d+)$') { Stop-Leg "tag '$Tag' is not a stable gui-vX.Y.Z tag" }
-$tagVersion = $Matches[1]
+$tagVersion = Get-GuiTagVersion $Tag
 if ($Mode -eq 'prepare' -and -not $Payload) { Stop-Leg 'prepare needs -Payload' }
 
 $crate = Join-Path $SrcDir 'crates/bdinfo-rs-gui'
 if (-not (Test-Path -LiteralPath (Join-Path $crate 'Cargo.toml'))) { Stop-Leg "no gui crate under $SrcDir" }
 
-# cargo publishes whatever version Cargo.toml carries, not the tag — fail
-# fast on a mismatch (the publish-crates.yml guard, on the gui crate's
-# [package] table).
-$inPackage = $false
-$crateVersion = $null
-foreach ($line in Get-Content -LiteralPath (Join-Path $crate 'Cargo.toml')) {
-    if ($line -match '^\[package\]') { $inPackage = $true; continue }
-    if ($line -match '^\[') { $inPackage = $false; continue }
-    if ($inPackage -and $line -match '^version\s*=\s*"([^"]+)"') { $crateVersion = $Matches[1]; break }
-}
-if (-not $crateVersion) { Stop-Leg 'no [package] version found in the gui Cargo.toml' }
+# cargo publishes whatever version the manifest carries, not the tag — fail
+# fast on a mismatch (the publish-crates.yml guard, on the gui crate).
+$crateVersion = Get-CrateVersion -Name 'bdinfo-rs-gui' -ManifestPath (Join-Path $crate 'Cargo.toml')
 if ($crateVersion -ne $tagVersion) { Stop-Leg "tag $Tag does not match the gui crate version $crateVersion" }
 
 Push-Location -LiteralPath $crate

--- a/.github/scripts/publish-gui-homebrew.ps1
+++ b/.github/scripts/publish-gui-homebrew.ps1
@@ -33,32 +33,23 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 
-function Stop-Leg([string] $why) {
-    Write-Host "FAILED: $why" -ForegroundColor Red
-    exit 1
-}
+. "$PSScriptRoot/_common.ps1"
 
 $repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..' '..')).Path
 
 if ($Mode -eq 'prepare') {
     foreach ($p in @($Sums, $Payload)) { if (-not $p) { Stop-Leg 'prepare needs -Sums and -Payload' } }
 
-    # Not `$sums`: PowerShell variable names are case-insensitive, so that
-    # would overwrite the $Sums path parameter before the loop reads it.
-    $shaByName = @{}
-    foreach ($line in Get-Content -LiteralPath $Sums) {
-        if ($line -match '^([0-9a-f]{64})\s+\*?(.+)$') { $shaByName[$Matches[2].Trim()] = $Matches[1] }
-    }
+    $shaByName = Get-Sha256Sums -Path $Sums
     $shaArm = $shaByName['bdinfo-rs-gui-aarch64-apple-darwin.dmg']
     $shaIntel = $shaByName['bdinfo-rs-gui-x86_64-apple-darwin.dmg']
     if (-not $shaArm -or -not $shaIntel) { Stop-Leg 'SHA256SUMS carries no entry for one of the two .dmg assets' }
 
-    $template = Join-Path $repoRoot 'packaging/homebrew/bdinfo-rs-gui.rb.template'
-    $cask = (Get-Content -LiteralPath $template -Raw).
-    Replace('__PKGVER__', $Version).
-    Replace('__SHA256_ARM__', $shaArm).
-    Replace('__SHA256_INTEL__', $shaIntel)
-    if ($cask -match '__[A-Z0-9_]+__') { Stop-Leg "an unreplaced placeholder survived the render: $($Matches[0])" }
+    $cask = Expand-Template -Path (Join-Path $repoRoot 'packaging/homebrew/bdinfo-rs-gui.rb.template') -Values @{
+        '__PKGVER__'       = $Version
+        '__SHA256_ARM__'   = $shaArm
+        '__SHA256_INTEL__' = $shaIntel
+    }
 
     New-Item -ItemType Directory -Force $Payload | Out-Null
     $out = Join-Path $Payload 'bdinfo-rs-gui.rb'

--- a/.github/scripts/publish-gui-verify.ps1
+++ b/.github/scripts/publish-gui-verify.ps1
@@ -35,27 +35,19 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 
-function Stop-Verify([string] $why) {
-    Write-Host "FAILED: $why" -ForegroundColor Red
-    exit 1
-}
+. "$PSScriptRoot/_common.ps1"
 
 $repo = $env:GITHUB_REPOSITORY
-if (-not $repo) { Stop-Verify 'GITHUB_REPOSITORY is not set' }
+if (-not $repo) { Stop-Leg 'GITHUB_REPOSITORY is not set' }
 
-# Stable releases only — a prerelease suffix never reaches a package manager
-# (the packages.yml gate's rule).
-if ($Tag -notmatch '^gui-v(\d+\.\d+\.\d+)$') {
-    Stop-Verify "tag '$Tag' is not a stable gui-vX.Y.Z tag"
-}
-$version = $Matches[1]
+$version = Get-GuiTagVersion $Tag
 
 $releaseJson = gh api "repos/$repo/releases/tags/$Tag" 2>&1 | Out-String
-if ($LASTEXITCODE -ne 0) { Stop-Verify "no release found for tag $Tag`: $releaseJson" }
+if ($LASTEXITCODE -ne 0) { Stop-Leg "no release found for tag $Tag`: $releaseJson" }
 $release = $releaseJson | ConvertFrom-Json
-if ($release.draft) { Stop-Verify "the release for $Tag is a draft" }
+if ($release.draft) { Stop-Leg "the release for $Tag is a draft" }
 if (-not $release.immutable) {
-    Stop-Verify "release $Tag is not immutable - its assets could change after this verification, so no channel may publish from it"
+    Stop-Leg "release $Tag is not immutable - its assets could change after this verification, so no channel may publish from it"
 }
 
 # The exact asset contract gui-release.yml publishes: 12 packages +
@@ -79,25 +71,23 @@ $actual = @($release.assets.name)
 $diff = @(Compare-Object -ReferenceObject $expected -DifferenceObject $actual)
 if ($diff.Count) {
     $diff | ForEach-Object { Write-Host "    $($_.SideIndicator) $($_.InputObject)" }
-    Stop-Verify "release $Tag does not carry exactly the expected asset set (<= missing, => unexpected)"
+    Stop-Leg "release $Tag does not carry exactly the expected asset set (<= missing, => unexpected)"
 }
 
 New-Item -ItemType Directory -Force $OutDir | Out-Null
 gh release download $Tag --repo $repo --dir $OutDir
-if ($LASTEXITCODE -ne 0) { Stop-Verify "gh release download $Tag failed" }
+if ($LASTEXITCODE -ne 0) { Stop-Leg "gh release download $Tag failed" }
 
-# Every SHA256SUMS line must name one of the 12 packages, cover all 12, and
-# match the downloaded bytes.
-$sums = @{}
-foreach ($line in Get-Content -LiteralPath (Join-Path $OutDir 'SHA256SUMS')) {
-    if ($line -notmatch '^([0-9a-f]{64})\s+\*?(.+)$') { Stop-Verify "unparseable SHA256SUMS line: $line" }
-    $sums[$Matches[2].Trim()] = $Matches[1]
-}
+# Every SHA256SUMS line must name one of the 12 packages (-Strict), cover all
+# 12, and match the downloaded bytes. This is the run's only reading of the file
+# that proves it well-formed; the prepare legs look names up in the copy this
+# job publishes as an artifact.
+$sums = Get-Sha256Sums -Path (Join-Path $OutDir 'SHA256SUMS') -Strict
 $sumDiff = @(Compare-Object -ReferenceObject $packages -DifferenceObject @($sums.Keys))
-if ($sumDiff.Count) { Stop-Verify 'SHA256SUMS does not cover exactly the 12 packages' }
+if ($sumDiff.Count) { Stop-Leg 'SHA256SUMS does not cover exactly the 12 packages' }
 foreach ($name in $packages) {
     $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $OutDir $name)).Hash.ToLowerInvariant()
-    if ($hash -ne $sums[$name]) { Stop-Verify "checksum mismatch for $name (SHA256SUMS $($sums[$name]), downloaded $hash)" }
+    if ($hash -ne $sums[$name]) { Stop-Leg "checksum mismatch for $name (SHA256SUMS $($sums[$name]), downloaded $hash)" }
     Write-Host "    sha256 ok  $name"
 }
 
@@ -105,7 +95,7 @@ foreach ($name in $packages) {
 # release job attests the full set).
 foreach ($name in $expected) {
     gh attestation verify (Join-Path $OutDir $name) --repo $repo
-    if ($LASTEXITCODE -ne 0) { Stop-Verify "attestation verification failed for $name" }
+    if ($LASTEXITCODE -ne 0) { Stop-Leg "attestation verification failed for $name" }
 }
 
 # Channel matrix. AUR is armed by the AUR_ENABLED repo variable, like the
@@ -113,7 +103,7 @@ foreach ($name in $expected) {
 $selected = if ($Channels -eq 'all') { @('winget', 'homebrew', 'aur', 'cloudsmith', 'crates') } else { @($Channels) }
 if ($env:AUR_ENABLED -ne 'true' -and $selected -contains 'aur') {
     if ($Channels -eq 'aur') {
-        Stop-Verify 'AUR publishing is paused (repo variable AUR_ENABLED is not true); set it before an explicit aur dispatch'
+        Stop-Leg 'AUR publishing is paused (repo variable AUR_ENABLED is not true); set it before an explicit aur dispatch'
     }
     Write-Host '::warning::AUR publishing is paused (repo variable AUR_ENABLED is not true) - dropping the aur channel from this run.'
     $selected = @($selected | Where-Object { $_ -ne 'aur' })

--- a/.github/scripts/publish-gui-winget.ps1
+++ b/.github/scripts/publish-gui-winget.ps1
@@ -61,17 +61,14 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 
+. "$PSScriptRoot/_common.ps1"
+
 $packageId = 'agentjp.bdinfo-rs-gui'
 # Dots split publisher/package into directory levels: manifests/<first
 # letter>/<publisher>/<package>/<version>/ is winget-pkgs' tree shape.
 $pkgTree = 'repos/microsoft/winget-pkgs/contents/manifests/a/agentjp/bdinfo-rs-gui'
 $base = "https://github.com/agentjp/bdinfo-rs/releases/download/gui-v$Version"
 $msiUrls = @("$base/bdinfo-rs-gui-x86_64-pc-windows-msvc.msi", "$base/bdinfo-rs-gui-aarch64-pc-windows-msvc.msi")
-
-function Stop-Leg([string] $why) {
-    Write-Host "FAILED: $why" -ForegroundColor Red
-    exit 1
-}
 
 if (-not $env:GITHUB_TOKEN) { Stop-Leg 'GITHUB_TOKEN is not set (komac and the state probe both need it)' }
 if (-not $env:KOMAC_VERSION) { Stop-Leg 'KOMAC_VERSION is not set (the workflow pins it)' }

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -29,7 +29,7 @@ name: packages
 # Secrets required (configure before the first release, or the jobs fail):
 #   WINGET_TOKEN       - classic PAT (public_repo) on the bot account that forked winget-pkgs
 #   AUR_SSH_KEY        - private SSH key whose public half is on the aur.archlinux.org account
-#   CLOUDSMITH_API_KEY - Cloudsmith API key (used by the active deb/rpm jobs)
+#   CLOUDSMITH_API_KEY - Cloudsmith API key (used by the linux-packages job)
 #
 # These three publish secrets live on the `release` ENVIRONMENT (not as repo secrets), so
 # only a release run can read them — a workflow on any other branch is structurally locked
@@ -214,182 +214,111 @@ jobs:
           commit_message: Update to ${{ env.VERSION }}
           ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
 
-  # ── Debian/Ubuntu: .deb attached to the release (x64 + arm64) ──────────────
-  deb:
-    name: .deb (${{ matrix.triple }})
-    runs-on: ${{ matrix.os }}
+  # ── Linux packages attached to the release: .deb + .rpm, x64 + arm64 ───────
+  # One job over both formats. What actually differs between them is the install
+  # command and the Debian-only copyright assertion; download, contents check and
+  # Cloudsmith push are identical, so they are written once. The trade is that
+  # the release UI shows one check-run name per format+arch pair rather than a
+  # separate .deb / .rpm job — nothing gates on those names.
+  linux-packages:
+    name: .${{ matrix.format }} (${{ matrix.target.triple }})
+    runs-on: ${{ matrix.target.os }}
     environment: release # CLOUDSMITH_API_KEY is an env secret on `release` (see header)
     needs: gate
     if: needs.gate.outputs.stable == 'true'
-    # contents: read (inherited) is enough — the .deb is already a release asset; this
-    # job downloads + verifies + pushes to Cloudsmith and uploads nothing back. (The
-    # old job needed contents: write for `gh release upload`; dropping it resolves the
-    # #78/#79 Token-Permissions residuals.)
+    # contents: read (inherited) is enough — the package is already a release asset;
+    # this job downloads + verifies + pushes to Cloudsmith and uploads nothing back.
+    # (The old job needed contents: write for `gh release upload`; dropping it
+    # resolves the #78/#79 Token-Permissions residuals.)
     env:
       VERSION: ${{ needs.gate.outputs.version }}
+      FILE: dl/bdinfo-rs-${{ matrix.target.triple }}.${{ matrix.format }}
+      # The pipx pin cloudsmith-push.ps1 installs. A pip pin invisible to
+      # Dependabot; version-freshness.yml watches it and asserts it agrees with
+      # gui-publish.yml's copy.
+      CLOUDSMITH_CLI_VERSION: 1.21.0
     strategy:
       fail-fast: false
       # One NATIVE runner per arch so the install test runs the arch-matching binary
       # (x64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) — no emulation/Docker.
       matrix:
-        include:
+        format: [deb, rpm]
+        target:
           - {triple: x86_64-unknown-linux-musl, os: ubuntu-latest}
           - {triple: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm}
     steps:
+      # For .github/scripts/cloudsmith-push.ps1 — the only thing this job needs
+      # out of the repository.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       # The package was built + attached to the release by dist `extra-artifacts`
       # (.github/build-linux-packages.sh); just pull it back to verify + republish.
-      - name: Download the .deb attached to the release
+      - name: Download the package attached to the release
         shell: bash
-        run: gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" -p "bdinfo-rs-${{ matrix.triple }}.deb" -D dl
+        run: gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" -p "$(basename "$FILE")" -D dl
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify the .deb (install + run + man/completions on the native arch)
+      - name: Install the .deb on the native arch
+        if: matrix.format == 'deb'
         shell: bash
         run: |
           set -euo pipefail
-          deb="dl/bdinfo-rs-${{ matrix.triple }}.deb"
-          echo "== $deb =="; dpkg-deb --contents "$deb"
-          sudo dpkg -i "$deb"
-          bdinfo-rs --version
-          # cargo-deb gzips the man page (.1.gz); cargo-generate-rpm keeps it (.1) — accept either.
-          ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
-          for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
-            test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
-          done
-          # Debian carries NO License field in control metadata — the license lives only in
-          # the DEP-5 copyright, which is what license scanners (Cloudsmith) read. Assert the
-          # copyright installed AND carries the machine-readable License short-name.
-          grep -q '^License: LGPL-2.1-or-later' /usr/share/doc/bdinfo-rs/copyright || { echo "NOT INSTALLED: DEP-5 copyright License field"; exit 1; }
-          echo "${{ matrix.triple }} .deb: installs, runs, and ships man + completions + DEP-5 copyright"
+          echo "== $FILE =="; dpkg-deb --contents "$FILE"
+          sudo dpkg -i "$FILE"
 
-      # Publish the SAME bytes to the Cloudsmith apt repo so users can `apt install
-      # bdinfo-rs` by name (one `any-distro/any-version` upload serves every
-      # Debian-family distro).
-      #
-      # IDEMPOTENT by preflight (best practice, replacing the old unconditional
-      # `--republish`): a workflow_dispatch re-run / backfill must not re-upload a
-      # version that is already there. A plain re-push of an existing version uploads
-      # then FAILS mid-sync ("...already exists...This package should be deleted"),
-      # leaving a broken entry; `--republish` avoids that but needlessly re-uploads and
-      # is discouraged by Cloudsmith. So query the public API by filename (matching the
-      # version base — Cloudsmith stores it revisioned, e.g. 1.2.0-1) and SKIP if present;
-      # push cleanly (no `--republish`) only when absent. `--republish`
-      # is kept solely as the safe fallback for the two cases where a plain push would
-      # otherwise strand a broken entry: the preflight could not determine state, or the
-      # push races another run and hits "already exists".
-      - name: Publish the .deb to Cloudsmith
-        shell: bash
-        env:
-          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
-        run: |
-          set -euo pipefail
-          pipx install cloudsmith-cli==1.21.0 >/dev/null
-          ver="${VERSION#v}"
-          repo=bdinfo-rs/bdinfo-rs
-          file="dl/bdinfo-rs-${{ matrix.triple }}.deb"
-          # Cloudsmith stores the packaging-revisioned version (e.g. 1.2.0-1), so a bare
-          # `version:${ver}` matches NOTHING. Query the anonymous public API by the exact
-          # filename and match the version BASE (strip the trailing -<revision>) — exact
-          # and revision-agnostic. count stays empty on any query error → --republish fallback.
-          count=""
-          if json=$(curl -sSf -G "https://api.cloudsmith.io/v1/packages/$repo/" --data-urlencode "query=filename:bdinfo-rs-${{ matrix.triple }}.deb" --data-urlencode "page_size=100" 2>/dev/null); then
-            count=$(printf '%s' "$json" | jq --arg v "$ver" '[.[] | select((.version | sub("-[0-9]+$"; "")) == $v)] | length' 2>/dev/null || true)
-          fi
-          if [ -n "$count" ] && [ "$count" != "0" ]; then
-            echo "bdinfo-rs-${{ matrix.triple }}.deb ${ver} already in Cloudsmith (${count}) — skipping"
-          elif [ "$count" = "0" ]; then
-            cloudsmith push deb "$repo/any-distro/any-version" "$file" \
-              || { echo "plain push failed — retrying idempotently with --republish"; cloudsmith push deb --republish "$repo/any-distro/any-version" "$file"; }
-          else
-            echo "could not query Cloudsmith state — pushing with --republish (safe)"
-            cloudsmith push deb --republish "$repo/any-distro/any-version" "$file"
-          fi
-
-  # ── Fedora/RHEL: .rpm attached to the release (x64 + arm64) ────────────────
-  rpm:
-    name: .rpm (${{ matrix.triple }})
-    runs-on: ${{ matrix.os }}
-    environment: release # CLOUDSMITH_API_KEY is an env secret on `release` (see header)
-    needs: gate
-    if: needs.gate.outputs.stable == 'true'
-    # contents: read (inherited) is enough — see the .deb job; this uploads nothing back.
-    env:
-      VERSION: ${{ needs.gate.outputs.version }}
-    strategy:
-      fail-fast: false
-      # One NATIVE runner per arch so the install test runs the arch-matching binary
-      # (x64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) — no emulation/Docker.
-      matrix:
-        include:
-          - {triple: x86_64-unknown-linux-musl, os: ubuntu-latest}
-          - {triple: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm}
-    steps:
-      # The package was built + attached to the release by dist `extra-artifacts`
-      # (.github/build-linux-packages.sh); just pull it back to verify + republish.
-      - name: Download the .rpm attached to the release
-        shell: bash
-        run: gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" -p "bdinfo-rs-${{ matrix.triple }}.rpm" -D dl
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify the .rpm (install + run + man/completions on the native arch)
+      - name: Install the .rpm on the native arch
+        if: matrix.format == 'rpm'
         shell: bash
         run: |
           set -euo pipefail
           sudo apt-get update -qq && sudo apt-get install -y -qq rpm
           sudo rpm --initdb 2>/dev/null || true
-          rpmf="dl/bdinfo-rs-${{ matrix.triple }}.rpm"
-          echo "== $rpmf =="; rpm -qpl "$rpmf"
+          echo "== $FILE =="; rpm -qpl "$FILE"
           # rpm tool on Ubuntu lays the package's files onto the filesystem; --nodeps
           # (the binary is static, no deps) and --ignorearch (rpm's host-arch string
           # may not match the package arch label) keep it from balking.
-          sudo rpm -i --nodeps --ignorearch --force "$rpmf"
+          sudo rpm -i --nodeps --ignorearch --force "$FILE"
+
+      - name: Verify what the package installed
+        shell: bash
+        run: |
+          set -euo pipefail
           bdinfo-rs --version
           # cargo-deb gzips the man page (.1.gz); cargo-generate-rpm keeps it (.1) — accept either.
           ls /usr/share/man/man1/bdinfo-rs.1* >/dev/null 2>&1 || { echo "NOT INSTALLED: man page"; exit 1; }
           for f in /usr/bin/bdinfo-rs /usr/share/bash-completion/completions/bdinfo-rs /usr/share/zsh/site-functions/_bdinfo-rs /usr/share/fish/vendor_completions.d/bdinfo-rs.fish; do
             test -f "$f" || { echo "NOT INSTALLED: $f"; exit 1; }
           done
-          echo "${{ matrix.triple }} .rpm: installs (rpm -i), runs, and ships man + completions"
+          # Debian carries NO License field in control metadata — the license lives only
+          # in the DEP-5 copyright, which is what license scanners (Cloudsmith) read.
+          # Assert the copyright installed AND carries the machine-readable short-name.
+          # RPM has a License tag in its own metadata and ships no such file.
+          if [ "${{ matrix.format }}" = deb ]; then
+            grep -q '^License: LGPL-2.1-or-later' /usr/share/doc/bdinfo-rs/copyright || { echo "NOT INSTALLED: DEP-5 copyright License field"; exit 1; }
+          fi
+          echo "${{ matrix.target.triple }} .${{ matrix.format }}: installs, runs, and ships man + completions"
 
-      # Publish the SAME bytes to the Cloudsmith yum repo so users can `dnf install
-      # bdinfo-rs` by name (one `any-distro/any-version` upload serves every
-      # RPM-family distro). Preflight-skip-if-present, `--republish` only as the safe
-      # fallback — see the .deb job for the full rationale.
-      - name: Publish the .rpm to Cloudsmith
-        shell: bash
+      # Publish the SAME bytes to Cloudsmith so users can `apt install bdinfo-rs` /
+      # `dnf install bdinfo-rs` by name. The push is idempotent by preflight; the
+      # rationale lives in cloudsmith-push.ps1.
+      - name: Publish the package to Cloudsmith
+        shell: pwsh
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
-          set -euo pipefail
-          pipx install cloudsmith-cli==1.21.0 >/dev/null
-          ver="${VERSION#v}"
-          repo=bdinfo-rs/bdinfo-rs
-          file="dl/bdinfo-rs-${{ matrix.triple }}.rpm"
-          # Match the version BASE via the anonymous public API — see the .deb job for why
-          # a bare `version:${ver}` misses Cloudsmith's revisioned version (e.g. 1.2.0-1).
-          count=""
-          if json=$(curl -sSf -G "https://api.cloudsmith.io/v1/packages/$repo/" --data-urlencode "query=filename:bdinfo-rs-${{ matrix.triple }}.rpm" --data-urlencode "page_size=100" 2>/dev/null); then
-            count=$(printf '%s' "$json" | jq --arg v "$ver" '[.[] | select((.version | sub("-[0-9]+$"; "")) == $v)] | length' 2>/dev/null || true)
-          fi
-          if [ -n "$count" ] && [ "$count" != "0" ]; then
-            echo "bdinfo-rs-${{ matrix.triple }}.rpm ${ver} already in Cloudsmith (${count}) — skipping"
-          elif [ "$count" = "0" ]; then
-            cloudsmith push rpm "$repo/any-distro/any-version" "$file" \
-              || { echo "plain push failed — retrying idempotently with --republish"; cloudsmith push rpm --republish "$repo/any-distro/any-version" "$file"; }
-          else
-            echo "could not query Cloudsmith state — pushing with --republish (safe)"
-            cloudsmith push rpm --republish "$repo/any-distro/any-version" "$file"
-          fi
+          ./.github/scripts/cloudsmith-push.ps1 -Version ($env:VERSION -replace '^v', '') -Path $env:FILE
 
   # ── Verify the PUBLISHED Cloudsmith repo: install bdinfo-rs BY NAME and confirm
   # ── the binary + man + completions all land — on both arches, native runners, no
-  # ── Docker. Runs after `deb` has pushed; retries while the apt index propagates.
+  # ── Docker. Runs after linux-packages has pushed (both formats, since the two
+  # ── share one job); retries while the apt index propagates.
   cloudsmith-verify:
     name: verify Cloudsmith apt install (${{ matrix.triple }})
     runs-on: ${{ matrix.os }}
-    needs: [gate, deb]
+    needs: [gate, linux-packages]
     if: needs.gate.outputs.stable == 'true'
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -58,22 +58,24 @@ jobs:
 
       # cargo publishes whatever version is in Cargo.toml, not the tag — fail fast
       # if a tag was cut that does not match (mirrors the guard in docker.yml).
+      # The version it resolves is a step output, so the publish step below reads
+      # the value this step validated instead of re-deriving it.
       - name: Verify the tag matches the workspace version
+        id: version
         shell: pwsh
         run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $false
+          . ./.github/scripts/_common.ps1
+
           $tag = $env:GITHUB_REF_NAME
-          if ($tag -notmatch '^v(?<base>\d+\.\d+\.\d+)(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$') {
-            throw "Tag '$tag' is not vMAJOR.MINOR.PATCH[-prerelease]"
-          }
-          $base = $Matches['base']
-          $inWp = $false; $crate = $null
-          foreach ($line in (Get-Content Cargo.toml)) {
-            if ($line -match '^\[workspace\.package\]') { $inWp = $true; continue }
-            if ($line -match '^\[') { $inWp = $false; continue }
-            if ($inWp -and $line -match '^version\s*=\s*"([^"]+)"') { $crate = $Matches[1]; break }
-          }
-          if (-not $crate) { throw 'No [workspace.package] version found in Cargo.toml' }
-          if ($base -ne $crate) { throw "Tag $tag (base $base) does not match workspace version $crate" }
+          $base = Get-ReleaseTagBase $tag
+          # Both crates inherit the version from [workspace.package], so either
+          # one reports it.
+          $crate = Get-CrateVersion -Name 'bdinfo-rs-core'
+          if ($base -ne $crate) { Stop-Leg "Tag $tag (base $base) does not match workspace version $crate" }
+          "version=$crate" | Add-Content -Path $env:GITHUB_OUTPUT
 
       - name: Authenticate to crates.io (Trusted Publishing / OIDC)
         id: auth
@@ -94,17 +96,9 @@ jobs:
         shell: pwsh
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          # The published version is the [workspace.package] version (both crates
-          # inherit it via version.workspace = true) — the same value the tag guard
-          # above verified. Read it authoritatively from Cargo.toml.
-          $inWp = $false; $version = $null
-          foreach ($line in (Get-Content Cargo.toml)) {
-            if ($line -match '^\[workspace\.package\]') { $inWp = $true; continue }
-            if ($line -match '^\[') { $inWp = $false; continue }
-            if ($inWp -and $line -match '^version\s*=\s*"([^"]+)"') { $version = $Matches[1]; break }
-          }
-          if (-not $version) { throw 'No [workspace.package] version found in Cargo.toml' }
+          $version = $env:VERSION
 
           # crates.io versions are immutable: re-publishing an existing version errors
           # cleanly with "already uploaded", which we tolerate as success. So we do NOT

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -191,32 +191,22 @@ jobs:
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $false
+          . ./.github/scripts/_common.ps1
+
           $tag = $env:TAG
-          if ($tag -notmatch '^v(?<base>\d+\.\d+\.\d+)(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$') {
-            throw "Tag '$tag' is not vMAJOR.MINOR.PATCH[-prerelease]"
-          }
-          $base = $Matches['base']
-          $inWp = $false; $ws = $null
-          foreach ($line in (Get-Content Cargo.toml)) {
-            if ($line -match '^\[workspace\.package\]') { $inWp = $true; continue }
-            if ($line -match '^\[') { $inWp = $false; continue }
-            if ($inWp -and $line -match '^version\s*=\s*"([^"]+)"') { $ws = $Matches[1]; break }
-          }
-          if (-not $ws) { throw 'No [workspace.package] version found in Cargo.toml' }
-          if ($base -ne $ws) { throw "Tag $tag (base $base) does not match workspace version $ws" }
+          $base = Get-ReleaseTagBase $tag
+          $ws = Get-CrateVersion -Name 'bdinfo-rs-core'
+          if ($base -ne $ws) { Stop-Leg "Tag $tag (base $base) does not match workspace version $ws" }
           $pkg = (Get-Content crates/bdinfo-rs-wasm/web/package.json -Raw | ConvertFrom-Json).version
-          if ($base -ne $pkg) { throw "Tag $tag (base $base) does not match web/package.json version $pkg" }
-          # The wasm crate is an excluded workspace with a literal [package] version
-          # (not version.workspace), so guard it too — `cargo set-version --workspace`
-          # does not reach it and a drifted literal would otherwise ship unnoticed.
-          $inPkg = $false; $wasm = $null
-          foreach ($line in (Get-Content crates/bdinfo-rs-wasm/Cargo.toml)) {
-            if ($line -match '^\[package\]') { $inPkg = $true; continue }
-            if ($line -match '^\[') { $inPkg = $false; continue }
-            if ($inPkg -and $line -match '^version\s*=\s*"([^"]+)"') { $wasm = $Matches[1]; break }
-          }
-          if (-not $wasm) { throw 'No [package] version in crates/bdinfo-rs-wasm/Cargo.toml' }
-          if ($base -ne $wasm) { throw "Tag $tag (base $base) does not match wasm crate version $wasm" }
+          if ($base -ne $pkg) { Stop-Leg "Tag $tag (base $base) does not match web/package.json version $pkg" }
+          # The wasm crate is an excluded workspace carrying its own version (not
+          # version.workspace), so guard it too — `cargo set-version --workspace`
+          # does not reach it and a drifted value would otherwise ship unnoticed.
+          $wasm = Get-CrateVersion -Name 'bdinfo-rs-wasm' -ManifestPath crates/bdinfo-rs-wasm/Cargo.toml
+          if ($base -ne $wasm) { Stop-Leg "Tag $tag (base $base) does not match wasm crate version $wasm" }
 
       - name: Install the web toolchain
         working-directory: crates/bdinfo-rs-wasm/web

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -58,8 +58,8 @@ name: version-freshness
 #     fetched at a static version invisible to Dependabot; checked vs the highest
 #     SEMVER tag AppImage/appimagetool has released, since its `releases/latest`
 #     is the rolling `continuous` nightly), and
-#     cloudsmith-cli (the `cloudsmith-cli==X` pipx pin in packages.yml — a pip pin
-#     invisible to Dependabot's cargo/npm/actions scans; pinned once per push job,
+#     cloudsmith-cli (the CLOUDSMITH_CLI_VERSION pipx pin — a pip pin invisible to
+#     Dependabot's cargo/npm/actions scans; pinned once per publishing workflow,
 #     every occurrence checked to agree, then vs PyPI),
 # (Cargo deps/dev-deps, the web npm devDependencies — typescript / biome /
 # binaryen / playwright-core — and GitHub Action SHAs are already auto-bumped by
@@ -613,18 +613,17 @@ jobs:
             Add-Problem "komac $komacPin->$komacLatest" "- komac pin ``$komacPin`` (packages.yml KOMAC_VERSION) is behind the latest release ``$komacLatest``"
           }
 
-          # --- cloudsmith-cli: packages.yml `pipx install` pin vs PyPI --------------
-          # The deb/rpm jobs push to Cloudsmith with a pinned `cloudsmith-cli==X`
-          # (pipx). A pip pin invisible to Dependabot's cargo/npm/actions scans, so a
-          # server-side API change could break the frozen client silently; nag here
-          # like the other hand-bumped tools when a newer client ships. The pin
-          # occurs once PER PUSH JOB (.deb and .rpm) in packages.yml plus as the
-          # CLOUDSMITH_CLI_VERSION env in gui-publish.yml, so read every
-          # occurrence and assert they agree — a first-match-only read validates
-          # one job while the others drift unseen — then run freshness on the
-          # agreed value.
-          $cloudsmithPins = Read-AllPins '.github/workflows/packages.yml' 'cloudsmith-cli==([0-9.]+)'
-          if (-not $cloudsmithPins.Count) { throw 'No `cloudsmith-cli==<version>` pin in packages.yml' }
+          # --- cloudsmith-cli: the CLOUDSMITH_CLI_VERSION pins vs PyPI --------------
+          # The push legs install a pinned `cloudsmith-cli==X` with pipx, from the
+          # CLOUDSMITH_CLI_VERSION each workflow sets. A pip pin invisible to
+          # Dependabot's cargo/npm/actions scans, so a server-side API change could
+          # break the frozen client silently; nag here like the other hand-bumped
+          # tools when a newer client ships. The pin occurs once per publishing
+          # workflow — packages.yml for the CLI packages, gui-publish.yml for the
+          # GUI's — so read every occurrence and assert they agree; a
+          # first-match-only read validates one lane while the other drifts unseen.
+          $cloudsmithPins = Read-AllPins '.github/workflows/packages.yml' 'CLOUDSMITH_CLI_VERSION:\s*([0-9.]+)'
+          if (-not $cloudsmithPins.Count) { throw 'No CLOUDSMITH_CLI_VERSION pin in packages.yml' }
           $cloudsmithGuiPin = Read-Pin '.github/workflows/gui-publish.yml' 'CLOUDSMITH_CLI_VERSION:\s*([0-9.]+)'
           if (-not $cloudsmithGuiPin) { throw 'No CLOUDSMITH_CLI_VERSION pin in gui-publish.yml' }
           $cloudsmithPins = @($cloudsmithPins) + $cloudsmithGuiPin


### PR DESCRIPTION
Dot-source `.github/scripts/_common.ps1` from every publishing leg. It now holds, once each:

- `Stop-Leg` — six copies before, one of them renamed `Stop-Verify`.
- the SHA256SUMS parser — four copies; `-Strict` keeps the verify leg's rejection of an unparseable line.
- `Get-GuiTagVersion` / `Get-ReleaseTagBase` — the two release-tag regexes.
- `Get-CrateVersion` — cargo metadata, replacing five hand-rolled `^version =` TOML line parsers.
- `Expand-Template` — render plus the assertion that no placeholder survived; two copies before.

The strict-mode preamble stays in each script and the convention is documented in the shared file: it has to be in force before the dot-source, and `$PSNativeCommandUseErrorActionPreference = $false` is what makes the `$LASTEXITCODE` checks these scripts are built on reachable.

`publish-crates.yml` resolved the workspace version twice; the guard step now emits it as a step output and the publish step reads it.

New `.github/scripts/cloudsmith-push.ps1` carries the preflight-and-push. Both the CLI lane and `publish-gui-cloudsmith.ps1` call it, and the skip / plain-push / `--republish`-fallback behaviour is unchanged, so a re-dispatch stays safe. `packages.yml` deb and rpm fold into one `linux-packages` job with a `format` matrix axis; the real differences survive as the two install steps and the Debian-only DEP-5 copyright assertion. That job pins cloudsmith-cli through `CLOUDSMITH_CLI_VERSION` like `gui-publish.yml`, so `version-freshness.yml` reads one name in both lanes.

One check-run name per format+arch pair replaces the separate `.deb` / `.rpm` jobs. Nothing gates on those names — the workflow is tag-triggered and outside branch protection.

`classify-diff.ps1` maps the two new script paths; its self-test passes with them tracked.

Verification: helper smoke tests over both tag regexes, all four `cargo metadata` version reads (core, CLI, wasm, GUI all report 3.0.0), both SHA256SUMS spellings, and every failure path; `classify-diff.ps1 -SelfTest` (35 cases, 6971 tracked paths); the `ty`/`av`/`yl`/`zz`/`cc` gate steps. No tag was pushed.