### PR TITLE
ci: gate composite actions and consolidate the mutation-job family

### DIFF
--- a/.github/actions/mutate-crate/action.yml
+++ b/.github/actions/mutate-crate/action.yml
@@ -1,0 +1,250 @@
+# The one body shared by every cargo-mutants job: ci.yml's three advisory
+# PR-diff jobs and the full-sweep legs sweep-mutants.yml runs for sweep.yml.
+# A COMPOSITE action rather than a reusable workflow, deliberately: a failure
+# inside a called workflow reddens its caller, and ci.yml's callers sit in
+# ci-ok's `needs`, so packaging the advisory jobs' body as a reusable would
+# silently promote them to gating (ci.yml's header documents the posture). A
+# composite's failure surfaces on the calling job itself, which ci-ok never
+# reads.
+#
+# The skeleton: optional full-sweep marker short-circuit (compute key →
+# restore) → rust-cache → install cargo-mutants + cargo-nextest → run. The
+# real per-crate differences ride as inputs.
+#
+# Both run steps build with CARGO_INCREMENTAL=1: cargo-mutants rebuilds the
+# tree once per mutant, each rebuild differing from the last by one function
+# body — exactly the case incremental compilation is built for, and the
+# reason a mutation run is affordable at all. This overrides the
+# CARGO_INCREMENTAL=0 that ci.yml sets workflow-wide to keep archived caches
+# small, at exactly the steps that invoke cargo.
+name: mutate-crate
+description: >-
+  Run cargo-mutants over a crate — the pull request's diff or the full mutant
+  list — behind the shared marker/cache/install skeleton.
+
+inputs:
+  mode:
+    description: >-
+      `pr-diff` mutates the pull request's committed diff under
+      `working-directory` (needs a fetch-depth-0 checkout to reach the base
+      branch); `full` mutates the whole crate, or one `shard` of it.
+    required: true
+  working-directory:
+    description: >-
+      Directory cargo runs in — the repository root, or an excluded sibling
+      crate whose `../bdinfo-rs-core` path dependency requires `--in-place`
+      in `mutants-args` (cargo-mutants' default temp copy does not carry a
+      path dependency).
+    required: false
+    default: .
+  shard:
+    description: >-
+      A `k/N` value for `cargo mutants --shard` (`full` mode only); empty
+      runs unsharded.
+    required: false
+    default: ''
+  mutants-args:
+    description: >-
+      Extra cargo-mutants arguments — `--in-place` for the path-dependency
+      crates, `--workspace` where a workspace member's tests are the mutant
+      killers.
+    required: false
+    default: ''
+  extra-env:
+    description: >-
+      KEY=VALUE lines exported into the run step's environment, for what the
+      mutants' test suite needs (e.g. a deterministic software renderer on a
+      GPU-less runner).
+    required: false
+    default: ''
+  marker-prefix:
+    description: >-
+      Full-sweep marker key prefix (e.g. `gui-mutants-ok`); empty disables
+      the marker short-circuit. A marker hit means the byte-identical tree
+      already passed a green full sweep, which subsumes both a re-run and any
+      diff slice — every later step is skipped.
+    required: false
+    default: ''
+  marker-paths:
+    description: >-
+      Space-separated repository paths whose committed object hashes form the
+      marker key — everything that can change the crate's mutants verdict.
+    required: false
+    default: ''
+  marker-fold:
+    description: >-
+      `sha256` folds the hash list through sha256sum to keep a many-path key
+      short; empty joins the hashes with `-` verbatim.
+    required: false
+    default: ''
+  save-marker:
+    description: >-
+      `true` writes and saves the marker after a green run. Only a job whose
+      run covers the WHOLE crate may pass it — a diff slice proves nothing
+      about the rest of the crate, so the PR-diff jobs stay restore-only, and
+      the sharded sweep legs save through their caller's fan-in job instead,
+      after ALL shards ran green.
+    required: false
+    default: 'false'
+  cache-workspaces:
+    description: >-
+      Swatinem/rust-cache `workspaces` — the sibling-crate jobs point it at
+      their crate; empty keeps the root default.
+    required: false
+    default: ''
+  cache-shared-key:
+    description: >-
+      Swatinem/rust-cache `shared-key` — the sweep legs share one lineage per
+      crate so N shards' identical baselines do not save N multi-GB archives
+      into the repository's least-recently-used cache budget.
+    required: false
+    default: ''
+  cache-lookup-only:
+    description: >-
+      Swatinem/rust-cache `lookup-only` — the sweep's tag legs build fresh so
+      a cache poisoned elsewhere cannot taint a release-adjacent run.
+    required: false
+    default: 'false'
+  cache-save-if:
+    description: >-
+      Swatinem/rust-cache `save-if`. The default always saves — right for the
+      PR-diff jobs, which are PR-only (a master-gated save would never write,
+      and their own PR-scoped save speeds the next push to the same PR); the
+      sweep legs gate it to master.
+    required: false
+    default: 'true'
+
+outputs:
+  marker-key:
+    description: >-
+      The computed full-sweep marker key; empty when `marker-prefix` is
+      empty.
+    value: ${{ steps.key.outputs.key }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compute the full-sweep marker key
+      id: key
+      if: inputs.marker-prefix != ''
+      shell: bash
+      env:
+        PREFIX: ${{ inputs.marker-prefix }}
+        PATHS: ${{ inputs.marker-paths }}
+        FOLD: ${{ inputs.marker-fold }}
+      run: |
+        # ONE construction site on purpose: the sweep's full legs and ci.yml's
+        # advisory PR-diff jobs must produce byte-identical keys for the same
+        # tree — a green full sweep saves the marker, the PR jobs
+        # short-circuit on it — so both sides reach this step with the same
+        # inputs and the key format lives nowhere else. Keep both formats
+        # stable: a changed key orphans every saved marker silently.
+        specs=""
+        for p in $PATHS; do
+          specs="$specs HEAD:$p"
+        done
+        # shellcheck disable=SC2086 # word-splitting $specs is the point
+        hashes=$(git rev-parse $specs)
+        echo "$hashes"
+        if [ "$FOLD" = sha256 ]; then
+          key="$PREFIX-$(echo "$hashes" | sha256sum | cut -d' ' -f1)"
+        else
+          key="$PREFIX-$(printf '%s' "$hashes" | tr '\n' '-')"
+        fi
+        echo "key=$key" >> "$GITHUB_OUTPUT"
+
+    # Restore-only: whether and where the marker gets SAVED is the caller's
+    # decision (`save-marker`, or a fan-in job after a sharded run).
+    - name: Restore the full-sweep marker
+      id: marker
+      if: inputs.marker-prefix != ''
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .mutants-ok
+        key: ${{ steps.key.outputs.key }}
+
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      if: steps.marker.outputs.cache-hit != 'true'
+      with:
+        workspaces: ${{ inputs.cache-workspaces }}
+        shared-key: ${{ inputs.cache-shared-key }}
+        lookup-only: ${{ inputs.cache-lookup-only }}
+        save-if: ${{ inputs.cache-save-if }}
+
+    # `fallback: none`: install only from the action's checksummed manifest,
+    # never its runtime-resolved cargo-binstall fallback (rationale in
+    # core.yml).
+    - name: Install mutation tools
+      if: steps.marker.outputs.cache-hit != 'true'
+      uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
+      with:
+        tool: cargo-mutants,cargo-nextest
+        fallback: none
+
+    - name: Mutate the PR diff
+      if: inputs.mode == 'pr-diff' && steps.marker.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        CARGO_INCREMENTAL: '1'   # cargo-mutants' rebuild model — see the header
+        WORK_DIR: ${{ inputs.working-directory }}
+        MUTANTS_ARGS: ${{ inputs.mutants-args }}
+        EXTRA_ENV: ${{ inputs.extra-env }}
+      run: |
+        while IFS= read -r kv; do
+          [ -n "$kv" ] && export "$kv"
+        done <<< "$EXTRA_ENV"
+        cd "$WORK_DIR"
+        # HEAD is the PR merge commit, so this three-dot diff is exactly the
+        # pull request's effective diff against its base. --relative both
+        # scopes the diff to this directory and makes its paths match
+        # cargo-mutants' working directory (a no-op at the repository root).
+        #
+        # --no-renames is LOAD-BEARING: with rename detection on (git's
+        # default), a moved file becomes a `rename from/to` hunk carrying
+        # only the lines that changed relative to the old path, and
+        # `cargo mutants --in-diff` (27.1.0) then produces NO mutants for the
+        # WHOLE diff — logging only "No mutants to filter" and exiting 0, so
+        # a move-heavy PR's mutation check passes having tested nothing.
+        # Measured 2026-08-05 on a pull request moving one source file
+        # between crates: 19 mutants with --no-renames, 0 without.
+        git diff --relative --no-renames "origin/${GITHUB_BASE_REF}...HEAD" --output "$RUNNER_TEMP/pr.diff"
+        if [ ! -s "$RUNNER_TEMP/pr.diff" ]; then
+          echo "no changes under $WORK_DIR in this PR — nothing to mutate"
+          exit 0
+        fi
+        # shellcheck disable=SC2086 # $MUTANTS_ARGS carries whole flags
+        cargo mutants --no-shuffle --in-diff "$RUNNER_TEMP/pr.diff" $MUTANTS_ARGS
+
+    - name: Mutate the crate
+      if: inputs.mode == 'full' && steps.marker.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        CARGO_INCREMENTAL: '1'   # cargo-mutants' rebuild model — see the header
+        WORK_DIR: ${{ inputs.working-directory }}
+        SHARD: ${{ inputs.shard }}
+        MUTANTS_ARGS: ${{ inputs.mutants-args }}
+        EXTRA_ENV: ${{ inputs.extra-env }}
+      run: |
+        while IFS= read -r kv; do
+          [ -n "$kv" ] && export "$kv"
+        done <<< "$EXTRA_ENV"
+        cd "$WORK_DIR"
+        # --in-place: each leg owns its runner's checkout, so the temp copy
+        # buys nothing, and the path-dependency crates cannot use one anyway;
+        # --no-shuffle keeps a shard partition deterministic.
+        # shellcheck disable=SC2086 # $MUTANTS_ARGS carries whole flags
+        cargo mutants --in-place --no-shuffle ${SHARD:+--shard "$SHARD"} $MUTANTS_ARGS
+
+    - name: Write the marker
+      if: inputs.save-marker == 'true' && steps.marker.outputs.cache-hit != 'true'
+      shell: bash
+      run: echo ok > .mutants-ok
+
+    # Reached only when every prior step succeeded, so the save attests a
+    # green run.
+    - name: Save the marker (green run only)
+      if: inputs.save-marker == 'true' && steps.marker.outputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .mutants-ok
+        key: ${{ steps.key.outputs.key }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,14 @@ updates:
       include: scope
 
   - package-ecosystem: github-actions
-    directory: "/"
+    # "/" reaches the workflow files under .github/workflows plus a root-level
+    # action.yml only — pinned `uses:` inside the composite actions under
+    # .github/actions/*/action.yml sit outside it and need their directories
+    # listed (GitHub's dependabot.yml reference, checked 2026-08-06). The glob
+    # covers every composite, present and future, without further edits here.
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: daily
     groups:

--- a/.github/scripts/classify-diff.ps1
+++ b/.github/scripts/classify-diff.ps1
@@ -295,6 +295,13 @@ begin {
             Match      = { param($f) $f -eq '.github/zizmor.yml' }
         },
         @{
+            Name       = 'mutation composite action'
+            Areas      = @('core', 'gui', 'wasm', 'yaml', 'workflows')
+            Structural = $true
+            Why        = 'The mutate-crate composite is the body of the three advisory PR-diff mutation jobs, which the core, gui and wasm areas gate; action-validator and zizmor read the action definitions under .github/actions as well as the workflows.'
+            Match      = { param($f) Test-Match $f @('.github/actions/mutate-crate/*') }
+        },
+        @{
             Name       = 'source rule script'
             Areas      = @('core')
             Structural = $true
@@ -501,7 +508,9 @@ end {
             @{ Path = '.github/workflows/core.yml'; Areas = 'core deps dist fuzz links pkg typos workflows yaml' }
             @{ Path = '.github/workflows/repo.yml'; Areas = 'links toml typos workflows yaml' }
             @{ Path = '.github/workflows/gui.yml'; Areas = 'gui links typos workflows yaml' }
+            @{ Path = '.github/workflows/sweep-mutants.yml'; Areas = 'links typos workflows yaml' }
             @{ Path = '.github/workflows/docker.yml'; Areas = 'links typos workflows yaml' }
+            @{ Path = '.github/actions/mutate-crate/action.yml'; Areas = 'core gui links typos wasm workflows yaml' }
             @{ Path = '.github/scripts/gui-package-windows.ps1'; Areas = 'gui links typos' }
             @{ Path = '.github/scripts/wasm-rules.ps1'; Areas = 'links typos wasm' }
             @{ Path = '.github/scripts/cov-floor.ps1'; Areas = 'gui links typos wasm' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ name: CI
 # prefixed (`core / build + test (…)`, `repo / lint YAML (action-validator +
 # ryl)`). The three mutation jobs stay HERE rather than inside a reusable: a
 # failure inside a called workflow reddens its caller and so reaches ci-ok,
-# which would silently promote an advisory job to a gating one.
+# which would silently promote an advisory job to a gating one. Their shared
+# body is the .github/actions/mutate-crate COMPOSITE action — a composite's
+# failure surfaces on the calling job itself, preserving that posture.
 #
 # A job fires if and only if the diff could change that job's verdict, so the
 # classifier asks what KIND of input a file is before it asks which directory
@@ -63,8 +65,8 @@ env:
   # compiled-tool caches, whose miss costs minutes of `cargo install` on the
   # pull-request path. Smaller archives also restore faster, on every job.
   #
-  # Jobs running cargo-mutants override CARGO_INCREMENTAL back to 1 — see the
-  # `mutants` job.
+  # Jobs running cargo-mutants override CARGO_INCREMENTAL back to 1 — the
+  # mutate-crate composite action does it for all of them.
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
 
@@ -146,7 +148,15 @@ jobs:
             # HEAD is the PR merge commit, so parent 1 is the up-to-date base
             # tip and this two-dot diff is exactly the PR's effective diff
             # against master.
-            $changed = @(git diff --name-only 'HEAD^1' HEAD)
+            #
+            # --no-renames on both name-only diffs here: rename detection
+            # (git's default) lists only the NEW path of a moved file, so a
+            # pure move-out-of-an-area diff would never fire the old area's
+            # gates. Listing both paths is fail-open — it can only classify
+            # MORE areas, never fewer. Measured 2026-08-05 on a pull request
+            # moving one source file between crates: the deleted path was
+            # absent with detection on, present with --no-renames.
+            $changed = @(git diff --name-only --no-renames 'HEAD^1' HEAD)
             if ($LASTEXITCODE -ne 0) { $mode = 'all'; $reason = 'git diff failed' }
           }
           elseif ($env:EVENT -eq 'push') {
@@ -156,7 +166,7 @@ jobs:
               $mode = 'all'; $reason = 'no usable before SHA'
             }
             else {
-              $changed = @(git diff --name-only $env:BEFORE $env:AFTER)
+              $changed = @(git diff --name-only --no-renames $env:BEFORE $env:AFTER)
               if ($LASTEXITCODE -ne 0) { $mode = 'all'; $reason = 'git diff failed' }
             }
           }
@@ -185,9 +195,10 @@ jobs:
   # Incremental mutation testing on the PR diff: every line a pull request
   # changes must be killed by a test that FAILS when the line is mutated. The
   # full-tree sweep (~hours) lives in sweep.yml (sharded, daily + release
-  # tags); this PR-scoped slice (cargo mutants --in-diff) is fast. It reads the tracked .cargo/mutants.toml
-  # policy and the `mutants` nextest profile (.config/nextest.toml) — both now
-  # published, so CI mutates exactly as the local gate does.
+  # tags); this PR-scoped slice (cargo mutants --in-diff, via the mutate-crate
+  # composite) is fast. It reads the tracked .cargo/mutants.toml policy and
+  # the `mutants` nextest profile (.config/nextest.toml) — both published, so
+  # CI mutates exactly as the local gate does.
   #
   # ADVISORY, by design: this job is intentionally NOT in branch protection's
   # required status checks AND NOT in ci-ok's `needs`. cargo-mutants --in-diff
@@ -208,165 +219,92 @@ jobs:
     # only), and `fallback: none` turns a missing prebuilt into a hard failure.
     # Same for gui-mutants and wasm-mutants below.
     runs-on: ubuntu-latest
-    env:
-      # cargo-mutants rebuilds the tree once per mutant, each rebuild differing
-      # from the last by one function body — exactly the case incremental
-      # compilation is built for, and the reason a mutation run is affordable
-      # at all. So every job that runs cargo-mutants overrides the
-      # workflow-level 0, trading a larger target/ for the rebuild time.
-      CARGO_INCREMENTAL: "1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0   # need the base branch to diff the PR against
           persist-credentials: false
 
-      # Default save-if: the job is PR-only, so a master-gated save would never
-      # write; its own PR-scoped save is what speeds the next push to the same
-      # PR.
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
-      # `fallback: none` on every install-action step here: install only from the
-      # action's checksummed manifest, never its runtime-resolved cargo-binstall
-      # fallback (rationale in core.yml).
-      - name: Install mutation tools
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
+      # No marker inputs: the root workspace has no PR-side short-circuit, so
+      # every run diffs and mutates.
+      - uses: ./.github/actions/mutate-crate
         with:
-          tool: cargo-mutants,cargo-nextest
-          fallback: none
+          mode: pr-diff
 
-      - name: Mutate the PR diff
-        run: |
-          git diff "origin/${GITHUB_BASE_REF}...HEAD" > pr.diff
-          cargo mutants --no-shuffle --in-diff pr.diff
-
-  # Advisory in-diff mutation over the GUI crate on the PR path: mirrors
-  # the local `gui-compliance.ps1` gate's default mt scope — the diff is taken
-  # --relative from inside the crate so its paths match cargo-mutants' working
-  # directory, and --in-place because a temp copy would not carry the
-  # ../bdinfo-rs-core path dep. When the `gui` area fired via the core edge
-  # only, the crate's own diff is empty and there is nothing to mutate. Same
-  # ADVISORY posture and false-TIMEOUT rationale as `mutants` above: not
-  # required, not in ci-ok's needs, not inside a reusable. The authoritative
-  # full-crate 0-missed bar lives in sweep.yml (daily when the crate changed +
-  # release tags).
+  # Advisory in-diff mutation over the GUI crate on the PR path: mirrors the
+  # local gui gate's default mt scope. When the `gui` area fired via the core
+  # edge only, the crate's own diff is empty and the composite exits with
+  # nothing to mutate. Same ADVISORY posture and false-TIMEOUT rationale as
+  # `mutants` above: not required, not in ci-ok's needs, not inside a
+  # reusable. The authoritative full-crate 0-missed bar lives in sweep.yml
+  # (daily when the crate changed + release tags).
   #
   # The sweep's tree-hash marker short-circuits this job too, RESTORE-ONLY: a
   # marker hit means this byte-identical crate tree (+ toolchain) already
   # passed a green FULL sweep, which subsumes any diff slice of it — mutating
   # the slice again would re-verify unchanged inputs. Only a green full sweep
-  # ever writes the marker; this job must never save it (a diff slice proves
-  # nothing about the rest of the crate). The guard is what keeps a
-  # crate-sized PR diff (e.g. the branch that introduces a crate) from
-  # re-paying the ~50-min sweep on every push that leaves the crate untouched.
+  # ever writes the marker; this job must never save one (a diff slice proves
+  # nothing about the rest of the crate), so it leaves `save-marker` off. The
+  # marker prefix + paths are byte-identical to sweep.yml's gui-mutants call
+  # ON PURPOSE — the composite builds the key in one place, and matching
+  # inputs are what let a green sweep short-circuit this job. The guard is
+  # what keeps a crate-sized PR diff (e.g. the branch that introduces a
+  # crate) from re-paying the ~50-min sweep on every push that leaves the
+  # crate untouched.
   gui-mutants:
     name: gui mutation testing (PR diff)
     needs: plan
     if: github.event_name == 'pull_request' && needs.plan.outputs.gui == 'true'
     runs-on: ubuntu-latest   # no aarch64 cargo-mutants prebuilt — see `mutants`
-    env:
-      # The suite the mutants face includes the iced_test snapshot ties; the
-      # deterministic software backend is what makes them run on a GPU-less
-      # runner at all (same as gui.yml).
-      ICED_TEST_BACKEND: tiny-skia
-      CARGO_INCREMENTAL: "1"   # cargo-mutants' rebuild model — see the `mutants` job
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0   # need the base branch to diff the PR against
           persist-credentials: false
 
-      - name: Compute the full-sweep marker key (crate tree hash)
-        id: key
-        run: echo "key=gui-mutants-ok-$(git rev-parse HEAD:crates/bdinfo-rs-gui)-$(git rev-parse HEAD:rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore the full-sweep marker (restore-only)
-        id: marker
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/mutate-crate
         with:
-          path: .mutants-ok
-          key: ${{ steps.key.outputs.key }}
-
-      # Default save-if: PR-only job, so a master-gated save would never write;
-      # its own PR-scoped save speeds the next push to the same PR.
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        if: steps.marker.outputs.cache-hit != 'true'
-        with:
-          workspaces: crates/bdinfo-rs-gui
-
-      - name: Install mutation tools
-        if: steps.marker.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
-        with:
-          tool: cargo-mutants,cargo-nextest
-          fallback: none
-
-      - name: Mutate the crate's PR diff
-        if: steps.marker.outputs.cache-hit != 'true'
-        working-directory: crates/bdinfo-rs-gui
-        run: |
-          git diff --relative "origin/${GITHUB_BASE_REF}...HEAD" --output "$RUNNER_TEMP/crate.diff"
-          if [ ! -s "$RUNNER_TEMP/crate.diff" ]; then
-            echo "no gui-crate changes in this PR (the area fired via the core edge) — nothing to mutate"
-            exit 0
-          fi
-          # --workspace so a diff touching the assets-gen member is mutated
-          # too (cargo-mutants otherwise scopes to the root package).
-          cargo mutants --in-place --no-shuffle --workspace --in-diff "$RUNNER_TEMP/crate.diff"
+          mode: pr-diff
+          working-directory: crates/bdinfo-rs-gui
+          marker-prefix: gui-mutants-ok
+          marker-paths: crates/bdinfo-rs-gui rust-toolchain.toml
+          # --in-place: the ../bdinfo-rs-core path dependency does not survive
+          # cargo-mutants' temp copy; --workspace: a diff touching the
+          # assets-gen member is mutated too (cargo-mutants otherwise scopes
+          # to the root package).
+          mutants-args: --in-place --workspace
+          # The suite the mutants face includes the iced_test snapshot ties;
+          # the deterministic software backend is what makes them run on a
+          # GPU-less runner at all (same as gui.yml).
+          extra-env: ICED_TEST_BACKEND=tiny-skia
+          cache-workspaces: crates/bdinfo-rs-gui
 
   # The wasm twin of gui-mutants: advisory in-diff mutation over the wasm
-  # crate's own PR diff (--relative + --in-place for the same path-dep reason;
-  # the crate-local .cargo/mutants.toml carries the Tier-B cfg(wasm32)
-  # exclusions), with the same restore-only full-sweep marker short-circuit.
-  # Not required, not in ci-ok's needs, not inside a reusable; the full-crate
-  # bar lives in sweep.yml.
+  # crate's own PR diff (--in-place for the same path-dep reason; the
+  # crate-local .cargo/mutants.toml carries the cfg(wasm32) exclusions), with
+  # the same restore-only full-sweep marker short-circuit and the same
+  # byte-identical marker inputs as sweep.yml's wasm-mutants call. Not
+  # required, not in ci-ok's needs, not inside a reusable; the full-crate bar
+  # lives in sweep.yml.
   wasm-mutants:
     name: wasm mutation testing (PR diff)
     needs: plan
     if: github.event_name == 'pull_request' && needs.plan.outputs.wasm == 'true'
     runs-on: ubuntu-latest   # no aarch64 cargo-mutants prebuilt — see `mutants`
-    env:
-      CARGO_INCREMENTAL: "1"   # cargo-mutants' rebuild model — see the `mutants` job
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0   # need the base branch to diff the PR against
           persist-credentials: false
 
-      - name: Compute the full-sweep marker key (crate tree hash)
-        id: key
-        run: echo "key=wasm-mutants-ok-$(git rev-parse HEAD:crates/bdinfo-rs-wasm)-$(git rev-parse HEAD:rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore the full-sweep marker (restore-only)
-        id: marker
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: ./.github/actions/mutate-crate
         with:
-          path: .mutants-ok
-          key: ${{ steps.key.outputs.key }}
-
-      # Default save-if: PR-only job (see gui-mutants).
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        if: steps.marker.outputs.cache-hit != 'true'
-        with:
-          workspaces: crates/bdinfo-rs-wasm
-
-      - name: Install mutation tools
-        if: steps.marker.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
-        with:
-          tool: cargo-mutants,cargo-nextest
-          fallback: none
-
-      - name: Mutate the crate's PR diff
-        if: steps.marker.outputs.cache-hit != 'true'
-        working-directory: crates/bdinfo-rs-wasm
-        run: |
-          git diff --relative "origin/${GITHUB_BASE_REF}...HEAD" --output "$RUNNER_TEMP/crate.diff"
-          if [ ! -s "$RUNNER_TEMP/crate.diff" ]; then
-            echo "no wasm-crate changes in this PR (the area fired via the core edge) — nothing to mutate"
-            exit 0
-          fi
-          cargo mutants --in-place --no-shuffle --in-diff "$RUNNER_TEMP/crate.diff"
+          mode: pr-diff
+          working-directory: crates/bdinfo-rs-wasm
+          marker-prefix: wasm-mutants-ok
+          marker-paths: crates/bdinfo-rs-wasm rust-toolchain.toml
+          mutants-args: --in-place
+          cache-workspaces: crates/bdinfo-rs-wasm
 
   # The root-workspace gate: build + test, the quality gate, coverage, the
   # install + scan and FROM-scratch scans, the .deb/.rpm smoke, the two

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -35,7 +35,9 @@ on:
         required: true
         type: string
       workflows:
-        description: A workflow file or the zizmor suppression list changed.
+        description: >-
+          A workflow file, a composite action, or the zizmor suppression list
+          changed.
         required: true
         type: string
       typos:
@@ -58,12 +60,14 @@ env:
 
 jobs:
   # Lint the config YAML two ways, both with Rust tools. action-validator
-  # schema-checks the workflow files (catches schema errors + invalid-YAML traps
-  # like an unquoted colon in a step name). ryl (a Rust yamllint) style/syntax-
-  # lints EVERY tracked YAML against .yamllint.yml — duplicate keys, trailing
-  # whitespace, bad indentation, missing final newline, etc. — and covers the
-  # non-workflow YAML (dependabot, issue templates, scorecard) that
-  # action-validator's workflow-only schema can't read. Mirrors the local gate.
+  # schema-checks the workflow files and the composite action definitions
+  # under .github/actions (catches schema errors + invalid-YAML traps like an
+  # unquoted colon in a step name; it picks the action schema for files named
+  # action.yml). ryl (a Rust yamllint) style/syntax-lints EVERY tracked YAML
+  # against .yamllint.yml — duplicate keys, trailing whitespace, bad
+  # indentation, missing final newline, etc. — and covers the non-workflow
+  # YAML (dependabot, issue templates, scorecard) that action-validator's
+  # schemas can't read. Mirrors the local gate.
   yaml:
     name: lint YAML (action-validator + ryl)
     if: inputs.yaml == 'true'
@@ -106,9 +110,9 @@ jobs:
           cargo install action-validator --locked
           cargo install ryl --version 0.21.0 --locked
 
-      - name: Schema-validate the workflow YAML (action-validator)
+      - name: Schema-validate the workflow and action YAML (action-validator)
         run: |
-          for f in .github/workflows/*.yml; do
+          for f in .github/workflows/*.yml .github/actions/*/action.yml; do
             echo "validating $f"
             action-validator "$f"
           done
@@ -148,8 +152,9 @@ jobs:
       - name: Lint (taplo lint)
         run: taplo lint
 
-  # Static security analysis of the GitHub Actions workflows themselves (zizmor):
-  # template injection, token over-permissioning, unpinned/impostor actions, cache
+  # Static security analysis of the GitHub Actions workflows and the composite
+  # action definitions under .github/actions (zizmor audits both): template
+  # injection, token over-permissioning, unpinned/impostor actions, cache
   # poisoning, dangerous triggers, credential persistence, and more. Runs the FULL
   # audit set online — the GITHUB_TOKEN enables the impostor-commit /
   # known-vulnerable-actions checks that need the GitHub API — and hard-fails on any
@@ -174,8 +179,8 @@ jobs:
           tool: zizmor
           fallback: none
 
-      - name: Audit the workflows
-        run: zizmor .github/workflows
+      - name: Audit the workflows and composite actions
+        run: zizmor .github/workflows .github/actions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/sweep-mutants.yml
+++ b/.github/workflows/sweep-mutants.yml
@@ -1,0 +1,168 @@
+name: sweep-mutants
+
+# The full-crate cargo-mutants leg of the daily sweep, one workflow_call per
+# crate from sweep.yml: a shard-matrix `mutate` job wrapping the mutate-crate
+# composite action, plus a `marker` fan-in that saves the crate's tree-hash
+# marker once every shard ran green. One call per crate keeps the rolling
+# failure issue's granularity — each caller job reddens on its own crate's
+# legs alone.
+#
+# Called only from sweep.yml, and it must stay a LEAF: workflow_call nesting
+# is capped at 4 connected levels and sweep.yml → ci.yml → core.yml already
+# uses 3, so a reusable reached from any deeper caller would sit at the
+# ceiling. The advisory PR-diff mutation jobs must never move in here either
+# — a failure inside a called workflow reddens its caller, which for ci.yml
+# means silently promoting an advisory job to a gating one (ci.yml's header);
+# they share the composite action instead.
+
+on:
+  workflow_call:
+    inputs:
+      shards:
+        description: >-
+          JSON array of `k/N` values for `cargo mutants --shard`, one matrix
+          leg each; the default single empty string runs the crate unsharded
+          in one leg.
+        required: false
+        type: string
+        default: '[""]'
+      working-directory:
+        description: Directory cargo runs in (see the composite's input).
+        required: false
+        type: string
+        default: .
+      marker-prefix:
+        description: >-
+          Full-sweep marker key prefix. The composite builds the key, so a
+          caller that passes the same prefix and paths gets the byte-identical
+          key — which is how ci.yml's advisory PR-diff jobs short-circuit on a
+          marker saved here.
+        required: true
+        type: string
+      marker-paths:
+        description: >-
+          Space-separated repository paths whose committed object hashes form
+          the marker key (see the composite's input).
+        required: true
+        type: string
+      marker-fold:
+        description: >-
+          `sha256` folds the hash list; empty joins it verbatim (see the
+          composite's input).
+        required: false
+        type: string
+        default: ''
+      marker-save:
+        description: >-
+          `fan-in` saves the marker from the `marker` job after ALL shards ran
+          green; `inline` lets the single unsharded leg save its own marker and
+          skips the fan-in.
+        required: false
+        type: string
+        default: fan-in
+      mutants-args:
+        description: Extra cargo-mutants arguments (see the composite's input).
+        required: false
+        type: string
+        default: ''
+      extra-env:
+        description: >-
+          KEY=VALUE lines the mutants' test suite needs (see the composite's
+          input).
+        required: false
+        type: string
+        default: ''
+      cache-workspaces:
+        description: Swatinem/rust-cache `workspaces` (see the composite's input).
+        required: false
+        type: string
+        default: ''
+      cache-shared-key:
+        description: >-
+          Swatinem/rust-cache `shared-key` — one lineage per crate, shared by
+          all its shards (see the composite's input).
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+env:
+  # Line tables instead of full DWARF, to hold down the target/ the legs
+  # archive through rust-cache (ci.yml carries the full rationale). Declared
+  # here because a called workflow inherits none of its caller's env. No
+  # CARGO_INCREMENTAL: the composite sets it to 1 itself.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+
+jobs:
+  mutate:
+    name: mutants${{ matrix.shard != '' && format(' (shard {0})', matrix.shard) || '' }}
+    # x64: taiki-e/install-action's cargo-mutants manifest carries no aarch64
+    # Linux asset (ci.yml's `mutants` job documents the gap).
+    runs-on: ubuntu-latest
+    outputs:
+      # Identical across legs (each computes it from the same HEAD), so the
+      # matrix-output last-writer-wins rule is harmless; the fan-in reuses it
+      # instead of recomputing.
+      key: ${{ steps.mutate.outputs.marker-key }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(inputs.shards) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Mutate
+        id: mutate
+        uses: ./.github/actions/mutate-crate
+        with:
+          mode: full
+          shard: ${{ matrix.shard }}
+          working-directory: ${{ inputs.working-directory }}
+          marker-prefix: ${{ inputs.marker-prefix }}
+          marker-paths: ${{ inputs.marker-paths }}
+          marker-fold: ${{ inputs.marker-fold }}
+          mutants-args: ${{ inputs.mutants-args }}
+          extra-env: ${{ inputs.extra-env }}
+          cache-workspaces: ${{ inputs.cache-workspaces }}
+          cache-shared-key: ${{ inputs.cache-shared-key }}
+          # Tag legs build fresh and never save: a cache poisoned elsewhere
+          # must not taint a release-adjacent run. Schedule runs execute on
+          # master, so their saves seed every pull request.
+          cache-lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
+          save-marker: ${{ inputs.marker-save == 'inline' }}
+
+  # The marker fan-in for sharded calls: runs only when every leg succeeded
+  # (default `needs` semantics), so the one saved marker attests the WHOLE
+  # crate passed. Probes first: on a marker hit the legs all short-circuited
+  # and the key already exists — saving it again would only warn. An
+  # `inline`-saving call skips this job, and a skipped job counts as success
+  # for the caller.
+  marker:
+    name: marker
+    needs: [mutate]
+    if: inputs.marker-save == 'fan-in'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe for an existing marker
+        id: marker
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .mutants-ok
+          key: ${{ needs.mutate.outputs.key }}
+          lookup-only: true
+
+      - name: Write the marker
+        if: steps.marker.outputs.cache-hit != 'true'
+        run: echo ok > .mutants-ok
+
+      - name: Save the marker (all shards green)
+        if: steps.marker.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .mutants-ok
+          key: ${{ needs.mutate.outputs.key }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -61,20 +61,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # Line tables instead of full DWARF, to hold down the target/ this workflow's
-  # legs archive through rust-cache — cache entries compete for one
-  # least-recently-used store across the whole repository, so a fat archive
-  # here evicts a cache a pull request needs. Enough debuginfo remains for
-  # file:line in a backtrace. Declared here because a called workflow inherits
-  # none of its caller's env; ci.yml carries the full rationale.
-  #
-  # CARGO_INCREMENTAL is deliberately absent: every job here that builds Rust
-  # is a cargo-mutants leg, and incremental rebuilds are what make mutation
-  # affordable (ci.yml sets 0 workflow-wide and overrides it back on exactly
-  # those jobs).
-  CARGO_PROFILE_DEV_DEBUG: line-tables-only
-
 concurrency:
   group: sweep-${{ github.ref }}
   # Never cancel a running sweep: a half-finished mutants pass saves no marker,
@@ -96,257 +82,81 @@ jobs:
   # comes from the tracked .cargo/mutants.toml: test_workspace = true (every
   # mutant faces the whole suite, the CLI's end-to-end fixture flow included),
   # which is what makes this expensive — ~3-4 h on a 24-core dev box, more on
-  # a 4-core hosted runner, against the 6 h job limit. So the run is SHARDED
-  # (cargo mutants --shard k/8): each shard builds its own baseline, then
-  # mutates a deterministic eighth of the mutant list, fitting comfortably
-  # (minutes are free on a public repo; concurrency is the only budget).
-  # --in-place skips the tree copy (each shard owns its runner's checkout);
-  # --no-shuffle keeps the shard partition deterministic.
-  #
-  # The marker key must capture EVERYTHING that can change a mutants verdict
-  # for the root workspace — wider than the gui/wasm single-crate keys (miss
-  # an input and a stale green marker lies): both crate trees, the workspace
-  # manifest (lints + the [profile.mutants] build profile), the lockfile, the
-  # mutants policy, the nextest profile (the `mutants` profile's timeouts),
-  # and the toolchain. Folded through sha256 to keep the key short. Every
-  # shard computes the identical key; the marker itself is saved only by
-  # core-mutants-ok below, after ALL shards ran green.
+  # a 4-core hosted runner, against the 6 h job limit. So the run is SHARDED:
+  # each shard builds its own baseline, then mutates a deterministic
+  # fifteenth of the mutant list, fitting comfortably (minutes are free on a
+  # public repo; concurrency is the only budget).
   core-mutants:
-    name: core full mutants (shard ${{ matrix.shard }})
-    runs-on: ubuntu-latest
-    outputs:
-      # Identical across legs (each computes it from the same HEAD), so the
-      # matrix-output last-writer-wins rule is harmless; core-mutants-ok
-      # reuses it instead of recomputing.
-      key: ${{ steps.key.outputs.key }}
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+    name: core full mutants
+    uses: ./.github/workflows/sweep-mutants.yml
+    with:
+      shards: '["0/15","1/15","2/15","3/15","4/15","5/15","6/15","7/15","8/15","9/15","10/15","11/15","12/15","13/15","14/15"]'
+      # The key must capture EVERYTHING that can change a mutants verdict for
+      # the root workspace — wider than the gui/wasm single-crate keys (miss
+      # an input and a stale green marker lies): both crate trees, the
+      # workspace manifest (lints + the [profile.mutants] build profile), the
+      # lockfile, the mutants policy, the nextest profile (the `mutants`
+      # profile's timeouts), and the toolchain — folded through sha256 to
+      # keep the key short.
+      marker-prefix: core-mutants-ok
+      marker-paths: >-
+        crates/bdinfo-rs-core crates/bdinfo-rs Cargo.toml Cargo.lock
+        .cargo/mutants.toml .config/nextest.toml rust-toolchain.toml
+      marker-fold: sha256
+      # One cache lineage for all shards (identical baselines) — without it
+      # each shard saves its own multi-GB target cache and the repo's 10 GB
+      # Actions-cache budget churns, evicting the sweep markers and the
+      # master-seeded PR caches. First finisher saves; the rest skip
+      # gracefully.
+      cache-shared-key: core-mutants
 
-      - name: Compute the sweep marker key (root-workspace inputs hash)
-        id: key
-        run: |
-          inputs=$(git rev-parse HEAD:crates/bdinfo-rs-core HEAD:crates/bdinfo-rs HEAD:Cargo.toml HEAD:Cargo.lock HEAD:.cargo/mutants.toml HEAD:.config/nextest.toml HEAD:rust-toolchain.toml)
-          echo "$inputs"
-          echo "key=core-mutants-ok-$(echo "$inputs" | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore the last-green marker
-        id: marker
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .mutants-ok
-          key: ${{ steps.key.outputs.key }}
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        if: steps.marker.outputs.cache-hit != 'true'
-        with:
-          # shared-key: every shard builds the IDENTICAL baseline, so all
-          # shards share ONE cache lineage instead of rust-cache's default
-          # per-matrix-leg keys — without it each shard saves its own
-          # multi-GB target cache and the repo's 10 GB Actions-cache budget
-          # churns, evicting the sweep markers and the master-seeded PR
-          # caches. First finisher saves; the rest skip gracefully.
-          shared-key: core-mutants
-          # Same discipline as the sibling legs: tag legs build fresh, only
-          # master runs save.
-          lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      # `fallback: none` on every install-action step here: install only from the
-      # action's checksummed manifest, never its runtime-resolved cargo-binstall
-      # fallback (rationale in core.yml).
-      - name: Install mutation tools
-        if: steps.marker.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
-        with:
-          tool: cargo-mutants,cargo-nextest
-          fallback: none
-
-      - name: Mutants (0 missed, this shard)
-        if: steps.marker.outputs.cache-hit != 'true'
-        run: cargo mutants --in-place --no-shuffle --shard ${{ matrix.shard }}/15
-
-  # The marker fan-in: runs only when every shard succeeded (default `needs`
-  # semantics), so the one saved marker attests the WHOLE root workspace
-  # passed. Probes first: on a marker hit the shards all short-circuited and
-  # the key already exists — saving it again would only warn.
-  core-mutants-ok:
-    name: core full mutants marker
-    needs: [core-mutants]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Probe for an existing marker
-        id: marker
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .mutants-ok
-          key: ${{ needs.core-mutants.outputs.key }}
-          lookup-only: true
-
-      - name: Write the marker
-        if: steps.marker.outputs.cache-hit != 'true'
-        run: echo ok > .mutants-ok
-
-      - name: Save the marker (all shards green)
-        if: steps.marker.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .mutants-ok
-          key: ${{ needs.core-mutants.outputs.key }}
-
-  # Full Tier-A mutation over the GUI crate, 0 missed — SHARDED like the core
-  # leg (the one-job run took ~1.7 h for 608 mutants; the shards divide that
-  # mutation phase, each still paying the setup + iced/wgpu baseline, so the
-  # floor is the baseline, not zero). Shard count is deliberately modest: the sweep's tail
-  # is 8 core shards + these, and the account-wide concurrent-job budget
-  # (~20) is the scarce resource, not minutes. --in-place because a temp copy
-  # would not carry the ../bdinfo-rs-core path dep; --no-shuffle keeps the
-  # shard partition deterministic; reads the crate-local .cargo/mutants.toml
-  # Tier-B exclusions. The snapshot ties participate via the deterministic
-  # software renderer, keeping their mutant kill power (a palette or
-  # view-model mutation shifts the rendered hash). The marker key is
-  # byte-identical to the pre-shard one — ci.yml's advisory PR-diff job
-  # computes the same string for its short-circuit. (wasm below stays
-  # unsharded on purpose: a ~3-minute job would only get SLOWER paying N
-  # baselines.)
+  # Full mutation over the GUI crate, 0 missed under the crate-local
+  # .cargo/mutants.toml exclusions — SHARDED like the core leg (the one-job
+  # run took ~1.7 h for 608 mutants; the shards divide that mutation phase,
+  # each still paying the setup + iced/wgpu baseline, so the floor is the
+  # baseline, not zero). Shard count is deliberately modest: the sweep's tail
+  # is the core shards + these, and the account-wide concurrent-job budget
+  # (~20) is the scarce resource, not minutes.
   gui-mutants:
-    name: gui full mutants (shard ${{ matrix.shard }})
-    runs-on: ubuntu-latest
-    outputs:
-      # Identical across legs; gui-mutants-ok reuses it (see core-mutants).
-      key: ${{ steps.key.outputs.key }}
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3, 4]
-    env:
-      ICED_TEST_BACKEND: tiny-skia
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Compute the sweep marker key (crate tree hash)
-        id: key
-        run: echo "key=gui-mutants-ok-$(git rev-parse HEAD:crates/bdinfo-rs-gui)-$(git rev-parse HEAD:rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore the last-green marker
-        id: marker
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .mutants-ok
-          key: ${{ steps.key.outputs.key }}
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        if: steps.marker.outputs.cache-hit != 'true'
-        with:
-          workspaces: crates/bdinfo-rs-gui
-          # One shared lineage for all shards (identical baselines) — see the
-          # core shards' shared-key note.
-          shared-key: gui-mutants
-          # Tag legs build fresh: a cache poisoned elsewhere must not taint a
-          # release-adjacent run (the fuzz.yml precedent). Schedule runs are on
-          # master, so their saves seed every PR.
-          lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      - name: Install mutation tools
-        if: steps.marker.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
-        with:
-          tool: cargo-mutants,cargo-nextest
-          fallback: none
-
+    name: gui full mutants
+    uses: ./.github/workflows/sweep-mutants.yml
+    with:
+      shards: '["0/5","1/5","2/5","3/5","4/5"]'
+      working-directory: crates/bdinfo-rs-gui
+      # Byte-identical to the key ci.yml's advisory gui PR-diff job builds
+      # from the same prefix + paths — that is what lets a green sweep here
+      # short-circuit the PR job (the composite owns the key format).
+      marker-prefix: gui-mutants-ok
+      marker-paths: crates/bdinfo-rs-gui rust-toolchain.toml
       # --workspace: without it cargo-mutants scopes to the root package and
       # silently skips the assets-gen member (whose byte-tie tests are its
       # mutant killers).
-      - name: Mutants (Tier A 0 missed, this shard)
-        if: steps.marker.outputs.cache-hit != 'true'
-        working-directory: crates/bdinfo-rs-gui
-        run: cargo mutants --in-place --no-shuffle --workspace --shard ${{ matrix.shard }}/5
+      mutants-args: --workspace
+      # The deterministic software backend is what makes the iced_test
+      # snapshot ties run on a GPU-less runner at all (same as gui.yml) —
+      # they keep their mutant kill power (a palette or view-model mutation
+      # shifts the rendered hash).
+      extra-env: ICED_TEST_BACKEND=tiny-skia
+      cache-workspaces: crates/bdinfo-rs-gui
+      cache-shared-key: gui-mutants
 
-  # The gui marker fan-in — same shape and reasoning as core-mutants-ok.
-  gui-mutants-ok:
-    name: gui full mutants marker
-    needs: [gui-mutants]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Probe for an existing marker
-        id: marker
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .mutants-ok
-          key: ${{ needs.gui-mutants.outputs.key }}
-          lookup-only: true
-
-      - name: Write the marker
-        if: steps.marker.outputs.cache-hit != 'true'
-        run: echo ok > .mutants-ok
-
-      - name: Save the marker (all shards green)
-        if: steps.marker.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .mutants-ok
-          key: ${{ needs.gui-mutants.outputs.key }}
-
-  # Full Tier-A mutation over the wasm crate, 0 missed — same marker pattern.
-  # --in-place for the same path-dep reason; the crate-local .cargo/mutants.toml
-  # carries the Tier-B cfg(wasm32) exclusions (browser glue is verified by the
-  # multi-runtime parity tests in the gate instead).
+  # Full mutation over the wasm crate, 0 missed under the crate-local
+  # .cargo/mutants.toml exclusions (the cfg(wasm32) browser glue is verified
+  # by the multi-runtime parity tests in the wasm gate instead). Unsharded on
+  # purpose: a ~3-minute job would only get SLOWER paying N baselines, so one
+  # leg runs everything and saves its own marker inline instead of through
+  # the fan-in.
   wasm-mutants:
-    name: wasm full mutants (Tier A 0 missed)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Compute the sweep marker key (crate tree hash)
-        id: key
-        run: echo "key=wasm-mutants-ok-$(git rev-parse HEAD:crates/bdinfo-rs-wasm)-$(git rev-parse HEAD:rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore the last-green marker
-        id: marker
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .mutants-ok
-          key: ${{ steps.key.outputs.key }}
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        if: steps.marker.outputs.cache-hit != 'true'
-        with:
-          workspaces: crates/bdinfo-rs-wasm
-          lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      - name: Install mutation tools
-        if: steps.marker.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
-        with:
-          tool: cargo-mutants,cargo-nextest
-          fallback: none
-
-      - name: Mutants (Tier A 0 missed)
-        if: steps.marker.outputs.cache-hit != 'true'
-        working-directory: crates/bdinfo-rs-wasm
-        run: cargo mutants --in-place
-
-      - name: Write the marker
-        if: steps.marker.outputs.cache-hit != 'true'
-        run: echo ok > .mutants-ok
-
-      - name: Save the marker (green sweep only)
-        if: steps.marker.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .mutants-ok
-          key: ${{ steps.key.outputs.key }}
+    name: wasm full mutants
+    uses: ./.github/workflows/sweep-mutants.yml
+    with:
+      working-directory: crates/bdinfo-rs-wasm
+      # Byte-identical to ci.yml's advisory wasm PR-diff key (see gui-mutants).
+      marker-prefix: wasm-mutants-ok
+      marker-paths: crates/bdinfo-rs-wasm rust-toolchain.toml
+      marker-save: inline
+      cache-workspaces: crates/bdinfo-rs-wasm
+      cache-shared-key: wasm-mutants
 
   # ONE rolling issue for sweep failures (the ruff daily-fuzz pattern):
   # refreshed while the sweep stays red, closed again once a sweep passes.
@@ -364,7 +174,10 @@ jobs:
   # gated areas whose failure filed the issue.
   report:
     name: rolling failure issue
-    needs: [orchestrator, core-mutants, core-mutants-ok, gui-mutants, gui-mutants-ok, wasm-mutants]
+    # One entry per crate: a red anywhere inside a called sweep-mutants.yml
+    # (a leg or its marker fan-in) reddens its caller job here, so the issue
+    # title names the failing crate without listing its inner jobs.
+    needs: [orchestrator, core-mutants, gui-mutants, wasm-mutants]
     if: ${{ !cancelled() && github.event_name != 'push' }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The six mutation jobs shared one six-step skeleton (checkout, marker key, marker restore, rust-cache, tool install, run), duplicated across ci.yml's three advisory PR-diff jobs and sweep.yml's three full legs plus two byte-identical marker fan-in jobs.

- `.github/actions/mutate-crate/action.yml`: the shared skeleton as a composite action. The advisory trio stays in ci.yml — a called workflow's failure would redden its caller and reach `ci-ok`, silently promoting the jobs to gating, while a composite's failure surfaces on the calling job itself — and each job shrinks to a checkout plus one composite step. The per-crate differences ride as inputs: the gui's `--workspace` and `ICED_TEST_BACKEND`, the sibling work dirs and `--in-place`, the marker prefix and paths.
- `.github/workflows/sweep-mutants.yml`: a `workflow_call` reusable for the sweep legs, called once per crate from sweep.yml so the rolling failure issue keeps per-crate granularity. It wraps the composite in a shard matrix and absorbs the two marker fan-ins; core keeps its 15 shards, gui its 5, and wasm stays unsharded, saving its marker inline. The marker key is built in one place (the composite), so the sweep legs and the PR-diff jobs produce byte-identical keys from the same prefix and paths; the key formats are unchanged.
- Every `git diff` in ci.yml and the composite carries `--no-renames` (five sites). With rename detection on, `cargo mutants --in-diff` (27.1.0) produces no mutants for a diff containing a moved file — 19 mutants with the flag, 0 without, measured on a one-file move — and the plan job's name-only diffs listed only a moved file's new path, so a pure move out of an area never fired that area's gates. Listing both paths is fail-open.
- `.github/actions/**` joins the hygiene surface: action-validator and zizmor scan it in repo.yml (zizmor's pass over the new directory caught a real `github-env` finding in the composite, fixed by scoping the env to the run steps; a schema-broken probe action fails the action-validator loop), `classify-diff.ps1` maps it — the composite fires the core, gui and wasm areas, so the advisory mutation jobs run whenever it changes — and Dependabot's github-actions entry now uses `directories` with a `/.github/actions/*` glob, since `directory: "/"` reaches only `.github/workflows` plus a root-level action.yml.

The wasm sweep leg's rust-cache lineage restarts once (it gains an explicit `shared-key`); the sweep markers and their keys are untouched.
