### PR TITLE
ci: read tool and toolchain pins from one committed manifest

### DIFF
--- a/.github/actions/pins/action.yml
+++ b/.github/actions/pins/action.yml
@@ -1,0 +1,96 @@
+# Every hand-maintained tool and toolchain version in this repository lives in
+# .github/pins.env; this action is how a workflow reads one. A job adds
+#
+#     - id: pins
+#       uses: ./.github/actions/pins
+#
+# after its checkout (a local action needs the repository on disk), then spells
+# the version as `${{ steps.pins.outputs.NIGHTLY }}` where it used to carry a
+# literal. That expression is safe in `with:`, `env:` and a cache `key:`, but
+# route it through a step's `env:` before a `run:` block reads it — zizmor's
+# template-injection audit rejects any expansion inside a run block.
+#
+# STEP OUTPUTS, not $GITHUB_ENV, which would be the shorter spelling: zizmor's
+# github-env audit reports any write to the environment file from an action as a
+# HIGH finding (measured against zizmor 1.26.1, 2026-08-06), and findings in
+# hand-maintained files here are fixed rather than suppressed. The cost is that
+# each consuming step names the pins it uses, which reads as documentation.
+#
+# A COMPOSITE action rather than a reusable workflow: composites are callable
+# from inside core.yml / gui.yml / wasm.yml, which already sit at the four-level
+# workflow_call nesting ceiling (sweep.yml -> ci.yml -> the reusable), and a
+# composite's failure surfaces on the calling job instead of reddening its
+# caller.
+name: pins
+description: >-
+  Expose the versions in .github/pins.env as step outputs, so a workflow can
+  install a pinned tool without carrying a copy of its version.
+
+outputs:
+  NIGHTLY:
+    description: The nightly toolchain for the rustfmt and llvm-cov steps.
+    value: ${{ steps.read.outputs.NIGHTLY }}
+  CARGO_VET:
+    description: cargo-vet, compiled from crates.io and cached.
+    value: ${{ steps.read.outputs.CARGO_VET }}
+  CARGO_FUZZ:
+    description: cargo-fuzz, compiled from crates.io and cached.
+    value: ${{ steps.read.outputs.CARGO_FUZZ }}
+  CARGO_DEB:
+    description: cargo-deb, the .deb packager.
+    value: ${{ steps.read.outputs.CARGO_DEB }}
+  CARGO_GENERATE_RPM:
+    description: cargo-generate-rpm, the .rpm packager.
+    value: ${{ steps.read.outputs.CARGO_GENERATE_RPM }}
+  APPIMAGETOOL:
+    description: appimagetool, the GUI lane's AppImage packer.
+    value: ${{ steps.read.outputs.APPIMAGETOOL }}
+  RYL:
+    description: ryl, the YAML linter.
+    value: ${{ steps.read.outputs.RYL }}
+  TAPLO_CLI:
+    description: taplo-cli, the TOML formatter and linter.
+    value: ${{ steps.read.outputs.TAPLO_CLI }}
+  CONVCO:
+    description: convco, the conventional-commit checker.
+    value: ${{ steps.read.outputs.CONVCO }}
+  WASM_BINDGEN_CLI:
+    description: wasm-bindgen-cli, which must equal the wasm-bindgen crate version.
+    value: ${{ steps.read.outputs.WASM_BINDGEN_CLI }}
+  NODE:
+    description: The Node version the browser package builds and tests on.
+    value: ${{ steps.read.outputs.NODE }}
+  NPM:
+    description: The npm version the staged npm publish runs on.
+    value: ${{ steps.read.outputs.NPM }}
+  WRANGLER:
+    description: wrangler, which deploys the demo site to Cloudflare Pages.
+    value: ${{ steps.read.outputs.WRANGLER }}
+  KOMAC:
+    description: komac, which submits the WinGet manifests.
+    value: ${{ steps.read.outputs.KOMAC }}
+  CLOUDSMITH_CLI:
+    description: cloudsmith-cli, which pushes the .deb/.rpm packages.
+    value: ${{ steps.read.outputs.CLOUDSMITH_CLI }}
+
+runs:
+  using: composite
+  steps:
+    # pwsh, not bash: the same Get-Pins the PowerShell scripts and
+    # version-freshness.yml call, so the manifest has ONE parser and one
+    # definition of a malformed line. pwsh ships on every GitHub-hosted runner
+    # image, which this action is used from on all three.
+    #
+    # Get-Pins finds the manifest beside its own script directory, so this step
+    # does not depend on the working directory; the dot-source does, and composite
+    # run steps start in the workspace.
+    - name: Read the pin manifest
+      id: read
+      shell: pwsh
+      run: |
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = 'Stop'
+        . ./.github/scripts/_common.ps1
+        foreach ($pin in (Get-Pins).GetEnumerator()) {
+          "$($pin.Key)=$($pin.Value)" | Add-Content -LiteralPath $env:GITHUB_OUTPUT
+        }

--- a/.github/actions/wasm-build/action.yml
+++ b/.github/actions/wasm-build/action.yml
@@ -1,0 +1,60 @@
+# The toolchain the in-browser package is built with, in one place: the wasm32
+# target, the wasm-bindgen CLI that generates its JS glue, and the Node the web
+# tooling runs on. Three workflows need exactly this — wasm.yml (the gate),
+# publish-npm.yml (the tag-time npm publish) and deploy-pages.yml (the demo
+# deploy) — and all three must build the shipped artifact with the same tools,
+# so a divergence between them is a bug by construction.
+#
+# The two npm steps are optional because only their POSITION differs between the
+# callers: wasm.yml runs its whole gate between `npm ci` and `npm run build`, and
+# publish-npm.yml pins npm and verifies the tag against the manifests in between,
+# so neither can take the pair as one block.
+#
+# A COMPOSITE action rather than a reusable workflow (rationale in
+# .github/actions/pins).
+name: wasm-build
+description: >-
+  Install the wasm32 target, the pinned wasm-bindgen CLI and the pinned Node,
+  and optionally install and run the browser package's web build.
+
+inputs:
+  web:
+    description: >-
+      `install` also runs `npm ci` in the web directory; `build` also runs
+      `npm run build` after it; empty stops after the toolchain.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - id: pins
+      uses: ./.github/actions/pins
+
+    - name: Add the wasm32 target
+      shell: bash
+      run: rustup target add wasm32-unknown-unknown
+
+    # `fallback: none`: install only from install-action's checksummed manifest,
+    # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
+    - name: Install wasm-bindgen-cli (pinned to the crate version)
+      uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
+      with:
+        tool: wasm-bindgen-cli@${{ steps.pins.outputs.WASM_BINDGEN_CLI }}
+        fallback: none
+
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: ${{ steps.pins.outputs.NODE }}
+
+    - name: Install the web toolchain (binaryen / biome / typescript / playwright-core)
+      if: inputs.web != ''
+      working-directory: crates/bdinfo-rs-wasm/web
+      shell: bash
+      run: npm ci
+
+    - name: Build the browser artifact (wasm-bindgen + wasm-opt -Oz + tsc)
+      if: inputs.web == 'build'
+      working-directory: crates/bdinfo-rs-wasm/web
+      shell: bash
+      run: npm run build

--- a/.github/build-linux-packages.sh
+++ b/.github/build-linux-packages.sh
@@ -28,17 +28,21 @@ TRIPLES=(x86_64-unknown-linux-musl aarch64-unknown-linux-musl)
 OUT=dist-extra
 mkdir -p "$OUT"
 
-# The pure-Rust packagers, compiled from source (dist runs this file as a plain
-# shell script inside build-global-artifacts, so taiki-e/install-action — a `uses:`
-# step — is not available here; `cargo install` is the fallback). PINNED, because
-# this compile runs INSIDE dist's fail-fast release: a broken or schema-changing
-# upstream release would abort the ENTIRE release (all six binaries + every
-# channel), and only at tag time. The pins are the versions that shipped the last
-# release; version-freshness.yml nags when a newer one ships so the bump stays a
-# deliberate, reviewed change. Skip if a cached copy is already on PATH (re-runs /
-# future dist caching).
+# The versions of every hand-maintained tool in this repository, as KEY=VALUE
+# lines (the file's own header documents the format). This is the one consumer
+# that sources it rather than reading it through .github/actions/pins: dist runs
+# this file as a plain shell script inside build-global-artifacts, where a
+# `uses:` step does not exist.
+. "$(dirname "$0")/pins.env"
+
+# The pure-Rust packagers, compiled from source (`cargo install` is the only
+# channel available here, for the same reason). PINNED, because this compile runs
+# INSIDE dist's fail-fast release: a broken or schema-changing upstream release
+# would abort the ENTIRE release (all six binaries + every channel), and only at
+# tag time. Skip if a cached copy is already on PATH (re-runs / future dist
+# caching).
 command -v cargo-deb >/dev/null 2>&1 && command -v cargo-generate-rpm >/dev/null 2>&1 \
-  || cargo install --locked cargo-deb@3.7.0 cargo-generate-rpm@0.21.0
+  || cargo install --locked "cargo-deb@$CARGO_DEB" "cargo-generate-rpm@$CARGO_GENERATE_RPM"
 
 for triple in "${TRIPLES[@]}"; do
   archive="target/distrib/bdinfo-rs-${triple}.tar.gz"

--- a/.github/pins.env
+++ b/.github/pins.env
@@ -1,0 +1,97 @@
+# The one home for every hand-maintained tool and toolchain version in this
+# repository. A pin listed here appears NOWHERE else: the workflows read it
+# through the .github/actions/pins composite action, the PowerShell scripts
+# through Get-Pin in .github/scripts/_common.ps1, and
+# .github/build-linux-packages.sh — a plain shell script dist runs inside the
+# release, where no `uses:` step exists — sources this file directly. That is
+# what the format below is for: one file that a shell, PowerShell and
+# $GITHUB_OUTPUT can all read without a parser.
+#
+# FORMAT (enforced by the parser, which fails on anything else):
+#   - `KEY=VALUE`, no spaces around the `=`, no quotes
+#   - KEY matches [A-Z][A-Z0-9_]*  — a valid shell and environment-variable name
+#   - VALUE contains no whitespace
+#   - `#` comment lines and blank lines are ignored
+#
+# Bumping a pin is a deliberate, reviewed change: version-freshness.yml compares
+# every value here against its upstream latest daily and opens one tracking issue
+# when something falls behind. It no longer has to check that copies of a pin
+# agree, because there are no copies.
+#
+# PINS THAT DELIBERATELY LIVE ELSEWHERE, because a third-party tool reads their
+# file directly and would not look here:
+#   - `channel` in rust-toolchain.toml — rustup reads it to pick the stable
+#     toolchain for every cargo invocation in the tree.
+#   - `cargo-dist-version` in dist-workspace.toml — dist reads it to decide which
+#     generator produced v-release.yml. core.yml's release-yaml job carries a
+#     DIST_VERSION/DIST_SHA256 pair beside it (the archive it downloads and the
+#     digest it verifies); version-freshness.yml keeps that pair equal to the TOML.
+#   - `binaryen` in crates/bdinfo-rs-wasm/web/package.json — npm resolves it, and
+#     the committed package-lock.json is what actually fixes the wasm-opt build.
+#   - the `$schema` URL in crates/bdinfo-rs-wasm/web/biome.json — biome reads it,
+#     and the version it must match is the @biomejs/biome dependency Dependabot
+#     bumps in the same package.json.
+# SHA-pinned `uses:` action references are not versions and are not listed here
+# either: Dependabot bumps them in place, in the workflow and composite files.
+
+# The nightly toolchain behind the `cargo fmt` steps (rustfmt.toml sets
+# nightly-only options) and the llvm-cov coverage steps (`--branch` and the
+# `coverage_nightly` cfg are nightly-only). Everything else builds on the stable
+# channel in rust-toolchain.toml.
+NIGHTLY=nightly-2026-07-06
+
+# cargo-vet: only 0.10.0 ships a prebuilt binary anywhere, so this is compiled
+# from crates.io and cached. Must be a version that accepts the committed
+# supply-chain/imports.lock.
+CARGO_VET=0.10.2
+
+# cargo-fuzz: absent from taiki-e/install-action's manifest, so the corpus replay
+# and the tag-time fresh-fuzz pass both compile it from crates.io.
+CARGO_FUZZ=0.13.2
+
+# The two pure-Rust Linux packagers. They are compiled from source INSIDE dist's
+# fail-fast release, so a broken upstream release would abort a whole release at
+# tag time; the CLI and GUI packaging smoke tests pre-install these same versions
+# so they package with the exact release tools.
+CARGO_DEB=3.7.0
+CARGO_GENERATE_RPM=0.21.0
+
+# appimagetool, fetched over curl by the GUI's Linux packaging script. Its
+# `releases/latest` is the rolling `continuous` nightly, so this is the highest
+# semver tag it has released.
+APPIMAGETOOL=1.9.1
+
+# The YAML and TOML linters, and the conventional-commit checker. All three are
+# pinned rather than floated because their output is a verdict on the tree: a new
+# release relinting or reformatting differently would red-X an unrelated pull
+# request.
+RYL=0.21.0
+TAPLO_CLI=0.10.0
+CONVCO=0.7.1
+
+# wasm-bindgen-cli MUST equal the wasm-bindgen crate version resolved in
+# crates/bdinfo-rs-wasm/Cargo.lock — wasm-bindgen hard-errors on any crate/CLI
+# mismatch, and wasm.yml proves the equality on every run.
+WASM_BINDGEN_CLI=0.2.126
+
+# The Node line the browser package builds and tests on: 26 reaches LTS in
+# October 2026. Odd majors are never LTS and are not adopted.
+NODE=26.6.0
+
+# npm, pinned independently of whichever npm a given Node 26.x bundles: `npm
+# stage publish` needs >= 11.15.0 and `--provenance` needs a working bundled
+# sigstore (npm 12.0.0 shipped that broken, npm/cli#9722; 12.0.1 fixed it,
+# npm/cli#9740).
+NPM=12.0.2
+
+# wrangler, invoked with npx to deploy the demo site. Pinned because it runs with
+# the Cloudflare Pages deploy token.
+WRANGLER=4.118.0
+
+# komac, fetched over curl to submit the WinGet manifests. winget-releaser wraps
+# the same tool but bootstraps it through cargo-bins/cargo-binstall@main, which
+# this repository's SHA-pinning policy rejects.
+KOMAC=2.16.0
+
+# cloudsmith-cli, installed with pipx by the package push legs.
+CLOUDSMITH_CLI=1.21.0

--- a/.github/scripts/_common.ps1
+++ b/.github/scripts/_common.ps1
@@ -3,7 +3,7 @@
 
 <#
 .SYNOPSIS
-    Helpers shared by the publish lanes.
+    Helpers shared by the CI scripts and the publish lanes.
 
 .DESCRIPTION
     Dot-source this file; every function below then runs in the caller's scope:
@@ -22,8 +22,9 @@
     scripts are built on reachable at all — with it left at $true a non-zero exit
     from a native command throws instead.
 
-    Consumers: the publish-gui-*.ps1 channel legs, cloudsmith-push.ps1, and the
-    inline pwsh steps of publish-crates.yml and publish-npm.yml.
+    Consumers: the publish-gui-*.ps1 channel legs, cloudsmith-push.ps1,
+    gui-package-linux.ps1, the pins composite action, and the inline pwsh steps
+    of publish-crates.yml, publish-npm.yml and version-freshness.yml.
 #>
 
 # Fail a publishing leg. Never a `throw`: these run as the whole body of a
@@ -34,6 +35,47 @@ function Stop-Leg {
 
     Write-Host "FAILED: $Why" -ForegroundColor Red
     exit 1
+}
+
+# The pin manifest (.github/pins.env) as an ordered name -> version map, in file
+# order. Every hand-maintained tool and toolchain version in this repository is
+# read through here or through the pins composite action, which calls this.
+#
+# A line that is neither blank, nor a `#` comment, nor `KEY=VALUE` in the shape
+# the manifest's header documents is a hard error rather than a skipped line: the
+# same file is `source`d by .github/build-linux-packages.sh and appended verbatim
+# to $GITHUB_OUTPUT, and both would take a malformed line silently.
+#
+# `throw`, not Stop-Leg: the callers include the local gate and a workflow step,
+# where the message plus a non-zero exit is what is wanted, not a publish leg's
+# one-line verdict.
+function Get-Pins {
+    param([string] $Path = (Join-Path $PSScriptRoot '..' 'pins.env'))
+
+    $pins = [ordered]@{}
+    $lineNo = 0
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        $lineNo++
+        if ($line -match '^\s*(#|$)') { continue }
+        if ($line -notmatch '^([A-Z][A-Z0-9_]*)=(\S+)$') {
+            throw "pins.env line ${lineNo}: expected KEY=VALUE with no spaces or quotes, got: $line"
+        }
+        if ($pins.Contains($Matches[1])) { throw "pins.env line ${lineNo}: $($Matches[1]) is pinned twice" }
+        $pins[$Matches[1]] = $Matches[2]
+    }
+    if ($pins.Count -eq 0) { throw "no pins in $Path" }
+    return $pins
+}
+
+# One pin by name. Missing is an error: a caller silently installing an empty
+# version would resolve to whatever is latest, which is what the manifest exists
+# to prevent.
+function Get-Pin {
+    param([Parameter(Mandatory)] [string] $Name)
+
+    $pins = Get-Pins
+    if (-not $pins.Contains($Name)) { throw "no $Name pin in .github/pins.env" }
+    return $pins[$Name]
 }
 
 # Parse a SHA256SUMS file into a filename -> lower-case hex hash map, accepting

--- a/.github/scripts/classify-diff.ps1
+++ b/.github/scripts/classify-diff.ps1
@@ -81,6 +81,15 @@ begin {
     # sources reach `core` alone.
     $script:CoreDependents = @('core', 'gui', 'wasm', 'fuzz')
 
+    # The areas whose jobs install a tool or toolchain named in .github/pins.env,
+    # and so change their verdict when a pin — or the machinery that reads one —
+    # changes: the nightly reaches core, gui, wasm and the corpus replay; cargo-vet
+    # reaches deps; the two Linux packagers reach pkg and the gui packaging smoke;
+    # ryl reaches the YAML lint and taplo the TOML lint. The remaining pins (npm,
+    # wrangler, komac, cloudsmith-cli, appimagetool) are read only by the tag and
+    # dispatch publishing lanes, which no pull-request job runs.
+    $script:PinConsumers = @('core', 'gui', 'wasm', 'fuzz', 'deps', 'pkg', 'yaml', 'toml')
+
     function Test-Match {
         param([string] $File, [string[]] $Patterns)
 
@@ -295,6 +304,34 @@ begin {
             Match      = { param($f) $f -eq '.github/zizmor.yml' }
         },
         @{
+            Name       = 'pin manifest'
+            Areas      = $script:PinConsumers
+            Structural = $true
+            Why        = 'The one home for every hand-maintained tool and toolchain version. A change here changes which compiler or tool those jobs install, so it has to reach all of them.'
+            Match      = { param($f) $f -eq '.github/pins.env' }
+        },
+        @{
+            Name       = 'pin composite action'
+            Areas      = $script:PinConsumers + @('workflows')
+            Structural = $true
+            Why        = 'Every job that installs a pinned tool reads the manifest through this action, so a break in it is a break in all of them; action-validator and zizmor read the action definitions under .github/actions as well as the workflows.'
+            Match      = { param($f) Test-Match $f @('.github/actions/pins/*') }
+        },
+        @{
+            Name       = 'wasm build composite action'
+            Areas      = @('wasm', 'yaml', 'workflows')
+            Structural = $true
+            Why        = 'The action installs the wasm32 target, the wasm-bindgen CLI and Node for the wasm gate; the npm publish and the demo deploy also use it, and neither runs on a pull request.'
+            Match      = { param($f) Test-Match $f @('.github/actions/wasm-build/*') }
+        },
+        @{
+            Name       = 'shared script helpers'
+            Areas      = $script:PinConsumers
+            Structural = $true
+            Why        = 'Get-Pins here is the manifest''s only parser, called by the pins action on behalf of every job that installs a pinned tool. Its other functions are shared by the publishing lanes, which no pull-request job runs.'
+            Match      = { param($f) $f -eq '.github/scripts/_common.ps1' }
+        },
+        @{
             Name       = 'mutation composite action'
             Areas      = @('core', 'gui', 'wasm', 'yaml', 'workflows')
             Structural = $true
@@ -386,8 +423,8 @@ begin {
             Name       = 'publishing helpers'
             Areas      = @()
             Structural = $true
-            Why        = 'Run only by the tag and dispatch publishing lanes, which the orchestrator never calls; their dry runs verify them. _common.ps1 carries what those legs share and cloudsmith-push.ps1 the package push both the CLI and the GUI lane call, so the two are named here as well as the publish-* legs.'
-            Match      = { param($f) Test-Match $f @('.github/scripts/publish-*.ps1', '.github/scripts/_common.ps1', '.github/scripts/cloudsmith-push.ps1') }
+            Why        = 'Run only by the tag and dispatch publishing lanes, which the orchestrator never calls; their dry runs verify them. cloudsmith-push.ps1 is the package push both the CLI and the GUI lane call, so it is named here as well as the publish-* legs.'
+            Match      = { param($f) Test-Match $f @('.github/scripts/publish-*.ps1', '.github/scripts/cloudsmith-push.ps1') }
         },
         @{
             Name       = 'banned-word and classifier scripts'
@@ -511,11 +548,14 @@ end {
             @{ Path = '.github/workflows/sweep-mutants.yml'; Areas = 'links typos workflows yaml' }
             @{ Path = '.github/workflows/docker.yml'; Areas = 'links typos workflows yaml' }
             @{ Path = '.github/actions/mutate-crate/action.yml'; Areas = 'core gui links typos wasm workflows yaml' }
+            @{ Path = '.github/pins.env'; Areas = 'core deps fuzz gui links pkg toml typos wasm yaml' }
+            @{ Path = '.github/actions/pins/action.yml'; Areas = 'core deps fuzz gui links pkg toml typos wasm workflows yaml' }
+            @{ Path = '.github/actions/wasm-build/action.yml'; Areas = 'links typos wasm workflows yaml' }
             @{ Path = '.github/scripts/gui-package-windows.ps1'; Areas = 'gui links typos' }
             @{ Path = '.github/scripts/wasm-rules.ps1'; Areas = 'links typos wasm' }
             @{ Path = '.github/scripts/cov-floor.ps1'; Areas = 'gui links typos wasm' }
             @{ Path = '.github/scripts/publish-gui-aur.ps1'; Areas = 'links typos' }
-            @{ Path = '.github/scripts/_common.ps1'; Areas = 'links typos' }
+            @{ Path = '.github/scripts/_common.ps1'; Areas = 'core deps fuzz gui links pkg toml typos wasm yaml' }
             @{ Path = '.github/scripts/cloudsmith-push.ps1'; Areas = 'links typos' }
             @{ Path = 'packaging/aur/PKGBUILD.template'; Areas = 'links typos' }
             @{ Path = 'Dockerfile'; Areas = 'links typos' }

--- a/.github/scripts/gui-package-linux.ps1
+++ b/.github/scripts/gui-package-linux.ps1
@@ -6,9 +6,10 @@
 # asset paths and their $auto/auto-req scans assume it). Shared by the gui.yml
 # packaging smoke and the gui-release.yml lane.
 #
-# cargo-deb / cargo-generate-rpm ride the same pins as the CLI's
-# .github/build-linux-packages.sh (version-freshness.yml cross-checks the two
-# files); appimagetool is pinned below with its own freshness watch. The
+# cargo-deb, cargo-generate-rpm and appimagetool are read from
+# .github/pins.env, the one home for every hand-maintained tool version here, so
+# this lane and the CLI's .github/build-linux-packages.sh package with the same
+# tools by construction. The
 # AppDir carries exactly what the spec mandates in its root — AppRun, ONE
 # .desktop, the icon named by its Icon= key, and .DirIcon — plus the usual
 # usr/ tree; nothing graphics/driver-adjacent is bundled (the binary has no C
@@ -32,10 +33,11 @@ $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 
 # Pinned because a broken or schema-changing upstream release must not abort a
-# release run at tag time; version-freshness.yml nags when newer ones ship.
-$cargoDebVersion = '3.7.0'
-$cargoGenerateRpmVersion = '0.21.0'
-$appimagetoolVersion = '1.9.1'
+# release run at tag time.
+. "$PSScriptRoot/_common.ps1"
+$cargoDebVersion = Get-Pin CARGO_DEB
+$cargoGenerateRpmVersion = Get-Pin CARGO_GENERATE_RPM
+$appimagetoolVersion = Get-Pin APPIMAGETOOL
 
 $repo = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..' '..')).Path
 $crate = Join-Path $repo 'crates/bdinfo-rs-gui'

--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -49,12 +49,15 @@ jobs:
       - name: Fetch full history without blobs
         run: git fetch --no-tags --filter=blob:none --unshallow origin
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       # `fallback: none`: install only from install-action's checksummed manifest,
       # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install convco (prebuilt, no from-source compile)
         uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
-          tool: convco@0.7.1
+          tool: convco@${{ steps.pins.outputs.CONVCO }}
           fallback: none
 
       # Prove the banned-word regex still rejects attribution and passes innocent

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -71,9 +71,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # The nightly that backs the `fmt` step (rustfmt.toml has nightly-only options).
-  # Keep in lockstep with $script:Nightly in scripts/_common.ps1.
-  NIGHTLY: nightly-2026-07-06
   # Keep the cached target/ small: no incremental-compilation metadata, and line
   # tables instead of full DWARF (still enough for file:line in a test
   # backtrace). A called workflow inherits none of its caller's env, so these are
@@ -208,8 +205,13 @@ jobs:
           fetch-depth: 0   # semver-checks needs the v* baseline tag
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       - name: Install pinned nightly rustfmt
-        run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component rustfmt
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
+        run: rustup toolchain install "$NIGHTLY" --profile minimal --component rustfmt
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -240,7 +242,9 @@ jobs:
         run: ./.github/scripts/source-rules.ps1
 
       - name: Format (nightly rustfmt)
-        run: cargo +${{ env.NIGHTLY }} fmt --all --check
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
+        run: cargo "+$NIGHTLY" fmt --all --check
 
       - name: Clippy (-D warnings, pedantic/nursery/restriction)
         run: cargo lt
@@ -285,8 +289,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       - name: Install pinned nightly with llvm-tools
-        run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component llvm-tools-preview
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
+        run: rustup toolchain install "$NIGHTLY" --profile minimal --component llvm-tools-preview
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -299,7 +308,9 @@ jobs:
           fallback: none
 
       - name: Coverage (100% lines/regions/functions)
-        run: cargo +${{ env.NIGHTLY }} llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
+        run: cargo "+$NIGHTLY" llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100
 
   # The declared MSRV is enforced, not decorative: build the whole root workspace
   # with exactly the rust-version toolchain from Cargo.toml, read from the
@@ -511,13 +522,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       # The committed imports.lock omits the `user-id` publisher field that
       # cargo-vet 0.10.0 still rejects; 0.10.1+ relaxed it. Only 0.10.0 ships a
       # prebuilt binary anywhere (mozilla's release page and the install-action
-      # manifest both stop there), so 0.10.2 is compiled from crates.io once and
-      # cached — keep the cache key in lockstep with the install pin below,
-      # which version-freshness.yml watches. Keep both in lockstep with the
-      # version that writes supply-chain/.
+      # manifest both stop there), so the pinned version is compiled from
+      # crates.io once and cached. It must also be a version that can write
+      # supply-chain/.
       # The key carries `runner.arch` because the entry holds an EXECUTABLE and
       # `runner.os` is `Linux` on both the x64 and the arm64 runners: without it
       # an x86_64 binary would restore onto an arm64 host and fail to run.
@@ -526,11 +539,13 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/cargo-vet
-          key: cargo-vet-${{ runner.os }}-${{ runner.arch }}-0.10.2
+          key: cargo-vet-${{ runner.os }}-${{ runner.arch }}-${{ steps.pins.outputs.CARGO_VET }}
 
-      - name: Install cargo-vet 0.10.2 (cache miss)
+      - name: Install the pinned cargo-vet (cache miss)
         if: steps.vet-bin.outputs.cache-hit != 'true'
-        run: cargo install cargo-vet --version 0.10.2 --locked
+        env:
+          CARGO_VET: ${{ steps.pins.outputs.CARGO_VET }}
+        run: cargo install cargo-vet --version "$CARGO_VET" --locked
 
       - name: Vet the dependency tree against the committed store
         run: cargo vet --locked
@@ -601,7 +616,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       - name: Install pinned nightly
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: |
           rustup toolchain install "$NIGHTLY" --profile minimal
           rustup target add "$FUZZ_TARGET" --toolchain "$NIGHTLY"
@@ -628,8 +648,7 @@ jobs:
       # cargo-fuzz is absent from taiki-e/install-action's manifest (101 tools at
       # the revision pinned in this file), so with the binstall fallback disabled
       # it has no prebuilt channel here. Compile the pinned version from crates.io
-      # once and cache the binary, the same lane cargo-vet uses; keep the pin equal
-      # to fuzz.yml's, which version-freshness.yml enforces and watches.
+      # once and cache the binary, the same lane cargo-vet uses.
       # NOT keyed by matrix.arch: cargo-fuzz is a HOST executable driving a
       # cross-compile, identical for both legs. On a cold cache both legs miss and
       # both save the same bytes; the loser logs a reserve conflict and moves on.
@@ -638,16 +657,20 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/cargo-fuzz
-          key: cargo-fuzz-${{ runner.os }}-0.13.2
+          key: cargo-fuzz-${{ runner.os }}-${{ steps.pins.outputs.CARGO_FUZZ }}
 
-      - name: Install cargo-fuzz 0.13.2 (cache miss)
+      - name: Install the pinned cargo-fuzz (cache miss)
         if: steps.fuzz-bin.outputs.cache-hit != 'true'
-        run: cargo install cargo-fuzz --version 0.13.2 --locked
+        env:
+          CARGO_FUZZ: ${{ steps.pins.outputs.CARGO_FUZZ }}
+        run: cargo install cargo-fuzz --version "$CARGO_FUZZ" --locked
 
       - name: Verify the committed fuzz lockfile is in sync
         # cargo-fuzz's `run` has no --locked flag (it forwards everything after
         # `--` to libFuzzer), so enforce the committed fuzz/Cargo.lock with a real
         # cargo command up front; this also pre-fetches the deps for the build.
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: cargo +"$NIGHTLY" fetch --locked --manifest-path fuzz/Cargo.toml
 
       # The target list comes from fuzz/targets.txt — the one place it lives,
@@ -658,6 +681,8 @@ jobs:
       # and -max_len DROPS an over-long seed rather than truncating it, which
       # would quietly shrink the regression set this job exists to hold.
       - name: Replay the committed corpus through every target
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: |
           targets=$(awk '!/^[[:space:]]*#/ && NF { print $1 }' fuzz/targets.txt)
           [ -n "$targets" ] || { echo "no targets in fuzz/targets.txt"; exit 1; }
@@ -726,36 +751,40 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       # build.rs writes the shell completions + man page into OUT_DIR during the build;
       # the host triple nests output under target/<triple>/ (mirroring what the release
       # archives carry). --locked keeps the smoke build honest against the lockfile.
       - name: Build the binary (generates completions + man page)
         run: cargo build --release --locked --target "$HOST" -p bdinfo-rs
 
-      # Both at the SAME versions build-linux-packages.sh pins — so the script's
+      # Both from the same manifest build-linux-packages.sh reads — so the script's
       # `command -v cargo-deb` guard finds them and skips its (slower) source compile,
       # and the smoke test packages with the exact release tools.
       - name: Install cargo-deb (release pin, prebuilt)
         uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
-          tool: cargo-deb@3.7.0
+          tool: cargo-deb@${{ steps.pins.outputs.CARGO_DEB }}
           fallback: none
 
       # cargo-generate-rpm is absent from taiki-e/install-action's manifest (101
       # tools at the revision pinned in this file), so with the binstall fallback
       # disabled it gets the same compile-once-and-cache lane as cargo-fuzz and
-      # cargo-vet. The `@0.21.0` pin is the one build-linux-packages.sh and gui.yml
-      # carry; version-freshness.yml cross-checks all three.
+      # cargo-vet.
       - name: Cache the pinned cargo-generate-rpm binary
         id: rpm-bin
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/cargo-generate-rpm
-          key: cargo-generate-rpm-${{ runner.os }}-0.21.0
+          key: cargo-generate-rpm-${{ runner.os }}-${{ steps.pins.outputs.CARGO_GENERATE_RPM }}
 
       - name: Install cargo-generate-rpm (cache miss)
         if: steps.rpm-bin.outputs.cache-hit != 'true'
-        run: cargo install --locked cargo-generate-rpm@0.21.0
+        env:
+          CARGO_GENERATE_RPM: ${{ steps.pins.outputs.CARGO_GENERATE_RPM }}
+        run: cargo install --locked "cargo-generate-rpm@$CARGO_GENERATE_RPM"
 
       # Synthesize the two dist archives the script consumes, in dist's exact
       # `<pkg>-<triple>/` layout, from the host build (binary stand-in + real assets).

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -54,30 +54,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Add the wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+      - id: pins
+        uses: ./.github/actions/pins
 
-      # `fallback: none`: install only from install-action's checksummed manifest,
-      # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
-      - name: Install wasm-bindgen-cli (pinned to the crate version)
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
+      # The wasm32 target, the pinned wasm-bindgen CLI, the pinned Node, `npm ci`
+      # and `npm run build` — the same block wasm.yml gates with and
+      # publish-npm.yml publishes with, so the demo is the artifact the gate
+      # proved.
+      - uses: ./.github/actions/wasm-build
         with:
-          tool: wasm-bindgen-cli@0.2.126
-          fallback: none
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          # Keep in lockstep with wasm.yml + publish-npm.yml (version-freshness.yml
-          # cross-checks the three agree). The active Node line: 26 -> LTS Oct 2026.
-          node-version: "26.6.0"
-
-      - name: Install the web toolchain (binaryen / typescript / biome)
-        working-directory: crates/bdinfo-rs-wasm/web
-        run: npm ci
-
-      - name: Build the browser artifact (wasm-bindgen + wasm-opt -Oz + tsc)
-        working-directory: crates/bdinfo-rs-wasm/web
-        run: npm run build
+          web: build
 
       - name: Assemble the static site (index.html + icons + _headers + dist/ + pkg/)
         working-directory: crates/bdinfo-rs-wasm/web
@@ -95,13 +81,12 @@ jobs:
           Get-ChildItem -Recurse $site | ForEach-Object { $_.FullName }
 
       # Pages Direct Upload of the prebuilt site/. wrangler reads the token +
-      # account id from the env below; pinned to an EXACT version because it runs
-      # with the deploy token (the repo's pin-everything posture — bump it
-      # deliberately). --branch=master makes this the production deployment (the
-      # project's production branch must be `master`).
+      # account id from the env below. --branch=master makes this the production
+      # deployment (the project's production branch must be `master`).
       - name: Deploy to Cloudflare Pages (Direct Upload)
         working-directory: crates/bdinfo-rs-wasm/web
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx --yes wrangler@4.118.0 pages deploy site --project-name=bdinfo-rs --branch=master
+          WRANGLER: ${{ steps.pins.outputs.WRANGLER }}
+        run: npx --yes "wrangler@$WRANGLER" pages deploy site --project-name=bdinfo-rs --branch=master

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -93,9 +93,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # cargo-fuzz needs nightly. Keep in lockstep with core.yml NIGHTLY and
-  # $script:Nightly in scripts/_common.ps1.
-  NIGHTLY: nightly-2026-07-06
   # Per-unit guards (mirror scripts/fuzz-docker.sh): -timeout bounds a single
   # unit's wall time (non-termination guard); -rss_limit_mb bounds its memory
   # (allocation-amplification guard). Both turn a hang or an allocation blow-up
@@ -208,7 +205,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
+      # cargo-fuzz and libFuzzer need a nightly toolchain.
       - name: Install pinned nightly
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: |
           rustup toolchain install "$NIGHTLY" --profile minimal
           rustup target add "$FUZZ_TARGET" --toolchain "$NIGHTLY"
@@ -245,8 +248,8 @@ jobs:
       # runs that action with `fallback: none` so a manifest-missing tool fails
       # loudly instead of resolving through its unpinned cargo-binstall fallback
       # (rationale in core.yml). core.yml's replay job compiles the pinned version
-      # and OWNS the save of this cache entry on master; both keys must stay
-      # identical, as must the pin — version-freshness.yml enforces the pin.
+      # and OWNS the save of this cache entry on master; both keys are built from
+      # the same manifest value and must stay identical.
       # Restoring an EXECUTABLE is the one place cache poisoning would matter, so
       # tag runs skip the restore and compile it, exactly as before.
       - name: Restore the pinned cargo-fuzz binary (non-tag runs)
@@ -255,16 +258,20 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/cargo-fuzz
-          key: cargo-fuzz-${{ runner.os }}-0.13.2
+          key: cargo-fuzz-${{ runner.os }}-${{ steps.pins.outputs.CARGO_FUZZ }}
 
-      - name: Install cargo-fuzz 0.13.2
+      - name: Install the pinned cargo-fuzz
         if: ${{ steps.fuzz-bin.outputs.cache-hit != 'true' }}
-        run: cargo install cargo-fuzz --version 0.13.2 --locked
+        env:
+          CARGO_FUZZ: ${{ steps.pins.outputs.CARGO_FUZZ }}
+        run: cargo install cargo-fuzz --version "$CARGO_FUZZ" --locked
 
       - name: Verify the committed fuzz lockfile is in sync
         # cargo-fuzz's `run` has no --locked flag (it forwards everything after
         # `--` to libFuzzer), so enforce the committed fuzz/Cargo.lock with a real
         # cargo command up front; this also pre-fetches the deps for the build.
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: cargo +"$NIGHTLY" fetch --locked --manifest-path fuzz/Cargo.toml
 
       # The accumulated corpus: everything earlier runs found that the committed
@@ -355,6 +362,8 @@ jobs:
       # finds would then be unattributable to the width.
       - name: Fresh-fuzz ${{ matrix.target }} (${{ matrix.arch }})
         id: run
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: |
           flags=$(awk -v t="$TARGET" -v dir="$PWD/fuzz" '
             !/^[[:space:]]*#/ && $1 == t {
@@ -427,6 +436,8 @@ jobs:
       - name: Quarantine the crashing unit
         id: crash
         if: ${{ steps.run.outputs.rc != '0' }}
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: |
           repro=$(find fuzz/artifacts -type f ! -name 'slow-unit-*' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2-)
           find fuzz/artifacts -type f ! -name 'slow-unit-*' -print0 2>/dev/null | xargs -0 -r sha1sum | cut -c1-40 | sort -u > crash-hashes.txt
@@ -465,6 +476,8 @@ jobs:
       - name: Minimise and collect the new units
         id: collect
         if: ${{ !cancelled() }}
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: |
           # Every corpus file whose bytes are not in the committed seed set.
           new_units() {

--- a/.github/workflows/gui-publish.yml
+++ b/.github/workflows/gui-publish.yml
@@ -101,12 +101,6 @@ concurrency:
   group: gui-publish-${{ github.event.inputs.tag || github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
-env:
-  # Tool pins, hand-bumped (invisible to Dependabot; version-freshness.yml
-  # watches them and asserts they agree with packages.yml's copies).
-  KOMAC_VERSION: 2.16.0
-  CLOUDSMITH_CLI_VERSION: 1.21.0
-
 jobs:
   # Resolve tag/channels/mode from either trigger (the packages.yml gate
   # pattern). The auto path proceeds only for a successful gui-release run
@@ -198,6 +192,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       - name: Download the verified SHA256SUMS
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -210,6 +207,7 @@ jobs:
         env:
           # komac and the winget-pkgs state probe only read public repos here.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KOMAC_VERSION: ${{ steps.pins.outputs.KOMAC }}
         run: >-
           .github/scripts/publish-gui-winget.ps1
           -Version $env:VERSION -Mode prepare -Payload payload
@@ -233,6 +231,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLOUDSMITH_CLI_VERSION: ${{ steps.pins.outputs.CLOUDSMITH_CLI }}
         run: >-
           .github/scripts/publish-gui-cloudsmith.ps1
           -Version $env:VERSION -Tag $env:TAG -Mode prepare -Sums sums/SHA256SUMS -Payload payload
@@ -293,6 +292,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       - name: Download the validated payload
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -306,6 +308,7 @@ jobs:
           # The bot PAT komac forks microsoft/winget-pkgs under; also serves
           # the script's read-only state probe.
           GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          KOMAC_VERSION: ${{ steps.pins.outputs.KOMAC }}
         run: >-
           .github/scripts/publish-gui-winget.ps1
           -Version $env:VERSION -Mode publish -Payload payload
@@ -353,6 +356,7 @@ jobs:
         shell: pwsh
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          CLOUDSMITH_CLI_VERSION: ${{ steps.pins.outputs.CLOUDSMITH_CLI }}
         run: >-
           .github/scripts/publish-gui-cloudsmith.ps1
           -Version $env:VERSION -Tag $env:TAG -Mode publish -Payload payload

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -46,7 +46,6 @@ permissions:
   contents: read
 
 env:
-  NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + core.yml (cross-checked by version-freshness.yml)
   # Every iced_test renderer (interaction, snapshots, and the same tests under
   # coverage/mutants) must be the deterministic tiny-skia software backend —
   # never a GPU whose pixels vary by driver. Also what makes the suites run on
@@ -296,7 +295,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       - name: Install pinned nightly rustfmt + llvm-tools (for llvm-cov)
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: rustup toolchain install "$NIGHTLY" --profile minimal --component rustfmt --component llvm-tools-preview
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -320,6 +324,8 @@ jobs:
 
       - name: Format (nightly rustfmt)
         working-directory: crates/bdinfo-rs-gui
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: cargo "+$NIGHTLY" fmt --check
 
       - name: Typos
@@ -365,6 +371,8 @@ jobs:
       - name: Coverage (llvm-cov nextest — Tier A 100% lines/regions/functions)
         working-directory: crates/bdinfo-rs-gui
         shell: pwsh
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         # The floor itself lives in the single-source .github/scripts/cov-floor.ps1
         # the local gate runs too. No branch floor is passed — branch counts are
         # platform-variant (see cov-floor.ps1).
@@ -423,9 +431,7 @@ jobs:
   # pattern core.yml's pkg job uses for the CLI's .deb/.rpm. One leg per OS
   # family: the packaging logic is arch-independent (the release lane's
   # native arm legs run the identical scripts; its check script asserts the
-  # arm64 MSI's platform tag there). The cargo-deb/cargo-generate-rpm pins
-  # must equal .github/build-linux-packages.sh's (version-freshness.yml
-  # cross-checks all three homes).
+  # arm64 MSI's platform tag there).
   package:
     name: gui packaging smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -447,6 +453,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - id: pins
+        uses: ./.github/actions/pins
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -471,7 +480,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
-          tool: cargo-deb@3.7.0
+          tool: cargo-deb@${{ steps.pins.outputs.CARGO_DEB }}
           fallback: none
 
       # cargo-generate-rpm is absent from taiki-e/install-action's manifest, so
@@ -483,11 +492,13 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/cargo-generate-rpm
-          key: cargo-generate-rpm-${{ runner.os }}-0.21.0
+          key: cargo-generate-rpm-${{ runner.os }}-${{ steps.pins.outputs.CARGO_GENERATE_RPM }}
 
       - name: Install cargo-generate-rpm (cache miss)
         if: runner.os == 'Linux' && steps.rpm-bin.outputs.cache-hit != 'true'
-        run: cargo install --locked cargo-generate-rpm@0.21.0
+        env:
+          CARGO_GENERATE_RPM: ${{ steps.pins.outputs.CARGO_GENERATE_RPM }}
+        run: cargo install --locked "cargo-generate-rpm@$CARGO_GENERATE_RPM"
 
       - name: Build (release profile)
         working-directory: crates/bdinfo-rs-gui

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -101,18 +101,24 @@ jobs:
     if: needs.gate.outputs.stable == 'true'
     env:
       VERSION: ${{ needs.gate.outputs.version }}
-      # Komac release to pin — the tool the manual backfills use, and what
-      # winget-releaser wrapped internally. A submission tool (not output-coupled),
-      # so it is a static pin bumped by hand; the winget-pkgs manifest schema is
-      # stable, so an occasional lag is harmless.
-      KOMAC_VERSION: 2.16.0
     steps:
+      # Only for .github/pins.env below — this job submits from release assets and
+      # needs nothing else out of the repository.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - id: pins
+        uses: ./.github/actions/pins
+
       # Submit with komac DIRECTLY — the same tool winget-releaser wraps, but
       # without its `cargo-bins/cargo-binstall@main` bootstrap, which this repo's
       # `sha_pinning_required` + allowlist policy (correctly) rejects. komac has no
       # taiki-e/install-action entry, so fetch its pinned release binary over curl
       # (a `run:` step, so no action-allowlist involvement at all).
       - name: Install komac
+        env:
+          KOMAC_VERSION: ${{ steps.pins.outputs.KOMAC }}
         run: |
           url="https://github.com/russellbanks/Komac/releases/download/v${KOMAC_VERSION}/komac-${KOMAC_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
           curl -fsSL "$url" -o komac.tar.gz
@@ -233,10 +239,6 @@ jobs:
     env:
       VERSION: ${{ needs.gate.outputs.version }}
       FILE: dl/bdinfo-rs-${{ matrix.target.triple }}.${{ matrix.format }}
-      # The pipx pin cloudsmith-push.ps1 installs. A pip pin invisible to
-      # Dependabot; version-freshness.yml watches it and asserts it agrees with
-      # gui-publish.yml's copy.
-      CLOUDSMITH_CLI_VERSION: 1.21.0
     strategy:
       fail-fast: false
       # One NATIVE runner per arch so the install test runs the arch-matching binary
@@ -247,11 +249,14 @@ jobs:
           - {triple: x86_64-unknown-linux-musl, os: ubuntu-latest}
           - {triple: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm}
     steps:
-      # For .github/scripts/cloudsmith-push.ps1 — the only thing this job needs
-      # out of the repository.
+      # For .github/scripts/cloudsmith-push.ps1 and .github/pins.env — the only
+      # things this job needs out of the repository.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - id: pins
+        uses: ./.github/actions/pins
 
       # The package was built + attached to the release by dist `extra-artifacts`
       # (.github/build-linux-packages.sh); just pull it back to verify + republish.
@@ -308,6 +313,7 @@ jobs:
         shell: pwsh
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          CLOUDSMITH_CLI_VERSION: ${{ steps.pins.outputs.CLOUDSMITH_CLI }}
         run: |
           ./.github/scripts/cloudsmith-push.ps1 -Version ($env:VERSION -replace '^v', '') -Path $env:FILE
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -110,6 +110,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       # The release tag drives the version guard + npm dist-tag. On a tag push it
       # is the ref; on a manual dispatch it is the input, or `v<package.json
       # version>`. GitHub context is routed through env (never inlined into the
@@ -134,45 +137,27 @@ jobs:
           Write-Host "resolved release tag: $tag"
 
       - name: Install pinned nightly rustfmt
-        run: rustup toolchain install nightly-2026-07-06 --profile minimal --component rustfmt
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
+        run: rustup toolchain install "$NIGHTLY" --profile minimal --component rustfmt
 
-      - name: Add the wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+      # The wasm32 target, the pinned wasm-bindgen CLI and the pinned Node — the
+      # same block wasm.yml gates with and deploy-pages.yml deploys with, so the
+      # published artifact is built with the tools the gate proved. `npm ci` is
+      # NOT taken from it: the npm pin and the tag/version guards below have to
+      # run between setup-node and the install.
+      - uses: ./.github/actions/wasm-build
 
-      # `fallback: none`: install only from install-action's checksummed manifest,
-      # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
-      - name: Install wasm-bindgen-cli (pinned to the crate version)
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
-        with:
-          tool: wasm-bindgen-cli@0.2.126
-          fallback: none
-
-      # zizmor flags setup-node in this tag-triggered (publishing) workflow as a
-      # cache-poisoning vector, but no `cache:` input is set, so it neither restores
-      # nor saves any cache — there is nothing to poison. setup-node is required to
-      # get a modern Node/npm for OIDC, and the tag trigger is intrinsic to a
-      # publish workflow, so this is an unavoidable false positive (cf. the inline
-      # ref-version-mismatch ignore documented in .github/zizmor.yml).
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0 # zizmor: ignore[cache-poisoning]
-        with:
-          # The active Node line (26 -> LTS Oct 2026); kept in lockstep with
-          # wasm.yml + deploy-pages.yml (version-freshness.yml cross-checks the three).
-          node-version: "26.6.0"
-
-      # Staged publishing (`npm stage publish`) needs npm >= 11.15.0, and
-      # `--provenance` needs a working bundled `sigstore`. npm 12.0.0 shipped
-      # BROKEN here (`npm publish --provenance` died with `Cannot find module
-      # 'sigstore'`, npm/cli#9722 — the reason this pin sat on 11.18.0); 12.0.1
-      # ships the fix (npm/cli#9740), so the pin follows `latest` again. Pinning
-      # keeps the publish deterministic regardless of which npm a given Node 26.x
-      # bundles (the repo's pin-everything posture); the published wasm bytes are
-      # fixed by the pinned rustc / wasm-bindgen / binaryen, independent of npm.
+      # Installing an exact npm keeps the publish deterministic regardless of
+      # which npm a given Node 26.x bundles; the published wasm bytes are fixed by
+      # the pinned rustc / wasm-bindgen / binaryen and are independent of npm.
+      # What the version has to satisfy is recorded with it in .github/pins.env.
       # zizmor's adhoc-packages audit flags any runtime install; pinning npm (from
-      # the official registry) carries a scoped inline ignore. Keep this pin in
-      # lockstep with version-freshness.yml (its "behind latest" nag is the
-      # reminder to bump).
+      # the official registry) carries a scoped inline ignore.
       - name: Pin npm to a staged-publishing-capable version
-        run: npm install -g npm@12.0.2 # zizmor: ignore[adhoc-packages]
+        env:
+          NPM: ${{ steps.pins.outputs.NPM }}
+        run: npm install -g "npm@$NPM" # zizmor: ignore[adhoc-packages]
 
       - name: Verify Node >= 26 and npm >= 11.15.0
         shell: pwsh

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -77,12 +77,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       # Neither tool ships via taiki-e/install-action, so cache the compiled
       # binaries instead of paying the from-source compile every run. ryl is
-      # version-pinned (reproducible lint verdicts; watched by
-      # version-freshness.yml); action-validator deliberately floats at latest
-      # (a schema checker self-updates), so its half of the key tracks the
-      # latest crates.io release — a new release recompiles once, then caches.
+      # version-pinned (reproducible lint verdicts); action-validator deliberately
+      # floats at latest (a schema checker self-updates), so its half of the key
+      # tracks the latest crates.io release — a new release recompiles once, then
+      # caches.
       # A failed lookup salts the key with the run id: a guaranteed miss and a
       # fresh install rather than a silently stale binary.
       - name: Resolve the latest action-validator (cache key)
@@ -102,13 +105,15 @@ jobs:
           path: |
             ~/.cargo/bin/action-validator
             ~/.cargo/bin/ryl
-          key: yaml-tools-${{ runner.os }}-${{ runner.arch }}-av-${{ steps.av.outputs.version }}-ryl-0.21.0
+          key: yaml-tools-${{ runner.os }}-${{ runner.arch }}-av-${{ steps.av.outputs.version }}-ryl-${{ steps.pins.outputs.RYL }}
 
       - name: Install action-validator + ryl (cache miss)
         if: steps.yaml-tools.outputs.cache-hit != 'true'
+        env:
+          RYL: ${{ steps.pins.outputs.RYL }}
         run: |
           cargo install action-validator --locked
-          cargo install ryl --version 0.21.0 --locked
+          cargo install ryl --version "$RYL" --locked
 
       - name: Schema-validate the workflow and action YAML (action-validator)
         run: |
@@ -135,13 +140,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       - name: Install taplo (prebuilt, no from-source compile)
         uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
-          # Pinned (not latest) so a new taplo can't reformat/relint the tree and
-          # red-X an unrelated PR; version-freshness watches it against crates.io
-          # and the bump stays deliberate, like rustfmt's nightly pin.
-          tool: taplo-cli@0.10.0
+          tool: taplo-cli@${{ steps.pins.outputs.TAPLO_CLI }}
           fallback: none
 
       # taplo auto-discovers taplo.toml (include/exclude + formatting). --check

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -1,85 +1,59 @@
 name: version-freshness
 
 # Several versions in this repo are pinned for reproducibility but rot SILENTLY —
-# nothing else watches them:
-#   - the Rust toolchains (rust-toolchain.toml stable + the NIGHTLY pin, which is
-#     hardcoded in core.yml + fuzz.yml + wasm.yml + gui.yml + publish-npm.yml and
-#     cross-checked for agreement here so a bump to one can't silently drift the
-#     rest),
-#   - cargo-dist (dist-workspace.toml `cargo-dist-version` AND the `DIST_VERSION`
-#     env in core.yml's release-yaml job, which downloads that release's prebuilt
-#     archive — the two must stay equal; the `DIST_SHA256` committed beside it is
-#     the archive's published digest, so it is re-checked against upstream here
-#     because a version bump that forgets it only fails on the next dist-area PR),
+# nothing else watches them. Most of them live in ONE file, .github/pins.env, and
+# are read from there by every consumer, so this job never has to check that
+# copies of a pin agree; it only asks whether each pin is behind upstream:
+#   - the pinned NIGHTLY (an age nag, not an upstream comparison — a nightly
+#     always has a newer one),
+#   - cargo-vet, cargo-fuzz, ryl, taplo, convco, cargo-deb, cargo-generate-rpm,
+#     wasm-bindgen-cli — hand-bumped tools with no Dependabot ecosystem behind
+#     them (cargo's ecosystem watches Cargo.toml dependencies, not `cargo install`
+#     lines or install-action `tool:` inputs),
+#   - appimagetool and komac, fetched over curl at a static version. komac's
+#     `releases/latest` is a normal semver tag; appimagetool's is the rolling
+#     `continuous` nightly, so its check reads the highest SEMVER tag instead,
+#   - Node, npm and wrangler — a setup-node input, an `npm install -g` and an npx
+#     invocation, none of them package.json dependencies, so Dependabot's npm scan
+#     cannot see any of the three,
+#   - cloudsmith-cli — a pipx pin, invisible to the cargo/npm/actions scans.
+# Pins that deliberately live outside the manifest are checked here too, and those
+# are where an AGREEMENT check is still needed, because the copy is real:
+#   - the stable toolchain in rust-toolchain.toml,
+#   - cargo-dist: `cargo-dist-version` in dist-workspace.toml AND the
+#     `DIST_VERSION` env in core.yml's release-yaml job, which downloads that
+#     release's prebuilt archive — the two must stay equal; the `DIST_SHA256`
+#     committed beside it is the archive's published digest, so it is re-checked
+#     against upstream because a version bump that forgets it only fails on the
+#     next dist-area PR,
 #   - the four action SHAs in dist-workspace.toml `[dist.github-action-commits]`
 #     (checkout, upload-/download-artifact, attest) — the SOURCE dist generates
 #     v-release.yml from, invisible to Dependabot (it bumps the GENERATED file,
 #     which then fails `dist generate --check`) — cross-checked against the
 #     hand-maintained workflows' pins for the same actions so the drift becomes
 #     a scheduled nag instead of a red X on an unrelated Dependabot PR,
-#   - cargo-vet (the `--version` pin in core.yml's vet job),
-#   - cargo-fuzz (the `--version` pins in core.yml's replay job and fuzz.yml — absent
-#     from taiki-e/install-action's manifest, so both compile it from crates.io and
-#     the two pins must stay equal),
-#   - ryl (the `cargo install ryl --version` pin in repo.yml's YAML-lint job),
-#   - taplo (the `tool: taplo-cli@X` pin in repo.yml's TOML job — a formatter, pinned like
-#     rustfmt so a new release can't reformat/relint the tree out from under a PR),
-#   - convco (the `tool: convco@X` pin in conventional.yml — pinned because its
-#     output drives a reproducible changelog/version format, like taplo/rustfmt),
-#   - wasm-bindgen-cli (the `wasm-bindgen-cli@X` pin in wasm.yml + publish-npm.yml
-#     + deploy-pages.yml — all three must equal the wasm-bindgen crate they
-#     generate glue for; wasm-pack is not
-#     used), and binaryen (the `"binaryen"` pin in web/package.json — wasm-opt's
-#     version is coupled to the committed wasm size budget),
-#   - the Node version (the `NODE_VERSION`/`node-version` pins in wasm.yml +
-#     deploy-pages.yml + publish-npm.yml — the three must AGREE; the active line is
-#     26 -> LTS Oct 2026; checked for same-major patch drift AND for a newer
-#     even/LTS-bound line), the npm pin (`npm install -g npm@X` in publish-npm.yml
-#     — the staged-publishing floor), and wrangler (`npx wrangler@X` in
-#     deploy-pages.yml) — the last two are npx/setup-node inputs, NOT package.json
-#     deps, so Dependabot's npm scan cannot see them,
-#   - the Homebrew/actions/setup-homebrew SHA (install-smoke-test.yml) pins a
-#     TAGLESS repo's `master` — a moving `# master` comment tag Dependabot can't bump
-#     and zizmor's ref-version-mismatch would red-X a PR once it drifts, so it is
-#     nagged here when it drifts past the pinned SHA, keeping re-pinning deliberate,
-#   - komac (the `KOMAC_VERSION` pin in packages.yml — the WinGet job submits with
-#     komac DIRECTLY, fetched over curl at a static hand-bumped version invisible to
-#     Dependabot; checked against russellbanks/Komac's latest release),
-#   - cargo-deb + cargo-generate-rpm (the `cargo-deb@X` / `cargo-generate-rpm@X` pins
-#     in build-linux-packages.sh — the .deb/.rpm packagers are compiled from source
-#     INSIDE dist's fail-fast release, so they are version-pinned there so a broken
-#     upstream release can't abort the whole release; both checked vs crates.io, and
-#     both cross-checked against every other copy — core.yml's pkg job, the GUI
-#     packaging script (.github/scripts/gui-package-linux.ps1), and gui.yml's
-#     packaging smoke — which must all stay EQUAL so the PR smoke tests package
-#     with the exact release tools),
-#   - appimagetool (the `$appimagetoolVersion` curl-download pin in
-#     .github/scripts/gui-package-linux.ps1 — the GUI lane's AppImage packer,
-#     fetched at a static version invisible to Dependabot; checked vs the highest
-#     SEMVER tag AppImage/appimagetool has released, since its `releases/latest`
-#     is the rolling `continuous` nightly), and
-#     cloudsmith-cli (the CLOUDSMITH_CLI_VERSION pipx pin — a pip pin invisible to
-#     Dependabot's cargo/npm/actions scans; pinned once per publishing workflow,
-#     every occurrence checked to agree, then vs PyPI),
-# (Cargo deps/dev-deps, the web npm devDependencies — typescript / biome /
-# binaryen / playwright-core — and GitHub Action SHAs are already auto-bumped by
+#   - binaryen (the `"binaryen"` devDependency in web/package.json — wasm-opt's
+#     version is coupled to the committed wasm size budget, so it is re-checked
+#     here even though Dependabot does bump it),
+#   - biome.json's versioned schema URL, cross-checked against the @biomejs/biome
+#     version the lockfile installs (Dependabot moves the dep and leaves the URL),
+#   - the Homebrew/actions/setup-homebrew SHA (install-smoke-test.yml), which pins
+#     a TAGLESS repo's `master` — a moving `# master` comment tag Dependabot can't
+#     bump and zizmor's ref-version-mismatch would red-X a PR once it drifts, so it
+#     is nagged here when it drifts past the pinned SHA, keeping re-pinning
+#     deliberate.
+# (Cargo deps/dev-deps, the rest of the web npm devDependencies — typescript /
+# biome / playwright-core — and GitHub Action SHAs are already auto-bumped by
 # Dependabot — cargo + npm + github-actions ecosystems — so they are deliberately
-# NOT re-checked here, EXCEPT: the one tagless branch-pinned action noted above
-# that Dependabot cannot bump, the binaryen pin (re-checked anyway for its size-
-# budget coupling), the Node / npm / wrangler pins above (setup-node inputs and
-# npx invocations, invisible to Dependabot's package.json scan), and biome.json's
-# versioned schema URL (cross-checked against the bumped dep — Dependabot moves the
-# @biomejs/biome dep but leaves the schema URL behind). The remaining gate
-# tools — zizmor (a security linter, kept at
-# latest on purpose so new vuln checks land immediately), action-validator,
+# NOT re-checked here. The remaining gate tools — zizmor (a security linter, kept
+# at latest on purpose so new vuln checks land immediately), action-validator,
 # cargo-{machete,shear,semver-checks,llvm-cov,nextest,mutants,deny}, typos — are
 # installed at LATEST every run, so they self-update and have no pin to rot. The
 # Dockerfile is `FROM scratch`, so there is no build-base tag to track either.)
 #
 # This daily ~1-minute job compares each silently-rotting pin to its upstream
-# latest (and cross-checks the pins that must agree); when anything is stale or
-# inconsistent it opens (or refreshes) one tracking issue. The bump itself stays a
-# deliberate, human-reviewed change.
+# latest; when anything is stale or inconsistent it opens (or refreshes) one
+# tracking issue. The bump itself stays a deliberate, human-reviewed change.
 
 on:
   schedule:
@@ -104,7 +78,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # No Set-StrictMode here, unlike the publish legs: several upstream
+          # lookups below read a property off a pipeline that legitimately yields
+          # nothing (no release on the pinned Node major, say) and rely on getting
+          # $null back rather than a terminating error. The other two preamble
+          # lines are load-bearing — the second makes every `if ($LASTEXITCODE...)`
+          # check below reachable at all.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $false
+          . ./.github/scripts/_common.ps1
+
+          # Every version in .github/pins.env. Get-Pins refuses a malformed line
+          # and Get-Pin a missing key, so a pin that is renamed or dropped fails
+          # this job loudly instead of silently going unwatched.
+          $pins = Get-Pins
+
           $problems = @()
+          $summary = @()
 
           # Record one finding: $tag is a short package->version summary for the issue
           # TITLE, $line the full markdown bullet for the body.
@@ -112,23 +102,13 @@ jobs:
             $script:problems += [pscustomobject]@{ tag = $tag; line = $line }
           }
 
-          # First pin matched by $regex (group 1) in $path, or $null.
+          # First pin matched by $regex (group 1) in $path, or $null. Only the
+          # pins that live outside the manifest are read this way.
           function Read-Pin($path, $regex) {
             foreach ($line in (Get-Content $path)) {
               if ($line -match $regex) { return $Matches[1] }
             }
             return $null
-          }
-
-          # EVERY pin matched by $regex (group 1, one per line) in $path, in file
-          # order — for a pin that exists more than once in one file and must
-          # agree with itself (Read-Pin sees only the first occurrence).
-          function Read-AllPins($path, $regex) {
-            $found = @()
-            foreach ($line in (Get-Content $path)) {
-              if ($line -match $regex) { $found += $Matches[1] }
-            }
-            return , $found
           }
 
           # A SHA-pinned action reference (`<sha> # <tag>`), normalized, from a
@@ -217,37 +197,32 @@ jobs:
             catch { return $null }
           }
 
+          # One pin against one upstream version, and one line of the run's
+          # summary either way. A FAILED QUERY is reported, not skipped: a check
+          # that quietly stops comparing reads exactly like a fresh pin.
+          function Compare-Pin($name, $current, $upstream, $source, $fix) {
+            $script:summary += "${name}: $current (latest $upstream)"
+            if (-not $upstream) {
+              Add-Problem "$name (query failed)" "- could not query the latest $name release ($source)"
+              return
+            }
+            if ([version]$upstream -gt [version]$current) {
+              Add-Problem "$name $current->$upstream" "- $name pin ``$current`` is behind the latest release ``$upstream``$fix"
+            }
+          }
+
           # --- Rust stable: rust-toolchain.toml vs rust-lang/rust ---------------
           $stablePin = Read-Pin 'rust-toolchain.toml' '^channel\s*=\s*"([0-9.]+)"'
           if (-not $stablePin) { throw 'No pinned stable channel in rust-toolchain.toml' }
-          $stableLatest = Latest-Semver 'rust-lang/rust'
-          if (-not $stableLatest) {
-            Add-Problem 'Rust stable (query failed)' '- could not query the latest Rust stable release (rust-lang/rust)'
-          } elseif ([version]$stableLatest -gt [version]$stablePin) {
-            Add-Problem "Rust stable $stablePin->$stableLatest" "- stable Rust pin ``$stablePin`` (rust-toolchain.toml) is behind the latest release ``$stableLatest``"
-          }
+          Compare-Pin 'Rust stable' $stablePin (Latest-Semver 'rust-lang/rust') 'rust-lang/rust' ' (rust-toolchain.toml)'
 
-          # --- Rust nightly: age of the core.yml NIGHTLY pin -------------------
-          $nightlyPin = Read-Pin '.github/workflows/core.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
-          if (-not $nightlyPin) { throw 'No NIGHTLY pin in core.yml' }
+          # --- Rust nightly: the age of the NIGHTLY pin ------------------------
+          # A nightly always has a newer one, so the nag is age, not distance.
+          $nightlyPin = (Get-Pin NIGHTLY) -replace '^nightly-', ''
           $nightlyAgeDays = [int]((Get-Date) - [datetime]::ParseExact($nightlyPin, 'yyyy-MM-dd', $null)).TotalDays
+          $summary += "nightly: $nightlyPin ($nightlyAgeDays d)"
           if ($nightlyAgeDays -gt 30) {
-            Add-Problem "nightly-$nightlyPin ($nightlyAgeDays d old)" "- nightly pin ``nightly-$nightlyPin`` (core.yml NIGHTLY) is $nightlyAgeDays days old"
-          }
-          # The nightly is hardcoded in FIVE places (core.yml/fuzz.yml/wasm.yml/gui.yml
-          # NIGHTLY env + publish-npm.yml's rustup install) that Dependabot can't see,
-          # so a bump to one silently drifts the rest. Cross-check they AGREE (like
-          # the cargo-dist / wasm-bindgen-cli / Node pin agreements).
-          $nightlyFuzz = Read-Pin '.github/workflows/fuzz.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
-          $nightlyWasm = Read-Pin '.github/workflows/wasm.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
-          $nightlyGui  = Read-Pin '.github/workflows/gui.yml' 'NIGHTLY:\s*nightly-(\d{4}-\d{2}-\d{2})'
-          $nightlyNpm  = Read-Pin '.github/workflows/publish-npm.yml' 'install nightly-(\d{4}-\d{2}-\d{2})'
-          if (-not $nightlyFuzz) { throw 'No NIGHTLY pin in fuzz.yml' }
-          if (-not $nightlyWasm) { throw 'No NIGHTLY pin in wasm.yml' }
-          if (-not $nightlyGui)  { throw 'No NIGHTLY pin in gui.yml' }
-          if (-not $nightlyNpm)  { throw 'No nightly install pin in publish-npm.yml' }
-          if (($nightlyPin -ne $nightlyFuzz) -or ($nightlyPin -ne $nightlyWasm) -or ($nightlyPin -ne $nightlyGui) -or ($nightlyPin -ne $nightlyNpm)) {
-            Add-Problem 'nightly pins disagree' "- nightly pin mismatch: core.yml ``$nightlyPin`` / fuzz.yml ``$nightlyFuzz`` / wasm.yml ``$nightlyWasm`` / gui.yml ``$nightlyGui`` / publish-npm.yml ``$nightlyNpm`` — all must be identical"
+            Add-Problem "nightly-$nightlyPin ($nightlyAgeDays d old)" "- nightly pin ``nightly-$nightlyPin`` is $nightlyAgeDays days old"
           }
 
           # --- cargo-dist: two pins must agree, both vs axodotdev/cargo-dist ----
@@ -258,12 +233,7 @@ jobs:
           if ($distCfg -ne $distCi) {
             Add-Problem 'cargo-dist pins disagree' "- cargo-dist pin mismatch: dist-workspace.toml has ``$distCfg`` but core.yml installs ``$distCi`` — they must be identical"
           }
-          $distLatest = Latest-Semver 'axodotdev/cargo-dist'
-          if (-not $distLatest) {
-            Add-Problem 'cargo-dist (query failed)' '- could not query the latest cargo-dist release (axodotdev/cargo-dist)'
-          } elseif ([version]$distLatest -gt [version]$distCfg) {
-            Add-Problem "cargo-dist $distCfg->$distLatest" "- cargo-dist pin ``$distCfg`` (dist-workspace.toml + core.yml) is behind the latest release ``$distLatest`` — bump both pins, re-take DIST_SHA256 from the release's ``.sha256`` asset, then re-run ``dist generate``"
-          }
+          Compare-Pin 'cargo-dist' $distCfg (Latest-Semver 'axodotdev/cargo-dist') 'axodotdev/cargo-dist' " — bump dist-workspace.toml and core.yml together, re-take DIST_SHA256 from the release's ``.sha256`` asset, then re-run ``dist generate``"
 
           # --- DIST_SHA256: core.yml's committed digest vs the published .sha256 -
           # core.yml verifies the downloaded dist archive against this digest before
@@ -297,7 +267,7 @@ jobs:
           # docker.yml; the github-actions Dependabot group bumps all
           # hand-maintained workflows together, so any one file represents the
           # fleet). A drift line here turns the red-X surprise into a scheduled
-          # nag; the fix is unchanged (scripts/dist-sync.ps1 / dist generate).
+          # nag; the fix is unchanged (dist generate).
           $distActionSources = [ordered]@{
             'actions/checkout'          = '.github/workflows/ci.yml'
             'actions/upload-artifact'   = '.github/workflows/gui.yml'
@@ -311,190 +281,62 @@ jobs:
             if (-not $tomlPin) { throw "No $action pin in dist-workspace.toml [dist.github-action-commits]" }
             if (-not $wfPin) { throw "No $action pin in $wf" }
             if ($tomlPin -ne $wfPin) {
-              Add-Problem "$action dist pin drifted" "- dist-workspace.toml ``[dist.github-action-commits]`` pins ``$action`` at ``$tomlPin`` but $wf uses ``$wfPin`` — set the TOML pin to the workflow's value and re-run ``dist generate`` (scripts/dist-sync.ps1)"
+              Add-Problem "$action dist pin drifted" "- dist-workspace.toml ``[dist.github-action-commits]`` pins ``$action`` at ``$tomlPin`` but $wf uses ``$wfPin`` — set the TOML pin to the workflow's value and re-run ``dist generate``"
             }
           }
 
-          # --- cargo-vet: core.yml vs mozilla/cargo-vet ------------------------
-          $vetPin = Read-Pin '.github/workflows/core.yml' 'cargo-vet --version ([0-9.]+)'
-          if (-not $vetPin) { throw 'No cargo-vet --version pin in core.yml' }
-          $vetLatest = Latest-Semver 'mozilla/cargo-vet'
-          if (-not $vetLatest) {
-            Add-Problem 'cargo-vet (query failed)' '- could not query the latest cargo-vet release (mozilla/cargo-vet)'
-          } elseif ([version]$vetLatest -gt [version]$vetPin) {
-            Add-Problem "cargo-vet $vetPin->$vetLatest" "- cargo-vet pin ``$vetPin`` (core.yml) is behind the latest release ``$vetLatest``"
+          # --- the manifest pins whose upstream is a crates.io release ----------
+          # One shape, one loop: `cargo install <crate> --version X` and
+          # install-action's `tool: <crate>@X` both resolve against crates.io, and
+          # a crate may publish no GitHub release at all.
+          $cratesPins = [ordered]@{
+            CARGO_FUZZ         = @('cargo-fuzz', '')
+            RYL                = @('ryl', '')
+            TAPLO_CLI          = @('taplo-cli', '')
+            CONVCO             = @('convco', '')
+            CARGO_DEB          = @('cargo-deb', '')
+            CARGO_GENERATE_RPM = @('cargo-generate-rpm', '')
+            WASM_BINDGEN_CLI   = @('wasm-bindgen-cli', ' — bump the wasm-bindgen crate dependency with it; the two must be equal')
+          }
+          foreach ($key in $cratesPins.Keys) {
+            $crate = $cratesPins[$key][0]
+            Compare-Pin $crate $pins[$key] (Latest-CratesIo $crate) 'crates.io' $cratesPins[$key][1]
           }
 
-          # --- cargo-fuzz: core.yml + fuzz.yml pins vs crates.io ---------------
-          # taiki-e/install-action's manifest has no cargo-fuzz entry, so both the
-          # per-PR corpus replay (core.yml) and the tag-time fresh-fuzz pass
-          # (fuzz.yml) compile a pinned version from crates.io. The two must agree
-          # — a one-sided bump would fuzz the release tag with a different tool
-          # than the gate proved green.
-          $fuzzCi   = Read-Pin '.github/workflows/core.yml' 'cargo install cargo-fuzz --version ([0-9.]+)'
-          $fuzzTag  = Read-Pin '.github/workflows/fuzz.yml' 'cargo install cargo-fuzz --version ([0-9.]+)'
-          if (-not $fuzzCi)  { throw 'No `cargo install cargo-fuzz --version` pin in core.yml' }
-          if (-not $fuzzTag) { throw 'No `cargo install cargo-fuzz --version` pin in fuzz.yml' }
-          if ($fuzzCi -ne $fuzzTag) {
-            Add-Problem 'cargo-fuzz pins disagree' "- cargo-fuzz pin mismatch: core.yml ``$fuzzCi`` / fuzz.yml ``$fuzzTag`` — both must be identical"
+          # --- the manifest pins whose upstream is a GitHub release --------------
+          # komac is not published to any registry, and cargo-vet's own release
+          # page is where its prebuilt binaries and release notes are.
+          $releasePins = [ordered]@{
+            CARGO_VET = @('cargo-vet', 'mozilla/cargo-vet')
+            KOMAC     = @('komac', 'russellbanks/Komac')
           }
-          $fuzzLatest = Latest-CratesIo 'cargo-fuzz'
-          if (-not $fuzzLatest) {
-            Add-Problem 'cargo-fuzz (query failed)' '- could not query the latest cargo-fuzz release (crates.io)'
-          } elseif ([version]$fuzzLatest -gt [version]$fuzzCi) {
-            Add-Problem "cargo-fuzz $fuzzCi->$fuzzLatest" "- cargo-fuzz pin ``$fuzzCi`` (core.yml + fuzz.yml) is behind the latest release ``$fuzzLatest`` — bump both pins together"
+          foreach ($key in $releasePins.Keys) {
+            $repo = $releasePins[$key][1]
+            Compare-Pin $releasePins[$key][0] $pins[$key] (Latest-Semver $repo) $repo ''
           }
 
-          # --- ryl: repo.yml YAML-lint pin vs crates.io ------------------------
-          # ryl is pinned (`cargo install ryl --version X`) so the YAML lint stays
-          # reproducible; nothing else watches it, so check it here like cargo-vet.
-          $rylPin = Read-Pin '.github/workflows/repo.yml' 'cargo install ryl --version ([0-9.]+)'
-          if (-not $rylPin) { throw 'No `cargo install ryl --version` pin in repo.yml' }
-          $rylLatest = Latest-CratesIo 'ryl'
-          if (-not $rylLatest) {
-            Add-Problem 'ryl (query failed)' '- could not query the latest ryl release (crates.io)'
-          } elseif ([version]$rylLatest -gt [version]$rylPin) {
-            Add-Problem "ryl $rylPin->$rylLatest" "- ryl pin ``$rylPin`` (repo.yml) is behind the latest release ``$rylLatest``"
-          }
+          # --- appimagetool: highest semver tag, not `releases/latest` ----------
+          Compare-Pin 'appimagetool' $pins.APPIMAGETOOL (Latest-Semver-Listed 'AppImage/appimagetool') 'AppImage/appimagetool' ''
 
-          # --- taplo: repo.yml `tool: taplo-cli@X` pin vs crates.io -------------
-          # Pinned like ryl so the TOML format/lint stays reproducible; nothing
-          # else watches it.
-          $taploPin = Read-Pin '.github/workflows/repo.yml' 'tool:\s*taplo-cli@([0-9.]+)'
-          if (-not $taploPin) { throw 'No `tool: taplo-cli@<version>` pin in repo.yml' }
-          $taploLatest = Latest-CratesIo 'taplo-cli'
-          if (-not $taploLatest) {
-            Add-Problem 'taplo (query failed)' '- could not query the latest taplo release (crates.io taplo-cli)'
-          } elseif ([version]$taploLatest -gt [version]$taploPin) {
-            Add-Problem "taplo $taploPin->$taploLatest" "- taplo pin ``$taploPin`` (repo.yml) is behind the latest release ``$taploLatest``"
-          }
+          # --- the manifest pins whose upstream is the npm registry -------------
+          Compare-Pin 'npm' $pins.NPM (Latest-Npm 'npm') 'npm registry' ''
+          Compare-Pin 'wrangler' $pins.WRANGLER (Latest-Npm 'wrangler') 'npm registry' ''
 
-          # --- convco: conventional.yml `tool: convco@X` pin vs crates.io -------
-          # Pinned because its output drives a reproducible changelog/version
-          # format (like taplo/rustfmt); nothing else watches it.
-          $convcoPin = Read-Pin '.github/workflows/conventional.yml' 'tool:\s*convco@([0-9.]+)'
-          if (-not $convcoPin) { throw 'No `tool: convco@<version>` pin in conventional.yml' }
-          $convcoLatest = Latest-CratesIo 'convco'
-          if (-not $convcoLatest) {
-            Add-Problem 'convco (query failed)' '- could not query the latest convco release (crates.io)'
-          } elseif ([version]$convcoLatest -gt [version]$convcoPin) {
-            Add-Problem "convco $convcoPin->$convcoLatest" "- convco pin ``$convcoPin`` (conventional.yml) is behind the latest release ``$convcoLatest``"
-          }
-
-          # --- cargo-deb / cargo-generate-rpm: build-linux-packages.sh vs crates.io -
-          # The .deb/.rpm packagers are compiled from source INSIDE dist's fail-fast
-          # release (a shell script in build-global-artifacts, where a `uses:` install
-          # action is unavailable), so they are version-pinned there — a broken upstream
-          # release would otherwise abort the whole release. Nothing else watches them,
-          # so nag here like the other hand-bumped tools when a newer one ships.
-          $cargoDebPin = Read-Pin '.github/build-linux-packages.sh' 'cargo-deb@([0-9.]+)'
-          if (-not $cargoDebPin) { throw 'No cargo-deb@<version> pin in build-linux-packages.sh' }
-          $cargoDebLatest = Latest-CratesIo 'cargo-deb'
-          if (-not $cargoDebLatest) {
-            Add-Problem 'cargo-deb (query failed)' '- could not query the latest cargo-deb release (crates.io)'
-          } elseif ([version]$cargoDebLatest -gt [version]$cargoDebPin) {
-            Add-Problem "cargo-deb $cargoDebPin->$cargoDebLatest" "- cargo-deb pin ``$cargoDebPin`` (build-linux-packages.sh) is behind the latest release ``$cargoDebLatest``"
-          }
-          $cargoRpmPin = Read-Pin '.github/build-linux-packages.sh' 'cargo-generate-rpm@([0-9.]+)'
-          if (-not $cargoRpmPin) { throw 'No cargo-generate-rpm@<version> pin in build-linux-packages.sh' }
-          $cargoRpmLatest = Latest-CratesIo 'cargo-generate-rpm'
-          if (-not $cargoRpmLatest) {
-            Add-Problem 'cargo-generate-rpm (query failed)' '- could not query the latest cargo-generate-rpm release (crates.io)'
-          } elseif ([version]$cargoRpmLatest -gt [version]$cargoRpmPin) {
-            Add-Problem "cargo-generate-rpm $cargoRpmPin->$cargoRpmLatest" "- cargo-generate-rpm pin ``$cargoRpmPin`` (build-linux-packages.sh) is behind the latest release ``$cargoRpmLatest``"
-          }
-          # Both pins exist a SECOND time in core.yml's pkg job (`tool:
-          # cargo-deb@…,cargo-generate-rpm@…`) — deliberately equal so the PR
-          # smoke test packages with the exact release tools (the script's
-          # already-on-PATH guard then skips its source compile). A one-sided
-          # bump silently de-syncs the smoke test from the release path, so
-          # cross-check agreement like the NIGHTLY pins; freshness of the value
-          # itself is already covered above.
-          $cargoDebCi = Read-Pin '.github/workflows/core.yml' 'cargo-deb@([0-9.]+)'
-          $cargoRpmCi = Read-Pin '.github/workflows/core.yml' 'cargo-generate-rpm@([0-9.]+)'
-          if (-not $cargoDebCi) { throw 'No cargo-deb@<version> pin in core.yml (pkg job)' }
-          if (-not $cargoRpmCi) { throw 'No cargo-generate-rpm@<version> pin in core.yml (pkg job)' }
-          if ($cargoDebCi -ne $cargoDebPin) {
-            Add-Problem 'cargo-deb pins disagree' "- cargo-deb pin mismatch: build-linux-packages.sh has ``$cargoDebPin`` but core.yml's pkg job installs ``$cargoDebCi`` — they must be identical (the smoke test must use the exact release tools)"
-          }
-          if ($cargoRpmCi -ne $cargoRpmPin) {
-            Add-Problem 'cargo-generate-rpm pins disagree' "- cargo-generate-rpm pin mismatch: build-linux-packages.sh has ``$cargoRpmPin`` but core.yml's pkg job installs ``$cargoRpmCi`` — they must be identical (the smoke test must use the exact release tools)"
-          }
-          # The GUI lane carries two MORE copies of the same two pins: the
-          # packaging script's source-compile pins (what the release legs run
-          # — their ubuntu-22.04 glibc floor rules out the prebuilt binaries)
-          # plus the taiki-e pre-install in gui.yml's packaging smoke. All
-          # must equal build-linux-packages.sh's, for the same
-          # smoke-packages-with-the-release-tools reason.
-          $guiPackagerHomes = [ordered]@{
-            '.github/scripts/gui-package-linux.ps1' = @("cargoDebVersion\s*=\s*'([0-9.]+)'", "cargoGenerateRpmVersion\s*=\s*'([0-9.]+)'")
-            '.github/workflows/gui.yml'             = @('cargo-deb@([0-9.]+)', 'cargo-generate-rpm@([0-9.]+)')
-          }
-          foreach ($file in $guiPackagerHomes.Keys) {
-            $debHere = Read-Pin $file $guiPackagerHomes[$file][0]
-            $rpmHere = Read-Pin $file $guiPackagerHomes[$file][1]
-            if (-not $debHere) { throw "No cargo-deb pin in $file" }
-            if (-not $rpmHere) { throw "No cargo-generate-rpm pin in $file" }
-            if ($debHere -ne $cargoDebPin) {
-              Add-Problem 'cargo-deb pins disagree' "- cargo-deb pin mismatch: build-linux-packages.sh has ``$cargoDebPin`` but $file pins ``$debHere`` — every copy must be identical"
-            }
-            if ($rpmHere -ne $cargoRpmPin) {
-              Add-Problem 'cargo-generate-rpm pins disagree' "- cargo-generate-rpm pin mismatch: build-linux-packages.sh has ``$cargoRpmPin`` but $file pins ``$rpmHere`` — every copy must be identical"
-            }
-          }
-
-          # --- appimagetool: gui-package-linux.ps1 pin vs AppImage/appimagetool ---
-          # The GUI lane's AppImage packer, fetched over curl at a static
-          # version — invisible to Dependabot, watched here like komac.
-          $appimagetoolPin = Read-Pin '.github/scripts/gui-package-linux.ps1' "appimagetoolVersion\s*=\s*'([0-9.]+)'"
-          if (-not $appimagetoolPin) { throw 'No appimagetoolVersion pin in gui-package-linux.ps1' }
-          $appimagetoolLatest = Latest-Semver-Listed 'AppImage/appimagetool'
-          if (-not $appimagetoolLatest) {
-            Add-Problem 'appimagetool (query failed)' '- could not query the latest appimagetool release (AppImage/appimagetool)'
-          } elseif ([version]$appimagetoolLatest -gt [version]$appimagetoolPin) {
-            Add-Problem "appimagetool $appimagetoolPin->$appimagetoolLatest" "- appimagetool pin ``$appimagetoolPin`` (gui-package-linux.ps1) is behind the latest release ``$appimagetoolLatest``"
-          }
-
-          # --- wasm-bindgen-cli: wasm.yml + publish-npm.yml pins vs crates.io ---
-          # The browser package builds with `wasm-bindgen-cli@X` (taiki-e); X MUST
-          # equal the wasm-bindgen crate it generates glue for, so it is pinned and
-          # nothing else watches it. (wasm-pack is NOT used — the build is plain
-          # cargo + the CLI + wasm-opt.) The two workflow pins must also agree.
-          $wbGate   = Read-Pin '.github/workflows/wasm.yml' 'wasm-bindgen-cli@([0-9.]+)'
-          $wbPub    = Read-Pin '.github/workflows/publish-npm.yml' 'wasm-bindgen-cli@([0-9.]+)'
-          $wbDeploy = Read-Pin '.github/workflows/deploy-pages.yml' 'wasm-bindgen-cli@([0-9.]+)'
-          if (-not $wbGate)   { throw 'No wasm-bindgen-cli pin in wasm.yml' }
-          if (-not $wbPub)    { throw 'No wasm-bindgen-cli pin in publish-npm.yml' }
-          if (-not $wbDeploy) { throw 'No wasm-bindgen-cli pin in deploy-pages.yml' }
-          if (($wbGate -ne $wbPub) -or ($wbGate -ne $wbDeploy)) {
-            Add-Problem 'wasm-bindgen-cli pins disagree' "- wasm-bindgen-cli pin mismatch: wasm.yml has ``$wbGate`` / publish-npm.yml has ``$wbPub`` / deploy-pages.yml has ``$wbDeploy`` — all three must be identical"
-          }
-          $wbLatest = Latest-CratesIo 'wasm-bindgen-cli'
-          if (-not $wbLatest) {
-            Add-Problem 'wasm-bindgen-cli (query failed)' '- could not query the latest wasm-bindgen-cli release (crates.io)'
-          } elseif ([version]$wbLatest -gt [version]$wbGate) {
-            Add-Problem "wasm-bindgen-cli $wbGate->$wbLatest" "- wasm-bindgen-cli pin ``$wbGate`` (wasm.yml + publish-npm.yml) is behind the latest release ``$wbLatest`` — bump both pins AND the wasm-bindgen crate dep together"
-          }
+          # --- cloudsmith-cli: a pip package -----------------------------------
+          Compare-Pin 'cloudsmith-cli' $pins.CLOUDSMITH_CLI (Latest-PyPI 'cloudsmith-cli') 'PyPI' ''
 
           # --- binaryen (wasm-opt): web/package.json pin vs npm ----------------
           # wasm-opt -Oz shrinks the shipped payload; its version is coupled to the
-          # committed size budget (wasm-size-budget.txt), so it is pinned (the
-          # devDependency + lockfile) and watched here like the other size/format
-          # tools.
+          # committed size budget (wasm-size-budget.txt), so it is watched here like
+          # the other size/format tools even though Dependabot bumps it.
           $binPin = Read-Pin 'crates/bdinfo-rs-wasm/web/package.json' '"binaryen"\s*:\s*"\^?([0-9.]+)"'
           if (-not $binPin) { throw 'No binaryen pin in crates/bdinfo-rs-wasm/web/package.json' }
-          $binLatest = Latest-Npm 'binaryen'
-          if (-not $binLatest) {
-            Add-Problem 'binaryen (query failed)' '- could not query the latest binaryen release (npm)'
-          } elseif ([version]$binLatest -gt [version]$binPin) {
-            Add-Problem "binaryen $binPin->$binLatest" "- binaryen pin ``$binPin`` (web/package.json) is behind the latest release ``$binLatest`` — bump it, rebuild, and re-check the wasm size budget"
-          }
+          Compare-Pin 'binaryen' $binPin (Latest-Npm 'binaryen') 'npm registry' ' — bump it, rebuild, and re-check the wasm size budget'
 
           # --- biome: biome.json $schema must match the installed @biomejs/biome -
           # Dependabot bumps the @biomejs/biome devDependency (npm ecosystem) but
           # cannot touch biome.json's versioned schema URL, so the two silently
-          # drift on a biome bump. Cross-check them (a consistency check, like the
-          # cargo-dist / wasm-bindgen / Node pin agreements); freshness itself stays
+          # drift on a biome bump. Cross-check them; freshness itself stays
           # Dependabot's job. Read the resolved version from the lockfile, not the
           # `^2` range. (`-AsHashtable`: npm lockfiles have a `""` root package key
           # that plain ConvertFrom-Json rejects.)
@@ -505,29 +347,19 @@ jobs:
             $biomeLock = (Get-Content -Raw 'crates/bdinfo-rs-wasm/web/package-lock.json' |
                 ConvertFrom-Json -AsHashtable).packages.'node_modules/@biomejs/biome'.version
           } catch { }
+          $summary += "biome-schema: $biomeSchema (dep $biomeLock)"
           if (-not $biomeLock) {
             Add-Problem 'biome (version unreadable)' '- could not read the @biomejs/biome version from web/package-lock.json'
           } elseif ($biomeSchema -ne $biomeLock) {
             Add-Problem "biome schema $biomeSchema vs $biomeLock" "- biome.json schema URL is pinned to ``$biomeSchema`` but the lockfile installs @biomejs/biome ``$biomeLock`` — bump the schema URL in biome.json to match"
           }
 
-          # --- Node: the 3 workflow pins must AGREE, vs nodejs.org/dist ----------
-          # Pinned in wasm.yml (NODE_VERSION), deploy-pages.yml + publish-npm.yml
-          # (node-version); setup-node consumes these, so Dependabot never sees them.
+          # --- Node: the manifest pin vs nodejs.org/dist ------------------------
           # Two nags: same-major patch drift (stay current on the chosen line), and
           # a newer even/LTS-bound major shipping (the cue to plan the next line, as
           # 26 was adopted ahead of its Oct-2026 LTS). Odd "Current" majors never
           # trigger the second nag — they are never LTS, so we do not chase them.
-          $nodeWasm = Read-Pin '.github/workflows/wasm.yml' 'NODE_VERSION:\s*"([0-9.]+)"'
-          $nodeDeploy = Read-Pin '.github/workflows/deploy-pages.yml' 'node-version:\s*"([0-9.]+)"'
-          $nodePub = Read-Pin '.github/workflows/publish-npm.yml' 'node-version:\s*"([0-9.]+)"'
-          if (-not $nodeWasm) { throw 'No NODE_VERSION pin in wasm.yml' }
-          if (-not $nodeDeploy) { throw 'No node-version pin in deploy-pages.yml' }
-          if (-not $nodePub) { throw 'No node-version pin in publish-npm.yml' }
-          if (($nodeWasm -ne $nodeDeploy) -or ($nodeWasm -ne $nodePub)) {
-            Add-Problem 'Node pins disagree' "- Node pin mismatch: wasm.yml ``$nodeWasm`` / deploy-pages.yml ``$nodeDeploy`` / publish-npm.yml ``$nodePub`` — they must be identical"
-          }
-          $nodePin = $nodeWasm
+          $nodePin = $pins.NODE
           $nodePinMajor = [int]($nodePin.Split('.')[0])
           $nodeLatestOnMajor = $null; $nodeNewestEven = $null
           $nodeRel = Get-NodeReleases
@@ -541,37 +373,14 @@ jobs:
               })
             $nodeLatestOnMajor = (@($nodeParsed | Where-Object { $_.major -eq $nodePinMajor }) | Sort-Object ver -Descending | Select-Object -First 1).ver
             if ($nodeLatestOnMajor -and [version]$nodePin -lt $nodeLatestOnMajor) {
-              Add-Problem "Node $nodePin->$nodeLatestOnMajor" "- Node pin ``$nodePin`` (wasm.yml + deploy-pages.yml + publish-npm.yml) is behind the latest $nodePinMajor.x release ``$nodeLatestOnMajor`` — bump all three pins together"
+              Add-Problem "Node $nodePin->$nodeLatestOnMajor" "- Node pin ``$nodePin`` is behind the latest $nodePinMajor.x release ``$nodeLatestOnMajor``"
             }
             $nodeNewestEven = (@($nodeParsed | Where-Object { $_.major % 2 -eq 0 }) | Sort-Object major -Descending | Select-Object -First 1).major
             if ($nodeNewestEven -and $nodeNewestEven -gt $nodePinMajor) {
-              Add-Problem "Node $nodeNewestEven.x available" "- a newer even (LTS-bound) Node line ``$nodeNewestEven.x`` has shipped; the pins are on ``$nodePinMajor.x`` — plan the move (update all three pins together)"
+              Add-Problem "Node $nodeNewestEven.x available" "- a newer even (LTS-bound) Node line ``$nodeNewestEven.x`` has shipped; the pin is on ``$nodePinMajor.x`` — plan the move"
             }
           }
-
-          # --- npm: publish-npm.yml `npm install -g npm@X` vs the npm registry ----
-          # An `npm install -g` line, not a package.json dep, so Dependabot is blind
-          # to it. The staged-publishing floor; pinned so the publish stays on a
-          # deterministic npm independent of which npm a given Node 26.x bundles.
-          $npmPin = Read-Pin '.github/workflows/publish-npm.yml' 'npm install -g npm@([0-9.]+)'
-          if (-not $npmPin) { throw 'No `npm install -g npm@<version>` pin in publish-npm.yml' }
-          $npmLatest = Latest-Npm 'npm'
-          if (-not $npmLatest) {
-            Add-Problem 'npm (query failed)' '- could not query the latest npm release (npm registry)'
-          } elseif ([version]$npmLatest -gt [version]$npmPin) {
-            Add-Problem "npm $npmPin->$npmLatest" "- npm pin ``$npmPin`` (publish-npm.yml) is behind the latest release ``$npmLatest``"
-          }
-
-          # --- wrangler: deploy-pages.yml `npx wrangler@X` vs the npm registry ----
-          # An npx invocation (not a package.json dep), so Dependabot can't bump it.
-          $wranglerPin = Read-Pin '.github/workflows/deploy-pages.yml' 'wrangler@([0-9.]+)'
-          if (-not $wranglerPin) { throw 'No `wrangler@<version>` pin in deploy-pages.yml' }
-          $wranglerLatest = Latest-Npm 'wrangler'
-          if (-not $wranglerLatest) {
-            Add-Problem 'wrangler (query failed)' '- could not query the latest wrangler release (npm)'
-          } elseif ([version]$wranglerLatest -gt [version]$wranglerPin) {
-            Add-Problem "wrangler $wranglerPin->$wranglerLatest" "- wrangler pin ``$wranglerPin`` (deploy-pages.yml) is behind the latest release ``$wranglerLatest``"
-          }
+          $summary += "node: $nodePin (latest-on-major $nodeLatestOnMajor, newest-even $nodeNewestEven)"
 
           # --- Homebrew/actions/setup-homebrew: install-smoke-test.yml vs master HEAD ---
           # SHA-pinned to a TAGLESS repo's master branch, so Dependabot can't bump it
@@ -586,59 +395,9 @@ jobs:
           } elseif ($brewPin -ne $brewHead) {
             Add-Problem 'setup-homebrew SHA drifted' "- Homebrew/actions/setup-homebrew pin ``$($brewPin.Substring(0, 12))`` (install-smoke-test.yml) is behind master HEAD ``$($brewHead.Substring(0, 12))`` — re-pin deliberately (the repo ships no tags, so the SHA is frozen on purpose)"
           }
-          $brewPinShort = if ($brewPin) { $brewPin.Substring(0, 12) } else { '?' }
-          $brewHeadShort = if ($brewHead) { $brewHead.Substring(0, 12) } else { '?' }
+          $summary += "brew: $($brewPin.Substring(0, 12)) (head $(if ($brewHead) { $brewHead.Substring(0, 12) } else { '?' }))"
 
-          # --- komac: packages.yml KOMAC_VERSION vs russellbanks/Komac latest ------
-          # The WinGet job submits with komac DIRECTLY (winget-releaser's
-          # cargo-binstall@main bootstrap trips this repo's SHA-pinning policy), fetched
-          # over curl at a static hand-bumped KOMAC_VERSION invisible to Dependabot.
-          # Nothing else watches it, so nag here like the other hand-bumped tools
-          # (taplo/convco/ryl) when a newer komac ships; the winget-pkgs manifest schema
-          # is stable, so an occasional lag is harmless.
-          $komacPin = Read-Pin '.github/workflows/packages.yml' 'KOMAC_VERSION:\s*([0-9.]+)'
-          if (-not $komacPin) { throw 'No KOMAC_VERSION pin in packages.yml' }
-          # gui-publish.yml pins the same tool for the GUI's winget leg; the
-          # agreement check keeps that copy from rotting invisibly behind the
-          # freshness check on the packages.yml value below.
-          $komacGuiPin = Read-Pin '.github/workflows/gui-publish.yml' 'KOMAC_VERSION:\s*([0-9.]+)'
-          if (-not $komacGuiPin) { throw 'No KOMAC_VERSION pin in gui-publish.yml' }
-          if ($komacGuiPin -ne $komacPin) {
-            Add-Problem 'komac pins disagree' "- KOMAC_VERSION mismatch: packages.yml ``$komacPin`` vs gui-publish.yml ``$komacGuiPin`` — bump both together"
-          }
-          $komacLatest = Latest-Semver 'russellbanks/Komac'
-          if (-not $komacLatest) {
-            Add-Problem 'komac (query failed)' '- could not query the latest komac release (russellbanks/Komac)'
-          } elseif ([version]$komacLatest -gt [version]$komacPin) {
-            Add-Problem "komac $komacPin->$komacLatest" "- komac pin ``$komacPin`` (packages.yml KOMAC_VERSION) is behind the latest release ``$komacLatest``"
-          }
-
-          # --- cloudsmith-cli: the CLOUDSMITH_CLI_VERSION pins vs PyPI --------------
-          # The push legs install a pinned `cloudsmith-cli==X` with pipx, from the
-          # CLOUDSMITH_CLI_VERSION each workflow sets. A pip pin invisible to
-          # Dependabot's cargo/npm/actions scans, so a server-side API change could
-          # break the frozen client silently; nag here like the other hand-bumped
-          # tools when a newer client ships. The pin occurs once per publishing
-          # workflow — packages.yml for the CLI packages, gui-publish.yml for the
-          # GUI's — so read every occurrence and assert they agree; a
-          # first-match-only read validates one lane while the other drifts unseen.
-          $cloudsmithPins = Read-AllPins '.github/workflows/packages.yml' 'CLOUDSMITH_CLI_VERSION:\s*([0-9.]+)'
-          if (-not $cloudsmithPins.Count) { throw 'No CLOUDSMITH_CLI_VERSION pin in packages.yml' }
-          $cloudsmithGuiPin = Read-Pin '.github/workflows/gui-publish.yml' 'CLOUDSMITH_CLI_VERSION:\s*([0-9.]+)'
-          if (-not $cloudsmithGuiPin) { throw 'No CLOUDSMITH_CLI_VERSION pin in gui-publish.yml' }
-          $cloudsmithPins = @($cloudsmithPins) + $cloudsmithGuiPin
-          $cloudsmithPin = $cloudsmithPins[0]
-          if (@($cloudsmithPins | Sort-Object -Unique).Count -gt 1) {
-            Add-Problem 'cloudsmith-cli pins disagree' "- cloudsmith-cli pin mismatch across packages.yml / gui-publish.yml: ``$($cloudsmithPins -join '` / `')`` — every push job must pin the same version"
-          }
-          $cloudsmithLatest = Latest-PyPI 'cloudsmith-cli'
-          if (-not $cloudsmithLatest) {
-            Add-Problem 'cloudsmith-cli (query failed)' '- could not query the latest cloudsmith-cli release (PyPI)'
-          } elseif ([version]$cloudsmithLatest -gt [version]$cloudsmithPin) {
-            Add-Problem "cloudsmith-cli $cloudsmithPin->$cloudsmithLatest" "- cloudsmith-cli pin ``$cloudsmithPin`` (packages.yml) is behind the latest release ``$cloudsmithLatest``"
-          }
-
-          Write-Host "stable: $stablePin (latest $stableLatest)  nightly: $nightlyPin ($nightlyAgeDays d)  cargo-dist: $distCfg (latest $distLatest)  cargo-vet: $vetPin (latest $vetLatest)  cargo-fuzz: $fuzzCi (latest $fuzzLatest)  ryl: $rylPin (latest $rylLatest)  taplo: $taploPin (latest $taploLatest)  convco: $convcoPin (latest $convcoLatest)  wasm-bindgen-cli: $wbGate (latest $wbLatest)  binaryen: $binPin (latest $binLatest)  biome-schema: $biomeSchema (dep $biomeLock)  node: $nodePin (latest-on-major $nodeLatestOnMajor, newest-even $nodeNewestEven)  npm: $npmPin (latest $npmLatest)  wrangler: $wranglerPin (latest $wranglerLatest)  brew: $brewPinShort (head $brewHeadShort)  komac: $komacPin (latest $komacLatest)  cargo-deb: $cargoDebPin (latest $cargoDebLatest)  cargo-generate-rpm: $cargoRpmPin (latest $cargoRpmLatest)  appimagetool: $appimagetoolPin (latest $appimagetoolLatest)  cloudsmith-cli: $cloudsmithPin (latest $cloudsmithLatest)"
+          Write-Host ($summary -join '  ')
           if ($problems.Count -eq 0) { Write-Host 'All pinned versions are fresh and consistent.'; exit 0 }
 
           $bodyLines = @($problems | ForEach-Object { $_.line })
@@ -649,19 +408,19 @@ jobs:
           # stays readable when several pins rot at once.
           $maxShown = 3
           if ($tags.Count -le $maxShown) {
-            $summary = $tags -join ', '
+            $summaryTags = $tags -join ', '
           }
           else {
-            $summary = (@($tags | Select-Object -First $maxShown) -join ', ') + " (+$($tags.Count - $maxShown) more)"
+            $summaryTags = (@($tags | Select-Object -First $maxShown) -join ', ') + " (+$($tags.Count - $maxShown) more)"
           }
-          $title = if ($tags.Count -eq 1) { "Stale pin: $summary" } else { "Stale pins: $summary" }
+          $title = if ($tags.Count -eq 1) { "Stale pin: $summaryTags" } else { "Stale pins: $summaryTags" }
 
           $body = @(
             'The daily version-freshness check found:'
             ''
             $bodyLines
             ''
-            'Bump deliberately: update the pin(s) in the file(s) named above, keep the five NIGHTLY pins (core.yml / fuzz.yml / wasm.yml / gui.yml / publish-npm.yml) identical, and after any cargo-dist bump re-take `DIST_SHA256` from the release''s `.sha256` asset and re-run `dist generate`. CI re-validates on the next push.'
+            'Bump deliberately: every tool and toolchain version above lives in `.github/pins.env` unless the line names another file, and after any cargo-dist bump re-take `DIST_SHA256` from the release''s `.sha256` asset and re-run `dist generate`. CI re-validates on the next push.'
           ) -join "`n"
 
           # One rolling issue, tracked by a stable label — the title varies with the

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -32,8 +32,6 @@ permissions:
   contents: read
 
 env:
-  NIGHTLY: nightly-2026-07-06 # keep in lockstep with scripts/_common.ps1 + core.yml
-  NODE_VERSION: "26.6.0"      # the active Node line (26 -> LTS Oct 2026); watched by version-freshness.yml
   # Keep the cached target/ small: no incremental-compilation metadata, and
   # line tables instead of full DWARF (still enough for file:line in a test
   # backtrace). A called workflow inherits none of its caller's env, so these
@@ -54,6 +52,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - id: pins
+        uses: ./.github/actions/pins
+
       # The LGPL hygiene rule that the npm tarball's web/ LICENSE + NOTICE copies
       # still match their repo-root originals — the single-source script the
       # local gate runs too. Cheap + dependency-free, so it runs first.
@@ -62,10 +63,18 @@ jobs:
         run: ./.github/scripts/wasm-rules.ps1 -Check licenses
 
       - name: Install pinned nightly rustfmt + llvm-tools (for llvm-cov)
-        run: rustup toolchain install ${{ env.NIGHTLY }} --profile minimal --component rustfmt --component llvm-tools-preview
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
+        run: rustup toolchain install "$NIGHTLY" --profile minimal --component rustfmt --component llvm-tools-preview
 
-      - name: Add the wasm32 target
-        run: rustup target add wasm32-unknown-unknown
+      # The wasm32 target, the pinned wasm-bindgen CLI, the pinned Node and
+      # `npm ci` — the same block publish-npm.yml and deploy-pages.yml build the
+      # shipped artifact with. `npm run build` runs far below instead of here:
+      # every gate step between the two would otherwise be measuring a stale
+      # artifact.
+      - uses: ./.github/actions/wasm-build
+        with:
+          web: install
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -75,20 +84,12 @@ jobs:
           # save; PRs restore the master-seeded cache.
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
-      # `fallback: none` on every install-action step here: install only from the
-      # action's checksummed manifest, never its runtime-resolved cargo-binstall
-      # fallback (rationale in core.yml).
-      - name: Install wasm-bindgen-cli (pinned to the crate version)
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
-        with:
-          tool: wasm-bindgen-cli@0.2.126
-          fallback: none
-
-      # The pinned wasm-bindgen-cli MUST equal the wasm-bindgen version resolved in
-      # Cargo.lock — wasm-bindgen hard-errors on any crate<->CLI mismatch. A
-      # Dependabot bump of the wasm-bindgen crate moves the lockfile but not the
-      # `tool: wasm-bindgen-cli@X` pins (here + publish-npm.yml + deploy-pages.yml),
-      # so catch the drift early with the exact fix (or run scripts/wasm-sync.ps1).
+      # The installed wasm-bindgen-cli MUST equal the wasm-bindgen version
+      # resolved in Cargo.lock — wasm-bindgen hard-errors on any crate<->CLI
+      # mismatch. The two move independently: Dependabot bumps the crate in the
+      # lockfile and cannot touch the hand-maintained CLI pin, so this catches
+      # that drift here, with the exact fix, instead of inside a wasm-bindgen
+      # invocation later in the build.
       - name: wasm-bindgen CLI matches the lockfile
         working-directory: crates/bdinfo-rs-wasm
         shell: pwsh
@@ -98,22 +99,16 @@ jobs:
           $cli = [regex]::Match((& wasm-bindgen --version), '([0-9]+\.[0-9]+\.[0-9]+)').Value
           Write-Host "Cargo.lock wasm-bindgen $lock / CLI $cli"
           if ($lock -ne $cli) {
-            throw "wasm-bindgen mismatch: Cargo.lock=$lock CLI=$cli. Set wasm-bindgen-cli@$lock in wasm.yml + publish-npm.yml + deploy-pages.yml (or run: pwsh scripts/wasm-sync.ps1)."
+            throw "wasm-bindgen mismatch: Cargo.lock=$lock CLI=$cli. Set WASM_BINDGEN_CLI=$lock in .github/pins.env."
           }
 
+      # `fallback: none`: install only from the action's checksummed manifest,
+      # never its runtime-resolved cargo-binstall fallback (rationale in core.yml).
       - name: Install the Rust gate tools (llvm-cov / nextest / machete / shear / typos)
         uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-llvm-cov,cargo-nextest,cargo-machete,cargo-shear,cargo-deny,typos-cli
           fallback: none
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install the web toolchain (binaryen / biome / typescript / playwright-core)
-        working-directory: crates/bdinfo-rs-wasm/web
-        run: npm ci
 
       # The fixed unsafe-token count in src/lib.rs (the cfg-gated marker impls the
       # browser bindings need) — the same single-source script, which carries the
@@ -124,7 +119,9 @@ jobs:
 
       - name: Format (nightly rustfmt)
         working-directory: crates/bdinfo-rs-wasm
-        run: cargo +${{ env.NIGHTLY }} fmt --check
+        env:
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
+        run: cargo "+$NIGHTLY" fmt --check
 
       - name: Typos
         working-directory: crates/bdinfo-rs-wasm
@@ -171,7 +168,7 @@ jobs:
         working-directory: crates/bdinfo-rs-wasm
         shell: pwsh
         env:
-          NIGHTLY: ${{ env.NIGHTLY }}
+          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         # The floor itself lives in the single-source .github/scripts/cov-floor.ps1
         # the local gate runs too. The crate's own src/ is the denominator: the
         # bdinfo-rs-core path dependency is measured by the root workspace, and


### PR DESCRIPTION
Version pins fanned out across the tree behind hand-written "keep in lockstep with" comments: the nightly toolchain had six homes, cargo-deb and cargo-generate-rpm four each, wasm-bindgen-cli and Node three each, and cargo-vet, cargo-fuzz and cargo-generate-rpm each appeared twice inside a single job because a cache key repeated the install pin. Roughly three quarters of version-freshness.yml existed to check that those copies still agreed with each other rather than that anything was behind upstream.

All 15 hand-maintained tool and toolchain versions now live in .github/pins.env, a flat KEY=VALUE file that a shell can source, PowerShell can parse with Get-Pins, and a composite action can append to GITHUB_OUTPUT verbatim. Workflows read it through .github/actions/pins; the two PowerShell packaging scripts and the local gate call Get-Pins; build-linux-packages.sh sources it directly, because dist runs that file as a plain shell script where a uses: step does not exist.

Every pin VALUE is unchanged. This moves where pins live and bumps nothing.

Pins that deliberately stay out of the manifest, each documented there: the channel in rust-toolchain.toml (rustup reads it), cargo-dist-version in dist-workspace.toml (dist reads it, and core.yml's DIST_VERSION/DIST_SHA256 pair stays beside it with its agreement check), binaryen in web/package.json (npm resolves it), and the biome schema URL in biome.json (biome reads it). SHA-pinned action references are not versions and stay where Dependabot bumps them.

Also here: one wasm-build composite replaces the wasm32 target, wasm-bindgen CLI and Node steps spelled three times across wasm.yml, publish-npm.yml and deploy-pages.yml, with npm ci and npm run build behind an input because only their position differs between the callers.

version-freshness.yml loses every copy-agreement check that the single home makes impossible to violate (nightly five-way, cargo-fuzz, cargo-deb, cargo-generate-rpm, wasm-bindgen-cli, Node, komac, cloudsmith-cli) along with the Read-AllPins helper that existed for the last of them. What remains is one freshness check per pin, table-driven by upstream kind, plus the three agreement checks that still guard a real copy: cargo-dist against dist-workspace.toml, the four dist action SHAs against the workflows, and the biome schema URL against the lockfile.

## Grep proof: one home per pin

    $ git grep -n "nightly-2026-07-06"
    .github/pins.env:41:NIGHTLY=nightly-2026-07-06

    $ git grep -n "wasm-bindgen-cli@"
    .github/actions/wasm-build/action.yml:43:  tool: wasm-bindgen-cli@${{ steps.pins.outputs.WASM_BINDGEN_CLI }}

The other matches for the wasm-bindgen version string are Dependabot-managed lockfile entries for the wasm-bindgen crate itself, plus one dated measurement note in wasm-size-budget.txt.

## Deviations from the plan

Two, both deliberate.

1. The pins composite exposes step OUTPUTS instead of writing GITHUB_ENV. Measured against zizmor 1.26.1: a GITHUB_ENV write from an action is a HIGH github-env finding, and findings in hand-maintained files here are fixed rather than suppressed. The cost is that each consuming step names the pins it uses, and that an output must be routed through a step env: before a run block reads it, since zizmor rejects any expansion inside one.

2. wasm.yml keeps its "wasm-bindgen CLI matches the lockfile" step. The plan retired it as redundant once the CLI pin had one home, but that step compares the installed CLI against the wasm-bindgen CRATE resolved in Cargo.lock, not against another copy of the CLI pin. Dependabot moves the crate independently of the hand-maintained pin, so consolidating three pins into one does not make that drift impossible; without the step it would surface later, inside a wasm-bindgen invocation, without the fix. Its message now names the manifest key to set.

## Verification

- Local gate PASS: the classifier fired every area (core, gui, wasm, fuzz, deps, pkg, yaml, workflows, dist, toml, links, typos), coverage 100/100/100 with branches at 97.71%.
- action-validator over every workflow and composite, ryl strict over the tree, and zizmor online over .github/workflows and .github/actions: no findings.
- classify-diff.ps1 -SelfTest: 40 cases, 6978 tracked paths, all claimed.
- version-freshness.yml was executed end to end locally against the real upstream APIs, with only the issue-creation tail removed. It reads every pin from the manifest and correctly reports the pins that are genuinely behind today.
- The cargo-fuzz and cargo-generate-rpm cache keys are still built from the same value on both sides of each pair, so no saved cache entry is orphaned.

## Not exercised by this PR

The tag-triggered and dispatch lanes: publish-npm.yml, deploy-pages.yml, packages.yml, gui-publish.yml, and build-linux-packages.sh inside the release. The next v* tag exercises the CLI lane and the wasm-build composite's publish path; the next gui-v* tag exercises the GUI lane, and gui-publish.yml's prepare-only dispatch rehearses it beforehand.

Two smaller notes on the publishing lanes: the winget job in packages.yml gains an actions/checkout step, because it previously published from release assets alone and now needs the manifest on disk; and the inline cache-poisoning suppression on publish-npm.yml's setup-node is gone, because zizmor cannot see a workflow trigger from inside a composite and no longer raises that false positive there.
