### PR TITLE
ci: share the msrv and fuzz-toolchain steps as composite actions

### DIFF
--- a/.github/actions/fuzz-toolchain/action.yml
+++ b/.github/actions/fuzz-toolchain/action.yml
@@ -1,0 +1,137 @@
+# Everything a libFuzzer leg needs on disk before it can run a single unit:
+# the pinned nightly with the leg's target, the 32-bit C++ toolchain the i686
+# legs need, the build cache, the pinned cargo-fuzz binary, and the committed
+# fuzz lockfile check. Two callers reach exactly this point by exactly these
+# steps — core.yml's `replay` (the per-pull-request corpus regression gate) and
+# fuzz.yml's `deep` (the nightly and tag-time fresh-fuzz pass) — and a
+# divergence between them would mean the gate and the deep pass fuzz different
+# builds.
+#
+# What stays per caller: the rust-cache key shape (the two legs partition their
+# fuzz/target archives differently, each for a documented reason at the call
+# site) and the cargo-fuzz binary cache's OWNERSHIP, below.
+#
+# A COMPOSITE action rather than a reusable workflow (rationale in
+# .github/actions/pins).
+name: fuzz-toolchain
+description: >-
+  Install the pinned nightly, the leg's target, the 32-bit C++ toolchain and
+  the pinned cargo-fuzz, and verify the committed fuzz lockfile.
+
+inputs:
+  target:
+    description: >-
+      The libFuzzer target triple this leg builds — the gnu host at 64 bits
+      (the workspace default musl target cannot link libFuzzer's sanitizers),
+      or the i686 proxy for wasm32's pointer width.
+    required: true
+  cxx-multilib:
+    description: >-
+      `true` installs gcc-multilib / g++-multilib. libfuzzer-sys's build script
+      COMPILES libFuzzer's C++ sources with the cc crate, which for an i686
+      target invokes the host compiler with -m32 — so a 32-bit C++ toolchain is
+      the FIRST thing that blocks such a leg, before any Rust code is reached.
+      Without it the failure names `libfuzzer-sys` and reads like a Rust
+      problem.
+    required: false
+    default: 'false'
+  cargo-fuzz-cache:
+    description: >-
+      Who owns the cargo-fuzz binary cache entry. `save` reads AND writes it
+      (core.yml's replay job compiles the pinned version and owns the save on
+      master); `restore` only reads, and skips the read entirely on a tag run,
+      because restoring an EXECUTABLE is the one place cache poisoning would
+      matter. Both modes build the key from the same manifest value, so the two
+      callers must keep producing byte-identical keys.
+    required: true
+  cache-key:
+    description: >-
+      Swatinem/rust-cache `key` — an extra key component; empty leaves the
+      job-derived key alone.
+    required: false
+    default: ''
+  cache-shared-key:
+    description: >-
+      Swatinem/rust-cache `shared-key` — replaces the job-derived key, so
+      legs that build the same dependency graph share one archive.
+    required: false
+    default: ''
+  cache-lookup-only:
+    description: >-
+      Swatinem/rust-cache `lookup-only` — a release-adjacent run builds fresh
+      rather than consuming a build cache poisoned elsewhere.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - id: pins
+      uses: ./.github/actions/pins
+
+    # cargo-fuzz and libFuzzer need a nightly toolchain.
+    - name: Install pinned nightly
+      shell: bash
+      env:
+        NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
+        FUZZ_TARGET: ${{ inputs.target }}
+      run: |
+        rustup toolchain install "$NIGHTLY" --profile minimal
+        rustup target add "$FUZZ_TARGET" --toolchain "$NIGHTLY"
+
+    - name: Install the 32-bit C++ toolchain
+      if: inputs.cxx-multilib == 'true'
+      shell: bash
+      run: sudo apt-get update -qq && sudo apt-get install -y -qq gcc-multilib g++-multilib
+
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        workspaces: fuzz
+        key: ${{ inputs.cache-key }}
+        shared-key: ${{ inputs.cache-shared-key }}
+        lookup-only: ${{ inputs.cache-lookup-only }}
+        save-if: ${{ github.ref == 'refs/heads/master' }}
+
+    # cargo-fuzz is absent from taiki-e/install-action's manifest, and this repo
+    # runs that action with `fallback: none` so a manifest-missing tool fails
+    # loudly instead of resolving through its unpinned cargo-binstall fallback
+    # (rationale in core.yml). So compile the pinned version from crates.io once
+    # and cache the binary, the same lane cargo-vet uses.
+    # The key is NOT keyed by arch: cargo-fuzz is a HOST executable driving a
+    # cross-compile, identical for every leg. On a cold cache the legs miss
+    # together and save the same bytes; the losers log a reserve conflict and
+    # move on.
+    - name: Cache the pinned cargo-fuzz binary
+      id: fuzz-bin-rw
+      if: inputs.cargo-fuzz-cache == 'save'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cargo/bin/cargo-fuzz
+        key: cargo-fuzz-${{ runner.os }}-${{ steps.pins.outputs.CARGO_FUZZ }}
+
+    - name: Restore the pinned cargo-fuzz binary (non-tag runs)
+      id: fuzz-bin-ro
+      if: inputs.cargo-fuzz-cache == 'restore' && !startsWith(github.ref, 'refs/tags/')
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cargo/bin/cargo-fuzz
+        key: cargo-fuzz-${{ runner.os }}-${{ steps.pins.outputs.CARGO_FUZZ }}
+
+    # A skipped cache step reports no `cache-hit`, so naming both ids here is
+    # what makes one condition serve both modes AND the tag run that reads
+    # neither.
+    - name: Install the pinned cargo-fuzz (cache miss)
+      if: steps.fuzz-bin-rw.outputs.cache-hit != 'true' && steps.fuzz-bin-ro.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        CARGO_FUZZ: ${{ steps.pins.outputs.CARGO_FUZZ }}
+      run: cargo install cargo-fuzz --version "$CARGO_FUZZ" --locked
+
+    - name: Verify the committed fuzz lockfile is in sync
+      # cargo-fuzz's `run` has no --locked flag (it forwards everything after
+      # `--` to libFuzzer), so enforce the committed fuzz/Cargo.lock with a real
+      # cargo command up front; this also pre-fetches the deps for the build.
+      shell: bash
+      env:
+        NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
+      run: cargo +"$NIGHTLY" fetch --locked --manifest-path fuzz/Cargo.toml

--- a/.github/actions/lint-crate/action.yml
+++ b/.github/actions/lint-crate/action.yml
@@ -1,0 +1,64 @@
+# The four hygiene checks the two sibling crates run identically: nightly
+# rustfmt, typos, and the two unused-dependency detectors (cargo-machete reads
+# the manifest and the sources textually, cargo-shear the AST — they disagree
+# often enough that both are worth running). gui.yml's `checks` job and
+# wasm.yml's `gate` job ran these as four byte-identical steps differing only in
+# which crate directory they run from.
+#
+# The COMMAND SPELLINGS are not defined here: `mc` and `sh` are aliases in each
+# crate's own .cargo/config.toml, which is what `working-directory` selects, so
+# the local gate and CI invoke one definition. What this action removes is the
+# duplicated YAML wiring around them.
+#
+# The three binaries stay the CALLER's to install: both callers already pull
+# cargo-machete / cargo-shear / typos-cli from one pinned install-action step
+# alongside the tools their own remaining gate steps need, and splitting that
+# step would buy an extra install for no isolation.
+#
+# core.yml deliberately does NOT call this. It runs the same tools under
+# different step names, through the ROOT workspace's aliases, and without Typos
+# — the repository-wide typos check lives in repo.yml and already covers the
+# root sources. Folding it in would mean renaming its steps or bypassing its
+# aliases to save nothing.
+#
+# A COMPOSITE action rather than a reusable workflow (rationale in
+# .github/actions/pins).
+name: lint-crate
+description: >-
+  Run a sibling crate's hygiene quartet — nightly rustfmt, typos, and the two
+  unused-dependency detectors — from that crate's directory.
+
+inputs:
+  working-directory:
+    description: >-
+      The crate directory. It selects both the manifest the tools read and the
+      .cargo/config.toml the `mc` / `sh` aliases come from.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - id: pins
+      uses: ./.github/actions/pins
+
+    - name: Format (nightly rustfmt)
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      env:
+        NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
+      run: cargo "+$NIGHTLY" fmt --check
+
+    - name: Typos
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: typos
+
+    - name: Machete (unused deps)
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: cargo mc
+
+    - name: Shear (unused deps, AST)
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: cargo sh

--- a/.github/actions/msrv-check/action.yml
+++ b/.github/actions/msrv-check/action.yml
@@ -1,0 +1,132 @@
+# The declared MSRV is enforced, not decorative, on all three shipping surfaces:
+# build with exactly the rust-version toolchain from the manifest, READ FROM THE
+# MANIFEST AT RUN TIME so an MSRV bump touches Cargo.toml ONLY. No version
+# literal lives in any workflow to drift; the version also stays out of the job
+# `name:`, because static YAML cannot interpolate a step output there. This is
+# what stops a dependency bump or a newer language feature from silently raising
+# the real floor under a downstream user who pins the declared one.
+#
+# BUILD-ONLY BY DESIGN: rust-version is a claim about building the packages, not
+# about the dev-dependency tree — the suites run on the pinned stable in each
+# workspace's own build+test job, and a dev-dependency (iced_test,
+# wasm-bindgen-test) may float its own MSRV.
+#
+# The three callers differ only in what this action takes as inputs: which
+# manifest to query, whether the floor comes from one named package or from all
+# packages agreeing, which extra target to install, and what to build. Everything
+# else — the metadata read, the toolchain install, the cache — is one body here.
+#
+# A COMPOSITE action rather than a reusable workflow (rationale in
+# .github/actions/pins).
+name: msrv-check
+description: >-
+  Read a workspace's declared rust-version floor from its manifest, install
+  exactly that toolchain, and build the crate with it.
+
+inputs:
+  package:
+    description: >-
+      Package whose `rust_version` is the floor. Empty asserts instead that
+      EVERY package in the queried metadata declares the same floor and uses
+      that — the shape for a workspace whose members inherit
+      `rust-version.workspace`, where a single member drifting is itself the
+      failure.
+    required: false
+    default: ''
+  manifest-path:
+    description: >-
+      `cargo metadata --manifest-path`. Empty queries the manifest at the
+      repository root.
+    required: false
+    default: ''
+  target:
+    description: >-
+      An extra rustup target added to the MSRV toolchain, for a crate that
+      SHIPS as a cross-compiled artifact and would otherwise never see
+      target-specific MSRV breakage in its target-only dependencies.
+    required: false
+    default: ''
+  working-directory:
+    description: Directory the check and build commands run in.
+    required: false
+    default: .
+  check-args:
+    description: >-
+      `cargo check` arguments, run before the build. Empty skips the step —
+      only a crate with a second (host) configuration to verify needs it.
+    required: false
+    default: ''
+  build-args:
+    description: >-
+      `cargo build` arguments — the configuration whose buildability the
+      declared floor is a claim about.
+    required: true
+  cache-workspaces:
+    description: >-
+      Swatinem/rust-cache `workspaces` — a sibling crate points it at its own
+      directory; empty keeps the root default.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Read the MSRV floor from Cargo.toml
+      id: msrv
+      shell: bash
+      env:
+        PACKAGE: ${{ inputs.package }}
+        MANIFEST_PATH: ${{ inputs.manifest-path }}
+      run: |
+        # `jq -e` fails loudly if rust-version ever disappears from the
+        # manifest, rather than yielding a null that would install a toolchain
+        # named "null" three steps later.
+        if [ -n "$PACKAGE" ]; then
+          query='.packages[] | select(.name == $p) | .rust_version'
+        else
+          query='[.packages[].rust_version] | unique | if length == 1 then .[0] else error("the queried workspace packages declare different rust-version floors") end'
+        fi
+        args=(--no-deps --format-version 1)
+        if [ -n "$MANIFEST_PATH" ]; then
+          args+=(--manifest-path "$MANIFEST_PATH")
+        fi
+        v="$(cargo metadata "${args[@]}" | jq -er --arg p "$PACKAGE" "$query")"
+        echo "MSRV floor: $v"
+        echo "version=$v" >> "$GITHUB_OUTPUT"
+
+    - name: Install the MSRV toolchain
+      shell: bash
+      env:
+        MSRV: ${{ steps.msrv.outputs.version }}
+        TARGET: ${{ inputs.target }}
+      run: |
+        rustup toolchain install "$MSRV" --profile minimal
+        if [ -n "$TARGET" ]; then
+          rustup target add "$TARGET" --toolchain "$MSRV"
+        fi
+
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        workspaces: ${{ inputs.cache-workspaces }}
+        save-if: ${{ github.ref == 'refs/heads/master' }}
+
+    - name: Check with the declared rust-version
+      if: inputs.check-args != ''
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      env:
+        MSRV: ${{ steps.msrv.outputs.version }}
+        CHECK_ARGS: ${{ inputs.check-args }}
+      run: |
+        # shellcheck disable=SC2086 # $CHECK_ARGS carries whole flags
+        cargo "+$MSRV" check $CHECK_ARGS
+
+    - name: Build with the declared rust-version
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      env:
+        MSRV: ${{ steps.msrv.outputs.version }}
+        BUILD_ARGS: ${{ inputs.build-args }}
+      run: |
+        # shellcheck disable=SC2086 # $BUILD_ARGS carries whole flags
+        cargo "+$MSRV" build $BUILD_ARGS

--- a/.github/scripts/classify-diff.ps1
+++ b/.github/scripts/classify-diff.ps1
@@ -339,6 +339,27 @@ begin {
             Match      = { param($f) Test-Match $f @('.github/actions/mutate-crate/*') }
         },
         @{
+            Name       = 'msrv composite action'
+            Areas      = @('core', 'gui', 'wasm', 'yaml', 'workflows')
+            Structural = $true
+            Why        = 'The msrv-check composite is the body of all three workspaces'' MSRV jobs, so a break in it is a break in each of them; action-validator and zizmor read the action definitions under .github/actions as well as the workflows.'
+            Match      = { param($f) Test-Match $f @('.github/actions/msrv-check/*') }
+        },
+        @{
+            Name       = 'fuzz toolchain composite action'
+            Areas      = @('fuzz', 'yaml', 'workflows')
+            Structural = $true
+            Why        = 'The fuzz-toolchain composite installs the nightly, target and cargo-fuzz for core.yml''s corpus replay gate — the only pull-request job it reaches, and the fuzz area is what runs it — and for fuzz.yml''s deep pass, which runs on its own schedule.'
+            Match      = { param($f) Test-Match $f @('.github/actions/fuzz-toolchain/*') }
+        },
+        @{
+            Name       = 'crate lint composite action'
+            Areas      = @('gui', 'wasm', 'yaml', 'workflows')
+            Structural = $true
+            Why        = 'The lint-crate composite runs the rustfmt/typos/machete/shear quartet for the two sibling crates'' gates. The root workspace runs those tools through its own steps and is unaffected.'
+            Match      = { param($f) Test-Match $f @('.github/actions/lint-crate/*') }
+        },
+        @{
             Name       = 'source rule script'
             Areas      = @('core')
             Structural = $true
@@ -551,6 +572,9 @@ end {
             @{ Path = '.github/pins.env'; Areas = 'core deps fuzz gui links pkg toml typos wasm yaml' }
             @{ Path = '.github/actions/pins/action.yml'; Areas = 'core deps fuzz gui links pkg toml typos wasm workflows yaml' }
             @{ Path = '.github/actions/wasm-build/action.yml'; Areas = 'links typos wasm workflows yaml' }
+            @{ Path = '.github/actions/msrv-check/action.yml'; Areas = 'core gui links typos wasm workflows yaml' }
+            @{ Path = '.github/actions/fuzz-toolchain/action.yml'; Areas = 'fuzz links typos workflows yaml' }
+            @{ Path = '.github/actions/lint-crate/action.yml'; Areas = 'gui links typos wasm workflows yaml' }
             @{ Path = '.github/scripts/gui-package-windows.ps1'; Areas = 'gui links typos' }
             @{ Path = '.github/scripts/wasm-rules.ps1'; Areas = 'links typos wasm' }
             @{ Path = '.github/scripts/cov-floor.ps1'; Areas = 'gui links typos wasm' }

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -312,17 +312,10 @@ jobs:
           NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
         run: cargo "+$NIGHTLY" llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100
 
-  # The declared MSRV is enforced, not decorative: build the whole root workspace
-  # with exactly the rust-version toolchain from Cargo.toml, read from the
-  # manifest at run time so an MSRV bump touches Cargo.toml ONLY (no version
-  # literals here to drift; the version also stays out of the job `name:` —
-  # static YAML can't interpolate step outputs there). This is what stops a
-  # dependency bump or a newer language feature from silently raising the real
-  # floor under a downstream user who pins the declared one. Build-only by
-  # design: rust-version is a claim about building the packages, not about the
-  # dev-dependency tree — the test suites run on the pinned stable in the
-  # build + test matrix above. `gui msrv` in gui.yml holds the same bar for the
-  # GUI crate, `msrv` in wasm.yml for the wasm crate.
+  # The root workspace's leg of the MSRV gate — the shared body, the rationale
+  # and the build-only posture live in .github/actions/msrv-check.
+  # `gui msrv` in gui.yml holds the same bar for the GUI crate and `wasm msrv`
+  # in wasm.yml for the wasm crate.
   msrv:
     name: msrv
     if: inputs.core == 'true'
@@ -332,30 +325,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Read the MSRV floor from Cargo.toml
-        id: msrv
-        # Both workspace members inherit `rust-version.workspace`, so the set of
-        # declared floors must be a single value — `unique | length == 1` asserts
-        # that rather than assuming it, and jq -er fails loudly if rust-version
-        # ever disappears from the manifest.
-        run: |
-          v="$(cargo metadata --no-deps --format-version 1 | jq -er '[.packages[].rust_version] | unique | if length == 1 then .[0] else error("the root workspace packages declare different rust-version floors") end')"
-          echo "MSRV floor: $v"
-          echo "version=$v" >> "$GITHUB_OUTPUT"
-
-      - name: Install the MSRV toolchain
-        env:
-          MSRV: ${{ steps.msrv.outputs.version }}
-        run: rustup toolchain install "$MSRV" --profile minimal
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # No `package`: both members inherit `rust-version.workspace`, so the set
+      # of declared floors must be a single value, and the action asserts that
+      # rather than reading one member and assuming the other agrees.
+      - uses: ./.github/actions/msrv-check
         with:
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      - name: Build with the declared rust-version
-        env:
-          MSRV: ${{ steps.msrv.outputs.version }}
-        run: cargo "+$MSRV" build --workspace --locked
+          build-args: --workspace --locked
 
   # The ultimate real-world gate: do exactly what a user does — install bdinfo-rs
   # the traditional way (build it from source; no package managers), scan the
@@ -619,59 +594,22 @@ jobs:
       - id: pins
         uses: ./.github/actions/pins
 
-      - name: Install pinned nightly
-        env:
-          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
-        run: |
-          rustup toolchain install "$NIGHTLY" --profile minimal
-          rustup target add "$FUZZ_TARGET" --toolchain "$NIGHTLY"
-
-      # libfuzzer-sys's build script COMPILES libFuzzer's C++ sources with the cc
-      # crate, which for an i686 target invokes the host compiler with -m32 — so a
-      # 32-bit C++ toolchain is the FIRST thing that blocks this leg, before any
-      # Rust code is reached. Without it the failure names `libfuzzer-sys` and
-      # reads like a Rust problem.
-      - name: Install the 32-bit C++ toolchain
-        if: matrix.arch == 'i686'
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq gcc-multilib g++-multilib
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # Nightly + target, the 32-bit C++ toolchain, the build cache, cargo-fuzz
+      # and the fuzz lockfile check — the shared body fuzz.yml's deep pass runs
+      # too, in .github/actions/fuzz-toolchain.
+      - uses: ./.github/actions/fuzz-toolchain
         with:
-          workspaces: fuzz
+          target: ${{ matrix.triple }}
+          cxx-multilib: ${{ matrix.arch == 'i686' }}
+          # This job OWNS the cargo-fuzz binary cache entry: it compiles the
+          # pinned version and saves it on master, and fuzz.yml's deep legs
+          # restore what it wrote.
+          cargo-fuzz-cache: save
           # Per arch: rust-cache keys off the job id, which both legs share, and
           # the two build different target triples into different subtrees of
           # fuzz/target. One archive would hold whichever leg saved first and the
           # other would restore a miss dressed as a hit.
-          key: ${{ matrix.arch }}
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      # cargo-fuzz is absent from taiki-e/install-action's manifest (101 tools at
-      # the revision pinned in this file), so with the binstall fallback disabled
-      # it has no prebuilt channel here. Compile the pinned version from crates.io
-      # once and cache the binary, the same lane cargo-vet uses.
-      # NOT keyed by matrix.arch: cargo-fuzz is a HOST executable driving a
-      # cross-compile, identical for both legs. On a cold cache both legs miss and
-      # both save the same bytes; the loser logs a reserve conflict and moves on.
-      - name: Cache the pinned cargo-fuzz binary
-        id: fuzz-bin
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/cargo-fuzz
-          key: cargo-fuzz-${{ runner.os }}-${{ steps.pins.outputs.CARGO_FUZZ }}
-
-      - name: Install the pinned cargo-fuzz (cache miss)
-        if: steps.fuzz-bin.outputs.cache-hit != 'true'
-        env:
-          CARGO_FUZZ: ${{ steps.pins.outputs.CARGO_FUZZ }}
-        run: cargo install cargo-fuzz --version "$CARGO_FUZZ" --locked
-
-      - name: Verify the committed fuzz lockfile is in sync
-        # cargo-fuzz's `run` has no --locked flag (it forwards everything after
-        # `--` to libFuzzer), so enforce the committed fuzz/Cargo.lock with a real
-        # cargo command up front; this also pre-fetches the deps for the build.
-        env:
-          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
-        run: cargo +"$NIGHTLY" fetch --locked --manifest-path fuzz/Cargo.toml
+          cache-key: ${{ matrix.arch }}
 
       # The target list comes from fuzz/targets.txt — the one place it lives,
       # read the same way by fuzz.yml and scripts/fuzz-docker.sh, so adding a

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -208,26 +208,18 @@ jobs:
       - id: pins
         uses: ./.github/actions/pins
 
-      # cargo-fuzz and libFuzzer need a nightly toolchain.
-      - name: Install pinned nightly
-        env:
-          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
-        run: |
-          rustup toolchain install "$NIGHTLY" --profile minimal
-          rustup target add "$FUZZ_TARGET" --toolchain "$NIGHTLY"
-
-      # libfuzzer-sys's build script COMPILES libFuzzer's C++ sources with the cc
-      # crate, which for an i686 target invokes the host compiler with -m32 — so a
-      # 32-bit C++ toolchain is the FIRST thing that blocks this leg, before any
-      # Rust code is reached. Without it the failure names `libfuzzer-sys` and
-      # reads like a Rust problem.
-      - name: Install the 32-bit C++ toolchain
-        if: matrix.arch == 'i686'
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq gcc-multilib g++-multilib
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # Nightly + target, the 32-bit C++ toolchain, the build cache, cargo-fuzz
+      # and the fuzz lockfile check — the shared body core.yml's replay gate runs
+      # too, in .github/actions/fuzz-toolchain.
+      - uses: ./.github/actions/fuzz-toolchain
         with:
-          workspaces: fuzz
+          target: ${{ matrix.triple }}
+          cxx-multilib: ${{ matrix.arch == 'i686' }}
+          # Restore-only, and skipped on a tag run: core.yml's replay job owns
+          # the save of the cargo-fuzz entry, and restoring an EXECUTABLE is the
+          # one place cache poisoning would matter, so a release-adjacent run
+          # compiles it instead.
+          cargo-fuzz-cache: restore
           # One cache lineage per ARCH, not per leg: within an arch every leg
           # builds the same dependency graph and differs only in which target
           # binary it links, and a per-leg archive of a few hundred MB would churn
@@ -236,43 +228,12 @@ jobs:
           # gracefully. Across arches the artifacts are different triples, so one
           # shared archive would give whichever arch lost the race a miss dressed
           # as a hit.
-          shared-key: fuzz-deep-${{ matrix.arch }}
+          cache-shared-key: fuzz-deep-${{ matrix.arch }}
           # Tag runs build fresh: this pass is release-adjacent and must not
           # consume a build cache poisoned elsewhere (zizmor cache-poisoning).
           # Scheduled runs execute on master, where only master-scoped runs can
           # have written the cache they restore.
-          lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      # cargo-fuzz is absent from taiki-e/install-action's manifest, and this repo
-      # runs that action with `fallback: none` so a manifest-missing tool fails
-      # loudly instead of resolving through its unpinned cargo-binstall fallback
-      # (rationale in core.yml). core.yml's replay job compiles the pinned version
-      # and OWNS the save of this cache entry on master; both keys are built from
-      # the same manifest value and must stay identical.
-      # Restoring an EXECUTABLE is the one place cache poisoning would matter, so
-      # tag runs skip the restore and compile it, exactly as before.
-      - name: Restore the pinned cargo-fuzz binary (non-tag runs)
-        id: fuzz-bin
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/cargo-fuzz
-          key: cargo-fuzz-${{ runner.os }}-${{ steps.pins.outputs.CARGO_FUZZ }}
-
-      - name: Install the pinned cargo-fuzz
-        if: ${{ steps.fuzz-bin.outputs.cache-hit != 'true' }}
-        env:
-          CARGO_FUZZ: ${{ steps.pins.outputs.CARGO_FUZZ }}
-        run: cargo install cargo-fuzz --version "$CARGO_FUZZ" --locked
-
-      - name: Verify the committed fuzz lockfile is in sync
-        # cargo-fuzz's `run` has no --locked flag (it forwards everything after
-        # `--` to libFuzzer), so enforce the committed fuzz/Cargo.lock with a real
-        # cargo command up front; this also pre-fetches the deps for the build.
-        env:
-          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
-        run: cargo +"$NIGHTLY" fetch --locked --manifest-path fuzz/Cargo.toml
+          cache-lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       # The accumulated corpus: everything earlier runs found that the committed
       # seeds do not already cover. The key carries the run id so every save is a

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -322,23 +322,11 @@ jobs:
         shell: pwsh
         run: .github/scripts/gui-rules.ps1
 
-      - name: Format (nightly rustfmt)
-        working-directory: crates/bdinfo-rs-gui
-        env:
-          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
-        run: cargo "+$NIGHTLY" fmt --check
-
-      - name: Typos
-        working-directory: crates/bdinfo-rs-gui
-        run: typos
-
-      - name: Machete (unused deps)
-        working-directory: crates/bdinfo-rs-gui
-        run: cargo mc
-
-      - name: Shear (unused deps, AST)
-        working-directory: crates/bdinfo-rs-gui
-        run: cargo sh
+      # rustfmt / typos / machete / shear — the quartet wasm.yml's gate runs
+      # identically, in .github/actions/lint-crate.
+      - uses: ./.github/actions/lint-crate
+        with:
+          working-directory: crates/bdinfo-rs-gui
 
       # Supply-chain audit of the GUI crate's OWN dependency tree (iced / wgpu /
       # winit / cosmic-text — compiled into the shipped binary but invisible to
@@ -382,13 +370,9 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           ../../.github/scripts/cov-floor.ps1 -JsonPath $json -Label 'GUI coverage' -Include 'bdinfo-rs-gui[\\/]src[\\/]' -Exclude '[\\/]src[\\/](main|ui)\.rs$'
 
-  # The declared MSRV is enforced, not decorative: build with exactly the
-  # rust-version toolchain from Cargo.toml, read from the manifest at run time
-  # so an MSRV bump touches Cargo.toml ONLY (no version literals here to drift;
-  # the version also stays out of the job `name:` — static YAML can't
-  # interpolate step outputs there). Build-only by design: rust-version is a
-  # claim about building the package, not about the dev-dependency tree
-  # (iced_test may float its own MSRV).
+  # The GUI crate's leg of the MSRV gate — the shared body, the rationale and
+  # the build-only posture live in .github/actions/msrv-check. Build-only costs
+  # nothing here in particular: iced_test may float its own MSRV.
   msrv:
     name: gui msrv
     # One Linux runner, arch-invariant verdict — arm64 (rationale in core.yml).
@@ -398,29 +382,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Read the MSRV floor from Cargo.toml
-        id: msrv
-        # jq -e fails loudly if rust-version ever disappears from the manifest.
-        run: |
-          v="$(cargo metadata --no-deps --format-version 1 --manifest-path crates/bdinfo-rs-gui/Cargo.toml | jq -er '.packages[] | select(.name == "bdinfo-rs-gui") | .rust_version')"
-          echo "MSRV floor: $v"
-          echo "version=$v" >> "$GITHUB_OUTPUT"
-
-      - name: Install the MSRV toolchain
-        env:
-          MSRV: ${{ steps.msrv.outputs.version }}
-        run: rustup toolchain install "$MSRV" --profile minimal
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: ./.github/actions/msrv-check
         with:
-          workspaces: crates/bdinfo-rs-gui
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      - name: Build with the declared rust-version
-        working-directory: crates/bdinfo-rs-gui
-        env:
-          MSRV: ${{ steps.msrv.outputs.version }}
-        run: cargo "+$MSRV" build --locked
+          package: bdinfo-rs-gui
+          manifest-path: crates/bdinfo-rs-gui/Cargo.toml
+          working-directory: crates/bdinfo-rs-gui
+          build-args: --locked
+          cache-workspaces: crates/bdinfo-rs-gui
 
   # The packaging smoke: assemble every distribution artifact shape on its
   # native runner with the SAME .github/scripts/gui-package-*.ps1 the

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -117,23 +117,11 @@ jobs:
         shell: pwsh
         run: ./.github/scripts/wasm-rules.ps1 -Check unsafe
 
-      - name: Format (nightly rustfmt)
-        working-directory: crates/bdinfo-rs-wasm
-        env:
-          NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
-        run: cargo "+$NIGHTLY" fmt --check
-
-      - name: Typos
-        working-directory: crates/bdinfo-rs-wasm
-        run: typos
-
-      - name: Machete (unused deps)
-        working-directory: crates/bdinfo-rs-wasm
-        run: cargo mc
-
-      - name: Shear (unused deps, AST)
-        working-directory: crates/bdinfo-rs-wasm
-        run: cargo sh
+      # rustfmt / typos / machete / shear — the quartet gui.yml's checks job runs
+      # identically, in .github/actions/lint-crate.
+      - uses: ./.github/actions/lint-crate
+        with:
+          working-directory: crates/bdinfo-rs-wasm
 
       # Supply-chain audit of the wasm crate's OWN dependency tree (js-sys /
       # wasm-bindgen / web-sys — compiled into the shipped `.wasm` but invisible to
@@ -248,57 +236,29 @@ jobs:
         # the shell ($CHROMEWEBDRIVER); the ${{ env.* }} context resolves empty.
         run: CHROMEDRIVER="$CHROMEWEBDRIVER/chromedriver" cargo test --target wasm32-unknown-unknown --release --locked --test parity
 
-  # The declared MSRV is enforced, not decorative: build with exactly the
-  # rust-version toolchain from crates/bdinfo-rs-wasm/Cargo.toml, read from the
-  # manifest at run time so an MSRV bump touches Cargo.toml ONLY (no version
-  # literals here to drift; the version also stays out of the job `name:` —
-  # static YAML can't interpolate step outputs there). This is what stops a
-  # dependency bump or a newer language feature from silently raising the real
-  # floor under a downstream user who pins the declared one. Build-only by
-  # design: rust-version is a claim about building the package, not about the
-  # dev-dependency tree (wasm-bindgen-test may float its own MSRV) — the gate
-  # job above runs the suites on the pinned stable. Both targets, because the
-  # crate SHIPS as wasm32: the native check is what `cargo check` covers on any
-  # host, and the wasm32 release build is the configuration published to npm, so
+  # The wasm crate's leg of the MSRV gate — the shared body, the rationale and
+  # the build-only posture live in .github/actions/msrv-check (dev-dependency
+  # here: wasm-bindgen-test may float its own MSRV; the gate job above runs the
+  # suites on the pinned stable). BOTH targets, because the crate SHIPS as
+  # wasm32: the native check is what `cargo check` covers on any host, and the
+  # wasm32 release build is the configuration published to npm, so
   # target-specific MSRV breakage in js-sys/web-sys/wasm-bindgen would otherwise
   # pass unnoticed. `msrv` in core.yml and `gui msrv` in gui.yml hold the same
   # bar for the other two shipping surfaces.
   msrv:
-    name: msrv
+    name: wasm msrv
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - name: Read the MSRV floor from Cargo.toml
-        id: msrv
-        # jq -e fails loudly if rust-version ever disappears from the manifest.
-        run: |
-          v="$(cargo metadata --no-deps --format-version 1 --manifest-path crates/bdinfo-rs-wasm/Cargo.toml | jq -er '.packages[] | select(.name == "bdinfo-rs-wasm") | .rust_version')"
-          echo "MSRV floor: $v"
-          echo "version=$v" >> "$GITHUB_OUTPUT"
-
-      - name: Install the MSRV toolchain with the wasm32 target
-        env:
-          MSRV: ${{ steps.msrv.outputs.version }}
-        run: |
-          rustup toolchain install "$MSRV" --profile minimal
-          rustup target add wasm32-unknown-unknown --toolchain "$MSRV"
-
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: ./.github/actions/msrv-check
         with:
-          workspaces: crates/bdinfo-rs-wasm
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      - name: Check with the declared rust-version (native)
-        working-directory: crates/bdinfo-rs-wasm
-        env:
-          MSRV: ${{ steps.msrv.outputs.version }}
-        run: cargo "+$MSRV" check --locked
-
-      - name: Build with the declared rust-version (wasm32, release)
-        working-directory: crates/bdinfo-rs-wasm
-        env:
-          MSRV: ${{ steps.msrv.outputs.version }}
-        run: cargo "+$MSRV" build --target wasm32-unknown-unknown --release --locked
+          package: bdinfo-rs-wasm
+          manifest-path: crates/bdinfo-rs-wasm/Cargo.toml
+          working-directory: crates/bdinfo-rs-wasm
+          target: wasm32-unknown-unknown
+          check-args: --locked
+          build-args: --target wasm32-unknown-unknown --release --locked
+          cache-workspaces: crates/bdinfo-rs-wasm


### PR DESCRIPTION
Three step families were hand-copied across workflows. Each becomes a composite
action, not a reusable workflow: sweep to ci to core is already three connected
workflow_call levels, so a reusable called from inside core.yml would sit at the
four-level ceiling.

**msrv-check** replaces the identical five-step MSRV job in core.yml, gui.yml and
wasm.yml. Inputs carry the real deltas: which manifest to query, one named package
or an all-packages-agree assertion (the root workspace, whose members inherit
rust-version.workspace), an extra rustup target, and what to check and build.

**fuzz-toolchain** replaces the nightly install, the 32-bit C++ toolchain step and
the committed-fuzz-lockfile check in core.yml's replay gate and fuzz.yml's deep
pass. A cache-ownership input preserves the deliberate cargo-fuzz split: replay
owns the read-write save on master, deep restores read-only and skips the restore
on a tag run, because restoring an executable is where cache poisoning would
matter. The rust-cache key differences stay at the call sites, with their
rationale.

**lint-crate** serves gui.yml and wasm.yml, whose rustfmt / typos / machete / shear
step run was byte-identical apart from the crate directory. core.yml is
deliberately not folded in: it runs the same tools under different step names
through the root aliases and without typos, which repo.yml already covers
repository-wide.

Both core.yml and wasm.yml named their MSRV job `msrv`; the wasm one is now
`wasm msrv`. No required status check is involved.

classify-diff.ps1 claims the three new action paths, so a change to one cannot
classify into no areas. Self-test: 43 cases green.

Local gate PASS, including action-validator and ryl over the new action files and
zizmor with no findings across .github/workflows and .github/actions.