### PR TITLE
ci(gui): package through one composite and one coordinate table

### DIFF
--- a/.github/actions/gui-package/action.yml
+++ b/.github/actions/gui-package/action.yml
@@ -1,0 +1,192 @@
+# Assemble one OS family's GUI distribution artifacts from an already-built
+# release binary, assert their contents, install and launch them for real, and
+# upload them. The LOGIC is not here — it is the tracked
+# .github/scripts/gui-package-*.ps1 trio plus gui-package-check.ps1 and
+# gui-install-smoke.ps1, which both callers already shared. What this action
+# removes is the ~75 lines of YAML wiring around them that gui.yml's packaging
+# smoke and gui-release.yml's build job carried twice, down to byte-identical
+# argument strings and a pair of comments each pointing at the other file.
+#
+# The two callers are the same packaging on two different occasions: gui.yml
+# proves it on every gui-area pull request, gui-release.yml runs it at tag time
+# on six native legs. Their real differences ride as inputs; what stays OUTSIDE
+# is what is genuinely each caller's own — the release build itself, the
+# rust-cache posture (the smoke reads `gui build + test`'s archive read-only,
+# the release lane keeps its own `gui-release` lineage and refuses to restore
+# on a tag), and where the version comes from.
+#
+# A COMPOSITE action rather than a reusable workflow (rationale in
+# .github/actions/pins).
+name: gui-package
+description: >-
+  Package the built GUI binary for one OS family, assert the artifact contents,
+  install and launch it, and upload the result.
+
+inputs:
+  kind:
+    description: >-
+      Which artifact set to build: `linux` (AppImage + deb + rpm), `windows`
+      (zip + MSI), `windows-zip` (the zip alone — the release lane's
+      windows-11-arm leg has no WiX, so its MSI is authored on the x64 runner),
+      or `macos` (a .app in a dmg).
+    required: true
+  version:
+    description: >-
+      The crate version the artifacts are named and stamped with. Each caller
+      resolves it its own way — the smoke reads the manifest in the same job,
+      the release lane takes it from the guard job that checked it against the
+      tag.
+    required: true
+  triple:
+    description: The target triple the binary was built for.
+    required: true
+  artifact-name:
+    description: >-
+      Name of the uploaded artifact directory. It is a release-lane asset glob
+      on one side and a hand-testing bundle on the other, so it never merges.
+    required: true
+  install-packagers:
+    description: >-
+      Pre-install cargo-deb and cargo-generate-rpm at the release-pinned
+      versions, rather than letting gui-package-linux.ps1 compile them from
+      source. Purely a speed choice on `linux`, and the release lane
+      deliberately declines it: install-action's prebuilt cargo-deb links
+      glibc 2.39 and dies on the ubuntu-22.04 legs that lane builds on (glibc
+      2.35, the compatibility floor the app ships against), so it takes the
+      compile-from-source path instead — the same posture as
+      .github/build-linux-packages.sh inside the dist release. Ignored unless
+      `kind` is `linux`.
+    required: false
+    default: 'true'
+  assert-contents:
+    description: >-
+      Run gui-package-check.ps1 over the finished artifacts. The caller turns
+      it off for an artifact set that is only half of a pair, so the assertion
+      can run once over the whole pair later.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    # The check script's validators (desktop-file-validate, appstream-util,
+    # rpm -qp) — none preinstalled on the runner image.
+    - name: Install the Linux packaging validators
+      if: inputs.kind == 'linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends desktop-file-utils appstream-util rpm
+
+    - id: pins
+      if: inputs.kind == 'linux' && inputs.install-packagers == 'true'
+      uses: ./.github/actions/pins
+
+    # Both packagers at the exact versions gui-package-linux.ps1 would compile
+    # from source if they were missing — see the input's description for who
+    # takes which path and why.
+    # `fallback: none`: install only from install-action's checksummed
+    # manifest, never its runtime-resolved cargo-binstall fallback (rationale
+    # in core.yml).
+    - name: Install cargo-deb (release-pinned, prebuilt)
+      if: inputs.kind == 'linux' && inputs.install-packagers == 'true'
+      uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
+      with:
+        tool: cargo-deb@${{ steps.pins.outputs.CARGO_DEB }}
+        fallback: none
+
+    # cargo-generate-rpm is absent from taiki-e/install-action's manifest, so
+    # with the binstall fallback disabled it is compiled from crates.io once and
+    # cached, the lane core.yml's cargo-fuzz and cargo-vet use.
+    - name: Cache the pinned cargo-generate-rpm binary
+      if: inputs.kind == 'linux' && inputs.install-packagers == 'true'
+      id: rpm-bin
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cargo/bin/cargo-generate-rpm
+        key: cargo-generate-rpm-${{ runner.os }}-${{ steps.pins.outputs.CARGO_GENERATE_RPM }}
+
+    - name: Install cargo-generate-rpm (cache miss)
+      if: inputs.kind == 'linux' && inputs.install-packagers == 'true' && steps.rpm-bin.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        CARGO_GENERATE_RPM: ${{ steps.pins.outputs.CARGO_GENERATE_RPM }}
+      run: cargo install --locked "cargo-generate-rpm@$CARGO_GENERATE_RPM"
+
+    # The four packaging invocations. Every step here is `shell: pwsh` — a
+    # composite step must name its shell, and pwsh is preinstalled on all three
+    # runner families, so the Linux and macOS legs call the script directly
+    # instead of shelling out to `pwsh script.ps1` from bash.
+    - name: Package (Linux — AppImage + deb + rpm)
+      if: inputs.kind == 'linux'
+      shell: pwsh
+      env:
+        VERSION: ${{ inputs.version }}
+        TRIPLE: ${{ inputs.triple }}
+      run: >
+        .github/scripts/gui-package-linux.ps1
+        -Version $env:VERSION -Triple $env:TRIPLE -OutDir dist-gui
+
+    - name: Package (Windows — zip + MSI)
+      if: inputs.kind == 'windows'
+      shell: pwsh
+      env:
+        VERSION: ${{ inputs.version }}
+        TRIPLE: ${{ inputs.triple }}
+      run: >
+        .github/scripts/gui-package-windows.ps1
+        -Exe crates/bdinfo-rs-gui/target/release/bdinfo-rs-gui.exe
+        -Version $env:VERSION -Triple $env:TRIPLE -OutDir dist-gui
+
+    - name: Package (Windows arm64 — zip; MSI authored on the x64 runner)
+      if: inputs.kind == 'windows-zip'
+      shell: pwsh
+      env:
+        VERSION: ${{ inputs.version }}
+        TRIPLE: ${{ inputs.triple }}
+      run: >
+        .github/scripts/gui-package-windows.ps1
+        -Exe crates/bdinfo-rs-gui/target/release/bdinfo-rs-gui.exe
+        -Version $env:VERSION -Triple $env:TRIPLE -OutDir dist-gui -Artifacts zip
+
+    - name: Package (macOS — .app in a dmg)
+      if: inputs.kind == 'macos'
+      shell: pwsh
+      env:
+        VERSION: ${{ inputs.version }}
+        TRIPLE: ${{ inputs.triple }}
+      run: >
+        .github/scripts/gui-package-macos.ps1
+        -Binary crates/bdinfo-rs-gui/target/release/bdinfo-rs-gui
+        -Version $env:VERSION -Triple $env:TRIPLE -OutDir dist-gui
+
+    - name: Assert the artifact contents
+      if: inputs.assert-contents == 'true'
+      shell: pwsh
+      env:
+        KIND: ${{ inputs.kind }}
+        TRIPLE: ${{ inputs.triple }}
+      run: .github/scripts/gui-package-check.ps1 -Kind $env:KIND -Dir dist-gui -Triple $env:TRIPLE
+
+    # Real install + launch of what was just packaged (MSI /qn install + probe
+    # + uninstall, dpkg -i + probe + remove, AppImage extract-and-run, dmg
+    # mount + probe). It runs on the half-pair leg too: a zip that installs and
+    # launches is a verdict the follow-up job cannot produce, because the arm64
+    # binary cannot execute on the x64 runner that authors its MSI.
+    - name: Install-and-launch smoke
+      shell: pwsh
+      env:
+        KIND: ${{ inputs.kind }}
+        TRIPLE: ${{ inputs.triple }}
+        VERSION: ${{ inputs.version }}
+      run: >
+        .github/scripts/gui-install-smoke.ps1
+        -Kind $env:KIND -Dir dist-gui -Triple $env:TRIPLE -Version $env:VERSION
+
+    - name: Upload the packaged artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: dist-gui/
+        retention-days: 7
+        if-no-files-found: error

--- a/.github/scripts/_gui-walk.ps1
+++ b/.github/scripts/_gui-walk.ps1
@@ -1,0 +1,46 @@
+#!/usr/bin/env pwsh
+# The GUI drive walk's click targets — ONE table, dot-sourced by all three
+# injected legs (gui-drive-inject-{windows,linux,macos}.ps1). The coordinates
+# are LOGICAL client coordinates of the app's default 880x960 layout (dark
+# theme, 100% UI scale), measured from a pinned-geometry capture; each leg
+# scales them by its own measured client width / 880 and offsets them by its
+# own client origin.
+#
+# They live here and not per-leg because a click target is a fact about the
+# APP, not about an operating system: every leg boots the same geometry through
+# BDINFO_GUI_WIN and renders with the same bundled fonts, so the logical layout
+# is identical across platforms. Before this file the table existed three
+# times, and a widget move silently broke the two copies nobody edited.
+#
+# A deliberate layout change must update this table in the same pull request —
+# snapshot-test semantics. The failure it guards against is a click landing on
+# nothing, which the injected legs catch as their pixel-change assert.
+#
+# Dot-sourced, never run: defining the function is all this file does.
+
+function Get-GuiWalkTargets {
+    <#
+    .SYNOPSIS
+    The injected walk's click targets, as @(x, y) logical client coordinates.
+    #>
+    [CmdletBinding()]
+    param(
+        # The logical height the window was actually GRANTED (client height /
+        # scale). 960 is what every leg requests, but a small runner display can
+        # clamp it — the macOS probe got 681 — so the bottom action bar and the
+        # centred dialog are measured from it rather than from 960. Top-anchored
+        # targets are fixed offsets and ignore it.
+        [Parameter(Mandatory)] [double] $LogicalHeight
+    )
+
+    [ordered]@{
+        SelectAll    = @(111, 127)
+        LengthHeader = @(484, 170)
+        FirstRow     = @(110, 206)
+        # The parentheses are load-bearing: `,` binds tighter than `-`, so
+        # `@(817, $LogicalHeight - 29)` would subtract 29 from the whole array.
+        SettingsBtn  = @(817, ($LogicalHeight - 29))
+        DialogCancel = @(538, (($LogicalHeight / 2) + 165))
+        ScanBtn      = @(566, ($LogicalHeight - 28))
+    }
+}

--- a/.github/scripts/classify-diff.ps1
+++ b/.github/scripts/classify-diff.ps1
@@ -360,6 +360,13 @@ begin {
             Match      = { param($f) Test-Match $f @('.github/actions/lint-crate/*') }
         },
         @{
+            Name       = 'gui packaging composite action'
+            Areas      = @('gui', 'yaml', 'workflows')
+            Structural = $true
+            Why        = 'The gui-package composite is the body of gui.yml''s packaging smoke, the only pull-request job that runs it; the gui-release.yml lane shares it but runs on a tag or a dispatch. action-validator and zizmor read the action definitions under .github/actions as well as the workflows.'
+            Match      = { param($f) Test-Match $f @('.github/actions/gui-package/*') }
+        },
+        @{
             Name       = 'source rule script'
             Areas      = @('core')
             Structural = $true
@@ -370,8 +377,8 @@ begin {
             Name       = 'gui gate scripts'
             Areas      = @('gui')
             Structural = $true
-            Why        = 'The gui workflow runs these directly. The publishing helpers are named publish-gui-* so that this pattern cannot reach them.'
-            Match      = { param($f) (Test-Match $f @('.github/scripts/gui-*.ps1')) }
+            Why        = 'The gui workflow runs these directly, and _gui-walk.ps1 is the click-target table its three injected drive legs dot-source. The publishing helpers are named publish-gui-* so that this pattern cannot reach them.'
+            Match      = { param($f) (Test-Match $f @('.github/scripts/gui-*.ps1', '.github/scripts/_gui-walk.ps1')) }
         },
         @{
             Name       = 'wasm gate script'
@@ -575,7 +582,9 @@ end {
             @{ Path = '.github/actions/msrv-check/action.yml'; Areas = 'core gui links typos wasm workflows yaml' }
             @{ Path = '.github/actions/fuzz-toolchain/action.yml'; Areas = 'fuzz links typos workflows yaml' }
             @{ Path = '.github/actions/lint-crate/action.yml'; Areas = 'gui links typos wasm workflows yaml' }
+            @{ Path = '.github/actions/gui-package/action.yml'; Areas = 'gui links typos workflows yaml' }
             @{ Path = '.github/scripts/gui-package-windows.ps1'; Areas = 'gui links typos' }
+            @{ Path = '.github/scripts/_gui-walk.ps1'; Areas = 'gui links typos' }
             @{ Path = '.github/scripts/wasm-rules.ps1'; Areas = 'links typos wasm' }
             @{ Path = '.github/scripts/cov-floor.ps1'; Areas = 'gui links typos wasm' }
             @{ Path = '.github/scripts/publish-gui-aur.ps1'; Areas = 'links typos' }

--- a/.github/scripts/gui-drive-inject-linux.ps1
+++ b/.github/scripts/gui-drive-inject-linux.ps1
@@ -3,10 +3,10 @@
 # walk" steps), Linux leg:
 # OS-LEVEL INPUT INJECTION with xdotool under xvfb (run this whole script via
 # `xvfb-run -a pwsh ...` so DISPLAY reaches the app, xdotool, and the capture
-# alike). Same walk, coordinates, and pixel-change assert as the Windows leg
-# (see gui-drive-inject-windows.ps1) — the logical layout is identical across
-# platforms (bundled fonts, pinned 880x960 geometry, dark theme, isolated
-# config), so one coordinate table serves both. Under bare Xvfb there is no
+# alike). Same walk, coordinates and pixel-change assert as the Windows leg
+# (see gui-drive-inject-windows.ps1); the targets come from the shared
+# _gui-walk.ps1, which carries why one table serves every leg. Under bare
+# Xvfb there is no
 # window manager: the window sits undecorated at its X11 position, and
 # `xdotool getwindowgeometry` gives the client origin directly.
 param(
@@ -64,29 +64,25 @@ function Save-Shot([string]$Name) {
     if ($LASTEXITCODE -ne 0) { Write-Host "!! capture failed for $Name" }
 }
 
-function Send-Click([double]$Lx, [double]$Ly) {
-    $px = [int][math]::Round($gx + ($Lx * $scale))
-    $py = [int][math]::Round($gy + ($Ly * $scale))
+function Send-Click([double[]]$Target) {
+    $px = [int][math]::Round($gx + ($Target[0] * $scale))
+    $py = [int][math]::Round($gy + ($Target[1] * $scale))
     & xdotool mousemove --sync $px $py click 1
     Start-Sleep -Milliseconds 900
 }
 
-# The shared logical coordinate table — see gui-drive-inject-windows.ps1.
-$SelectAll = @(111, 127)
-$LengthHeader = @(484, 170)
-$FirstRow = @(110, 206)
-$SettingsBtn = @(817, ($logicalH - 29))
-$DialogCancel = @(538, (($logicalH / 2) + 165))
-$ScanBtn = @(566, ($logicalH - 28))
+# The click targets, from the table all three injected legs share.
+. (Join-Path $PSScriptRoot '_gui-walk.ps1')
+$walk = Get-GuiWalkTargets -LogicalHeight $logicalH
 
 Save-Shot '00-listed'
 
-Send-Click @SelectAll; Save-Shot '01-select-all'
-Send-Click @LengthHeader; Save-Shot '02-sort-length'
-Send-Click @FirstRow; Save-Shot '03-row-activate'
-Send-Click @SettingsBtn; Save-Shot '04-settings-open'
-Send-Click @DialogCancel; Save-Shot '05-settings-cancel'
-Send-Click @ScanBtn
+Send-Click $walk.SelectAll; Save-Shot '01-select-all'
+Send-Click $walk.LengthHeader; Save-Shot '02-sort-length'
+Send-Click $walk.FirstRow; Save-Shot '03-row-activate'
+Send-Click $walk.SettingsBtn; Save-Shot '04-settings-open'
+Send-Click $walk.DialogCancel; Save-Shot '05-settings-cancel'
+Send-Click $walk.ScanBtn
 Start-Sleep -Milliseconds 1500
 Save-Shot '06-scanning'
 Write-Host '==> waiting for the measured scan'

--- a/.github/scripts/gui-drive-inject-macos.ps1
+++ b/.github/scripts/gui-drive-inject-macos.ps1
@@ -89,19 +89,26 @@ else {
     $title = 28.0
     $scale = $gw / 880.0
     $logicalH = ($gh - $title) / $scale
-    function Send-Click([double]$Lx, [double]$Ly) {
-        $px = [int][math]::Round($gx + ($Lx * $scale))
-        $py = [int][math]::Round($gy + $title + ($Ly * $scale))
+    function Send-Click([double[]]$Target) {
+        $px = [int][math]::Round($gx + ($Target[0] * $scale))
+        $py = [int][math]::Round($gy + $title + ($Target[1] * $scale))
         $out = & cliclick "c:$px,$py" 2>&1
         if ($LASTEXITCODE -ne 0) { $script:failures += "cliclick c:${px},${py}: $out"; Write-Host "!! $out" }
         Start-Sleep -Milliseconds 900
     }
+    # The click targets, from the table all three injected legs share. This leg
+    # deliberately walks a SHORTER route than the other two — it stops before
+    # the measured scan and never uses FirstRow or ScanBtn — because the point
+    # here is to record where the Accessibility wall is, not to complete the
+    # walk. Its pixel-change assert therefore compares 02-sort-length against
+    # 04-settings-open, with no 03-row-activate between them.
+    . (Join-Path $PSScriptRoot '_gui-walk.ps1')
+    $walk = Get-GuiWalkTargets -LogicalHeight $logicalH
     Save-Shot '00-listed'
-    # The shared logical coordinate table — see gui-drive-inject-windows.ps1.
-    Send-Click 111 127; Save-Shot '01-select-all'
-    Send-Click 484 170; Save-Shot '02-sort-length'
-    Send-Click 817 ($logicalH - 29); Save-Shot '04-settings-open'
-    Send-Click 538 (($logicalH / 2) + 165); Save-Shot '05-settings-cancel'
+    Send-Click $walk.SelectAll; Save-Shot '01-select-all'
+    Send-Click $walk.LengthHeader; Save-Shot '02-sort-length'
+    Send-Click $walk.SettingsBtn; Save-Shot '04-settings-open'
+    Send-Click $walk.DialogCancel; Save-Shot '05-settings-cancel'
     # Same hard assert as the other legs: the Settings click must change the
     # window pixels vs the shot before it. Now robust — the shots are cropped
     # to the window rect, so the menu-bar clock is out of frame.

--- a/.github/scripts/gui-drive-inject-windows.ps1
+++ b/.github/scripts/gui-drive-inject-windows.ps1
@@ -331,9 +331,9 @@ function Request-Foreground {
     return $false
 }
 
-function Send-Click([double]$Lx, [double]$Ly) {
-    $px = [int][math]::Round($origin.X + ($Lx * $scale))
-    $py = [int][math]::Round($origin.Y + ($Ly * $scale))
+function Send-Click([double[]]$Target) {
+    $px = [int][math]::Round($origin.X + ($Target[0] * $scale))
+    $py = [int][math]::Round($origin.Y + ($Target[1] * $scale))
     [void][GuiInput]::SetCursorPos($px, $py)
     Start-Sleep -Milliseconds 150
     # The precise no-blind-clicks guard: the top-level window that will
@@ -365,26 +365,18 @@ function Send-Click([double]$Lx, [double]$Ly) {
     Start-Sleep -Milliseconds 900   # let the resulting state render
 }
 
-# Logical client coordinates of the click targets at the default 880-wide
-# layout (dark theme, 100% UI scale) — measured from a pinned-geometry
-# capture. Top-anchored rows are fixed offsets; the bottom action bar and the
-# centred dialog buttons track the granted logical height (960 requested, but
-# a small runner display can clamp it — the macOS probe got 681).
-$SelectAll = @(111, 127)
-$LengthHeader = @(484, 170)
-$FirstRow = @(110, 206)
-$SettingsBtn = @(817, ($logicalH - 29))
-$DialogCancel = @(538, (($logicalH / 2) + 165))
-$ScanBtn = @(566, ($logicalH - 28))
+# The click targets, from the table all three injected legs share.
+. (Join-Path $PSScriptRoot '_gui-walk.ps1')
+$walk = Get-GuiWalkTargets -LogicalHeight $logicalH
 
 Save-Shot '00-listed'
 
-Send-Click @SelectAll; Save-Shot '01-select-all'
-Send-Click @LengthHeader; Save-Shot '02-sort-length'
-Send-Click @FirstRow; Save-Shot '03-row-activate'
-Send-Click @SettingsBtn; Save-Shot '04-settings-open'
-Send-Click @DialogCancel; Save-Shot '05-settings-cancel'
-Send-Click @ScanBtn
+Send-Click $walk.SelectAll; Save-Shot '01-select-all'
+Send-Click $walk.LengthHeader; Save-Shot '02-sort-length'
+Send-Click $walk.FirstRow; Save-Shot '03-row-activate'
+Send-Click $walk.SettingsBtn; Save-Shot '04-settings-open'
+Send-Click $walk.DialogCancel; Save-Shot '05-settings-cancel'
+Send-Click $walk.ScanBtn
 Start-Sleep -Milliseconds 1500
 Save-Shot '06-scanning'
 Write-Host '==> waiting for the measured scan'

--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -125,97 +125,26 @@ jobs:
           lookup-only: ${{ startsWith(github.ref, 'refs/tags/') }}
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
-      # No packager pre-install here, deliberately: install-action's prebuilt
-      # cargo-deb links glibc 2.39 and dies on these ubuntu-22.04 legs (glibc
-      # 2.35, the compatibility floor the app builds against). The packaging
-      # script compiles the release-pinned versions from source instead — the
-      # same posture as .github/build-linux-packages.sh inside the dist
-      # release. The PR smoke keeps the fast pre-install (ubuntu-latest).
-
-      # The check script's validators (desktop-file-validate, appstream-util,
-      # rpm -qp) — none preinstalled on the runner image.
-      - name: Install the Linux packaging validators
-        if: matrix.kind == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends desktop-file-utils appstream-util rpm
-
       - name: Build (release profile, locked)
         working-directory: crates/bdinfo-rs-gui
         run: cargo build --release --locked -p bdinfo-rs-gui
 
-      - name: Package (Linux — AppImage + deb + rpm)
-        if: matrix.kind == 'linux'
-        env:
-          VERSION: ${{ needs.guard-version.outputs.version }}
-          TRIPLE: ${{ matrix.triple }}
-        run: pwsh .github/scripts/gui-package-linux.ps1 -Version "$VERSION" -Triple "$TRIPLE" -OutDir dist-gui
-
-      - name: Package (Windows — zip + MSI)
-        if: matrix.kind == 'windows'
-        shell: pwsh
-        env:
-          VERSION: ${{ needs.guard-version.outputs.version }}
-          TRIPLE: ${{ matrix.triple }}
-        run: >
-          .github/scripts/gui-package-windows.ps1
-          -Exe crates/bdinfo-rs-gui/target/release/bdinfo-rs-gui.exe
-          -Version $env:VERSION -Triple $env:TRIPLE -OutDir dist-gui
-
-      # windows-11-arm has no WiX: zip here, MSI in msi-arm64 below.
-      - name: Package (Windows arm64 — zip; MSI authored on the x64 runner)
-        if: matrix.kind == 'windows-zip'
-        shell: pwsh
-        env:
-          VERSION: ${{ needs.guard-version.outputs.version }}
-          TRIPLE: ${{ matrix.triple }}
-        run: >
-          .github/scripts/gui-package-windows.ps1
-          -Exe crates/bdinfo-rs-gui/target/release/bdinfo-rs-gui.exe
-          -Version $env:VERSION -Triple $env:TRIPLE -OutDir dist-gui -Artifacts zip
-
-      - name: Package (macOS — .app in a dmg)
-        if: matrix.kind == 'macos'
-        env:
-          VERSION: ${{ needs.guard-version.outputs.version }}
-          TRIPLE: ${{ matrix.triple }}
-        run: >
-          pwsh .github/scripts/gui-package-macos.ps1
-          -Binary crates/bdinfo-rs-gui/target/release/bdinfo-rs-gui
-          -Version "$VERSION" -Triple "$TRIPLE" -OutDir dist-gui
-
-      # The same content assertions the PR smoke runs. Skipped only on the
-      # arm64 windows leg (its zip + the x64-authored MSI are asserted as a
-      # pair in msi-arm64).
-      - name: Assert the artifact contents
-        if: matrix.kind != 'windows-zip'
-        shell: pwsh
-        env:
-          KIND: ${{ matrix.kind }}
-          TRIPLE: ${{ matrix.triple }}
-        run: .github/scripts/gui-package-check.ps1 -Kind $env:KIND -Dir dist-gui -Triple $env:TRIPLE
-
-      # Real install + launch of what was just packaged (MSI /qn install +
-      # probe + uninstall, dpkg -i + probe + remove, AppImage
-      # extract-and-run, dmg mount + probe) — the same script gui.yml's
-      # packaging smoke runs on every gui-area PR.
-      - name: Install-and-launch smoke
-        shell: pwsh
-        env:
-          KIND: ${{ matrix.kind }}
-          TRIPLE: ${{ matrix.triple }}
-          VERSION: ${{ needs.guard-version.outputs.version }}
-        run: >
-          .github/scripts/gui-install-smoke.ps1
-          -Kind $env:KIND -Dir dist-gui -Triple $env:TRIPLE -Version $env:VERSION
-
-      - name: Upload the packaged artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      # Package, assert, install-and-launch, upload — the wiring gui.yml's
+      # packaging smoke runs on every gui-area pull request, in
+      # .github/actions/gui-package.
+      #
+      # `install-packagers: false` is load-bearing on these ubuntu-22.04 legs,
+      # not a preference: the reason lives on the input's description. The
+      # content assertion is skipped on the arm64 windows leg alone, whose zip
+      # and x64-authored MSI are asserted as a pair in msi-arm64 below.
+      - uses: ./.github/actions/gui-package
         with:
-          name: gui-release-${{ matrix.triple }}
-          path: dist-gui/
-          retention-days: 7
-          if-no-files-found: error
+          kind: ${{ matrix.kind }}
+          version: ${{ needs.guard-version.outputs.version }}
+          triple: ${{ matrix.triple }}
+          artifact-name: gui-release-${{ matrix.triple }}
+          install-packagers: 'false'
+          assert-contents: ${{ matrix.kind != 'windows-zip' }}
 
       # Transport for the arm64 MSI authoring below — never a release asset
       # itself (the name stays outside the publish job's gui-release-* glob).

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -422,9 +422,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - id: pins
-        uses: ./.github/actions/pins
-
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: crates/bdinfo-rs-gui
@@ -435,38 +432,6 @@ jobs:
           # archive under a shared key.
           shared-key: gui-build
           save-if: false
-
-      - name: Install the Linux packagers + validators
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends desktop-file-utils appstream-util rpm
-
-      # Both packagers at the exact versions the packaging script would compile
-      # from source if missing — this pre-install just makes the smoke fast.
-      - name: Install cargo-deb (release-pinned, prebuilt)
-        if: runner.os == 'Linux'
-        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
-        with:
-          tool: cargo-deb@${{ steps.pins.outputs.CARGO_DEB }}
-          fallback: none
-
-      # cargo-generate-rpm is absent from taiki-e/install-action's manifest, so
-      # with the binstall fallback disabled it is compiled from crates.io once and
-      # cached, the lane core.yml's cargo-fuzz and cargo-vet use.
-      - name: Cache the pinned cargo-generate-rpm binary
-        if: runner.os == 'Linux'
-        id: rpm-bin
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/cargo-generate-rpm
-          key: cargo-generate-rpm-${{ runner.os }}-${{ steps.pins.outputs.CARGO_GENERATE_RPM }}
-
-      - name: Install cargo-generate-rpm (cache miss)
-        if: runner.os == 'Linux' && steps.rpm-bin.outputs.cache-hit != 'true'
-        env:
-          CARGO_GENERATE_RPM: ${{ steps.pins.outputs.CARGO_GENERATE_RPM }}
-        run: cargo install --locked "cargo-generate-rpm@$CARGO_GENERATE_RPM"
 
       - name: Build (release profile)
         working-directory: crates/bdinfo-rs-gui
@@ -479,62 +444,17 @@ jobs:
           v="$(cargo metadata --no-deps --format-version 1 --manifest-path crates/bdinfo-rs-gui/Cargo.toml | jq -er '.packages[] | select(.name == "bdinfo-rs-gui") | .version')"
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
-      - name: Package (Linux — AppImage + deb + rpm)
-        if: matrix.kind == 'linux'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          TRIPLE: ${{ matrix.triple }}
-        run: pwsh .github/scripts/gui-package-linux.ps1 -Version "$VERSION" -Triple "$TRIPLE" -OutDir dist-gui
-
-      - name: Package (Windows — zip + MSI)
-        if: matrix.kind == 'windows'
-        shell: pwsh
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          TRIPLE: ${{ matrix.triple }}
-        run: >
-          .github/scripts/gui-package-windows.ps1
-          -Exe crates/bdinfo-rs-gui/target/release/bdinfo-rs-gui.exe
-          -Version $env:VERSION -Triple $env:TRIPLE -OutDir dist-gui
-
-      - name: Package (macOS — .app in a dmg)
-        if: matrix.kind == 'macos'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          TRIPLE: ${{ matrix.triple }}
-        run: >
-          pwsh .github/scripts/gui-package-macos.ps1
-          -Binary crates/bdinfo-rs-gui/target/release/bdinfo-rs-gui
-          -Version "$VERSION" -Triple "$TRIPLE" -OutDir dist-gui
-
-      - name: Assert the artifact contents
-        shell: pwsh
-        env:
-          KIND: ${{ matrix.kind }}
-          TRIPLE: ${{ matrix.triple }}
-        run: .github/scripts/gui-package-check.ps1 -Kind $env:KIND -Dir dist-gui -Triple $env:TRIPLE
-
-      # Real install + launch of what was just packaged (MSI /qn install +
-      # probe + uninstall, dpkg -i + probe + remove, AppImage
-      # extract-and-run, dmg mount + probe) — the same script the
-      # gui-release.yml legs run at tag time.
-      - name: Install-and-launch smoke
-        shell: pwsh
-        env:
-          KIND: ${{ matrix.kind }}
-          TRIPLE: ${{ matrix.triple }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: >
-          .github/scripts/gui-install-smoke.ps1
-          -Kind $env:KIND -Dir dist-gui -Triple $env:TRIPLE -Version $env:VERSION
-
-      - name: Upload the packaged artifacts (hand-testing)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      # Package, assert, install-and-launch, upload — the wiring gui-release.yml
+      # runs at tag time, in .github/actions/gui-package. The packager
+      # pre-install is taken here (ubuntu-latest, so install-action's prebuilt
+      # cargo-deb runs) and declined there; the artifact name marks these as
+      # throwaway hand-testing builds rather than release assets.
+      - uses: ./.github/actions/gui-package
         with:
-          name: gui-packages-${{ matrix.os }}
-          path: dist-gui/
-          retention-days: 7
-          if-no-files-found: error
+          kind: ${{ matrix.kind }}
+          version: ${{ steps.version.outputs.version }}
+          triple: ${{ matrix.triple }}
+          artifact-name: gui-packages-${{ matrix.os }}
 
   # The real-window DRIVE gates: the app driven end to end on a real desktop
   # session, a screenshot per step uploaded as a gallery either way. The gui


### PR DESCRIPTION
gui.yml's packaging smoke and gui-release.yml's build job wired the same
packaging twice: the four gui-package-*.ps1 invocations with identical
argument strings, the contents assertion, a byte-identical install-and-launch
smoke whose comments each pointed at the other file, and the upload. The
logic already lived in the tracked scripts; only the YAML was duplicated.

.github/actions/gui-package holds that wiring once. The real divergences are
inputs, not smoothed away:

- install-packagers: the release lane declines the cargo-deb /
  cargo-generate-rpm pre-install because install-action's prebuilt cargo-deb
  links glibc 2.39 and dies on its ubuntu-22.04 legs (glibc 2.35, the
  compatibility floor). That rationale now lives on the input description.
- assert-contents: the release lane's windows-11-arm leg skips it; its zip and
  the x64-authored MSI are asserted as a pair in msi-arm64.
- artifact-name: a release asset on one side, a hand-testing bundle on the
  other.

Outside the composite, per caller: the release build, the rust-cache posture
(the smoke reads gui build + test's archive read-only; the release lane keeps
its gui-release lineage and refuses to restore on a tag), and where the
version comes from.

The injected drive walk's screen-coordinate table is one fact about the app's
layout that lived in three scripts - two byte-identical six-line copies plus a
macOS subset. It is now .github/scripts/_gui-walk.ps1, dot-sourced by all
three legs through Get-GuiWalkTargets. macOS stays soft and experimental: it
keeps its shorter route (no FirstRow, no ScanBtn, no measured scan) and its
own pixel-change comparison, but reads the coordinates it does use from the
shared table. Save-Shot stays per-OS.

classify-diff.ps1 gains a gui packaging composite action rule and claims
_gui-walk.ps1 for the existing gui gate scripts rule, plus two golden cases.

Verification: local gate PASS (ty av yl zz cc; zizmor 1.26.1 reports no
findings over .github/workflows and .github/actions, the new action included).
classify-diff.ps1 -SelfTest green, 45 cases, 6981 tracked paths. The shared
table was exercised locally at both the requested 960 and a clamped 681
logical height and reproduces the old formulas exactly. Grep proof: each
coordinate literal now has exactly one home.

Artifact names and contents are unchanged on both sides.