### PR TITLE
refactor(core): delete dead API and record the codec seam contracts

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -104,18 +104,12 @@ exclude_re = [
     # `a_picture_started_inside_a_sequence_header_decodes_after_init`.
     "mpeg2\\.rs:\\d+:33: replace > with >= in scan",
 
-    # ── PES/PAT/PMT window guards proven equivalent ──────────────────────────
-    # These cannot be de-pinned to the bare fn name: parse_chunk, parse_pat, and
-    # parse_pmt each hold other `>` guards that are NOT equivalent and must stay
-    # killable, so a position disambiguates each exclusion. When the equivalent
-    # guard's operator column is unique within its function the pin uses only that
-    # column, which no edit above it can shift. Two are not unique: parse_pat's
-    # `pat_section_parse > 0` shares column 48 with the non-equivalent
-    # `pat_pointer_field > 0`, and parse_pmt's `pmt_program_info_length > 0` shares
-    # column 54 with `pmt_section_length > 1021`. A column-only pin there would
-    # SILENTLY exclude a real test gap, so those two also pin the operator's line
-    # and must be re-pinned to its current line when code above them in m2ts.rs
-    # shifts — a stale line pin surfaces loudly as a MISSED mutant.
+    # ── PES window guards proven equivalent ──────────────────────────────────
+    # Neither can be de-pinned to the bare fn name: `parse_chunk` holds eleven
+    # other `>` guards that are NOT equivalent and must stay killable, so the
+    # operator's own column disambiguates each exclusion. Both columns are unique
+    # within the function, so an edit above them cannot shift the pin (a LINE pin
+    # would go stale and silently stop excluding).
 
     # `parse_chunk` branch A guard `state.packet_length > 0` vs `>=`: a bounded
     # transfer closes the instant packet_length reaches 0 (transfer_state goes
@@ -130,25 +124,6 @@ exclude_re = [
     # whenever B's reach condition holds, the C-then-clamp fallback computes the
     # identical offset, so taking or skipping branch B changes nothing.
     "m2ts\\.rs:\\d+:57: replace > with (==|<|>=) in TsStreamFile::parse_chunk",
-
-    # `parse_pat` transfer window `>` vs `>=`: at `bl - i == section_length` both
-    # branches assign the same offset.
-    "m2ts\\.rs:\\d+:38: replace > with >= in TsStreamFile::parse_pat",
-
-    # `parse_pat` post-section guard `pat_section_parse > 0` vs `>=`: the countdown
-    # is a u32 that the mutant only ever decrements from the wrapped u32::MAX, so
-    # the acting arms (1, 0) are ~4 GiB of PID-0 bytes away, and the corrupted
-    # pat_section_length is only read under those arms.
-    "m2ts\\.rs:1277:\\d+: replace > with >= in TsStreamFile::parse_pat",
-
-    # `parse_pmt` program-info guard `pmt_program_info_length > 0` vs `>=`: the dead
-    # branch decrements pmt_section_length and the program-info countdown in
-    # LOCKSTEP from zero, so when the u16 wrap finally fires a transfer (64 KiB of
-    # padding later) the section length has wrapped back to exactly 0 — the
-    # transfer is zero-length and the stale section re-walk is idempotent
-    # (create_stream is keyed on contains_key). Traced and verified empirically
-    # with a 357-padding-packet stream.
-    "m2ts\\.rs:1433:\\d+: replace > with >= in TsStreamFile::parse_pmt",
 
     # ── environment/platform probes no test process can observe ──────────────
 

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -396,25 +396,6 @@ pub struct AngleTotals {
     pub timeline_packet_size: u64,
 }
 
-impl AngleTotals {
-    /// The angle's own bitrate in bits/s — [`packet_size`](Self::packet_size)
-    /// at 8 bits per byte over [`length`](Self::length), rounded half-to-even;
-    /// `0` when the angle has no length.
-    #[must_use]
-    pub fn bit_rate(&self) -> u64 {
-        rate_over(self.packet_size, self.length)
-    }
-
-    /// The angle's whole-timeline bitrate in bits/s —
-    /// [`timeline_packet_size`](Self::timeline_packet_size) over the
-    /// playlist's `total_length` (the timeline spans the whole playlist),
-    /// rounded half-to-even; `0` for a zero-length playlist.
-    #[must_use]
-    pub fn timeline_bit_rate(&self, total_length: f64) -> u64 {
-        rate_over(self.timeline_packet_size, total_length)
-    }
-}
-
 /// One presented stream's report fields.
 ///
 /// Carries the `streams` diff level's per-stream line group
@@ -2089,8 +2070,11 @@ fn scan_one_stream_file(
 ) -> Result<TsStreamFile, BdError> {
     let mut stream_file = TsStreamFile::new(file.name());
     stream_file.interleaved_file = interleaved.map(TsInterleavedFile::new);
-    // Select the demux source the way `scan_source` would (the interleaved
-    // 3D file when present), but wrapped so each read advances the progress.
+    // The interleaved 3D `*.ssif` is the demux source in preference to the plain
+    // `*.m2ts` whenever the clip has one: its base/dependent extents are just more
+    // source packets, and without reading it the dependent-view (MVC) streams
+    // never register. The selected reader is wrapped so each read advances the
+    // progress.
     let inner = match &stream_file.interleaved_file {
         Some(interleaved) => interleaved.open_read().map_err(BdError::Io)?,
         None => file.open_read()?,
@@ -3761,14 +3745,6 @@ mod tests {
 
         // No angles → no totals.
         assert!(playlist_summary(100.0, 0, Vec::new()).angle_totals().is_empty());
-
-        // The per-angle rates: angle 1's own clips over its own length
-        // (30 × 192 × 8 / 40 s = 1152), its timeline over the playlist length
-        // (50 × 192 × 8 / 100 s = 768); the clip-less angle 2 rates zero.
-        assert_eq!(one.bit_rate(), 1152);
-        assert_eq!(one.timeline_bit_rate(100.0), 768);
-        assert_eq!(two.bit_rate(), 0);
-        assert_eq!(two.timeline_bit_rate(0.0), 0);
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/bdrom/interleaved.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/interleaved.rs
@@ -9,9 +9,9 @@
 //! de-interleaves them transparently onto the same PID/PES path that registers the
 //! disc's elementary streams.
 //!
-//! [`TsStreamFile::scan_source`](super::m2ts::TsStreamFile::scan_source) selects
-//! this interleaved file over the plain `*.m2ts` when it is present and SSIF reading
-//! is enabled, so the dependent-view streams reach the demux at all.
+//! The per-file scan in [`super::disc`] opens this interleaved file in
+//! preference to the plain `*.m2ts` whenever the clip has one, so the
+//! dependent-view streams reach the demux at all.
 
 use core::fmt;
 use std::io;

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -12,10 +12,12 @@
 //! The demux ends at the codec seam — the [`scan`](TsStreamFile::scan) point
 //! where each assembled access unit is handed to the per-codec analysers
 //! ([`crate::codec`]), which fill the stream's codec fields and its initialised
-//! flag. SSIF 3D interleaving is layered on this core via
-//! [`scan_source`](TsStreamFile::scan_source) + [`super::interleaved`]: a
-//! `*.ssif` is just packet-aligned base/dependent extents, so the same per-byte
-//! state machine de-interleaves them onto the shared PID/PES path.
+//! flag. SSIF 3D interleaving is layered on this core by the caller: the
+//! per-file scan in [`super::disc`] opens the interleaved `*.ssif`
+//! ([`super::interleaved`]) in preference to the plain `*.m2ts` and hands that
+//! reader to [`scan`](TsStreamFile::scan). A `*.ssif` is just packet-aligned
+//! base/dependent extents, so the same per-byte state machine de-interleaves
+//! them onto the shared PID/PES path.
 //!
 //! Implementation notes:
 //! * **`u64` everywhere for file scale** ([`size`](TsStreamFile::size)); the in-memory chunk index
@@ -502,10 +504,10 @@ pub struct TsStreamFile {
     pub size: u64,
     /// Presentation length in seconds.
     pub length: f64,
-    /// The interleaved 3D source (`*.ssif`), when this clip has one.
-    /// When present and SSIF reading is enabled,
-    /// [`scan_source`](Self::scan_source) streams it instead of the plain `*.m2ts`
-    /// (see [`super::interleaved`]).
+    /// The interleaved 3D source (`*.ssif`), when this clip has one. When
+    /// present, the per-file scan in [`super::disc`] opens it and streams it
+    /// through [`scan`](Self::scan) instead of the plain `*.m2ts` (see
+    /// [`super::interleaved`]).
     pub interleaved_file: Option<TsInterleavedFile>,
     /// The elementary streams keyed by PID, registered from the PMT.
     pub streams: BTreeMap<u16, TsStream>,
@@ -559,37 +561,6 @@ impl TsStreamFile {
         match &self.interleaved_file {
             Some(interleaved) if enable_ssif => interleaved.name(),
             _ => &self.name,
-        }
-    }
-
-    /// Streams and demuxes this clip's source — the interleaved `*.ssif` when
-    /// present and `enable_ssif`, else the plain `*.m2ts` from `reader` — into
-    /// `playlists`. The interleaved base/dependent extents are run through the
-    /// same [`scan`](Self::scan) packet state machine, which de-interleaves them
-    /// onto the shared PID/PES path so the 3D disc's streams register;
-    /// without reading the `*.ssif` the dependent-view streams would never be
-    /// seen at all.
-    ///
-    /// # Errors
-    /// Returns [`BdError::Io`] if opening the interleaved file or reading the stream
-    /// fails. Malformed packet data never errors: it is resynchronised on the next
-    /// `0x47`.
-    pub fn scan_source(
-        &mut self,
-        reader: &mut dyn Read,
-        playlists: &mut [TsPlaylistFile],
-        is_full_scan: bool,
-        enable_ssif: bool,
-    ) -> Result<(), BdError> {
-        // Open the interleaved source first (ending the borrow of `interleaved_file`
-        // before the `&mut self` scan), then demux whichever source was selected.
-        let interleaved = match &self.interleaved_file {
-            Some(interleaved) if enable_ssif => Some(interleaved.open_read().map_err(BdError::Io)?),
-            _ => None,
-        };
-        match interleaved {
-            Some(mut ssif) => self.scan(&mut *ssif, playlists, is_full_scan),
-            None => self.scan(reader, playlists, is_full_scan),
         }
     }
 
@@ -3971,66 +3942,6 @@ mod tests {
         // the two interleaved extents were kept apart, not merged.
         assert_eq!(base.peak_transfer_length, 60);
         assert_eq!(dependent.peak_transfer_length, 40);
-    }
-
-    /// A plain `.m2ts` announcing only PID 0x1099 (so it is distinguishable from the
-    /// 3D pair the synthetic `.ssif` carries).
-    fn plain_m2ts() -> Vec<u8> {
-        let mut bytes = packet(0, true, &pat_payload(0x0100));
-        bytes.extend(packet(0x0100, true, &pmt_payload(&[(0x1B, 0x1099)])));
-        bytes
-    }
-
-    #[test]
-    fn scan_source_reads_the_interleaved_ssif_when_enabled() {
-        let mut file = TsStreamFile::new("00000.m2ts");
-        file.interleaved_file = Some(TsInterleavedFile::new(Box::new(MemBdFile::new(
-            "00000.ssif",
-            interleaved_ssif(),
-            false,
-        ))));
-        let mut m2ts = Cursor::new(plain_m2ts());
-        file.scan_source(&mut m2ts, &mut [empty_playlist()], true, true).expect("scan ssif");
-
-        // The .ssif's 3D pair registered; the m2ts-only 0x1099 did not.
-        assert!(file.streams.contains_key(&0x1011));
-        assert!(file.streams.contains_key(&0x1012));
-        assert!(!file.streams.contains_key(&0x1099));
-    }
-
-    #[test]
-    fn scan_source_falls_back_to_the_m2ts() {
-        // enable_ssif = false → the m2ts is read even though an interleaved file is set.
-        let mut file = TsStreamFile::new("00000.m2ts");
-        file.interleaved_file = Some(TsInterleavedFile::new(Box::new(MemBdFile::new(
-            "00000.ssif",
-            interleaved_ssif(),
-            false,
-        ))));
-        let mut m2ts = Cursor::new(plain_m2ts());
-        file.scan_source(&mut m2ts, &mut [empty_playlist()], true, false).expect("scan m2ts");
-        assert!(file.streams.contains_key(&0x1099));
-        assert!(!file.streams.contains_key(&0x1012));
-
-        // No interleaved file → the m2ts is read even with SSIF enabled.
-        let mut file = TsStreamFile::new("00000.m2ts");
-        let mut m2ts = Cursor::new(plain_m2ts());
-        file.scan_source(&mut m2ts, &mut [empty_playlist()], true, true).expect("scan m2ts");
-        assert!(file.streams.contains_key(&0x1099));
-        assert!(!file.streams.contains_key(&0x1012));
-    }
-
-    #[test]
-    fn scan_source_propagates_an_ssif_open_error() {
-        let mut file = TsStreamFile::new("00000.m2ts");
-        file.interleaved_file = Some(TsInterleavedFile::new(Box::new(MemBdFile::new(
-            "00000.ssif",
-            vec![0x47; 192],
-            true, // open_read fails
-        ))));
-        let mut m2ts = Cursor::new(Vec::new());
-        let err = file.scan_source(&mut m2ts, &mut [empty_playlist()], true, true).unwrap_err();
-        assert_eq!(err.to_string(), "io error: injected ssif open failure");
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/codec.rs
+++ b/crates/bdinfo-rs-core/src/codec.rs
@@ -79,10 +79,25 @@ pub(crate) fn scan_embedded_core(
 /// `bitrate` is the demux's per-PES audio bitrate estimate (only the DTS scanners
 /// take it; the others ignore it). `is_full_scan` gates the PGS caption analysis:
 /// a quick scan marks Presentation Graphics initialised without decoding it.
-/// `tag` is the caller's per-stream frame marker: the scanners that recognise a
-/// frame in this access unit set it (the video codecs' picture type feeds the
-/// per-frame bitrate diagnostics); the others leave it as passed in — resetting
-/// between access units is the caller's job.
+/// `tag` is the caller's per-stream frame marker. The scanners that recognise a
+/// frame in this access unit set it: the video codecs write the picture type
+/// (`"I"`/`"P"`/`"B"`…), [`truehd`] and [`dts_hd`] write `"CORE"`/`"HD"`, and
+/// [`pgs`] writes `"F"`/`"N"`. The demux copies whatever the last completed PES
+/// left there into each bitrate window's
+/// [`crate::bdrom::m2ts::TsStreamDiagnostics::tag`], for video streams only —
+/// which is why the marker survives the access unit at all. The others leave it
+/// as passed in; resetting between access units is the caller's job.
+///
+/// Six scanners take `tag` and never write it — [`aac`], [`ac3`], [`dts`],
+/// [`lpcm`], [`mpa`] and [`mvc`]. That is the reference's shape, not an
+/// oversight: all 13 of classic BDInfo's `TSCodecXXX.Scan` methods declare a
+/// `ref string tag` parameter, and exactly those six leave it untouched there too
+/// (checked against the UniqProject fork on 2026-08-06; the writers are
+/// `TSCodecAVC`, `TSCodecMPEG2`, `TSCodecVC1`, `TSCodecHEVC`, `TSCodecTrueHD`,
+/// `TSCodecDTSHD` and `TSCodecPGS`, and the consumer is `TSStreamFile.ScanStream`
+/// storing it into `TSStreamDiagnostics.Tag`). The uniform signature is what lets
+/// every scanner here be read line-for-line against its C# counterpart, so the
+/// six no-op parameters stay.
 pub(crate) fn scan_access_unit(
     stream: &mut TsStream,
     buffer: &mut TsStreamBuffer,

--- a/crates/bdinfo-rs-core/src/codec.rs
+++ b/crates/bdinfo-rs-core/src/codec.rs
@@ -90,9 +90,9 @@ pub(crate) fn scan_embedded_core(
 ///
 /// Six scanners take `tag` and never write it — [`aac`], [`ac3`], [`dts`],
 /// [`lpcm`], [`mpa`] and [`mvc`]. That is the reference's shape, not an
-/// oversight: all 13 of classic BDInfo's `TSCodecXXX.Scan` methods declare a
+/// oversight: all 13 `TSCodecXXX.Scan` methods in classic `BDInfo` declare a
 /// `ref string tag` parameter, and exactly those six leave it untouched there too
-/// (checked against the UniqProject fork on 2026-08-06; the writers are
+/// (checked against the `UniqProject/BDInfo` sources on 2026-08-06; the writers are
 /// `TSCodecAVC`, `TSCodecMPEG2`, `TSCodecVC1`, `TSCodecHEVC`, `TSCodecTrueHD`,
 /// `TSCodecDTSHD` and `TSCodecPGS`, and the consumer is `TSStreamFile.ScanStream`
 /// storing it into `TSStreamDiagnostics.Tag`). The uniform signature is what lets

--- a/crates/bdinfo-rs-core/src/codec/aac.rs
+++ b/crates/bdinfo-rs-core/src/codec/aac.rs
@@ -61,11 +61,11 @@ const fn get_aac_profile(profile_type: u16) -> &'static str {
 
 /// Scans one AAC access unit from `buffer` into `stream`.
 ///
-/// A non-`0xFFF` sync word leaves `stream` untouched (an early return). `tag`
-/// is part of the shared codec-scan signature and is never set here.
+/// A non-`0xFFF` sync word leaves `stream` untouched (an early return). `tag` is
+/// never set here, as in `TSCodecAAC.Scan`; [`super::scan_access_unit`] carries
+/// why it is still a parameter.
 pub fn scan(stream: &mut TsAudioStream, buffer: &mut TsStreamBuffer, tag: &mut Option<String>) {
-    // `tag` is part of the shared codec-scan signature; AAC never sets it (a
-    // `pub fn` is exempt from `needless_pass_by_ref_mut`).
+    // The `let _` silences the unused parameter without renaming it.
     let _ = tag;
     if stream.base.is_initialized {
         return;

--- a/crates/bdinfo-rs-core/src/codec/ac3.rs
+++ b/crates/bdinfo-rs-core/src/codec/ac3.rs
@@ -63,15 +63,14 @@ const fn to_i64_trunc(x: f64) -> i64 {
 /// Scans one AC-3 / E-AC-3 access unit from `buffer` into `stream`.
 ///
 /// A non-AC-3 sync word, or a buffer too short to hold the header, leaves `stream`
-/// untouched (early returns). `tag` is part of the shared
-/// codec-scan signature; this codec never sets it.
+/// untouched (early returns). `tag` is never set here, as in `TSCodecAC3.Scan`;
+/// [`super::scan_access_unit`] carries why it is still a parameter.
 #[expect(
     clippy::too_many_lines,
     reason = "one linear bit-stream-information parse; splitting it would obscure the header layout"
 )]
 pub fn scan(stream: &mut TsAudioStream, buffer: &mut TsStreamBuffer, tag: &mut Option<String>) {
-    // The `let _` silences the unused parameter; a `pub fn` is exempt from
-    // `needless_pass_by_ref_mut`, so the `&mut` stays.
+    // The `let _` silences the unused parameter without renaming it.
     let _ = tag;
     if stream.base.is_initialized {
         return;

--- a/crates/bdinfo-rs-core/src/codec/dts.rs
+++ b/crates/bdinfo-rs-core/src/codec/dts.rs
@@ -49,15 +49,15 @@ const DCA_BITS_PER_SAMPLE: [i32; 7] = [16, 16, 20, 20, 0, 24, 24];
 /// A missing `0x7FFE8001` sync, a frame size below 95, or an out-of-range source
 /// PCM resolution leaves `stream` (largely) untouched (early returns).
 /// `bitrate` is the demux-measured rate (used only for the open-rate marker);
-/// `tag` is part of the shared codec-scan signature and is never set here.
+/// `tag` is never set here, as in `TSCodecDTS.Scan`; [`super::scan_access_unit`]
+/// carries why it is still a parameter.
 pub fn scan(
     stream: &mut TsAudioStream,
     buffer: &mut TsStreamBuffer,
     bitrate: i64,
     tag: &mut Option<String>,
 ) {
-    // `tag` is part of the shared codec-scan signature; the DTS core never sets it
-    // (a `pub fn` is exempt from `needless_pass_by_ref_mut`).
+    // The `let _` silences the unused parameter without renaming it.
     let _ = tag;
     if stream.base.is_initialized {
         return;

--- a/crates/bdinfo-rs-core/src/codec/lpcm.rs
+++ b/crates/bdinfo-rs-core/src/codec/lpcm.rs
@@ -96,20 +96,20 @@ pub fn scan(stream: &mut TsAudioStream, buffer: &mut TsStreamBuffer, tag: &mut O
     }
 
     // Bit-depth code.
-    match (flags & 0xC0).wrapping_shr(6) {
-        1 => stream.bit_depth = 16,
-        2 => stream.bit_depth = 20,
-        3 => stream.bit_depth = 24,
-        _ => stream.bit_depth = 0,
-    }
+    stream.bit_depth = match (flags & 0xC0).wrapping_shr(6) {
+        1 => 16,
+        2 => 20,
+        3 => 24,
+        _ => 0,
+    };
 
     // Sample-rate nibble.
-    match (flags & 0xF00).wrapping_shr(8) {
-        1 => stream.sample_rate = 48_000,
-        4 => stream.sample_rate = 96_000,
-        5 => stream.sample_rate = 192_000,
-        _ => stream.sample_rate = 0,
-    }
+    stream.sample_rate = match (flags & 0xF00).wrapping_shr(8) {
+        1 => 48_000,
+        4 => 96_000,
+        5 => 192_000,
+        _ => 0,
+    };
 
     // `sample_rate * bit_depth * (channel_count + lfe)` — a wrapping product,
     // truncated through the unsigned 32-bit view, then widened to the i64 bit rate.

--- a/crates/bdinfo-rs-core/src/codec/lpcm.rs
+++ b/crates/bdinfo-rs-core/src/codec/lpcm.rs
@@ -19,11 +19,10 @@ use crate::stream::TsAudioStream;
 /// Scans one LPCM access unit from `buffer` into `stream`.
 ///
 /// A buffer too short for the four-byte header leaves `stream` untouched (an
-/// early return). `tag` is part of the shared codec-scan signature and is never
-/// set here.
+/// early return). `tag` is never set here, as in `TSCodecLPCM.Scan`;
+/// [`super::scan_access_unit`] carries why it is still a parameter.
 pub fn scan(stream: &mut TsAudioStream, buffer: &mut TsStreamBuffer, tag: &mut Option<String>) {
-    // `tag` is part of the shared codec-scan signature; LPCM never sets it (a
-    // `pub fn` is exempt from `needless_pass_by_ref_mut`).
+    // The `let _` silences the unused parameter without renaming it.
     let _ = tag;
     if stream.base.is_initialized {
         return;

--- a/crates/bdinfo-rs-core/src/codec/mpa.rs
+++ b/crates/bdinfo-rs-core/src/codec/mpa.rs
@@ -68,11 +68,11 @@ const MPA_CHANNELS: [i32; 4] = [2, 2, 2, 1];
 
 /// Scans one MPEG-audio access unit from `buffer` into `stream`.
 ///
-/// A non-`0x7FF` sync word leaves `stream` untouched (an early return). `tag`
-/// is part of the shared codec-scan signature and is never set here.
+/// A non-`0x7FF` sync word leaves `stream` untouched (an early return). `tag` is
+/// never set here, as in `TSCodecMPA.Scan`; [`super::scan_access_unit`] carries
+/// why it is still a parameter.
 pub fn scan(stream: &mut TsAudioStream, buffer: &mut TsStreamBuffer, tag: &mut Option<String>) {
-    // `tag` is part of the shared codec-scan signature; MPA never sets it (a
-    // `pub fn` is exempt from `needless_pass_by_ref_mut`).
+    // The `let _` silences the unused parameter without renaming it.
     let _ = tag;
     if stream.base.is_initialized {
         return;

--- a/crates/bdinfo-rs-core/src/codec/mvc.rs
+++ b/crates/bdinfo-rs-core/src/codec/mvc.rs
@@ -4,8 +4,10 @@
 //! is deliberately a stub that only marks the stream `is_vbr`/`is_initialized` —
 //! the displayed resolution / frame rate / aspect ratio and the `Left Eye`/`Right
 //! Eye` base-view tag all come from the CLPI/MPLS metadata, not from decoding the
-//! bitstream. [`scan`] therefore reads nothing from `buffer` and never sets `tag`;
-//! both are present only to match the shared codec-scan signature.
+//! bitstream. [`scan`] therefore reads nothing from `buffer` and never sets `tag`
+//! — as in `TSCodecMVC.Scan`, which is the same stub. Both parameters are there to
+//! match the scanner signature [`crate::codec::scan_access_unit`] dispatches
+//! through, and its doc carries why that signature is uniform.
 
 use crate::bitstream::TsStreamBuffer;
 use crate::stream::TsVideoStream;
@@ -19,8 +21,7 @@ pub const fn scan(
     buffer: &mut TsStreamBuffer,
     tag: &mut Option<String>,
 ) {
-    // The shared codec-scan signature; MVC reads neither (a `pub fn` is exempt from
-    // `needless_pass_by_ref_mut`).
+    // The `let _`s silence the unused parameters without renaming them.
     let _ = buffer;
     let _ = tag;
     stream.base.is_vbr = true;

--- a/crates/bdinfo-rs-core/src/report/text.rs
+++ b/crates/bdinfo-rs-core/src/report/text.rs
@@ -274,7 +274,7 @@ fn forums_table(bdrom: &BdRom, playlist: &PlaylistSummary, rows: &[&StreamSummar
         time_hh_short(seconds_to_ticks(playlist.total_length)),
         group(u128::from(playlist.total_packet_size())),
         group(u128::from(bdrom.full_size())),
-        format!("{} Mbps", cents(round_long(u64_to_f64(playlist.total_bit_rate()) / 10_000.0))),
+        format!("{} Mbps", cents(round_long(bytes_to_f64(playlist.total_bit_rate()) / 10_000.0))),
         format!("{video_bitrate} Mbps"),
         audio1,
         audio2
@@ -335,7 +335,7 @@ fn playlist_report(playlist: &PlaylistSummary) -> String {
         out,
         "{:<16}{} Mbps\r\n",
         "Total Bitrate:",
-        cents(round_long(u64_to_f64(playlist.total_bit_rate()) / 10_000.0))
+        cents(round_long(bytes_to_f64(playlist.total_bit_rate()) / 10_000.0))
     );
     if playlist.angle_count > 0 {
         for (index, angle) in playlist.angle_totals().iter().enumerate() {
@@ -394,7 +394,7 @@ fn playlist_report(playlist: &PlaylistSummary) -> String {
             out,
             "{:<24}{} Mbps\r\n",
             "All Angles Bitrate:",
-            cents(round_long(u64_to_f64(playlist.total_angle_bit_rate()) / 10_000.0))
+            cents(round_long(bytes_to_f64(playlist.total_angle_bit_rate()) / 10_000.0))
         );
     }
     out
@@ -554,7 +554,7 @@ fn files_section(playlist: &PlaylistSummary) -> String {
     for clip in &playlist.clips {
         let bitrate = format!(
             "{:>6} kbps",
-            group_signed(round_long(u64_to_f64(clip.packet_bit_rate()) / 1000.0))
+            group_signed(round_long(bytes_to_f64(clip.packet_bit_rate()) / 1000.0))
         );
         let _ = write!(
             out,
@@ -747,7 +747,7 @@ fn quick_summary(
         out,
         "{:<16}{} Mbps\r\n",
         "Total Bitrate:",
-        cents(round_long(u64_to_f64(playlist.total_bit_rate()) / 10_000.0))
+        cents(round_long(bytes_to_f64(playlist.total_bit_rate()) / 10_000.0))
     );
     out.push_str(stream_lines);
     out
@@ -799,12 +799,6 @@ fn group_signed(value: i64) -> String {
 )]
 const fn int_to_f64(value: i64) -> f64 {
     value as f64
-}
-
-/// Widens a `u64` (a model byte/bit-rate count) to `f64` — exact for every
-/// value the demux can produce.
-const fn u64_to_f64(value: u64) -> f64 {
-    bytes_to_f64(value)
 }
 
 /// Formats `value` with exactly `decimals` fractional digits, rounding the

--- a/crates/bdinfo-rs-core/src/stream.rs
+++ b/crates/bdinfo-rs-core/src/stream.rs
@@ -490,6 +490,8 @@ impl TsVideoStream {
     /// presents this stream (each presentation accumulates its own counters).
     #[must_use]
     pub fn ts_clone(&self) -> Self {
+        // Enumerated by hand so a field added to the struct must be consciously placed
+        // in or out of the reset-copy; `TsAudioStream::ts_clone` carries why.
         Self {
             base: self.base.reset_copy(),
             width: self.width,
@@ -752,6 +754,14 @@ impl TsAudioStream {
     /// their defaults in the copy.
     #[must_use]
     pub fn ts_clone(&self) -> Self {
+        // Every field is written out rather than filled from `..self.clone()` so that
+        // adding one to the struct stops compiling here until someone decides whether
+        // the reset-copy carries it. This body is the proof that pays: besides `base`,
+        // two fields diverge from a verbatim copy — `has_extensions` restarts at false
+        // and `core_stream` recurses through `ts_clone` — and struct-update syntax
+        // would have turned both decisions into silent defaults.
+        // `TsVideoStream::ts_clone` and `TsGraphicsStream::ts_clone` enumerate for
+        // the same reason.
         Self {
             base: self.base.reset_copy(),
             sample_rate: self.sample_rate,
@@ -1020,6 +1030,8 @@ impl TsGraphicsStream {
     /// with the demux counters back at their defaults.
     #[must_use]
     pub fn ts_clone(&self) -> Self {
+        // Enumerated by hand so a field added to the struct must be consciously placed
+        // in or out of the reset-copy; `TsAudioStream::ts_clone` carries why.
         Self {
             base: self.base.reset_copy(),
             width: self.width,

--- a/crates/bdinfo-rs-gui/deny.toml
+++ b/crates/bdinfo-rs-gui/deny.toml
@@ -38,13 +38,6 @@ ignore = [
     # WINDOW TITLE from system fonts. It never touches disc data. Clears when
     # winit moves sctk-adwaita to a maintained glyph stack.
     "RUSTSEC-2026-0192",
-    # quick-xml DoS advisories — via wayland-scanner, a BUILD-dependency that
-    # code-generates Wayland protocol bindings from the XML specs COMMITTED
-    # inside the wayland-* crates themselves. Build-time, trusted input,
-    # unreachable from any runtime path. wayland-scanner caps quick-xml below
-    # the fixed 0.41, so no lockfile bump resolves it yet.
-    "RUSTSEC-2026-0194",
-    "RUSTSEC-2026-0195",
 ]
 # A yanked crate version defaults to a WARN in advisories v2 (so it would pass
 # `cargo deny check` silently). A yanked dep is one the publisher pulled — treat it

--- a/fuzz/fuzz_targets/m2ts.rs
+++ b/fuzz/fuzz_targets/m2ts.rs
@@ -8,9 +8,10 @@
 //! `scan` is also the SSIF (3D) de-interleaving engine: a `*.ssif` is just
 //! packet-aligned base/dependent extents demuxed by this very state machine, so
 //! this target covers the interleaved framing too (the `ssif_*` seed is a
-//! multi-extent packet stream). `TsStreamFile::scan_source` merely *selects* the
-//! `.ssif` over the `.m2ts` — it parses no bytes of its own — so the only untrusted
-//! parsing surface it reaches is exactly this `scan`.
+//! multi-extent packet stream). The disc scan's per-file step merely *selects* the
+//! `.ssif` over the `.m2ts` before handing over the reader — it parses no bytes of
+//! its own — so the only untrusted parsing surface it reaches is exactly this
+//! `scan`.
 //!
 //! The fuzz bytes are the packet stream; a single dummy playlist (with one clip
 //! named to match) lets the demux run its full state machine and the bitrate

--- a/fuzz/fuzz_targets/m2ts_differential.rs
+++ b/fuzz/fuzz_targets/m2ts_differential.rs
@@ -43,9 +43,9 @@
 //!
 //! Two parts of the state are excluded, and each is a hole in the proof:
 //!
-//! - `TsStreamFile::interleaved_file` — neither strategy reads or writes it. It
-//!   selects the source *before* a scan (`TsStreamFile::scan_source`) and is
-//!   `None` for a clip this harness builds.
+//! - `TsStreamFile::interleaved_file` — neither strategy reads or writes it. The
+//!   disc scan's per-file step consults it to select the source *before* a scan,
+//!   and it is `None` for a clip this harness builds.
 //! - `TsStreamFile`'s private per-PID demux scratch — unreachable from outside
 //!   the crate, not output (the crate releases it once a scan's outputs are
 //!   captured), and holding a PES reassembly window of up to 5 MiB per PID, so


### PR DESCRIPTION
Two groups of dead public API removed, and the two codec/stream seams that a
fresh-eyes pass reads as removable now record why they are not.

Deletions (core): `AngleTotals::bit_rate`, `AngleTotals::timeline_bit_rate`,
`report::text::u64_to_f64`, `TsStreamFile::scan_source`. The library API
baseline reports no semver update required.

Contracts recorded:

- `codec::scan_access_unit`'s doc is now the single home for the `tag`
  contract - who writes the frame marker, that the demux copies it into each
  bitrate window's `TsStreamDiagnostics::tag` for video streams only, and why
  six scanners take a `tag` they never write. All 13 `TSCodecXXX.Scan` methods
  in classic BDInfo declare `ref string tag`, and exactly those six leave it
  untouched there too, so the uniform signature is what keeps every scanner
  readable 1:1 against its counterpart. The six sites keep a one-clause
  pointer.
- `TsAudioStream::ts_clone` is the home for the reset-copy tripwire: the field
  enumerations are hand-written so a new field stops compiling until someone
  places it in or out of the copy. That body is the proof - `has_extensions`
  restarts false and `core_stream` recurses.

Also drops `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` from the GUI advisory
ignore list. Their justifying comment claimed wayland-scanner caps quick-xml
below 0.41; the lockfile has 0.41.0 and cargo deny matched neither advisory.