### PR TITLE
refactor(vfs): share the in-memory backend and default the directory convenience methods

### DIFF
--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -2261,10 +2261,10 @@ mod tests {
         PlaylistFilter, PlaylistSummary, Progress, SOURCE_PACKET_BYTES, ScanMode, ScanProgress,
         ScanStage, Sink, TsPlaylistFile, TsStreamFile, backup_subdir_files,
         build_chapter_summaries, build_clip_summaries, build_sorted_streams, clear_measurements,
-        clip_has_50hz_video, clip_stem, collect_backups, fixtures, has_aacs_key_file, merge_stream,
-        rate_over, read_disc_title, read_file, read_file_capped, resolve_playlist_streams,
-        scan_stream_files, scan_total, select_reference, stream_content_encrypted, stream_summary,
-        unit_shows_encryption, walked_disc_root,
+        clip_has_50hz_video, clip_stem, collect_backups, directory_size, fixtures,
+        has_aacs_key_file, merge_stream, rate_over, read_disc_title, read_file, read_file_capped,
+        resolve_playlist_streams, scan_stream_files, scan_total, select_reference,
+        stream_content_encrypted, stream_summary, unit_shows_encryption, walked_disc_root,
     };
     use crate::bdrom::clpi::TsStreamClip;
     use crate::bdrom::clpi::clips::build_clpi;
@@ -2278,7 +2278,7 @@ mod tests {
         TsTextStream, TsVideoFormat, TsVideoStream,
     };
     use crate::vfs::fs::{FsDir, FsFile};
-    use crate::vfs::{BdDir, BdFile, ReadSeek, SearchOption};
+    use crate::vfs::{BdDir, BdFile, ReadSeek, SearchOption, extension_of_name};
 
     // ── synthetic metadata builders (minimal valid `*.clpi` / `*.mpls`) ──────
     //
@@ -4547,16 +4547,12 @@ mod tests {
     /// Builds a complete, valid mock disc (two playlists, all flag dirs) whose io
     /// operations all share `trip`.
     fn mock_disc(trip: &Trip) -> MockDir {
-        let file = |name: &str, bytes: Vec<u8>| {
-            let extension =
-                name.rsplit_once('.').map_or_else(String::new, |(_, ext)| format!(".{ext}"));
-            MockFile {
-                name: name.to_owned(),
-                extension,
-                bytes,
-                trip: trip.clone(),
-                fail_read: false,
-            }
+        let file = |name: &str, bytes: Vec<u8>| MockFile {
+            name: name.to_owned(),
+            extension: extension_of_name(name),
+            bytes,
+            trip: trip.clone(),
+            fail_read: false,
         };
         let dir = |name: &str, dirs: Vec<MockDir>, files: Vec<MockFile>| MockDir {
             name: name.to_owned(),
@@ -4618,6 +4614,28 @@ mod tests {
             ],
             vec![],
         )
+    }
+
+    #[test]
+    fn directory_size_keeps_an_uppercase_ssif_out_of_the_disc_size() {
+        // `extension_of_name` returns the suffix verbatim, case included, so the
+        // interleaved split is what has to fold case: a disc naming its file
+        // `00000.SSIF` must reach the same two totals as the lowercase spelling.
+        let trip = Trip::new(usize::MAX);
+        let file = |name: &str, len: usize| MockFile {
+            name: name.to_owned(),
+            extension: extension_of_name(name),
+            bytes: vec![0; len],
+            trip: trip.clone(),
+            fail_read: false,
+        };
+        let dir = MockDir {
+            name: "SSIF".to_owned(),
+            dirs: Vec::new(),
+            files: vec![file("00000.SSIF", 10), file("00001.ssif", 20), file("00000.m2ts", 5)],
+            trip,
+        };
+        assert_eq!(directory_size(&dir).expect("mock listing is infallible"), (5, 30));
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -4296,14 +4296,6 @@ mod tests {
             }
         }
 
-        fn get_files(&self) -> io::Result<Vec<Box<dyn BdFile>>> {
-            Ok(Vec::new())
-        }
-
-        fn get_files_pattern(&self, _pattern: &str) -> io::Result<Vec<Box<dyn BdFile>>> {
-            Ok(Vec::new())
-        }
-
         fn get_files_pattern_option(
             &self,
             _pattern: &str,
@@ -4521,6 +4513,11 @@ mod tests {
             None
         }
 
+        // Both convenience methods are provided by `BdDir`; these overrides
+        // exist so this fake ticks its failure countdown once per call and
+        // lists every file whatever the pattern — the provided bodies would
+        // route through `get_files_pattern_option`, tick there instead, and
+        // filter by `collect_matching`'s exact-name rule.
         fn get_files(&self) -> io::Result<Vec<Box<dyn BdFile>>> {
             self.trip.tick()?;
             Ok(self.files.iter().cloned().map(|f| -> Box<dyn BdFile> { Box::new(f) }).collect())

--- a/crates/bdinfo-rs-core/src/bdrom/interleaved.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/interleaved.rs
@@ -79,9 +79,7 @@ impl MemBdFile {
     /// Builds an in-memory file named `name` over `bytes`; `fail` makes `open_read`
     /// error.
     pub(crate) fn new(name: &str, bytes: Vec<u8>, fail: bool) -> Self {
-        let extension =
-            name.rsplit_once('.').map_or_else(String::new, |(_, ext)| format!(".{ext}"));
-        Self { name: name.to_owned(), extension, bytes, fail }
+        Self { name: name.to_owned(), extension: crate::vfs::extension_of_name(name), bytes, fail }
     }
 }
 

--- a/crates/bdinfo-rs-core/src/vfs.rs
+++ b/crates/bdinfo-rs-core/src/vfs.rs
@@ -96,18 +96,31 @@ pub trait BdDir {
 
     /// Every file directly in this directory.
     ///
+    /// Provided as the match-everything pattern `*` handed to
+    /// [`get_files_pattern`](BdDir::get_files_pattern), so a backend writes
+    /// [`get_files_pattern_option`](BdDir::get_files_pattern_option) alone and
+    /// gets both convenience forms. Overriding stays open — for a listing
+    /// cheaper than a glob pass, or a fake that must fail at this call and not
+    /// at the glob one.
+    ///
     /// # Errors
     /// Propagates the underlying IO error if the directory cannot be read.
-    fn get_files(&self) -> io::Result<Vec<Box<dyn BdFile>>>;
+    fn get_files(&self) -> io::Result<Vec<Box<dyn BdFile>>> {
+        self.get_files_pattern("*")
+    }
 
     /// Files in this directory matching `pattern`.
     ///
     /// `pattern` is an ASCII case-insensitive glob (`*` = any run, `?` = any one
-    /// character); see [`get_files_pattern_option`](BdDir::get_files_pattern_option).
+    /// character); this is provided as
+    /// [`get_files_pattern_option`](BdDir::get_files_pattern_option) with
+    /// [`SearchOption::TopDirectoryOnly`].
     ///
     /// # Errors
     /// Propagates the underlying IO error if the directory cannot be read.
-    fn get_files_pattern(&self, pattern: &str) -> io::Result<Vec<Box<dyn BdFile>>>;
+    fn get_files_pattern(&self, pattern: &str) -> io::Result<Vec<Box<dyn BdFile>>> {
+        self.get_files_pattern_option(pattern, SearchOption::TopDirectoryOnly)
+    }
 
     /// Files matching `pattern`, optionally recursing into subdirectories.
     ///

--- a/crates/bdinfo-rs-core/src/vfs.rs
+++ b/crates/bdinfo-rs-core/src/vfs.rs
@@ -5,6 +5,12 @@
 //! `std::fs` (folder input — see [`fs`]) or the UDF reader (`.iso` input — see
 //! [`udf`]). A ~12-method file/directory pair is all the parsers need.
 //!
+//! A third backend, [`mem`], serves no disc medium at all: it holds a
+//! synthetic disc as byte buffers in RAM, for harnesses — the browser export
+//! and the fuzz targets — whose input arrives as bytes rather than as a
+//! mounted folder or image. It also defines the section framing those
+//! harnesses share; see its module docs.
+//!
 //! Case-insensitive BDMV lookup is folded in here, done once and correctly and
 //! routed through [`crate::discovery`] — see [`find_directory`] and
 //! [`find_files`].
@@ -18,6 +24,7 @@ use std::io::{self, BufRead, Read, Seek};
 use crate::discovery::{BdFileKind, BdmvDir};
 
 pub mod fs;
+pub mod mem;
 pub mod udf;
 pub mod volume;
 
@@ -164,9 +171,9 @@ pub fn find_files(dir: &dyn BdDir, kind: BdFileKind) -> io::Result<Vec<Box<dyn B
 /// returned verbatim (a lone `.` for a trailing-dot name like `00000.`); no
 /// further normalization is applied.
 ///
-/// Both backends derive [`BdFile::extension`] through this one function, and
-/// that agreement is load-bearing: the disc-size total skips an interleaved
-/// stream by matching this string against `.ssif`
+/// Every built-in backend derives [`BdFile::extension`] through this one
+/// function, and that agreement is load-bearing: the disc-size total skips an
+/// interleaved stream by matching this string against `.ssif`
 /// ([`crate::bdrom::disc`]), so a folder and the same disc as an `.iso` would
 /// report different sizes if two lookalike derivations disagreed on a name.
 #[must_use]

--- a/crates/bdinfo-rs-core/src/vfs.rs
+++ b/crates/bdinfo-rs-core/src/vfs.rs
@@ -180,17 +180,22 @@ pub fn find_files(dir: &dyn BdDir, kind: BdFileKind) -> io::Result<Vec<Box<dyn B
 }
 
 /// The extension of `name` *including* the leading dot (e.g. `.SSIF`), or the
-/// empty string when `name` holds no `.`. The text after the last `.` is
-/// returned verbatim (a lone `.` for a trailing-dot name like `00000.`); no
-/// further normalization is applied.
+/// empty string when `name` holds no `.`.
 ///
-/// Every built-in backend derives [`BdFile::extension`] through this one
-/// function, and that agreement is load-bearing: the disc-size total skips an
-/// interleaved stream by matching this string against `.ssif`
-/// ([`crate::bdrom::disc`]), so a folder and the same disc as an `.iso` would
-/// report different sizes if two lookalike derivations disagreed on a name.
+/// The text after the last `.` is returned verbatim — case included, and a lone
+/// `.` for a trailing-dot name like `00000.`; no further normalization is
+/// applied. Callers that need a case-insensitive answer compare case-insensitively.
+///
+/// Every backend derives [`BdFile::extension`] through this one function — the
+/// three in this crate ([`fs`], [`udf`], [`mem`]) and the browser file backend
+/// in `bdinfo-rs-wasm`, which is why this is public — and that agreement is
+/// load-bearing: the disc-size total keeps an interleaved stream out of the
+/// disc size by matching this string against `.ssif` with
+/// [`eq_ignore_ascii_case`](str::eq_ignore_ascii_case) ([`crate::bdrom::disc`]),
+/// so a folder and the same disc as an `.iso` would report different sizes if
+/// two lookalike derivations disagreed on a name.
 #[must_use]
-pub(crate) fn extension_of_name(name: &str) -> String {
+pub fn extension_of_name(name: &str) -> String {
     match name.rsplit_once('.') {
         Some((_, ext)) => format!(".{ext}"),
         None => String::new(),

--- a/crates/bdinfo-rs-core/src/vfs/fs.rs
+++ b/crates/bdinfo-rs-core/src/vfs/fs.rs
@@ -274,14 +274,6 @@ impl BdDir for FsDir {
         Some(Box::new(self.related(parent.to_path_buf())))
     }
 
-    fn get_files(&self) -> io::Result<Vec<Box<dyn BdFile>>> {
-        self.get_files_pattern("*")
-    }
-
-    fn get_files_pattern(&self, pattern: &str) -> io::Result<Vec<Box<dyn BdFile>>> {
-        self.get_files_pattern_option(pattern, SearchOption::TopDirectoryOnly)
-    }
-
     fn get_files_pattern_option(
         &self,
         pattern: &str,

--- a/crates/bdinfo-rs-core/src/vfs/fs.rs
+++ b/crates/bdinfo-rs-core/src/vfs/fs.rs
@@ -342,11 +342,11 @@ fn extension_of(path: &Path) -> String {
 /// `*` matches any run (including empty) and `?` matches exactly one byte. One
 /// case-folded pass finds `*.mpls` and `*.MPLS` spellings alike.
 ///
-/// Shared with the UDF backend ([`super::udf`]) so `.iso` and folder input
-/// match patterns identically, and public so an out-of-crate
-/// [`BdDir`](crate::vfs::BdDir) backend — a browser file list, an in-memory
-/// tree — resolves [`get_files_pattern`](crate::vfs::BdDir::get_files_pattern)
-/// by the same rule rather than a lookalike of its own.
+/// Shared with the UDF ([`super::udf`]) and in-memory ([`super::mem`])
+/// backends so every input medium matches patterns identically, and public so
+/// an out-of-crate [`BdDir`](crate::vfs::BdDir) backend — a browser file list
+/// — resolves [`get_files_pattern`](crate::vfs::BdDir::get_files_pattern) by
+/// the same rule rather than a lookalike of its own.
 #[must_use]
 pub fn glob_ci(pattern: &[u8], name: &[u8]) -> bool {
     match pattern.split_first() {

--- a/crates/bdinfo-rs-core/src/vfs/mem.rs
+++ b/crates/bdinfo-rs-core/src/vfs/mem.rs
@@ -1,0 +1,468 @@
+//! In-memory backend for the [`vfs`](crate::vfs) seam — synthetic discs held
+//! entirely in RAM.
+//!
+//! The third backend beside [`fs`](super::fs) (folder input) and
+//! [`udf`](super::udf) (`.iso` input): [`MemFile`]/[`MemDir`] implement
+//! [`BdFile`]/[`BdDir`] over shared byte buffers, for harnesses whose disc
+//! never touches a filesystem — the browser (`bdinfo-rs-wasm`'s `scan_report`
+//! export is handed BDMV bytes by JavaScript) and fuzzing (the `parse_report`
+//! fuzz target turns each seed into a disc).
+//!
+//! ## Section framing
+//!
+//! Those two harnesses agree on one byte framing, defined here so a fuzz seed
+//! means the same disc to both:
+//!
+//! - [`split_sections`] cuts a buffer into `u32` big-endian length-prefixed sections. The prefix is
+//!   `u32` (not `u16`) so a real-scale `*.m2ts` stream section — megabytes — is expressible; a
+//!   truncated trailing section yields the bytes present rather than an error.
+//! - [`build_tree`] lays the first [`SECTION_COUNT`] sections, in order, onto a fixed BDMV skeleton
+//!   under a caller-named root: `BDMV/index.bdmv`, `BDMV/MovieObject.bdmv`, `PLAYLIST/00000.mpls`,
+//!   `CLIPINF/00000.clpi`, `STREAM/00000.m2ts`, and `META/DL/bdmt_eng.xml` (the [`roxmltree`] input
+//!   — the one third-party parser fed disc bytes). A missing section leaves its file present but
+//!   empty, exercising the resilient-open paths.
+//!
+//! A harness needing more than the skeleton appends entries through
+//! [`MemDir::add_file`] — e.g. a `BDMV/STREAM/SSIF/00000.ssif` file, whose
+//! directory is what marks a disc 3D.
+
+use std::io::{self, BufRead, Cursor};
+use std::sync::Arc;
+
+use super::fs::glob_ci;
+use super::{BdDir, BdFile, ReadSeek, SearchOption, extension_of_name};
+
+/// A file over a shared byte buffer — the [`BdFile`] implementation for
+/// in-memory input.
+///
+/// Cloning shares the buffer (an `Arc`), so handing a file into a tree walk or
+/// opening it twice never copies the bytes.
+#[derive(Debug, Clone)]
+pub struct MemFile {
+    name: String,
+    full_name: String,
+    /// Derived once at construction by [`extension_of_name`], the rule every
+    /// built-in backend shares, and borrowed by [`BdFile::extension`].
+    extension: String,
+    data: Arc<[u8]>,
+}
+
+impl MemFile {
+    /// Builds the file `name` under `dir` (its parent's full path — the full
+    /// name becomes `dir`/`name`), holding `data`.
+    #[must_use]
+    pub fn new(dir: &str, name: &str, data: Vec<u8>) -> Self {
+        Self {
+            full_name: format!("{dir}/{name}"),
+            extension: extension_of_name(name),
+            name: name.to_owned(),
+            data: Arc::from(data),
+        }
+    }
+}
+
+impl BdFile for MemFile {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn full_name(&self) -> &str {
+        &self.full_name
+    }
+
+    fn extension(&self) -> &str {
+        &self.extension
+    }
+
+    fn length(&self) -> u64 {
+        // usize -> u64 cannot lose width on any supported target; saturate
+        // rather than unwrap so the conversion stays panic-free by construction.
+        u64::try_from(self.data.len()).unwrap_or(u64::MAX)
+    }
+
+    fn is_dir(&self) -> bool {
+        false
+    }
+
+    fn open_read(&self) -> io::Result<Box<dyn ReadSeek>> {
+        Ok(Box::new(Cursor::new(Arc::clone(&self.data))))
+    }
+
+    fn open_text(&self) -> io::Result<Box<dyn BufRead>> {
+        Ok(Box::new(Cursor::new(Arc::clone(&self.data))))
+    }
+}
+
+/// A directory of in-memory entries — the [`BdDir`] implementation for
+/// in-memory input.
+///
+/// Listings enumerate in insertion order, which the builder fixes at
+/// construction — deterministic, with no filesystem involved.
+#[derive(Debug, Clone)]
+pub struct MemDir {
+    name: String,
+    full_name: String,
+    dirs: Vec<Self>,
+    files: Vec<MemFile>,
+}
+
+impl MemDir {
+    /// Builds an empty root directory named `name`. Its full name is the bare
+    /// `name` — a synthetic tree has no path above its root.
+    #[must_use]
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            full_name: name.to_owned(),
+            dirs: Vec::new(),
+            files: Vec::new(),
+        }
+    }
+
+    /// Adds the file `name` holding `data` at the end of the directory chain
+    /// `dirs` below this directory, creating intermediate directories as
+    /// needed; a directory already present under its chain name is descended
+    /// into, never duplicated. An empty chain places the file directly here.
+    pub fn add_file(&mut self, dirs: &[&str], name: &str, data: Vec<u8>) {
+        let mut node = self;
+        for &dir in dirs {
+            let idx = if let Some(found) = node.dirs.iter().position(|d| d.name == dir) {
+                found
+            } else {
+                let full_name = format!("{}/{dir}", node.full_name);
+                node.dirs.push(Self {
+                    name: dir.to_owned(),
+                    full_name,
+                    dirs: Vec::new(),
+                    files: Vec::new(),
+                });
+                node.dirs.len().saturating_sub(1)
+            };
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "idx is freshly found-or-pushed in node.dirs, always in bounds"
+            )]
+            let next = &mut node.dirs[idx];
+            node = next;
+        }
+        let file = MemFile::new(&node.full_name, name, data);
+        node.files.push(file);
+    }
+
+    /// Appends this directory's files matching `pattern` to `out`, recursing
+    /// into subdirectories when `recurse` is set. Recursion depth equals tree
+    /// depth, which only [`add_file`](Self::add_file) callers control — the
+    /// framed disc bytes never shape the tree, so no depth cap is needed.
+    fn collect_pattern(&self, pattern: &str, recurse: bool, out: &mut Vec<Box<dyn BdFile>>) {
+        for file in &self.files {
+            if glob_ci(pattern.as_bytes(), file.name.as_bytes()) {
+                out.push(Box::new(file.clone()));
+            }
+        }
+        if recurse {
+            for dir in &self.dirs {
+                dir.collect_pattern(pattern, recurse, out);
+            }
+        }
+    }
+}
+
+impl BdDir for MemDir {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn full_name(&self) -> &str {
+        &self.full_name
+    }
+
+    fn parent(&self) -> Option<Box<dyn BdDir>> {
+        // Handles are clones detached from the tree, so a child cannot point
+        // back up. The scan's disc-root walk-up tolerates this: every built
+        // tree wraps `BDMV` in a named root, so the walk finds the root before
+        // it needs a parent.
+        None
+    }
+
+    fn get_files(&self) -> io::Result<Vec<Box<dyn BdFile>>> {
+        Ok(self.files.iter().map(|f| -> Box<dyn BdFile> { Box::new(f.clone()) }).collect())
+    }
+
+    fn get_files_pattern(&self, pattern: &str) -> io::Result<Vec<Box<dyn BdFile>>> {
+        self.get_files_pattern_option(pattern, SearchOption::TopDirectoryOnly)
+    }
+
+    fn get_files_pattern_option(
+        &self,
+        pattern: &str,
+        option: SearchOption,
+    ) -> io::Result<Vec<Box<dyn BdFile>>> {
+        let mut out = Vec::new();
+        self.collect_pattern(pattern, option == SearchOption::AllDirectories, &mut out);
+        Ok(out)
+    }
+
+    fn get_directories(&self) -> io::Result<Vec<Box<dyn BdDir>>> {
+        Ok(self.dirs.iter().map(|d| -> Box<dyn BdDir> { Box::new(d.clone()) }).collect())
+    }
+}
+
+/// The number of sections [`build_tree`] lays onto the skeleton — one per
+/// synthetic file, in the order the module docs list them.
+pub const SECTION_COUNT: usize = 6;
+
+/// Splits `data` into up to `max` `u32` big-endian length-prefixed sections
+/// (the framing in the module docs).
+///
+/// A truncated trailing section yields the bytes present; anything after the
+/// last complete 4-byte prefix is dropped.
+#[must_use]
+pub fn split_sections(data: &[u8], max: usize) -> Vec<Vec<u8>> {
+    let mut sections: Vec<Vec<u8>> = Vec::new();
+    let mut rest = data;
+    while sections.len() < max {
+        let Some((len_bytes, tail)) = rest.split_first_chunk::<4>() else { break };
+        // Saturating on a <32-bit target (mirroring `udf::as_offset`); the
+        // `min` below then clamps to what is actually present.
+        let want = usize::try_from(u32::from_be_bytes(*len_bytes)).unwrap_or(usize::MAX);
+        let take = want.min(tail.len());
+        // `take <= tail.len()`, so `split_at` cannot panic. A truncated section
+        // (`take < want`) consumes the rest of the buffer, so the next iteration
+        // finds no further 4-byte prefix and the loop ends — no explicit break.
+        let (head, next) = tail.split_at(take);
+        sections.push(head.to_vec());
+        rest = next;
+    }
+    sections
+}
+
+/// Builds the synthetic disc tree: the first [`SECTION_COUNT`] of `sections`
+/// laid in order onto the fixed BDMV skeleton (see the module docs) under a
+/// root directory named `root_name`.
+///
+/// A missing section leaves its file present but empty. Sections beyond
+/// [`SECTION_COUNT`] are ignored — a harness with a private extension (the
+/// `parse_report` fuzz target's seventh, SSIF section) takes them off the
+/// [`split_sections`] result before calling and places them through
+/// [`MemDir::add_file`].
+#[must_use]
+pub fn build_tree(root_name: &str, sections: Vec<Vec<u8>>) -> MemDir {
+    let mut next = sections.into_iter();
+    let mut take = || next.next().unwrap_or_default();
+    let mut root = MemDir::new(root_name);
+    root.add_file(&["BDMV"], "index.bdmv", take());
+    root.add_file(&["BDMV"], "MovieObject.bdmv", take());
+    root.add_file(&["BDMV", "PLAYLIST"], "00000.mpls", take());
+    root.add_file(&["BDMV", "CLIPINF"], "00000.clpi", take());
+    root.add_file(&["BDMV", "STREAM"], "00000.m2ts", take());
+    root.add_file(&["BDMV", "META", "DL"], "bdmt_eng.xml", take());
+    root
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Seek, SeekFrom};
+
+    use proptest::prelude::{any, prop, prop_assert, prop_assert_eq, proptest};
+
+    use super::{MemDir, MemFile, SECTION_COUNT, build_tree, split_sections};
+    use crate::vfs::{BdDir, BdFile, SearchOption};
+
+    /// Every file under `dir` as `(full_name, bytes)`, in walk order.
+    fn all_files(dir: &MemDir) -> Vec<(String, Vec<u8>)> {
+        dir.get_files_pattern_option("*", SearchOption::AllDirectories)
+            .expect("in-memory walks cannot fail")
+            .iter()
+            .map(|file| {
+                let mut bytes = Vec::new();
+                file.open_read().expect("open").read_to_end(&mut bytes).expect("read");
+                (file.full_name().to_owned(), bytes)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn mem_file_exposes_metadata_and_reads_as_bytes_and_text() {
+        let file = MemFile::new("DISC/BDMV", "index.bdmv", b"hello".to_vec());
+        assert_eq!(file.name(), "index.bdmv");
+        assert_eq!(file.full_name(), "DISC/BDMV/index.bdmv");
+        assert_eq!(file.extension(), ".bdmv");
+        assert_eq!(file.length(), 5);
+        assert!(!file.is_dir());
+
+        // The reader is seekable (the parsers seek within disc files).
+        let mut reader = file.open_read().expect("open_read");
+        assert_eq!(reader.seek(SeekFrom::Start(1)).expect("seek"), 1);
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).expect("read bytes");
+        assert_eq!(bytes, b"ello");
+
+        let mut text = String::new();
+        file.open_text().expect("open_text").read_to_string(&mut text).expect("read text");
+        assert_eq!(text, "hello");
+
+        // An extensionless name yields the empty extension, per the shared rule.
+        assert_eq!(MemFile::new("DISC", "NOEXT", Vec::new()).extension(), "");
+    }
+
+    #[test]
+    fn mem_types_render_debug() {
+        // Exercise the derived Debug impls so coverage sees them.
+        let mut root = MemDir::new("DISC");
+        root.add_file(&["BDMV"], "index.bdmv", vec![1]);
+        let rendered = format!("{root:?}");
+        assert!(rendered.contains("BDMV"));
+        assert!(rendered.contains("index.bdmv"));
+    }
+
+    #[test]
+    fn dir_walk_matches_patterns_with_and_without_recursion() {
+        let mut root = MemDir::new("DISC");
+        root.add_file(&["BDMV"], "index.bdmv", vec![0_u8; 2]);
+        root.add_file(&["BDMV", "STREAM"], "00000.m2ts", vec![0_u8; 4]);
+        let bdmv = root.get_directories().expect("dirs").into_iter().next().expect("BDMV");
+
+        assert_eq!(bdmv.name(), "BDMV");
+        assert_eq!(bdmv.full_name(), "DISC/BDMV");
+        assert!(bdmv.parent().is_none());
+        assert_eq!(bdmv.get_files().expect("files").len(), 1);
+        assert_eq!(bdmv.get_directories().expect("dirs").len(), 1);
+
+        // TopDirectoryOnly does not descend into STREAM; AllDirectories does
+        // (covers `collect_pattern`'s `if recurse` both ways). Matching is
+        // ASCII case-insensitive, so the uppercase pattern finds the file too.
+        assert_eq!(bdmv.get_files_pattern("*.m2ts").expect("shallow").len(), 0);
+        assert_eq!(
+            bdmv.get_files_pattern_option("*.M2TS", SearchOption::AllDirectories)
+                .expect("deep")
+                .len(),
+            1
+        );
+        // A top-level match is found by either search.
+        assert_eq!(bdmv.get_files_pattern("*.bdmv").expect("top match").len(), 1);
+    }
+
+    #[test]
+    fn add_file_reuses_directories_and_derives_full_names() {
+        let mut root = MemDir::new("DISC");
+        root.add_file(&["BDMV", "PLAYLIST"], "00000.mpls", vec![b'a']);
+        root.add_file(&["BDMV", "PLAYLIST"], "00001.mpls", vec![b'b']);
+        root.add_file(&["BDMV", "CLIPINF"], "00000.clpi", vec![b'c']);
+        // An empty chain places the file directly in this directory.
+        root.add_file(&[], "readme.txt", vec![b'd']);
+
+        // One BDMV, reused across all three chains, holding its subdirectories
+        // in insertion order.
+        assert_eq!(root.dirs.len(), 1);
+        assert_eq!(root.files.iter().map(|f| f.name.as_str()).collect::<Vec<_>>(), ["readme.txt"]);
+        let bdmv = root.dirs.first().expect("BDMV");
+        assert_eq!(bdmv.full_name, "DISC/BDMV");
+        assert_eq!(
+            bdmv.dirs.iter().map(|d| d.name.as_str()).collect::<Vec<_>>(),
+            ["PLAYLIST", "CLIPINF"]
+        );
+        let playlist = bdmv.dirs.first().expect("PLAYLIST");
+        assert_eq!(
+            playlist.files.iter().map(|f| f.full_name.as_str()).collect::<Vec<_>>(),
+            ["DISC/BDMV/PLAYLIST/00000.mpls", "DISC/BDMV/PLAYLIST/00001.mpls"]
+        );
+    }
+
+    #[test]
+    fn split_sections_frames_prefixed_sections_up_to_max() {
+        // Two whole one-byte sections.
+        assert_eq!(
+            split_sections(&[0, 0, 0, 1, b'A', 0, 0, 0, 1, b'B'], 6),
+            [vec![b'A'], vec![b'B']]
+        );
+        // A length that overruns truncates to what is present, then stops.
+        assert_eq!(split_sections(&[0, 0, 0, 4, b'X', b'Y'], 6), [vec![b'X', b'Y']]);
+        // No 4-byte length prefix at all yields no sections.
+        assert!(split_sections(&[0, 0], 6).is_empty());
+        // Never more than `max` sections, even with more length-prefixed data —
+        // and `max` is exact, not one-off in either direction (32 zero bytes =
+        // eight empty sections' worth of prefixes).
+        let many: Vec<u8> = std::iter::repeat_n(0_u8, 32).collect();
+        assert_eq!(split_sections(&many, 6).len(), 6);
+        assert_eq!(split_sections(&many, 7).len(), 7);
+        assert!(split_sections(&many, 0).is_empty());
+    }
+
+    #[test]
+    fn build_tree_lays_the_sections_onto_the_skeleton_in_order() {
+        let sections: Vec<Vec<u8>> = (1_u8..=6).map(|i| vec![i]).collect();
+        let root = build_tree("WASMDISC", sections);
+        assert_eq!(root.name(), "WASMDISC");
+        assert_eq!(
+            all_files(&root),
+            [
+                ("WASMDISC/BDMV/index.bdmv".to_owned(), vec![1]),
+                ("WASMDISC/BDMV/MovieObject.bdmv".to_owned(), vec![2]),
+                ("WASMDISC/BDMV/PLAYLIST/00000.mpls".to_owned(), vec![3]),
+                ("WASMDISC/BDMV/CLIPINF/00000.clpi".to_owned(), vec![4]),
+                ("WASMDISC/BDMV/STREAM/00000.m2ts".to_owned(), vec![5]),
+                ("WASMDISC/BDMV/META/DL/bdmt_eng.xml".to_owned(), vec![6]),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_tree_leaves_missing_sections_empty_and_ignores_extras() {
+        // Two sections: the remaining four files exist with zero bytes.
+        let partial = build_tree("FUZZDISC", vec![vec![9], vec![8]]);
+        let files = all_files(&partial);
+        assert_eq!(files.len(), SECTION_COUNT);
+        assert_eq!(
+            files.iter().map(|(_, bytes)| bytes.len()).collect::<Vec<_>>(),
+            [1, 1, 0, 0, 0, 0]
+        );
+        assert!(files.iter().all(|(full, _)| full.starts_with("FUZZDISC/BDMV")));
+
+        // Sections beyond SECTION_COUNT never become files.
+        let overfull = build_tree("DISC", vec![vec![7]; 8]);
+        assert_eq!(all_files(&overfull).len(), SECTION_COUNT);
+    }
+
+    #[test]
+    fn a_built_tree_is_extendable_with_an_ssif_entry() {
+        // The extra-entry hook the fuzz harness's seventh section rides: the
+        // SSIF directory appends under the existing STREAM, after its file.
+        let mut root = build_tree("FUZZDISC", Vec::new());
+        root.add_file(&["BDMV", "STREAM", "SSIF"], "00000.ssif", vec![b's']);
+        let files = all_files(&root);
+        assert_eq!(files.len(), SECTION_COUNT.saturating_add(1));
+        assert!(
+            files.iter().any(
+                |(full, bytes)| full == "FUZZDISC/BDMV/STREAM/SSIF/00000.ssif" && bytes == b"s"
+            )
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn split_sections_never_panics_and_bounds_hold(
+            data in any::<Vec<u8>>(),
+            max in 0_usize..10,
+        ) {
+            let sections = split_sections(&data, max);
+            prop_assert!(sections.len() <= max);
+            // Every returned byte was cut out of `data`, so the total payload
+            // never exceeds the input.
+            let payload: usize = sections.iter().map(Vec::len).sum();
+            prop_assert!(payload <= data.len());
+        }
+
+        #[test]
+        fn split_sections_round_trips_whole_sections(
+            sections in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..64), 0..8),
+        ) {
+            let mut data = Vec::new();
+            for section in &sections {
+                let len = u32::try_from(section.len()).expect("sections are < 2^32 bytes");
+                data.extend_from_slice(&len.to_be_bytes());
+                data.extend_from_slice(section);
+            }
+            prop_assert_eq!(split_sections(&data, sections.len()), sections);
+        }
+    }
+}

--- a/crates/bdinfo-rs-core/src/vfs/mem.rs
+++ b/crates/bdinfo-rs-core/src/vfs/mem.rs
@@ -184,14 +184,6 @@ impl BdDir for MemDir {
         None
     }
 
-    fn get_files(&self) -> io::Result<Vec<Box<dyn BdFile>>> {
-        Ok(self.files.iter().map(|f| -> Box<dyn BdFile> { Box::new(f.clone()) }).collect())
-    }
-
-    fn get_files_pattern(&self, pattern: &str) -> io::Result<Vec<Box<dyn BdFile>>> {
-        self.get_files_pattern_option(pattern, SearchOption::TopDirectoryOnly)
-    }
-
     fn get_files_pattern_option(
         &self,
         pattern: &str,

--- a/crates/bdinfo-rs-core/src/vfs/udf/source.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/source.rs
@@ -122,7 +122,8 @@ impl Limits {
 /// VFS file handle reads through its own cursor (no shared seek state).
 ///
 /// The CLI backs this with a file path ([`PathIso`], reopening the `.iso`); tests
-/// back it with an in-memory buffer. Each [`BdFile::open_read`] calls [`open`] once.
+/// and fuzz harnesses back it with an in-memory buffer (`MemIso`, published by the
+/// `test-fixtures` feature). Each [`BdFile::open_read`] calls [`open`] once.
 /// It is object-safe (a [`Box<dyn ReadSeek>`](ReadSeek) return, no associated type)
 /// so the whole backend is **non-generic** — one monomorphization, smaller static
 /// binary (the prime directive), and a single coverage surface over all readers.
@@ -158,6 +159,35 @@ impl IsoReader for PathIso {
         // The dominant consumer is the demux streaming `.m2ts` runs front to
         // back, so the sequential-access hint applies to the image too.
         Ok(Box::new(crate::vfs::fs::open_sequential(&self.path)?))
+    }
+}
+
+/// A buffer-backed [`IsoReader`] — hands each handle its own cursor over one
+/// shared image.
+///
+/// The backend for `.iso` input built byte by byte instead of read from disk:
+/// this module's own descriptor fixtures, and the harnesses that turn arbitrary
+/// bytes into an image. Other crates reach it through the off-by-default
+/// `test-fixtures` feature; inside this crate `cfg(test)` alone brings it in.
+#[cfg(any(test, feature = "test-fixtures"))]
+#[derive(Debug, Clone)]
+pub struct MemIso {
+    data: Arc<[u8]>,
+}
+
+#[cfg(any(test, feature = "test-fixtures"))]
+impl MemIso {
+    /// Wraps `image` as the reader factory the `.iso` entry points take.
+    #[must_use]
+    pub fn boxed(image: Vec<u8>) -> Box<dyn IsoReader> {
+        Box::new(Self { data: Arc::from(image) })
+    }
+}
+
+#[cfg(any(test, feature = "test-fixtures"))]
+impl IsoReader for MemIso {
+    fn open(&self) -> io::Result<Box<dyn ReadSeek>> {
+        Ok(Box::new(io::Cursor::new(self.data.to_vec())))
     }
 }
 
@@ -1657,11 +1687,11 @@ mod tests {
     use proptest::prelude::{any, prop_assert_eq, proptest};
 
     use super::{
-        BdDir, BdFile, Content, EmbeddedReader, ExtentKind, FileEntry, IsoReader, Limits, Node,
-        NodeKind, PartitionLoc, PathIso, Run, UdfDir, UdfFileReader, UdfInner, UdfSource, Volume,
-        build_tree, collect_extents, directory_bytes, expand_directory, extent_runs, file_body,
-        metadata_runs, metadata_sector, offset_by, parse_volume, read_runs, resolve_partitions,
-        resolve_sector,
+        BdDir, BdFile, Content, EmbeddedReader, ExtentKind, FileEntry, IsoReader, Limits, MemIso,
+        Node, NodeKind, PartitionLoc, PathIso, Run, UdfDir, UdfFileReader, UdfInner, UdfSource,
+        Volume, build_tree, collect_extents, directory_bytes, expand_directory, extent_runs,
+        file_body, metadata_runs, metadata_sector, offset_by, parse_volume, read_runs,
+        resolve_partitions, resolve_sector,
     };
     use crate::error::ScanStage;
     use crate::vfs::SearchOption;
@@ -1936,24 +1966,6 @@ mod tests {
 
         fn into_bytes(self) -> Vec<u8> {
             self.bytes
-        }
-    }
-
-    /// An [`IsoReader`] over an in-memory image (each handle gets its own cursor).
-    #[derive(Debug, Clone)]
-    struct MemIso {
-        data: Arc<[u8]>,
-    }
-
-    impl MemIso {
-        fn boxed(bytes: Vec<u8>) -> Box<dyn IsoReader> {
-            Box::new(Self { data: Arc::from(bytes) })
-        }
-    }
-
-    impl IsoReader for MemIso {
-        fn open(&self) -> std::io::Result<Box<dyn super::ReadSeek>> {
-            Ok(Box::new(std::io::Cursor::new(self.data.to_vec())))
         }
     }
 

--- a/crates/bdinfo-rs-core/src/vfs/udf/source.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/source.rs
@@ -512,14 +512,6 @@ impl BdDir for UdfDir {
         dir_at(&self.inner, pidx).map(|d| -> Box<dyn BdDir> { Box::new(d) })
     }
 
-    fn get_files(&self) -> io::Result<Vec<Box<dyn BdFile>>> {
-        self.get_files_pattern("*")
-    }
-
-    fn get_files_pattern(&self, pattern: &str) -> io::Result<Vec<Box<dyn BdFile>>> {
-        self.get_files_pattern_option(pattern, SearchOption::TopDirectoryOnly)
-    }
-
     fn get_files_pattern_option(
         &self,
         pattern: &str,

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -34,23 +34,22 @@
 //! ## `scan_report` input framing
 //!
 //! [`scan_report`] takes one byte buffer holding up to six `u32` big-endian
-//! length-prefixed sections, assigned in fixed order to the synthetic disc's six
-//! files — `index.bdmv`, `MovieObject.bdmv`, the playlist, the clip, the stream
-//! file, and `META/DL/bdmt_eng.xml`. This mirrors the synthetic tree the
-//! `parse_report` fuzz target builds, widened from `u16` to `u32` so a
-//! real-scale `*.m2ts` stream file (megabytes) fits in a section. A missing or
-//! truncated section leaves its file empty (the resilient-open absence path).
+//! length-prefixed sections, assigned in fixed order to the synthetic disc's
+//! six files — the framing and BDMV layout defined by the core in-memory
+//! backend ([`mem`]), the same framing the `parse_report` fuzz target reads,
+//! so a seed means the same disc to both harnesses. A missing or truncated
+//! section leaves its file empty (the resilient-open absence path).
 
 // `BdmvDir`/`SeekFrom` are named only by the web-path logic and the reader math
 // (`assemble_tree`/`seek_target`) — tested natively, but absent from a native
 // NON-test build, so gate them to where they live to stay dead-code-clean.
-// `Read`/`Seek`/`JsCast`/`JsValue` are named only by the wasm32 browser glue.
+// `BufRead`/`BufReader`/`Read`/`Seek`/`ReadSeek`/`JsCast`/`JsValue` are named
+// only by the wasm32 browser glue.
+use std::io;
 #[cfg(any(target_arch = "wasm32", test))]
 use std::io::SeekFrom;
-use std::io::{self, BufRead, BufReader, Cursor};
 #[cfg(target_arch = "wasm32")]
-use std::io::{Read, Seek};
-use std::sync::Arc;
+use std::io::{BufRead, BufReader, Read, Seek};
 use std::sync::atomic::AtomicBool;
 
 use bdinfo_rs_core::bdrom::disc::{BdRom, ScanMode, ScanProgress, ScanReport};
@@ -61,9 +60,11 @@ use bdinfo_rs_core::bdrom::order::{named_selection, selection_order, selection_s
 use bdinfo_rs_core::discovery::BdmvDir;
 use bdinfo_rs_core::error::BdError;
 use bdinfo_rs_core::report::text::{self, RenderOptions};
+#[cfg(target_arch = "wasm32")]
+use bdinfo_rs_core::vfs::ReadSeek;
 use bdinfo_rs_core::vfs::fs::glob_ci;
 use bdinfo_rs_core::vfs::udf::source::{IsoReader, UdfSource};
-use bdinfo_rs_core::vfs::{BdDir, BdFile, ReadSeek, SearchOption};
+use bdinfo_rs_core::vfs::{BdDir, BdFile, SearchOption, mem};
 use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::{JsCast, JsValue};
@@ -88,9 +89,10 @@ const READ_WINDOW: usize = 1_048_576; // 1 MiB
 /// A node in a synthetic disc tree — a directory holding sub-directories and
 /// files of one concrete [`BdFile`] backend (`F`).
 ///
-/// Both backends ([`MemFile`] in-memory, [`WebFile`] file-backed) read through
-/// this one [`BdDir`] implementation, so the directory walk, glob matching, and
-/// recursion behave identically whatever the bytes are backed by.
+/// Production fills it with the file-backed [`WebFile`]; the native tests
+/// drive the same walk with the core in-memory file ([`mem::MemFile`]), so
+/// the directory walk, glob matching, and recursion behave identically
+/// whatever the bytes are backed by.
 #[derive(Clone)]
 struct Node<F> {
     name: String,
@@ -164,101 +166,11 @@ fn extension_of(name: &str) -> &str {
 
 // ── in-memory backend (the `scan_report` framing path) ──────────────────────
 
-/// An in-memory file node backed by a shared byte buffer.
-#[derive(Clone)]
-struct MemFile {
-    name: String,
-    full: String,
-    data: Arc<[u8]>,
-}
-
-impl BdFile for MemFile {
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn full_name(&self) -> &str {
-        &self.full
-    }
-
-    fn extension(&self) -> &str {
-        extension_of(&self.name)
-    }
-
-    fn length(&self) -> u64 {
-        self.data.len() as u64
-    }
-
-    fn is_dir(&self) -> bool {
-        false
-    }
-
-    fn open_read(&self) -> io::Result<Box<dyn ReadSeek>> {
-        Ok(Box::new(Cursor::new(Arc::clone(&self.data))))
-    }
-
-    fn open_text(&self) -> io::Result<Box<dyn BufRead>> {
-        Ok(Box::new(BufReader::new(Cursor::new(Arc::clone(&self.data)))))
-    }
-}
-
-fn mem_file(dir: &str, name: &str, data: Vec<u8>) -> MemFile {
-    MemFile { name: name.to_owned(), full: format!("{dir}/{name}"), data: Arc::from(data) }
-}
-
-/// Splits `data` into up to six `u32`-BE length-prefixed sections (see the
-/// module-level framing docs). Missing or truncated trailing sections yield
-/// empty buffers.
-fn split_sections(data: &[u8]) -> Vec<Vec<u8>> {
-    let mut sections: Vec<Vec<u8>> = Vec::new();
-    let mut rest = data;
-    while sections.len() < 6 {
-        let Some((len_bytes, tail)) = rest.split_first_chunk::<4>() else { break };
-        let want = u32::from_be_bytes(*len_bytes) as usize;
-        let take = want.min(tail.len());
-        // `take <= tail.len()`, so `split_at` cannot panic. A truncated section
-        // (`take < want`) consumes the rest of the buffer, so the next iteration
-        // finds no further 4-byte prefix and the loop ends — no explicit break.
-        let (head, next) = tail.split_at(take);
-        sections.push(head.to_vec());
-        rest = next;
-    }
-    sections
-}
-
-/// Builds the synthetic in-memory disc tree around the six framed sections.
-fn build_tree(data: &[u8]) -> Node<MemFile> {
-    let mut next = split_sections(data).into_iter();
-    let mut take = || next.next().unwrap_or_default();
-
-    let index = take();
-    let movie_object = take();
-    let mpls = take();
-    let clpi = take();
-    let m2ts = take();
-    let xml = take();
-
-    let mut playlist = Node::dir("PLAYLIST", "WASMDISC/BDMV/PLAYLIST");
-    playlist.files.push(mem_file("WASMDISC/BDMV/PLAYLIST", "00000.mpls", mpls));
-    let mut clipinf = Node::dir("CLIPINF", "WASMDISC/BDMV/CLIPINF");
-    clipinf.files.push(mem_file("WASMDISC/BDMV/CLIPINF", "00000.clpi", clpi));
-    let mut stream = Node::dir("STREAM", "WASMDISC/BDMV/STREAM");
-    stream.files.push(mem_file("WASMDISC/BDMV/STREAM", "00000.m2ts", m2ts));
-    let mut dl = Node::dir("DL", "WASMDISC/BDMV/META/DL");
-    dl.files.push(mem_file("WASMDISC/BDMV/META/DL", "bdmt_eng.xml", xml));
-    let mut meta = Node::dir("META", "WASMDISC/BDMV/META");
-    meta.dirs.push(dl);
-
-    let mut bdmv = Node::dir("BDMV", "WASMDISC/BDMV");
-    bdmv.dirs = vec![playlist, clipinf, stream, meta];
-    bdmv.files = vec![
-        mem_file("WASMDISC/BDMV", "index.bdmv", index),
-        mem_file("WASMDISC/BDMV", "MovieObject.bdmv", movie_object),
-    ];
-
-    let mut root = Node::dir("WASMDISC", "WASMDISC");
-    root.dirs.push(bdmv);
-    root
+/// The framed synthetic tree [`scan_report`] scans: the shared six-section
+/// framing and BDMV layout of the core in-memory backend ([`mem`]), built
+/// under the `WASMDISC` root the goldens pin.
+fn framed_tree(data: &[u8]) -> mem::MemDir {
+    mem::build_tree("WASMDISC", mem::split_sections(data, mem::SECTION_COUNT))
 }
 
 // ── file-backed backend (the `scan_files` FileReaderSync path) ──────────────
@@ -920,7 +832,7 @@ fn notify(callback: Option<&js_sys::Function>, progress: &ScanProgress<'_>) {
 /// absence path the `parse_report` fuzz target and the parity test expect.
 #[must_use]
 pub fn run_report(data: &[u8]) -> String {
-    render_disc(&build_tree(data), RenderOptions::default(), &mut |_| {}).unwrap_or_default()
+    render_disc(&framed_tree(data), RenderOptions::default(), &mut |_| {}).unwrap_or_default()
 }
 
 /// Opens `reader` as a UDF `.iso` and renders the whole-disc report.
@@ -1140,15 +1052,30 @@ pub fn scan_iso(
 mod tests {
     use std::io::{self, SeekFrom};
 
+    use bdinfo_rs_core::vfs::mem::MemFile;
+
     use super::{
-        MAX_TREE_DEPTH, RenderOptions, TreeError, assemble_tree, extension_of, path_components,
-        read_window, seek_target, split_sections,
+        MAX_TREE_DEPTH, RenderOptions, TreeError, assemble_tree, extension_of, framed_tree,
+        path_components, read_window, seek_target,
     };
 
     /// Parses path strings into the `(components, id)` entries `assemble_tree`
     /// takes, tagging each file with its index so placement stays checkable.
     fn entries<'a>(paths: &[&'a str]) -> Vec<(Vec<&'a str>, usize)> {
         paths.iter().enumerate().map(|(i, path)| (path_components(path), i)).collect()
+    }
+
+    /// Builds the `(components, MemFile)` entries `assemble_tree` takes from
+    /// `(path, bytes)` pairs, deriving each file's name and parent directory
+    /// from its path.
+    fn mem_entries<'a>(files: &[(&'a str, &[u8])]) -> Vec<(Vec<&'a str>, MemFile)> {
+        files
+            .iter()
+            .map(|&(path, data)| {
+                let (dir, name) = path.rsplit_once('/').expect("a file path has a directory");
+                (path_components(path), MemFile::new(dir, name, data.to_vec()))
+            })
+            .collect()
     }
 
     /// The committed Big Buck Bunny fixture framed into the six `u32`-BE sections
@@ -1173,19 +1100,6 @@ mod tests {
             blob.extend_from_slice(section);
         }
         blob
-    }
-
-    #[test]
-    fn split_sections_frames_up_to_six_and_stops_on_truncation() {
-        // Two whole one-byte sections.
-        assert_eq!(split_sections(&[0, 0, 0, 1, b'A', 0, 0, 0, 1, b'B']), [vec![b'A'], vec![b'B']]);
-        // A length that overruns truncates to what is present, then stops.
-        assert_eq!(split_sections(&[0, 0, 0, 4, b'X', b'Y']), [vec![b'X', b'Y']]);
-        // No 4-byte length prefix at all yields no sections.
-        assert!(split_sections(&[0, 0]).is_empty());
-        // Never more than six sections, even with more length-prefixed data.
-        let many: Vec<u8> = std::iter::repeat_n(0_u8, 4 * 8).collect();
-        assert_eq!(split_sections(&many).len(), 6);
     }
 
     #[test]
@@ -1268,9 +1182,7 @@ mod tests {
 
     #[test]
     fn a_bdmv_rooted_selection_renders_like_the_canonical_framing() {
-        use std::sync::Arc;
-
-        use super::{MemFile, build_tree, render_disc};
+        use super::render_disc;
 
         // The committed fixture's files — the same bytes the parity golden is
         // built from.
@@ -1288,31 +1200,22 @@ mod tests {
         // The canonical in-memory framing (`WASMDISC`-rooted) the golden pins.
         let mut blob = Vec::new();
         for section in [INDEX, MOVIE, MPLS, CLPI, M2TS, [].as_slice()] {
-            blob.extend_from_slice(&(section.len() as u32).to_be_bytes());
+            let len = u32::try_from(section.len()).expect("fixture sections are < 2^32 bytes");
+            blob.extend_from_slice(&len.to_be_bytes());
             blob.extend_from_slice(section);
         }
-        let framed = render_disc(&build_tree(&blob), RenderOptions::default(), &mut |_| {})
+        let framed = render_disc(&framed_tree(&blob), RenderOptions::default(), &mut |_| {})
             .expect("framed render");
 
         // The same disc handed over as a `webkitdirectory` pick of the BDMV
         // folder itself: the wrapper root makes it render identically.
-        let picked: [(&str, &[u8]); 5] = [
+        let tree = assemble_tree(mem_entries(&[
             ("BDMV/index.bdmv", INDEX),
             ("BDMV/MovieObject.bdmv", MOVIE),
             ("BDMV/PLAYLIST/00000.mpls", MPLS),
             ("BDMV/CLIPINF/00000.clpi", CLPI),
             ("BDMV/STREAM/00000.m2ts", M2TS),
-        ];
-        let tree = assemble_tree(
-            picked
-                .iter()
-                .map(|(path, data)| {
-                    let comps = path_components(path);
-                    let name = (*comps.last().expect("a file name")).to_owned();
-                    (comps, MemFile { name, full: (*path).to_owned(), data: Arc::from(*data) })
-                })
-                .collect(),
-        )
+        ]))
         .expect("assemble the BDMV-rooted selection");
         let from_bdmv =
             render_disc(&tree, RenderOptions::default(), &mut |_| {}).expect("BDMV-rooted render");
@@ -1322,9 +1225,7 @@ mod tests {
 
     #[test]
     fn the_render_drops_a_short_playlist_like_whole() {
-        use std::sync::Arc;
-
-        use super::{MemFile, render_disc};
+        use super::render_disc;
 
         const INDEX: &[u8] =
             include_bytes!("../../bdinfo-rs/tests/fixtures/BigBuckBunny/BDMV/index.bdmv");
@@ -1346,27 +1247,14 @@ mod tests {
             .expect("the fixture playlist has an OUT_time at offset 86")
             .copy_from_slice(&(27_000_000_u32 + 45_000 * 10).to_be_bytes());
 
-        let files: [(&str, Vec<u8>); 6] = [
-            ("DISC/BDMV/index.bdmv", INDEX.to_vec()),
-            ("DISC/BDMV/MovieObject.bdmv", MOVIE.to_vec()),
-            ("DISC/BDMV/PLAYLIST/00000.mpls", MPLS.to_vec()),
-            ("DISC/BDMV/PLAYLIST/00001.mpls", short),
-            ("DISC/BDMV/CLIPINF/00000.clpi", CLPI.to_vec()),
-            ("DISC/BDMV/STREAM/00000.m2ts", M2TS.to_vec()),
-        ];
-        let tree = assemble_tree(
-            files
-                .iter()
-                .map(|(path, data)| {
-                    let comps = path_components(path);
-                    let name = (*comps.last().expect("a file name")).to_owned();
-                    (
-                        comps,
-                        MemFile { name, full: (*path).to_owned(), data: Arc::from(data.clone()) },
-                    )
-                })
-                .collect(),
-        )
+        let tree = assemble_tree(mem_entries(&[
+            ("DISC/BDMV/index.bdmv", INDEX),
+            ("DISC/BDMV/MovieObject.bdmv", MOVIE),
+            ("DISC/BDMV/PLAYLIST/00000.mpls", MPLS),
+            ("DISC/BDMV/PLAYLIST/00001.mpls", &short),
+            ("DISC/BDMV/CLIPINF/00000.clpi", CLPI),
+            ("DISC/BDMV/STREAM/00000.m2ts", M2TS),
+        ]))
         .expect("assemble the two-playlist disc");
         let report = render_disc(&tree, RenderOptions::default(), &mut |_| {}).expect("render");
 
@@ -1408,41 +1296,15 @@ mod tests {
     }
 
     #[test]
-    fn mem_file_exposes_metadata_and_reads_as_bytes_and_text() {
-        use std::io::Read;
-
-        use bdinfo_rs_core::vfs::BdFile;
-
-        use super::mem_file;
-
-        // The scan reaches MemFile only through `open_read`; `full_name`,
-        // `is_dir`, and `open_text` are off the render path, so cover them here.
-        let file = mem_file("WASMDISC/BDMV", "index.bdmv", b"hello".to_vec());
-        assert_eq!(file.name(), "index.bdmv");
-        assert_eq!(file.full_name(), "WASMDISC/BDMV/index.bdmv");
-        assert_eq!(file.extension(), ".bdmv");
-        assert_eq!(file.length(), 5);
-        assert!(!file.is_dir());
-
-        let mut bytes = Vec::new();
-        file.open_read().expect("open_read").read_to_end(&mut bytes).expect("read bytes");
-        assert_eq!(bytes, b"hello");
-
-        let mut text = String::new();
-        file.open_text().expect("open_text").read_to_string(&mut text).expect("read text");
-        assert_eq!(text, "hello");
-    }
-
-    #[test]
     fn node_walk_matches_patterns_with_and_without_recursion() {
         use bdinfo_rs_core::vfs::{BdDir, SearchOption};
 
-        use super::{Node, mem_file};
+        use super::Node;
 
         let mut stream = Node::dir("STREAM", "DISC/BDMV/STREAM");
-        stream.files.push(mem_file("DISC/BDMV/STREAM", "00000.m2ts", vec![0_u8; 4]));
+        stream.files.push(MemFile::new("DISC/BDMV/STREAM", "00000.m2ts", vec![0_u8; 4]));
         let mut root = Node::dir("BDMV", "DISC/BDMV");
-        root.files.push(mem_file("DISC/BDMV", "index.bdmv", vec![0_u8; 2]));
+        root.files.push(MemFile::new("DISC/BDMV", "index.bdmv", vec![0_u8; 2]));
         root.dirs.push(stream);
 
         assert_eq!(root.name(), "BDMV");
@@ -1468,7 +1330,7 @@ mod tests {
     fn render_disc_renders_then_errors_without_bdmv() {
         use bdinfo_rs_core::bdrom::disc::ScanProgress;
 
-        use super::{MemFile, Node, build_tree, render_disc};
+        use super::{Node, render_disc};
 
         // One progress sink — a fn pointer, so it is generic over the progress
         // lifetime (a shared closure would pin it and fail to type-check across
@@ -1476,7 +1338,7 @@ mod tests {
         // unopenable tree (no BDMV/CLIPINF/PLAYLIST) then makes render_disc hit
         // the `?` early-return, the arm the parity `Ok` flow never reaches.
         let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
-        render_disc(&build_tree(&fixture_blob()), RenderOptions::default(), &mut sink)
+        render_disc(&framed_tree(&fixture_blob()), RenderOptions::default(), &mut sink)
             .expect("the fixture opens");
         let empty: Node<MemFile> = Node::dir("EMPTY", "EMPTY");
         assert!(render_disc(&empty, RenderOptions::default(), &mut sink).is_err());
@@ -1486,14 +1348,14 @@ mod tests {
     fn one_measured_scan_yields_both_the_report_and_the_disc() {
         use bdinfo_rs_core::bdrom::disc::ScanProgress;
 
-        use super::{build_tree, measured_result, scan_whole};
+        use super::{measured_result, scan_whole};
 
         /// The pinned report for the fixture disc — what the report-only
         /// exports render from the same scan.
         const GOLDEN: &[u8] = include_bytes!("../tests/golden_report.txt");
 
         let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
-        let scan = scan_whole(&build_tree(&fixture_blob()), &mut sink).expect("the fixture opens");
+        let scan = scan_whole(&framed_tree(&fixture_blob()), &mut sink).expect("the fixture opens");
         // One scan, both outputs: the report is the pinned bytes and the disc
         // is the same scan mirrored, neither derived from the other.
         let result =
@@ -1530,9 +1392,9 @@ mod tests {
         use super::run_iso_report;
 
         /// A trivially `Send + Sync` in-memory [`IsoReader`] over a shared byte
-        /// buffer — the `.iso` analogue of `MemFile`, proving the UDF-reader →
-        /// report wiring with no `web_sys` (the browser `WebIso` is irreducible
-        /// glue, held by the parity tests instead).
+        /// buffer — the `.iso` analogue of the in-memory file backend, proving
+        /// the UDF-reader → report wiring with no `web_sys` (the browser
+        /// `WebIso` is irreducible glue, held by the parity tests instead).
         #[derive(Debug)]
         struct MemIso(Arc<[u8]>);
         impl IsoReader for MemIso {
@@ -1704,12 +1566,12 @@ mod tests {
 
         #[test]
         fn scan_selection_measures_only_the_named_playlists() {
-            use std::sync::Arc;
-
             use bdinfo_rs_core::bdrom::disc::ScanProgress;
             use bdinfo_rs_core::report::text::RenderOptions;
+            use bdinfo_rs_core::vfs::mem::MemFile;
 
-            use crate::{MemFile, Node, assemble_tree, path_components, scan_selection};
+            use super::mem_entries;
+            use crate::{Node, assemble_tree, scan_selection};
 
             const INDEX: &[u8] =
                 include_bytes!("../../bdinfo-rs/tests/fixtures/BigBuckBunny/BDMV/index.bdmv");
@@ -1733,31 +1595,14 @@ mod tests {
                 .expect("the fixture playlist has an OUT_time at offset 86")
                 .copy_from_slice(&(27_000_000_u32 + 45_000 * 10).to_be_bytes());
 
-            let files: [(&str, Vec<u8>); 6] = [
-                ("DISC/BDMV/index.bdmv", INDEX.to_vec()),
-                ("DISC/BDMV/MovieObject.bdmv", MOVIE.to_vec()),
-                ("DISC/BDMV/PLAYLIST/00000.mpls", MPLS.to_vec()),
-                ("DISC/BDMV/PLAYLIST/00001.mpls", short),
-                ("DISC/BDMV/CLIPINF/00000.clpi", CLPI.to_vec()),
-                ("DISC/BDMV/STREAM/00000.m2ts", M2TS.to_vec()),
-            ];
-            let tree = assemble_tree(
-                files
-                    .iter()
-                    .map(|(path, data)| {
-                        let comps = path_components(path);
-                        let name = (*comps.last().expect("a file name")).to_owned();
-                        (
-                            comps,
-                            MemFile {
-                                name,
-                                full: (*path).to_owned(),
-                                data: Arc::from(data.clone()),
-                            },
-                        )
-                    })
-                    .collect(),
-            )
+            let tree = assemble_tree(mem_entries(&[
+                ("DISC/BDMV/index.bdmv", INDEX),
+                ("DISC/BDMV/MovieObject.bdmv", MOVIE),
+                ("DISC/BDMV/PLAYLIST/00000.mpls", MPLS),
+                ("DISC/BDMV/PLAYLIST/00001.mpls", &short),
+                ("DISC/BDMV/CLIPINF/00000.clpi", CLPI),
+                ("DISC/BDMV/STREAM/00000.m2ts", M2TS),
+            ]))
             .expect("assemble the two-playlist disc");
 
             // One progress sink for every call — a fn pointer so it is generic

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -44,7 +44,8 @@
 // the web-path logic and the reader math (`Node`/`assemble_tree`/`seek_target`)
 // — tested natively, but absent from a native NON-test build, so gate them to
 // where they live to stay dead-code-clean. `BufRead`/`BufReader`/`Read`/`Seek`/
-// `ReadSeek`/`JsCast`/`JsValue` are named only by the wasm32 browser glue.
+// `ReadSeek`/`extension_of_name`/`JsCast`/`JsValue` are named only by the wasm32
+// browser glue.
 #[cfg(any(target_arch = "wasm32", test))]
 use std::io::{self, SeekFrom};
 #[cfg(target_arch = "wasm32")]
@@ -59,14 +60,14 @@ use bdinfo_rs_core::bdrom::order::{named_selection, selection_order, selection_s
 use bdinfo_rs_core::discovery::BdmvDir;
 use bdinfo_rs_core::error::BdError;
 use bdinfo_rs_core::report::text::{self, RenderOptions};
-#[cfg(target_arch = "wasm32")]
-use bdinfo_rs_core::vfs::ReadSeek;
 #[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::vfs::fs::glob_ci;
 use bdinfo_rs_core::vfs::udf::source::{IsoReader, UdfSource};
 use bdinfo_rs_core::vfs::{BdDir, mem};
 #[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::vfs::{BdFile, SearchOption};
+#[cfg(target_arch = "wasm32")]
+use bdinfo_rs_core::vfs::{ReadSeek, extension_of_name};
 use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::{JsCast, JsValue};
@@ -155,16 +156,6 @@ impl<F: BdFile + Clone + 'static> BdDir for Node<F> {
     fn get_directories(&self) -> io::Result<Vec<Box<dyn BdDir>>> {
         Ok(self.dirs.iter().map(|d| Box::new(d.clone()) as Box<dyn BdDir>).collect())
     }
-}
-
-/// The extension *including* the leading dot, e.g. `.mpls`; the empty string
-/// when the name has no `.`.
-///
-/// Named only by [`WebFile::extension`] and its native test — the same
-/// `cfg(any(wasm32, test))` gate as the rest of the browser glue's helpers.
-#[cfg(any(target_arch = "wasm32", test))]
-fn extension_of(name: &str) -> &str {
-    name.rfind('.').and_then(|i| name.get(i..)).unwrap_or("")
 }
 
 // ── in-memory backend (the `scan_report` framing path) ──────────────────────
@@ -289,12 +280,17 @@ impl Seek for WebReader {
 
 /// A file backed by a browser `File` handle — the [`BdFile`] backend for the
 /// `webkitdirectory` streaming path. Bytes are read on demand through
-/// [`WebReader`]; only metadata (name, full path, length) is held eagerly.
+/// [`WebReader`]; only metadata (name, full path, extension, length) is held
+/// eagerly.
 #[cfg(target_arch = "wasm32")]
 #[derive(Clone)]
 struct WebFile {
     name: String,
     full: String,
+    /// Derived once at construction by the core seam's `extension_of_name`, the
+    /// rule every backend shares, and borrowed by [`BdFile::extension`] — which
+    /// returns a `&str`, so the owned `String` has to be stored.
+    extension: String,
     file: web_sys::File,
     length: u64,
 }
@@ -360,7 +356,7 @@ impl BdFile for WebFile {
     }
 
     fn extension(&self) -> &str {
-        extension_of(&self.name)
+        &self.extension
     }
 
     fn length(&self) -> u64 {
@@ -583,7 +579,13 @@ fn build_web_tree(paths: &[String], files: &js_sys::Array) -> Result<Node<WebFil
         let file: web_sys::File =
             value.dyn_into().map_err(|_| JsValue::from_str("entry is not a File"))?;
         let length = file.size() as u64;
-        let web_file = WebFile { name: name.to_owned(), full: path.clone(), file, length };
+        let web_file = WebFile {
+            name: name.to_owned(),
+            full: path.clone(),
+            extension: extension_of_name(name),
+            file,
+            length,
+        };
         entries.push((comps, web_file));
     }
 
@@ -1058,8 +1060,8 @@ mod tests {
     use bdinfo_rs_core::vfs::mem::MemFile;
 
     use super::{
-        MAX_TREE_DEPTH, RenderOptions, TreeError, assemble_tree, extension_of, framed_tree,
-        path_components, read_window, seek_target,
+        MAX_TREE_DEPTH, RenderOptions, TreeError, assemble_tree, framed_tree, path_components,
+        read_window, seek_target,
     };
 
     /// Parses path strings into the `(components, id)` entries `assemble_tree`
@@ -1111,14 +1113,6 @@ mod tests {
         assert_eq!(path_components("BDMV\\STREAM\\00000.m2ts"), ["BDMV", "STREAM", "00000.m2ts"]);
         assert_eq!(path_components("//a///b//"), ["a", "b"]);
         assert!(path_components("").is_empty());
-    }
-
-    #[test]
-    fn extension_of_returns_the_dotted_suffix_or_empty() {
-        assert_eq!(extension_of("00000.mpls"), ".mpls");
-        assert_eq!(extension_of("archive.tar.gz"), ".gz");
-        assert_eq!(extension_of("noext"), "");
-        assert_eq!(extension_of(".hidden"), ".hidden");
     }
 
     #[test]

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -142,14 +142,6 @@ impl<F: BdFile + Clone + 'static> BdDir for Node<F> {
         None
     }
 
-    fn get_files(&self) -> io::Result<Vec<Box<dyn BdFile>>> {
-        Ok(self.files.iter().map(|f| Box::new(f.clone()) as Box<dyn BdFile>).collect())
-    }
-
-    fn get_files_pattern(&self, pattern: &str) -> io::Result<Vec<Box<dyn BdFile>>> {
-        self.get_files_pattern_option(pattern, SearchOption::TopDirectoryOnly)
-    }
-
     fn get_files_pattern_option(
         &self,
         pattern: &str,

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -40,14 +40,13 @@
 //! so a seed means the same disc to both harnesses. A missing or truncated
 //! section leaves its file empty (the resilient-open absence path).
 
-// `BdmvDir`/`SeekFrom` are named only by the web-path logic and the reader math
-// (`assemble_tree`/`seek_target`) — tested natively, but absent from a native
-// NON-test build, so gate them to where they live to stay dead-code-clean.
-// `BufRead`/`BufReader`/`Read`/`Seek`/`ReadSeek`/`JsCast`/`JsValue` are named
-// only by the wasm32 browser glue.
-use std::io;
+// `BdmvDir`/`SeekFrom`/`io`/`glob_ci`/`BdFile`/`SearchOption` are named only by
+// the web-path logic and the reader math (`Node`/`assemble_tree`/`seek_target`)
+// — tested natively, but absent from a native NON-test build, so gate them to
+// where they live to stay dead-code-clean. `BufRead`/`BufReader`/`Read`/`Seek`/
+// `ReadSeek`/`JsCast`/`JsValue` are named only by the wasm32 browser glue.
 #[cfg(any(target_arch = "wasm32", test))]
-use std::io::SeekFrom;
+use std::io::{self, SeekFrom};
 #[cfg(target_arch = "wasm32")]
 use std::io::{BufRead, BufReader, Read, Seek};
 use std::sync::atomic::AtomicBool;
@@ -62,9 +61,12 @@ use bdinfo_rs_core::error::BdError;
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 #[cfg(target_arch = "wasm32")]
 use bdinfo_rs_core::vfs::ReadSeek;
+#[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::vfs::fs::glob_ci;
 use bdinfo_rs_core::vfs::udf::source::{IsoReader, UdfSource};
-use bdinfo_rs_core::vfs::{BdDir, BdFile, SearchOption, mem};
+use bdinfo_rs_core::vfs::{BdDir, mem};
+#[cfg(any(target_arch = "wasm32", test))]
+use bdinfo_rs_core::vfs::{BdFile, SearchOption};
 use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::{JsCast, JsValue};
@@ -92,7 +94,9 @@ const READ_WINDOW: usize = 1_048_576; // 1 MiB
 /// Production fills it with the file-backed [`WebFile`]; the native tests
 /// drive the same walk with the core in-memory file ([`mem::MemFile`]), so
 /// the directory walk, glob matching, and recursion behave identically
-/// whatever the bytes are backed by.
+/// whatever the bytes are backed by — hence the same
+/// `cfg(any(wasm32, test))` gate as the rest of the web-path logic.
+#[cfg(any(target_arch = "wasm32", test))]
 #[derive(Clone)]
 struct Node<F> {
     name: String,
@@ -101,12 +105,14 @@ struct Node<F> {
     files: Vec<F>,
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 impl<F> Node<F> {
     fn dir(name: &str, full: &str) -> Self {
         Self { name: name.to_owned(), full: full.to_owned(), dirs: Vec::new(), files: Vec::new() }
     }
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 impl<F: BdFile + Clone + 'static> Node<F> {
     fn collect_pattern(&self, pattern: &str, recurse: bool, out: &mut Vec<Box<dyn BdFile>>) {
         for f in &self.files {
@@ -122,6 +128,7 @@ impl<F: BdFile + Clone + 'static> Node<F> {
     }
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 impl<F: BdFile + Clone + 'static> BdDir for Node<F> {
     fn name(&self) -> &str {
         &self.name
@@ -160,6 +167,10 @@ impl<F: BdFile + Clone + 'static> BdDir for Node<F> {
 
 /// The extension *including* the leading dot, e.g. `.mpls`; the empty string
 /// when the name has no `.`.
+///
+/// Named only by [`WebFile::extension`] and its native test — the same
+/// `cfg(any(wasm32, test))` gate as the rest of the browser glue's helpers.
+#[cfg(any(target_arch = "wasm32", test))]
 fn extension_of(name: &str) -> &str {
     name.rfind('.').and_then(|i| name.get(i..)).unwrap_or("")
 }

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -1510,7 +1510,7 @@ mod tests {
     /// The fixture disc scanned through the in-memory tree, mirrored under the
     /// standard 20 s classification.
     fn a_fixture_disc(mode: ScanMode) -> Disc {
-        let tree = crate::build_tree(&crate::tests::fixture_blob());
+        let tree = crate::framed_tree(&crate::tests::fixture_blob());
         let report = BdRom::open_resilient(&tree, mode).expect("the fixture disc opens");
         Disc::from_scan(
             &report.bdrom,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,11 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-bdinfo-rs-core = { path = "../crates/bdinfo-rs-core" }
+# `test-fixtures` is what publishes `vfs::udf::source::MemIso`, the buffer-backed
+# `IsoReader` the two `.iso` targets hand their built images to. Declared here
+# because a feature is a package-level property: nothing else in this graph asks
+# for it, and a dependency that did could stop at any time.
+bdinfo-rs-core = { path = "../crates/bdinfo-rs-core", features = ["test-fixtures"] }
 # The browser package's own entry points. `run_report` / `run_iso_report` and
 # the `mirror::Disc` model are not `cfg(target_arch = "wasm32")`-gated, so a
 # native build reaches them; the six `#[wasm_bindgen]` exports around them are

--- a/fuzz/fuzz_targets/parse_report.rs
+++ b/fuzz/fuzz_targets/parse_report.rs
@@ -1,225 +1,42 @@
 #![no_main]
 //! End-to-end fuzz target: the whole `BdRom` pipeline plus the report renderer.
 //!
-//! The input bytes become a synthetic in-memory BDMV tree — `index.bdmv`,
-//! `MovieObject.bdmv`, a playlist, a clip, a stream file, and
-//! `META/DL/bdmt_eng.xml` (the roxmltree input — the one third-party parser fed
-//! disc bytes) — which is opened resiliently, packet-scanned, and rendered to
-//! the classic report. This holds the library's whole-pipeline no-panic /
-//! no-hang contract on hostile discs, end to end: discovery → index → MPLS /
-//! CLPI → M2TS demux → measured summaries → `report::text::render`.
+//! The input bytes become a synthetic in-memory BDMV tree through
+//! `bdinfo_rs_core::vfs::mem` — the `u32`-BE section framing and the six-file
+//! skeleton it lays them onto, documented there. The tree is opened resiliently,
+//! packet-scanned, and rendered to the classic report. This holds the library's
+//! whole-pipeline no-panic / no-hang contract on hostile discs, end to end:
+//! discovery → index → MPLS / CLPI → M2TS demux → measured summaries →
+//! `report::text::render`.
 //!
-//! Input framing: a sequence of `u32` big-endian length-prefixed sections,
-//! assigned in fixed order to the six files above and then to a seventh,
-//! `STREAM/SSIF/00000.ssif`; missing sections leave the file absent (exercising
-//! the resilient-open absence paths too).
+//! That framing is the one `bdinfo-rs-wasm`'s `scan_report` export reads, so a
+//! seed means the same disc to both harnesses and neither has to carry its own
+//! corpus dialect.
 //!
-//! The width is `u32` to match the framing `bdinfo-rs-wasm`'s `scan_report`
-//! export reads, so a seed means the same six files to both harnesses and
-//! neither has to carry its own corpus dialect. It also lifts the 65,535-byte
-//! per-section ceiling a `u16` prefix imposes, which is what a megabyte-scale
-//! `*.m2ts` section needs to be expressible at all.
-//!
-//! The seventh section is this target's own extension: the browser export reads
-//! six and ignores anything past them, so seeds stay portable in both
-//! directions. It exists because a `BDMV/STREAM/SSIF` directory is what makes a
-//! disc 3D, and with no way to express one the interleaved-stream handling and
-//! every `is_3d` branch behind it were unreachable from this harness. Absent
-//! when the seed supplies no seventh section, so the 2D shape is unchanged.
-
-use std::io::{self, BufRead, BufReader, Cursor};
-use std::sync::Arc;
+//! This target extends it by one section: a seventh becomes
+//! `BDMV/STREAM/SSIF/00000.ssif`. The browser export reads six and ignores
+//! anything past them, so seeds stay portable in both directions. It exists
+//! because a `BDMV/STREAM/SSIF` directory is what makes a disc 3D, and with no
+//! way to express one the interleaved-stream handling and every `is_3d` branch
+//! behind it were unreachable from this harness. The directory is absent when
+//! the seed supplies no seventh section, so the 2D shape is unchanged.
 
 use bdinfo_rs_core::bdrom::disc::{BdRom, ScanMode};
 use bdinfo_rs_core::report::text;
-use bdinfo_rs_core::vfs::fs::glob_ci;
-use bdinfo_rs_core::vfs::{BdDir, BdFile, ReadSeek, SearchOption};
+use bdinfo_rs_core::vfs::mem::{self, MemDir};
 use libfuzzer_sys::fuzz_target;
 
-/// An in-memory file node.
-#[derive(Clone)]
-struct MemFile {
-    name: String,
-    full: String,
-    data: Arc<Vec<u8>>,
-}
-
-impl BdFile for MemFile {
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn full_name(&self) -> &str {
-        &self.full
-    }
-
-    fn extension(&self) -> &str {
-        self.name.rfind('.').map_or("", |i| &self.name[i..])
-    }
-
-    fn length(&self) -> u64 {
-        self.data.len() as u64
-    }
-
-    fn is_dir(&self) -> bool {
-        false
-    }
-
-    fn open_read(&self) -> io::Result<Box<dyn ReadSeek>> {
-        Ok(Box::new(Cursor::new(self.data.as_ref().clone())))
-    }
-
-    fn open_text(&self) -> io::Result<Box<dyn BufRead>> {
-        Ok(Box::new(BufReader::new(Cursor::new(self.data.as_ref().clone()))))
-    }
-}
-
-/// An in-memory directory node.
-#[derive(Clone, Default)]
-struct MemDir {
-    name: String,
-    full: String,
-    dirs: Vec<MemDir>,
-    files: Vec<MemFile>,
-}
-
-impl MemDir {
-    fn collect_pattern(&self, pattern: &str, recurse: bool, out: &mut Vec<Box<dyn BdFile>>) {
-        for f in &self.files {
-            if glob_ci(pattern.as_bytes(), f.name.as_bytes()) {
-                out.push(Box::new(f.clone()));
-            }
-        }
-        if recurse {
-            for d in &self.dirs {
-                d.collect_pattern(pattern, recurse, out);
-            }
-        }
-    }
-}
-
-impl BdDir for MemDir {
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn full_name(&self) -> &str {
-        &self.full
-    }
-
-    fn parent(&self) -> Option<Box<dyn BdDir>> {
-        None
-    }
-
-    fn get_files(&self) -> io::Result<Vec<Box<dyn BdFile>>> {
-        Ok(self.files.iter().map(|f| Box::new(f.clone()) as Box<dyn BdFile>).collect())
-    }
-
-    fn get_files_pattern(&self, pattern: &str) -> io::Result<Vec<Box<dyn BdFile>>> {
-        self.get_files_pattern_option(pattern, SearchOption::TopDirectoryOnly)
-    }
-
-    fn get_files_pattern_option(
-        &self,
-        pattern: &str,
-        option: SearchOption,
-    ) -> io::Result<Vec<Box<dyn BdFile>>> {
-        let mut out = Vec::new();
-        self.collect_pattern(pattern, option == SearchOption::AllDirectories, &mut out);
-        Ok(out)
-    }
-
-    fn get_directories(&self) -> io::Result<Vec<Box<dyn BdDir>>> {
-        Ok(self.dirs.iter().map(|d| Box::new(d.clone()) as Box<dyn BdDir>).collect())
-    }
-}
-
-fn file(dir: &str, name: &str, data: Vec<u8>) -> MemFile {
-    MemFile { name: name.to_owned(), full: format!("{dir}/{name}"), data: Arc::new(data) }
-}
-
-/// Splits `data` into up to seven `u32`-BE length-prefixed sections and builds
-/// the synthetic disc tree around them.
+/// Builds the synthetic disc `data` describes (see the module docs).
 fn build_tree(data: &[u8]) -> MemDir {
-    let mut sections: Vec<Vec<u8>> = Vec::new();
-    let mut rest = data;
-    while sections.len() < 7 {
-        let Some((len_bytes, tail)) = rest.split_first_chunk::<4>() else { break };
-        let want = u32::from_be_bytes(*len_bytes) as usize;
-        let take = want.min(tail.len());
-        sections.push(tail[..take].to_vec());
-        rest = &tail[take..];
-        if take < want {
-            break;
-        }
+    let mut sections = mem::split_sections(data, mem::SECTION_COUNT + 1);
+    // The seventh section comes off before the skeleton is laid: `build_tree`
+    // consumes the vec and ignores anything past `SECTION_COUNT`.
+    let ssif = (sections.len() > mem::SECTION_COUNT).then(|| sections.remove(mem::SECTION_COUNT));
+    let mut root = mem::build_tree("FUZZDISC", sections);
+    if let Some(bytes) = ssif {
+        root.add_file(&["BDMV", "STREAM", "SSIF"], "00000.ssif", bytes);
     }
-    let mut next = sections.into_iter();
-    let mut take = || next.next().unwrap_or_default();
-
-    let index = take();
-    let movie_object = take();
-    let mpls = take();
-    let clpi = take();
-    let m2ts = take();
-    let xml = take();
-    let ssif = next.next();
-
-    let playlist = MemDir {
-        name: "PLAYLIST".to_owned(),
-        full: "FUZZDISC/BDMV/PLAYLIST".to_owned(),
-        files: vec![file("FUZZDISC/BDMV/PLAYLIST", "00000.mpls", mpls)],
-        ..MemDir::default()
-    };
-    let clipinf = MemDir {
-        name: "CLIPINF".to_owned(),
-        full: "FUZZDISC/BDMV/CLIPINF".to_owned(),
-        files: vec![file("FUZZDISC/BDMV/CLIPINF", "00000.clpi", clpi)],
-        ..MemDir::default()
-    };
-    // A `STREAM/SSIF` directory holding a file is what marks the disc 3D, so the
-    // directory exists only when the seed supplied a seventh section.
-    let ssif_dirs = ssif.map_or_else(Vec::new, |bytes| {
-        vec![MemDir {
-            name: "SSIF".to_owned(),
-            full: "FUZZDISC/BDMV/STREAM/SSIF".to_owned(),
-            files: vec![file("FUZZDISC/BDMV/STREAM/SSIF", "00000.ssif", bytes)],
-            ..MemDir::default()
-        }]
-    });
-    let stream = MemDir {
-        name: "STREAM".to_owned(),
-        full: "FUZZDISC/BDMV/STREAM".to_owned(),
-        dirs: ssif_dirs,
-        files: vec![file("FUZZDISC/BDMV/STREAM", "00000.m2ts", m2ts)],
-        ..MemDir::default()
-    };
-    let dl = MemDir {
-        name: "DL".to_owned(),
-        full: "FUZZDISC/BDMV/META/DL".to_owned(),
-        files: vec![file("FUZZDISC/BDMV/META/DL", "bdmt_eng.xml", xml)],
-        ..MemDir::default()
-    };
-    let meta = MemDir {
-        name: "META".to_owned(),
-        full: "FUZZDISC/BDMV/META".to_owned(),
-        dirs: vec![dl],
-        ..MemDir::default()
-    };
-    let bdmv = MemDir {
-        name: "BDMV".to_owned(),
-        full: "FUZZDISC/BDMV".to_owned(),
-        dirs: vec![playlist, clipinf, stream, meta],
-        files: vec![
-            file("FUZZDISC/BDMV", "index.bdmv", index),
-            file("FUZZDISC/BDMV", "MovieObject.bdmv", movie_object),
-        ],
-    };
-    MemDir {
-        name: "FUZZDISC".to_owned(),
-        full: "FUZZDISC".to_owned(),
-        dirs: vec![bdmv],
-        ..MemDir::default()
-    }
+    root
 }
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/shared/sparse_iso.rs
+++ b/fuzz/fuzz_targets/shared/sparse_iso.rs
@@ -15,12 +15,6 @@
 //! descriptor content or its placement, and none of it is the zero padding a
 //! whole-image framing must carry to reach the anchor at all.
 
-use std::io::{self, Cursor};
-use std::sync::Arc;
-
-use bdinfo_rs_core::vfs::ReadSeek;
-use bdinfo_rs_core::vfs::udf::source::IsoReader;
-
 /// The logical sector every placement in the framing is scaled by — the
 /// 2048-byte bootstrap sector a UDF image is addressed in.
 pub const SECTOR: usize = 2048;
@@ -29,25 +23,6 @@ pub const SECTOR: usize = 2048;
 /// what a hostile size field can make the HARNESS allocate, and it sits above
 /// the 330 sectors the largest committed seed describes.
 pub const MAX_IMAGE_SECTORS: usize = 512;
-
-/// An in-memory [`IsoReader`] — each handle gets an independent cursor.
-#[derive(Debug)]
-pub struct MemIso {
-    data: Arc<[u8]>,
-}
-
-impl MemIso {
-    /// Wraps `image` as the reader factory an `.iso` entry point takes.
-    pub fn boxed(image: Vec<u8>) -> Box<dyn IsoReader> {
-        Box::new(Self { data: Arc::from(image) })
-    }
-}
-
-impl IsoReader for MemIso {
-    fn open(&self) -> io::Result<Box<dyn ReadSeek>> {
-        Ok(Box::new(Cursor::new(self.data.to_vec())))
-    }
-}
 
 /// Materialises the image `data` describes (see the module docs).
 ///

--- a/fuzz/fuzz_targets/source.rs
+++ b/fuzz/fuzz_targets/source.rs
@@ -17,7 +17,7 @@
 
 use std::io::Read;
 
-use bdinfo_rs_core::vfs::udf::source::UdfSource;
+use bdinfo_rs_core::vfs::udf::source::{MemIso, UdfSource};
 use bdinfo_rs_core::vfs::{BdDir, SearchOption};
 use libfuzzer_sys::fuzz_target;
 
@@ -31,7 +31,7 @@ const READ_BUDGET: u64 = 1 << 20;
 
 fuzz_target!(|data: &[u8]| {
     let image = sparse_iso::build_image(data);
-    let Ok(source) = UdfSource::open(sparse_iso::MemIso::boxed(image)) else {
+    let Ok(source) = UdfSource::open(MemIso::boxed(image)) else {
         return;
     };
     // Walk the parsed volume: label, root, every directory, every file.

--- a/fuzz/fuzz_targets/wasm_iso.rs
+++ b/fuzz/fuzz_targets/wasm_iso.rs
@@ -20,6 +20,7 @@
 //! which drive this entry point over one fixture image and one image that is not
 //! a UDF volume at all.
 
+use bdinfo_rs_core::vfs::udf::source::MemIso;
 use bdinfo_rs_wasm::run_iso_report;
 use libfuzzer_sys::fuzz_target;
 
@@ -28,5 +29,5 @@ mod sparse_iso;
 
 fuzz_target!(|data: &[u8]| {
     let image = sparse_iso::build_image(data);
-    let _ = run_iso_report(sparse_iso::MemIso::boxed(image));
+    let _ = run_iso_report(MemIso::boxed(image));
 });


### PR DESCRIPTION
Three steps that give the vfs seam one in-memory backend and one home per rule.

**An in-memory backend in core.** vfs::mem is the third BdFile/BdDir backend
beside the folder and UDF ones: a synthetic disc held as byte buffers, plus the
section framing (u32 big-endian length prefixes over a fixed BDMV skeleton) that
the browser export and the parse_report fuzz target both read. Both harnesses
now build their tree through it instead of carrying a copy, and the fuzz target
also consumes the promoted MemIso image fixture behind the test-fixtures
feature.

**Provided directory convenience methods.** BdDir::get_files and
get_files_pattern delegate to get_files_pattern_option, so a backend writes one
listing method rather than three. The identical copies in the folder, UDF,
in-memory and browser backends are gone. One test fake keeps a deliberate
override: it must fail at that exact call and list every file whatever the
pattern.

**One extension derivation.** vfs::extension_of_name is public, and the browser
file backend computes and stores its extension through it instead of deriving
its own; the inline copies in core's test fakes call it too. The two derivations
were already identical in semantics - both return the text after the last dot
verbatim - so no scan result changes. Case folding belongs to the disc-size
split that keeps interleaved streams out of the disc total, and a new test pins
an upper-cased .SSIF name through it.

Verified locally: root gate PASS (lines, regions and functions 100%, branches
97.72%, in-diff mutation 38 mutants, 28 caught, 10 unviable, 0 missed); wasm
gate PASS with every Node and Chrome golden byte-identical.
