### PR TITLE
ci: bump the nightly, node, wrangler and setup-homebrew pins

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -38,7 +38,7 @@
 # nightly-only options) and the llvm-cov coverage steps (`--branch` and the
 # `coverage_nightly` cfg are nightly-only). Everything else builds on the stable
 # channel in rust-toolchain.toml.
-NIGHTLY=nightly-2026-07-06
+NIGHTLY=nightly-2026-08-05
 
 # cargo-vet: only 0.10.0 ships a prebuilt binary anywhere, so this is compiled
 # from crates.io and cached. Must be a version that accepts the committed
@@ -76,7 +76,7 @@ WASM_BINDGEN_CLI=0.2.126
 
 # The Node line the browser package builds and tests on: 26 reaches LTS in
 # October 2026. Odd majors are never LTS and are not adopted.
-NODE=26.6.0
+NODE=26.7.0
 
 # npm, pinned independently of whichever npm a given Node 26.x bundles: `npm
 # stage publish` needs >= 11.15.0 and `--provenance` needs a working bundled
@@ -86,7 +86,7 @@ NPM=12.0.2
 
 # wrangler, invoked with npx to deploy the demo site. Pinned because it runs with
 # the Cloudflare Pages deploy token.
-WRANGLER=4.118.0
+WRANGLER=4.119.0
 
 # komac, fetched over curl to submit the WinGet manifests. winget-releaser wraps
 # the same tool but bootstraps it through cargo-bins/cargo-binstall@main, which

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -307,10 +307,33 @@ jobs:
           tool: cargo-llvm-cov,cargo-nextest
           fallback: none
 
+      # --ignore-filename-regex drops crates/bdinfo-rs/build.rs — the completions
+      # and man-page generator — from the measured surface, and is the single
+      # home for that exclusion: scripts/compliance.ps1 passes the same regex so
+      # the local gate and this job measure one identical denominator.
+      #
+      # It is there to exclude in the first place because cargo-llvm-cov (0.8.7)
+      # hands llvm-cov every build-script object it finds under the target
+      # directory. A dependency's build script contributes no source rows anyway
+      # — cargo-llvm-cov's default ignore regex already covers ~/.cargo/registry
+      # and ~/.cargo/git — but a workspace member's build script is not on that
+      # list, so this one's rows survive into the report.
+      #
+      # Whether the toolchain emits any coverage for it is nightly-dependent:
+      # measured 2026-08-07, nightly-2026-08-05 records counters for it and
+      # nightly-2026-07-06 records none, so leaving it in would let the pinned
+      # NIGHTLY silently decide the denominator this floor is computed over.
+      # Excluding it pins the surface to the crates' own source either way.
+      #
+      # Nothing is lost by dropping it: a build script is not shipped surface,
+      # part of it is unreachable by construction (Cargo always sets OUT_DIR, so
+      # main's missing-OUT_DIR arm cannot run), and its real output is proven by
+      # the packaging jobs, which install the completions and the man page and
+      # assert they arrive.
       - name: Coverage (100% lines/regions/functions)
         env:
           NIGHTLY: ${{ steps.pins.outputs.NIGHTLY }}
-        run: cargo "+$NIGHTLY" llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100
+        run: cargo "+$NIGHTLY" llvm-cov nextest --workspace --locked --no-tests=fail --summary-only --ignore-filename-regex '[\\/]crates[\\/]bdinfo-rs[\\/]build\.rs$' --fail-under-lines 100 --fail-under-regions 100 --fail-under-functions 100
 
   # The root workspace's leg of the MSRV gate — the shared body, the rationale
   # and the build-only posture live in .github/actions/msrv-check.

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -55,7 +55,7 @@ jobs:
       # nags (files an issue) when Homebrew master moves past this SHA, and the bump
       # is then a deliberate edit here. Dependabot cannot do it (it bumps toward
       # releases, and this repo has none).
-      - uses: Homebrew/actions/setup-homebrew@f5448d3709dc32011524a9e0819671e08d21661c # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@d3565f64e59130f1fd713440276f7d3e11079b88 # zizmor: ignore[ref-version-mismatch]
 
       # The macOS runner image ships aws/tap + azure/bicep pre-tapped; Homebrew's tap-trust
       # check then warns about them on every brew command. We install bdinfo-rs by its
@@ -118,7 +118,7 @@ jobs:
     steps:
       # A SHA-frozen Homebrew/actions pin — the full rationale sits on the
       # homebrew job's identical line above.
-      - uses: Homebrew/actions/setup-homebrew@f5448d3709dc32011524a9e0819671e08d21661c # zizmor: ignore[ref-version-mismatch]
+      - uses: Homebrew/actions/setup-homebrew@d3565f64e59130f1fd713440276f7d3e11079b88 # zizmor: ignore[ref-version-mismatch]
 
       # The same tap-trust story as the homebrew job above, for its reasons.
       - name: Trust the taps (ours + the runner's pre-tapped ones)


### PR DESCRIPTION
Bumps the four pins the daily version-freshness check flagged.

.github/pins.env:

- NIGHTLY nightly-2026-07-06 to nightly-2026-08-05 (was 31 days old). Verified the
  new date ships rustfmt and llvm-tools-preview, and that it reformats nothing:
  fmt --check is clean across the root, gui and wasm workspaces. Coverage is
  unchanged on both toolchains, branch coverage included.
- NODE 26.6.0 to 26.7.0, the newest release on the pinned 26.x line.
- WRANGLER 4.118.0 to 4.119.0, the newest release on the npm registry.

.github/workflows/install-smoke-test.yml:

- Homebrew/actions/setup-homebrew re-pinned from f5448d3709dc to d3565f64e591,
  master HEAD. The repo publishes no tags, so the SHA is frozen deliberately and
  version-freshness watches it. The two commits in the range only change how the
  repository references its own internal actions; the setup-homebrew action
  definition itself is untouched.

No cargo-dist pin moved, so DIST_SHA256 and the generated release workflow are
unaffected.

The nightly bump needs one companion change, in the second commit. cargo-llvm-cov
hands llvm-cov every build-script object under the target directory; a
dependency's contributes no rows because its source sits under the cargo registry
that the default ignore regex covers, but a workspace member's build script is
not on that list. Whether the toolchain emits counters for it turns out to be
nightly-dependent: nightly-2026-08-05 records them and nightly-2026-07-06 records
none, so the bump alone pulled crates/bdinfo-rs/build.rs into the coverage
denominator for the first time, at 6 of 55 regions and 1 of 4 functions
uncovered, and the coverage job went red.

The coverage step now passes an ignore regex for that one file, so the pinned
nightly no longer decides what the floor is computed over. The remaining
denominator is exactly the one this job has been enforcing: 43370 regions, 2258
functions, 22891 lines, none uncovered. The build script keeps its own proof
elsewhere, since the packaging jobs install the completions and the man page and
assert they arrive.

Closes #278
