### PR TITLE
feat(core): unify the short-playlist threshold contract and extend the wasm surface

### DIFF
--- a/crates/bdinfo-rs-core/src/bdrom/order.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/order.rs
@@ -54,6 +54,21 @@ impl HiddenRule {
     }
 }
 
+/// The largest meaningful short-playlist threshold, in seconds — one full
+/// day, longer than any playlist a disc can hold.
+///
+/// The threshold contract every consumer of
+/// [`short_playlist_seconds`](PlaylistFilter::short_playlist_seconds) shares:
+/// a valid threshold lies in `0..=MAX_SHORT_PLAYLIST_SECONDS`, and `0`
+/// switches the short rule off (no playlist is strictly shorter than zero
+/// seconds). The filter itself judges whatever `f64` it is handed; holding an
+/// input to the domain — rejecting or clamping, as suits the input surface —
+/// is the caller's job at its own boundary.
+///
+/// `u32` because thresholds enter as whole seconds everywhere; the filter
+/// field converts losslessly through [`f64::from`].
+pub const MAX_SHORT_PLAYLIST_SECONDS: u32 = 86_400;
+
 /// The playlist filter switches for the presentation order. The defaults drop
 /// short and looping playlists — the standard report behaviour;
 /// [`PlaylistFilter::everything`] keeps both.
@@ -306,9 +321,9 @@ mod tests {
     use proptest::prelude::{prop_assert, prop_assert_eq, proptest};
 
     use super::{
-        HiddenRule, PlaylistFilter, hidden_by, named_selection, normalize_playlist_name,
-        presentation_cmp, presentation_groups, presentation_order, selection_order,
-        selection_stream_files, table_rows,
+        HiddenRule, MAX_SHORT_PLAYLIST_SECONDS, PlaylistFilter, hidden_by, named_selection,
+        normalize_playlist_name, presentation_cmp, presentation_groups, presentation_order,
+        selection_order, selection_stream_files, table_rows,
     };
     use crate::bdrom::disc::{PlaylistSummary, fixtures};
 
@@ -544,6 +559,26 @@ mod tests {
         // raised 60 s threshold.
         let raised = PlaylistFilter { short_playlist_seconds: 60.0, ..PlaylistFilter::default() };
         assert_eq!(raised.classify(&playlist("B.MPLS", 50.0, false, &[])), [HiddenRule::Short]);
+    }
+
+    #[test]
+    fn the_threshold_ceiling_is_one_day_and_zero_disables_the_short_rule() {
+        // The ceiling value is a contract with the surfaces that duplicate it
+        // (the CLI parser and the demo page cannot name this constant), so an
+        // edit here must be deliberate.
+        assert_eq!(MAX_SHORT_PLAYLIST_SECONDS, 86_400);
+        // The two domain ends behave: at the ceiling everything shorter than a
+        // day is short; at zero nothing is.
+        let ceiling = PlaylistFilter {
+            short_playlist_seconds: f64::from(MAX_SHORT_PLAYLIST_SECONDS),
+            ..PlaylistFilter::default()
+        };
+        assert_eq!(
+            ceiling.classify(&playlist("A.MPLS", 86_399.0, false, &[])),
+            [HiddenRule::Short]
+        );
+        let off = PlaylistFilter { short_playlist_seconds: 0.0, ..PlaylistFilter::default() };
+        assert!(off.classify(&playlist("B.MPLS", 0.0, false, &[])).is_empty());
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/settings.rs
+++ b/crates/bdinfo-rs-gui/src/settings.rs
@@ -51,8 +51,9 @@ const KEY_WINDOW_MAXIMIZED: &str = "window-maximized";
 /// `-32000` position) is dropped rather than restored.
 const MAX_AXIS: f32 = 16_384.0;
 
-/// The largest accepted short-playlist threshold, in seconds (a full day) —
-/// a stored or typed value beyond it clamps here rather than filtering every
+/// The largest accepted short-playlist threshold, in seconds (a full day).
+///
+/// A stored or typed value beyond it clamps here rather than filtering every
 /// playlist off a disc with a nonsense number. The ceiling itself is the
 /// library's shared threshold domain; only the clamping is this app's choice.
 pub const MAX_SHORT_SECONDS: u32 = bdinfo_rs_core::bdrom::order::MAX_SHORT_PLAYLIST_SECONDS;

--- a/crates/bdinfo-rs-gui/src/settings.rs
+++ b/crates/bdinfo-rs-gui/src/settings.rs
@@ -53,8 +53,9 @@ const MAX_AXIS: f32 = 16_384.0;
 
 /// The largest accepted short-playlist threshold, in seconds (a full day) —
 /// a stored or typed value beyond it clamps here rather than filtering every
-/// playlist off a disc with a nonsense number.
-pub const MAX_SHORT_SECONDS: u32 = 86_400;
+/// playlist off a disc with a nonsense number. The ceiling itself is the
+/// library's shared threshold domain; only the clamping is this app's choice.
+pub const MAX_SHORT_SECONDS: u32 = bdinfo_rs_core::bdrom::order::MAX_SHORT_PLAYLIST_SECONDS;
 
 /// The smallest accepted UI scale, in percent of the platform-native scale.
 ///

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -61,7 +61,9 @@ use bdinfo_rs_core::bdrom::disc::{
 };
 use bdinfo_rs_core::bdrom::order::PlaylistFilter;
 #[cfg(any(target_arch = "wasm32", test))]
-use bdinfo_rs_core::bdrom::order::{named_selection, selection_order, selection_stream_files};
+use bdinfo_rs_core::bdrom::order::{
+    MAX_SHORT_PLAYLIST_SECONDS, named_selection, selection_order, selection_stream_files,
+};
 #[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::discovery::BdmvDir;
 use bdinfo_rs_core::error::BdError;
@@ -611,25 +613,86 @@ fn build_web_tree(paths: &[String], files: &js_sys::Array) -> Result<Node<WebFil
 // wasm exports use them and the native test build covers + mutates them, while a
 // native non-test build omits them (so neither tier shows dead code).
 
+/// A rejected `shortPlaylistSeconds`: present but outside the valid domain
+/// (finite, `0..=`[`MAX_SHORT_PLAYLIST_SECONDS`]). The exports throw it
+/// rather than substituting a default, so a caller's out-of-range value —
+/// most likely a bug on their side — cannot silently scan as 20 s.
+#[cfg(any(target_arch = "wasm32", test))]
+#[derive(Debug)]
+struct ThresholdError(f64);
+
+#[cfg(any(target_arch = "wasm32", test))]
+impl std::fmt::Display for ThresholdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "shortPlaylistSeconds must be a finite value in 0..={}, got {}",
+            MAX_SHORT_PLAYLIST_SECONDS, self.0
+        )
+    }
+}
+
 /// The filter the disc model is classified against: the standard rules with
 /// `short_seconds` as the length under which a playlist counts as short.
 ///
-/// A present, finite, non-negative `short_seconds` is taken literally, so `0`
-/// leaves no playlist short and disables the short rule — the meaning the CLI's
-/// `--short-playlist-seconds 0` and the desktop app's threshold setting carry.
-/// An absent, negative or non-finite one means the 20 s default, so a caller
-/// that does not care about the threshold passes `None` and gets the classic
-/// behaviour. Only the threshold is read downstream — no export filters the
-/// playlists any more — so the two switches keep their defaults.
+/// An absent `short_seconds` means the 20 s default. A present one must be
+/// finite and within `0..=`[`MAX_SHORT_PLAYLIST_SECONDS`] and is taken
+/// literally, so `0` leaves no playlist short and disables the short rule —
+/// the meaning the CLI's `--short-playlist-seconds 0` and the desktop app's
+/// threshold setting carry. Only the threshold is read downstream — no export
+/// filters the playlists — so the two switches keep their defaults.
+///
+/// # Errors
+/// [`ThresholdError`] for a present value outside the domain — negative,
+/// non-finite, or past the ceiling.
 #[cfg(any(target_arch = "wasm32", test))]
-fn classification_filter(short_seconds: Option<f64>) -> PlaylistFilter {
+fn classification_filter(short_seconds: Option<f64>) -> Result<PlaylistFilter, ThresholdError> {
     let standard = PlaylistFilter::default();
-    PlaylistFilter {
-        short_playlist_seconds: short_seconds
-            .filter(|seconds| seconds.is_finite() && *seconds >= 0.0)
-            .unwrap_or(standard.short_playlist_seconds),
-        ..standard
+    let short_playlist_seconds = match short_seconds {
+        None => standard.short_playlist_seconds,
+        Some(seconds) => {
+            if !(seconds.is_finite()
+                && (0.0..=f64::from(MAX_SHORT_PLAYLIST_SECONDS)).contains(&seconds))
+            {
+                return Err(ThresholdError(seconds));
+            }
+            seconds
+        }
+    };
+    Ok(PlaylistFilter { short_playlist_seconds, ..standard })
+}
+
+/// How deep `options` asks an inspect to read: the bounded codec pass
+/// ([`ScanMode::Codecs`]) when `codecs` is on, else the metadata-only scan.
+/// An absent option — or no options object at all — means metadata-only, the
+/// classic inspect.
+#[cfg(any(target_arch = "wasm32", test))]
+fn inspect_mode(options: Option<&ScanOptions>) -> ScanMode {
+    if options.and_then(|options| options.codecs).unwrap_or(false) {
+        ScanMode::Codecs
+    } else {
+        ScanMode::Metadata
     }
+}
+
+/// The unmeasured scan every inspect export shares: opens `root` at `mode`
+/// depth and mirrors the result classified against `filter`.
+///
+/// The mirror says `measured: false` whichever mode ran: the codec pass reads
+/// each stream file's head for codec detail but measures no bitrate, so every
+/// measured value is zero because nothing measured it.
+///
+/// # Errors
+/// The [`BdError`] from [`BdRom::open_resilient`] when the structure is too
+/// damaged to open at all (no `BDMV`/`CLIPINF`/`PLAYLIST`).
+#[cfg(any(target_arch = "wasm32", test))]
+fn inspect_disc(
+    root: &dyn BdDir,
+    mode: ScanMode,
+    filter: &PlaylistFilter,
+) -> Result<Disc, BdError> {
+    let report = BdRom::open_resilient(root, mode)?;
+    Ok(Disc::from_scan(&report.bdrom, &report.errors, false, filter))
 }
 
 /// Why a by-name [`scan_selection`] could not produce a report.
@@ -906,13 +969,29 @@ pub fn scan_report(data: &[u8]) -> String {
     run_report(data)
 }
 
+/// The report's save-file name for a disc labelled `label` —
+/// `BDINFO.<stem>.txt` with every illegal or control character replaced by
+/// `_`, the same name the `bdinfo-rs` command line and the desktop app save
+/// their reports under.
+///
+/// This wraps the core library's sanitizer (property-tested there): whatever
+/// bytes a disc puts in its volume label, the result is one flat path
+/// component, so a hostile label can neither re-root a save path nor break
+/// the write. Pass `disc.volumeLabel` and hand the result to a download
+/// attribute or a save dialog.
+#[wasm_bindgen]
+#[must_use]
+pub fn report_file_name(label: &str) -> String {
+    bdinfo_rs_core::report::file_name(label)
+}
+
 /// The structural-scan entry point for the whole disc model: a
 /// `webkitdirectory`-selected BDMV folder in, a [`Disc`] out.
 ///
-/// Runs only the **structural** scan — no packet demux, so it reads the
-/// playlist and clip metadata rather than the multi-GB stream files — and
-/// returns everything the report prints that a metadata scan can know, plus
-/// every column of the selection table.
+/// Runs the **structural** scan — no whole-file demux, so it reads the
+/// playlist and clip metadata rather than measuring the multi-GB stream
+/// files — and returns everything the report prints that such a scan can
+/// know, plus every column of the selection table.
 ///
 /// `disc.measured` is false: the bitrates, packet counts and chapter rates are
 /// zero because nothing measured them.
@@ -920,29 +999,33 @@ pub fn scan_report(data: &[u8]) -> String {
 /// `disc.playlists` holds every playlist on the disc, each carrying the rules
 /// that withhold it in `hiddenBy`, so a caller renders the standard selection
 /// table by keeping the playlists whose `hiddenBy` is empty and re-applies
-/// either rule without scanning again. `short_playlist_seconds` sets the length
-/// under which a playlist counts as short, `0` leaving no playlist short;
-/// absent, negative or non-finite means the 20 s default.
+/// either rule without scanning again.
+///
+/// `options` takes the same object as [`scan_files`]; this call reads two of
+/// its options (a scan that renders no report ignores the rest).
+/// `short_playlist_seconds` is the classification threshold — 20 when
+/// omitted, `0` leaving no playlist short, and anything outside the valid
+/// `0..=86400` domain rejected (see [`classification_filter`]). `codecs`
+/// switches on the bounded codec pass: each stream file's head is read just
+/// far enough to parse the first parameter sets, so the streams carry their
+/// full codec detail — profile, level, HDR — while `measured` stays false.
 ///
 /// # Errors
-/// As [`scan_files`]: `paths`/`files` length mismatch, a non-`File` entry, an
-/// incoherent selection, or no readable Blu-ray structure.
+/// An out-of-domain `shortPlaylistSeconds`, and then as [`scan_files`]:
+/// `paths`/`files` length mismatch, a non-`File` entry, an incoherent
+/// selection, or no readable Blu-ray structure.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn inspect_files(
     paths: Vec<String>,
     files: js_sys::Array,
-    short_playlist_seconds: Option<f64>,
+    options: Option<ScanOptions>,
 ) -> Result<Disc, JsValue> {
+    let filter = classification_filter(options.and_then(|options| options.short_playlist_seconds))
+        .map_err(|err| JsValue::from_str(&err.to_string()))?;
     let root = build_web_tree(&paths, &files)?;
-    let report = BdRom::open_resilient(&root, ScanMode::Metadata)
-        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
-    Ok(Disc::from_scan(
-        &report.bdrom,
-        &report.errors,
-        false,
-        &classification_filter(short_playlist_seconds),
-    ))
+    inspect_disc(&root, inspect_mode(options.as_ref()), &filter)
+        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))
 }
 
 /// The structural-scan `.iso` entry point for the whole disc model: a single
@@ -951,28 +1034,21 @@ pub fn inspect_files(
 /// Opens the image through the core read-only UDF 2.50 reader ([`UdfSource`])
 /// instead of a `(relativePath, File)` list, then behaves exactly as
 /// [`inspect_files`] — same structural scan, same `measured: false`, same
-/// meaning for `short_playlist_seconds`.
+/// meaning for every option.
 ///
 /// # Errors
-/// Returns a `JsValue` if the image is not a readable UDF `.iso`, or holds no
-/// readable Blu-ray structure.
+/// An out-of-domain `shortPlaylistSeconds`; a `JsValue` if the image is not a
+/// readable UDF `.iso`, or holds no readable Blu-ray structure.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn inspect_iso(
-    file: web_sys::File,
-    short_playlist_seconds: Option<f64>,
-) -> Result<Disc, JsValue> {
+pub fn inspect_iso(file: web_sys::File, options: Option<ScanOptions>) -> Result<Disc, JsValue> {
+    let filter = classification_filter(options.and_then(|options| options.short_playlist_seconds))
+        .map_err(|err| JsValue::from_str(&err.to_string()))?;
     let length = file.size() as u64;
     let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
         .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
-    let report = BdRom::open_resilient(&source.root(), ScanMode::Metadata)
-        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
-    Ok(Disc::from_scan(
-        &report.bdrom,
-        &report.errors,
-        false,
-        &classification_filter(short_playlist_seconds),
-    ))
+    inspect_disc(&source.root(), inspect_mode(options.as_ref()), &filter)
+        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))
 }
 
 /// Renders the classic disc report from a [`Disc`] — no media, no rescan.
@@ -1043,14 +1119,14 @@ pub fn scan_files(
     on_progress: Option<js_sys::Function>,
     options: Option<ScanOptions>,
 ) -> Result<ScanResult, JsValue> {
+    // Validated before the scan: an out-of-domain threshold rejects up front
+    // rather than after a multi-GB demux.
+    let filter = classification_filter(options.and_then(|options| options.short_playlist_seconds))
+        .map_err(|err| JsValue::from_str(&err.to_string()))?;
     let root = build_web_tree(&paths, &files)?;
     let mut observe = |p: ScanProgress<'_>| notify(on_progress.as_ref(), &p);
     let scan = scan_root(&root, &selection, scan_options(options.as_ref()), &mut observe)?;
-    Ok(measured_result(
-        &scan,
-        render_options(options.as_ref()),
-        &classification_filter(options.and_then(|options| options.short_playlist_seconds)),
-    ))
+    Ok(measured_result(&scan, render_options(options.as_ref()), &filter))
 }
 
 /// The measured-scan `.iso` entry point: a single OS-picked Blu-ray `.iso`
@@ -1074,17 +1150,16 @@ pub fn scan_iso(
     on_progress: Option<js_sys::Function>,
     options: Option<ScanOptions>,
 ) -> Result<ScanResult, JsValue> {
+    // Validated before the scan, as in `scan_files`.
+    let filter = classification_filter(options.and_then(|options| options.short_playlist_seconds))
+        .map_err(|err| JsValue::from_str(&err.to_string()))?;
     let length = file.size() as u64;
     let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
         .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
     let scan = scan_root(&source.root(), &selection, scan_options(options.as_ref()), &mut |p| {
         notify(on_progress.as_ref(), &p);
     })?;
-    Ok(measured_result(
-        &scan,
-        render_options(options.as_ref()),
-        &classification_filter(options.and_then(|options| options.short_playlist_seconds)),
-    ))
+    Ok(measured_result(&scan, render_options(options.as_ref()), &filter))
 }
 
 #[cfg(test)]
@@ -1390,8 +1465,8 @@ mod tests {
             .expect("the fixture opens");
         // One scan, both outputs: the report is the pinned bytes and the disc
         // is the same scan mirrored, neither derived from the other.
-        let result =
-            measured_result(&scan, RenderOptions::default(), &super::classification_filter(None));
+        let filter = super::classification_filter(None).expect("an absent threshold is valid");
+        let result = measured_result(&scan, RenderOptions::default(), &filter);
         assert_eq!(result.report.as_bytes(), GOLDEN);
         assert!(result.disc.measured, "the packet scan ran, so the values were measured");
         assert_eq!(result.disc.volume_label, "WASMDISC");
@@ -1405,6 +1480,7 @@ mod tests {
             quick_summary: None,
             short_playlist_seconds: None,
             keep_partial: None,
+            codecs: None,
         }
     }
 
@@ -1448,6 +1524,80 @@ mod tests {
             scan_options(Some(&ScanOptions { keep_partial: Some(true), ..no_options() }))
                 .keep_partial
         );
+    }
+
+    #[test]
+    fn inspect_reads_codec_heads_only_when_asked() {
+        use super::{ScanMode, inspect_mode};
+
+        // No object, an object without the option, and an explicit false all
+        // mean the classic metadata-only inspect; only `codecs: true` deepens
+        // it to the bounded codec pass.
+        assert_eq!(inspect_mode(None), ScanMode::Metadata);
+        assert_eq!(inspect_mode(Some(&no_options())), ScanMode::Metadata);
+        assert_eq!(
+            inspect_mode(Some(&super::ScanOptions { codecs: Some(false), ..no_options() })),
+            ScanMode::Metadata
+        );
+        assert_eq!(
+            inspect_mode(Some(&super::ScanOptions { codecs: Some(true), ..no_options() })),
+            ScanMode::Codecs
+        );
+    }
+
+    #[test]
+    fn a_codecs_inspect_carries_codec_detail_and_stays_unmeasured() {
+        use super::{Node, ScanMode, classification_filter, inspect_disc};
+
+        let filter = classification_filter(None).expect("an absent threshold is valid");
+        let tree = framed_tree(&fixture_blob());
+        let metadata = inspect_disc(&tree, ScanMode::Metadata, &filter).expect("the fixture opens");
+        let codecs = inspect_disc(&tree, ScanMode::Codecs, &filter).expect("the fixture opens");
+
+        // Neither depth ran the whole-file bitrate pass: both mirrors are
+        // unmeasured and every rate is zero because nothing measured it.
+        // Both mirrors are unmeasured, and the video bitrate — a value only
+        // the whole-file pass can supply — is zero at either depth.
+        let streams = |disc: &super::Disc| {
+            let playlist = disc.playlists.first().expect("the fixture has one playlist");
+            let video = playlist.streams.first().expect("the playlist has a video stream");
+            let audio = playlist.streams.get(1).expect("the playlist has an audio stream");
+            (video.clone(), audio.clone())
+        };
+        for disc in [&metadata, &codecs] {
+            assert!(!disc.measured, "an inspect never claims measured values");
+            assert_eq!(streams(disc).0.bitrate_bps, 0, "no pass measures video bitrate");
+        }
+
+        // The codec pass parses each stream file's first parameter sets: the
+        // video description gains its profile/level, and the LPCM stream its
+        // parameter-declared bit depth and rate (1536 kbps for 48 kHz 16-bit
+        // stereo — declared, not measured). The metadata scan knows neither.
+        let (video, audio) = streams(&codecs);
+        assert!(video.full_description.contains("High Profile"), "{}", video.full_description);
+        assert!(audio.full_description.contains("16-bit"), "{}", audio.full_description);
+        assert_eq!(audio.bitrate_bps, 1_536_000);
+        let (video, audio) = streams(&metadata);
+        assert!(!video.full_description.contains("Profile"), "{}", video.full_description);
+        assert!(!audio.full_description.contains("16-bit"), "{}", audio.full_description);
+        assert_eq!(audio.bitrate_bps, 0);
+
+        // An unopenable tree (no BDMV) errors instead of mirroring nothing.
+        let empty: Node<MemFile> = Node::dir("EMPTY", "EMPTY");
+        assert!(inspect_disc(&empty, ScanMode::Metadata, &filter).is_err());
+    }
+
+    #[test]
+    fn report_file_name_is_the_core_sanitized_name() {
+        use super::report_file_name;
+
+        // A clean label passes through; separators, illegal-on-Windows
+        // characters and control bytes become underscores — the sanitizer
+        // itself is property-tested in the core library, so these pin the
+        // wrapping, not the rule set.
+        assert_eq!(report_file_name("WASMDISC"), "BDINFO.WASMDISC.txt");
+        assert_eq!(report_file_name("a/b:c"), "BDINFO.a_b_c.txt");
+        assert_eq!(report_file_name(""), "BDINFO..txt");
     }
 
     #[test]
@@ -1568,31 +1718,51 @@ mod tests {
         }
 
         #[test]
-        fn classification_filter_takes_the_threshold_and_falls_back_to_twenty_seconds() {
-            // Any finite threshold from zero up is used as given; a value no
-            // caller can have meant — absent, negative, non-finite — leaves the
-            // default 20 s in force, so a caller that does not set one gets the
-            // classic classification. Whole filters are compared, so the two
-            // switches the exports do not offer are pinned at their defaults.
-            for (short_seconds, in_force) in [
-                (Some(5.0), 5.0),
-                (Some(0.5), 0.5),
-                (Some(0.0), 0.0),
-                (None, 20.0),
-                (Some(-1.0), 20.0),
-                (Some(f64::NAN), 20.0),
-                (Some(f64::INFINITY), 20.0),
-            ] {
+        fn classification_filter_takes_a_valid_threshold_and_defaults_only_when_absent() {
+            // Absent means the classic 20 s default…
+            assert_eq!(
+                classification_filter(None).expect("an absent threshold is valid"),
+                PlaylistFilter::default()
+            );
+            // …and any finite in-domain value — both domain ends included — is
+            // taken as given. Whole filters are compared, so the two switches
+            // the exports do not offer are pinned at their defaults.
+            for seconds in [0.0, 0.5, 5.0, 86_400.0] {
                 assert_eq!(
-                    classification_filter(short_seconds),
+                    classification_filter(Some(seconds)).expect("an in-domain threshold is valid"),
                     PlaylistFilter {
                         filter_short_playlists: true,
                         filter_looping_playlists: true,
-                        short_playlist_seconds: in_force,
+                        short_playlist_seconds: seconds,
                     },
-                    "{short_seconds:?}"
+                    "{seconds:?}"
                 );
             }
+        }
+
+        #[test]
+        fn classification_filter_rejects_an_out_of_domain_threshold() {
+            // Negative (however slightly), past the one-day ceiling, or
+            // non-finite: rejected with the value echoed back, never silently
+            // replaced by the default.
+            for seconds in
+                [-1.0, -1e-9, 86_400.001, 1e9, f64::NAN, f64::INFINITY, f64::NEG_INFINITY]
+            {
+                let err = classification_filter(Some(seconds))
+                    .expect_err("an out-of-domain threshold must reject");
+                let message = err.to_string();
+                assert!(
+                    message.contains("shortPlaylistSeconds")
+                        && message.contains("0..=86400")
+                        && message.contains(&seconds.to_string()),
+                    "{seconds:?}: {message}"
+                );
+            }
+        }
+
+        /// The filter for a threshold every test here passes as valid.
+        fn valid_filter(short_seconds: Option<f64>) -> PlaylistFilter {
+            classification_filter(short_seconds).expect("a valid threshold")
         }
 
         #[test]
@@ -1606,12 +1776,12 @@ mod tests {
                 ..sample_playlist("00003.MPLS", 5.0, 0, 0, &[])
             };
             assert_eq!(
-                classification_filter(None).classify(&short),
+                valid_filter(None).classify(&short),
                 [bdinfo_rs_core::bdrom::order::HiddenRule::Short]
             );
-            assert!(classification_filter(Some(5.0)).classify(&short).is_empty());
+            assert!(valid_filter(Some(5.0)).classify(&short).is_empty());
             assert_eq!(
-                classification_filter(Some(5.0)).classify(&looping),
+                valid_filter(Some(5.0)).classify(&looping),
                 [bdinfo_rs_core::bdrom::order::HiddenRule::Looping]
             );
         }
@@ -1626,9 +1796,9 @@ mod tests {
                 has_loops: true,
                 ..sample_playlist("00003.MPLS", 1.0, 0, 0, &[])
             };
-            assert!(classification_filter(Some(0.0)).classify(&brief).is_empty());
+            assert!(valid_filter(Some(0.0)).classify(&brief).is_empty());
             assert_eq!(
-                classification_filter(Some(0.0)).classify(&looping),
+                valid_filter(Some(0.0)).classify(&looping),
                 [bdinfo_rs_core::bdrom::order::HiddenRule::Looping]
             );
         }

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -613,9 +613,9 @@ fn build_web_tree(paths: &[String], files: &js_sys::Array) -> Result<Node<WebFil
 // wasm exports use them and the native test build covers + mutates them, while a
 // native non-test build omits them (so neither tier shows dead code).
 
-/// A rejected `shortPlaylistSeconds`: present but outside the valid domain
-/// (finite, `0..=`[`MAX_SHORT_PLAYLIST_SECONDS`]). The exports throw it
-/// rather than substituting a default, so a caller's out-of-range value —
+/// A rejected `shortPlaylistSeconds`: present but outside the valid domain —
+/// finite, from zero up to [`MAX_SHORT_PLAYLIST_SECONDS`]. The exports throw
+/// it rather than substituting a default, so a caller's out-of-range value —
 /// most likely a bug on their side — cannot silently scan as 20 s.
 #[cfg(any(target_arch = "wasm32", test))]
 #[derive(Debug)]
@@ -636,8 +636,8 @@ impl std::fmt::Display for ThresholdError {
 /// `short_seconds` as the length under which a playlist counts as short.
 ///
 /// An absent `short_seconds` means the 20 s default. A present one must be
-/// finite and within `0..=`[`MAX_SHORT_PLAYLIST_SECONDS`] and is taken
-/// literally, so `0` leaves no playlist short and disables the short rule —
+/// finite and no more than [`MAX_SHORT_PLAYLIST_SECONDS`] (zero allowed) and
+/// is taken literally, so `0` leaves no playlist short and disables the rule —
 /// the meaning the CLI's `--short-playlist-seconds 0` and the desktop app's
 /// threshold setting carry. Only the threshold is read downstream — no export
 /// filters the playlists — so the two switches keep their defaults.
@@ -969,7 +969,8 @@ pub fn scan_report(data: &[u8]) -> String {
     run_report(data)
 }
 
-/// The report's save-file name for a disc labelled `label` —
+/// The report's save-file name for a disc labelled `label`.
+///
 /// `BDINFO.<stem>.txt` with every illegal or control character replaced by
 /// `_`, the same name the `bdinfo-rs` command line and the desktop app save
 /// their reports under.

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -109,15 +109,30 @@ pub struct ScanOptions {
     #[tsify(optional)]
     pub quick_summary: Option<bool>,
     /// The length in seconds under which a playlist counts as short, 20 when
-    /// omitted. Zero switches the short rule off, since no playlist is shorter
-    /// than zero seconds; a negative or non-finite value means the 20 s default.
+    /// omitted. Must be finite and within `0..=86400` (one day): zero switches
+    /// the short rule off, since no playlist is shorter than zero seconds, and
+    /// anything outside that domain — negative, non-finite, past the ceiling —
+    /// makes the call throw rather than silently scanning with the default.
     ///
-    /// Read by `scan_files` and `scan_iso`, which classify every playlist
-    /// against it and report the outcome in each playlist `hiddenBy`. It
-    /// changes no other value: which playlists a disc holds, which ones a
-    /// selection measures, and the rendered report are all the same either way.
+    /// Read by `inspect_files`, `inspect_iso`, `scan_files` and `scan_iso`,
+    /// which classify every playlist against it and report the outcome in each
+    /// playlist `hiddenBy`. It changes no other value: which playlists a disc
+    /// holds, which ones a selection measures, and the rendered report are all
+    /// the same either way.
     #[tsify(optional)]
     pub short_playlist_seconds: Option<f64>,
+    /// Read each stream file's head for codec detail during an inspect, off
+    /// unless switched on. Read by `inspect_files` and `inspect_iso` alone —
+    /// the measuring calls demux everything and carry full codec detail
+    /// already.
+    ///
+    /// Switched on, the inspect reads just far enough into each stream file to
+    /// parse the first parameter sets, so the streams carry their full codec
+    /// description — profile, level, HDR metadata — without the whole-file
+    /// demux a measured scan costs. `measured` stays false and every bitrate,
+    /// packet count and chapter rate is still zero.
+    #[tsify(optional)]
+    pub codecs: Option<bool>,
     /// Keep what the scan measured of a stream file whose read failed partway,
     /// on unless switched off. Read by `scan_files` and `scan_iso`.
     ///
@@ -1324,6 +1339,7 @@ mod tests {
             "quickSummary": false,
             "shortPlaylistSeconds": 5.0,
             "keepPartial": false,
+            "codecs": true,
         }))
         .expect("deserialize an options object");
         assert_eq!(
@@ -1333,6 +1349,7 @@ mod tests {
                 quick_summary: Some(false),
                 short_playlist_seconds: Some(5.0),
                 keep_partial: Some(false),
+                codecs: Some(true),
             }
         );
 
@@ -1346,6 +1363,7 @@ mod tests {
                 quick_summary: None,
                 short_playlist_seconds: None,
                 keep_partial: None,
+                codecs: None,
             }
         );
     }

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -102,6 +102,26 @@ side.
 measured value — bitrates, packet counts, chapter rates — is zero because
 nothing measured it; `true` after `scan`, where a zero is a genuine zero.
 
+### Codec detail without a full demux
+
+A plain `inspect` reads no stream bytes, so its streams carry only what the
+disc's metadata declares — codec name, resolution, channel layout — and none of
+the detail inside the streams themselves. `codecs: true` deepens the inspect to
+the bounded codec pass: each stream file's head is read just far enough to
+parse the first parameter sets, so every stream's `fullDescription` gains its
+profile, level and HDR metadata while the call stays far cheaper than a
+measured `scan` of a multi-GB disc:
+
+```ts
+const disc = await inspect(picked, { codecs: true });
+// e.g. "1080p / 23.976 fps / 16:9 / High Profile 4.1"
+console.log(disc.playlists[0].streams[0].fullDescription);
+```
+
+`disc.measured` is still `false`: bitrates, packet counts and chapter rates
+stay zero (a parameter-declared rate, like LPCM's, is the one exception),
+because only a full `scan` measures them.
+
 `disc.isAacsEncrypted` says the disc's stream content is AACS-encrypted. Neither
 call throws for it: the structure — playlists, streams as the disc declares
 them, chapters — comes from cleartext metadata and is correct either way. Only
@@ -143,6 +163,20 @@ const { disc } = await scan(picked, undefined, { keepPartial: false });
 zero throughout. The failure is reported in `disc.errors` either way, and a
 disc that reads cleanly produces the same bytes under both settings.
 
+### Saving the report
+
+`reportFileName` gives the name a report is saved under — `BDINFO.<label>.txt`,
+the same name the native CLI writes — with every character illegal in a file
+name replaced by `_`:
+
+```ts
+const name = await reportFileName(disc.volumeLabel); // "BDINFO.MY_DISC.txt"
+```
+
+The sanitizer is the core library's, property-tested there: whatever bytes a
+disc puts in its volume label, the result is one flat path component, so a
+hostile label can neither escape a chosen directory nor break the save.
+
 ### Playlist filtering
 
 The classic report withholds playlists shorter than 20 seconds and looping
@@ -168,9 +202,11 @@ playlist is judged against it:
 const disc = await inspect(picked, { shortPlaylistSeconds: 5 });
 ```
 
-It defaults to 20 seconds when omitted. Zero switches the short rule off — no
-playlist is shorter than zero seconds — so no `Disc` from that call names
-`"short"` in its `hiddenBy`.
+It defaults to 20 seconds when omitted, and must be finite and within 0..=86400
+(one day). Zero switches the short rule off — no playlist is shorter than zero
+seconds — so no `Disc` from that call names `"short"` in its `hiddenBy`. A
+value outside the domain (negative, non-finite, past the ceiling) rejects the
+call with an error rather than silently scanning with the default.
 
 Nothing else moves with it: which playlists a `Disc` holds, which ones a
 `selection` measures, and the rendered report are the same either way.
@@ -234,9 +270,10 @@ The raw wasm-bindgen module is also exported directly for advanced use:
 import init, { scan_files } from "@bdinfo-rs/wasm/wasm";
 ```
 
-It exports `inspect_files`, `inspect_iso`, `scan_files`, `scan_iso` and
-`render_report` — what `inspect`, `scan` and `renderReport` call, minus the
-Worker — plus one entry point the package deliberately does not wrap:
+It exports `inspect_files`, `inspect_iso`, `scan_files`, `scan_iso`,
+`render_report` and `report_file_name` — what `inspect`, `scan`, `renderReport`
+and `reportFileName` call, minus the Worker — plus one entry point the package
+deliberately does not wrap:
 `scan_report(bytes)` takes a whole disc pre-framed into one length-prefixed
 byte buffer and renders it from memory. It exists as the in-memory seam the
 byte-parity tests drive through both the native and the browser build; it is

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -887,10 +887,14 @@
           </label>
           <span class="threshold">
             <span>short&nbsp;=&nbsp;under</span>
+            <!-- min/max spell the shared threshold domain: 0 = the short rule
+                 off, 86400 = the library's MAX_SHORT_PLAYLIST_SECONDS ceiling
+                 (bdrom/order.rs), duplicated here because HTML cannot name a
+                 Rust constant. -->
             <input
               type="number"
               id="opt-short-seconds"
-              min="1"
+              min="0"
               max="86400"
               aria-label="Short-playlist threshold in seconds"
             />

--- a/crates/bdinfo-rs-wasm/web/src/analyze.ts
+++ b/crates/bdinfo-rs-wasm/web/src/analyze.ts
@@ -3,12 +3,16 @@
 // folder or a single Blu-ray `.iso` `File`:
 //
 //   - `inspect` — the fast STRUCTURAL scan (like `bdinfo-rs <disc> --list`): no
-//     packet demux, so it reads the playlist and clip metadata rather than the
-//     multi-GB stream files, and resolves with the whole disc model.
+//     whole-file demux, so it reads the playlist and clip metadata rather than
+//     measuring the multi-GB stream files, and resolves with the whole disc
+//     model. `options.codecs` deepens it to the bounded codec pass.
 //   - `scan` — the FULL measured scan (like `bdinfo-rs <disc>`), resolving with
 //     the rendered report AND the disc model, both from one demux.
 //   - `renderReport` — re-renders the report from a disc model `scan` returned,
 //     with different optional sections and without touching the media again.
+//
+// `reportFileName` rounds the flow off: the sanitized `BDINFO.<label>.txt` name
+// a report is saved under, from the same rule the native CLI applies.
 //
 // Each spawns the scan Worker (which hosts the WebAssembly module), hands it the
 // files, and resolves with the result — the rendered classic disc report being
@@ -86,8 +90,10 @@ export interface ScanOptions {
   selection?: string[];
   /**
    * The length in seconds under which a playlist counts as short, defaulting to
-   * 20 when omitted. Zero switches the short rule off, since no playlist is
-   * shorter than zero seconds; a negative or non-finite value means the default.
+   * 20 when omitted. Must be finite and within 0..=86400 (one day): zero
+   * switches the short rule off, since no playlist is shorter than zero
+   * seconds, and anything outside that domain — negative, non-finite, past the
+   * ceiling — rejects the call rather than silently scanning with the default.
    *
    * Read by {@link inspect} and {@link scan}, both of which classify every
    * playlist against it and report the outcome in {@link Playlist.hiddenBy}.
@@ -95,6 +101,20 @@ export interface ScanOptions {
    * `selection` measures, and the rendered report are all the same either way.
    */
   shortPlaylistSeconds?: number;
+  /**
+   * Read each stream file's head for codec detail during an {@link inspect},
+   * defaulting to `false`.
+   *
+   * Set it and the inspect reads just far enough into each stream file to
+   * parse the first parameter sets, so every {@link Stream} carries its full
+   * codec description — profile, level, HDR metadata — without the whole-file
+   * demux a {@link scan} costs. `Disc.measured` stays `false` and bitrates,
+   * packet counts and chapter rates are still zero.
+   *
+   * Read by {@link inspect} alone — a {@link scan} demuxes everything and
+   * carries full codec detail already.
+   */
+  codecs?: boolean;
   /**
    * Render the report's `STREAM DIAGNOSTICS:` section, defaulting to `true` —
    * the section the CLI's report carries.
@@ -138,6 +158,7 @@ type WorkerMessage =
   | { type: "done"; report: string }
   | { type: "disc"; disc: Disc }
   | { type: "result"; result: ScanResult }
+  | { type: "file-name"; name: string }
   | { type: "error"; message: string };
 
 /** Spawns the scan Worker (a module worker by the bundler-aware convention). */
@@ -178,6 +199,7 @@ function moduleOptions(options?: ScanOptions): ModuleOptions {
     quickSummary: options?.quickSummary,
     shortPlaylistSeconds: options?.shortPlaylistSeconds,
     keepPartial: options?.keepPartial,
+    codecs: options?.codecs,
   };
 }
 
@@ -265,11 +287,14 @@ function request<T>(
  * {@link Disc}) — a `webkitdirectory` folder pick or a single Blu-ray `.iso`
  * `File` in, everything the disc's metadata knows out.
  *
- * No stream file is demuxed, so it returns quickly and `disc.measured` is
+ * No stream file is measured, so it returns quickly and `disc.measured` is
  * `false`: every measured value — bitrates, packet counts, chapter rates — is
  * zero because nothing measured it rather than because it is genuinely zero.
- * Show the playlists as a checklist, then hand the chosen
- * {@link Playlist.name}s to {@link scan}'s `options.selection`.
+ * `options.codecs` deepens the scan to the bounded codec pass, which reads
+ * each stream file's head so the streams carry their full codec description
+ * (profile, level, HDR) while everything else stays as cheap as before. Show
+ * the playlists as a checklist, then hand the chosen {@link Playlist.name}s to
+ * {@link scan}'s `options.selection`.
  *
  * `disc.playlists` holds every playlist on the disc, each carrying its
  * {@link Playlist.group}, {@link Playlist.position} and
@@ -353,6 +378,28 @@ export function renderReport(disc: Disc, options?: ScanOptions): Promise<string>
   return request(
     { kind: "render", disc, options: moduleOptions(options) },
     (reply) => (reply.type === "done" ? { value: reply.report } : null),
+    options,
+  );
+}
+
+/**
+ * The file name a report for a disc labelled `label` is saved under —
+ * `BDINFO.<label>.txt` with every character illegal in a file name replaced,
+ * exactly the name the native CLI and the desktop app write.
+ *
+ * The sanitizer is the core library's (property-tested there): whatever bytes
+ * a disc puts in its volume label, the result is one flat path component, so a
+ * hostile label can neither escape a chosen directory nor break the save. Pass
+ * {@link Disc.volumeLabel} and hand the result to a download attribute.
+ *
+ * Of the options, only `createWorker` and `signal` apply — the name is
+ * computed by the WebAssembly module, so the call runs in the scan Worker like
+ * every other.
+ */
+export function reportFileName(label: string, options?: ScanOptions): Promise<string> {
+  return request(
+    { kind: "file-name", label, options: moduleOptions(options) },
+    (reply) => (reply.type === "file-name" ? { value: reply.name } : null),
     options,
   );
 }

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -20,6 +20,7 @@ import {
   inspect,
   type Playlist,
   renderReport,
+  reportFileName,
   type Stream,
   scan,
 } from "./analyze.js";
@@ -207,6 +208,14 @@ const SETTINGS_KEY = "bdinfo-rs.settings";
 const DEFAULT_SHORT_SECONDS = 20;
 
 /**
+ * The threshold domain's ceiling (0 = the short rule off), mirroring the
+ * `min`/`max` attributes on the `#opt-short-seconds` input and, through them,
+ * the library's shared threshold contract. A stored or typed value outside
+ * the domain reverts here rather than reaching the module, which throws on it.
+ */
+const MAX_SHORT_SECONDS = 86_400;
+
+/**
  * Reads the stored settings, defaulting to the standard filtered table with
  * every report section on. Sizes default to human-readable — the desktop app
  * ships thousands-grouped bytes instead, and this page has always shown
@@ -230,7 +239,10 @@ function loadSettings(): Settings {
     showShortPlaylists: stored.showShortPlaylists === true,
     showLoopingPlaylists: stored.showLoopingPlaylists === true,
     shortPlaylistSeconds:
-      typeof seconds === "number" && Number.isInteger(seconds) && seconds > 0
+      typeof seconds === "number" &&
+      Number.isInteger(seconds) &&
+      seconds >= 0 &&
+      seconds <= MAX_SHORT_SECONDS
         ? seconds
         : DEFAULT_SHORT_SECONDS,
     humanReadableSizes: stored.humanReadableSizes !== false,
@@ -871,12 +883,21 @@ async function copyReport(): Promise<void> {
   }
 }
 
-function downloadReport(): void {
+async function downloadReport(): Promise<void> {
+  // The module's sanitizer names the file: the disc controls its own label
+  // bytes, and this is the one place the demo turns that label into a path.
+  let name: string;
+  try {
+    name = await reportFileName(discName);
+  } catch (error) {
+    showError(errMessage(error));
+    return;
+  }
   const blob = new Blob([reportText], { type: "text/plain;charset=utf-8" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
-  link.download = `BDINFO.${discName}.txt`;
+  link.download = name;
   link.click();
   URL.revokeObjectURL(url);
 }
@@ -985,8 +1006,9 @@ async function applyReportSections(): Promise<void> {
  * table. A value equal to the one in force changes nothing and sends nothing.
  */
 async function applyThreshold(): Promise<void> {
+  // 0 is a committed value like any other: it turns the short rule off.
   const parsed = Number(optShortSeconds.value);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > MAX_SHORT_SECONDS) {
     optShortSeconds.value = String(settings.shortPlaylistSeconds);
     return;
   }
@@ -1085,4 +1107,6 @@ cancelBtn.addEventListener("click", () => {
 copyBtn.addEventListener("click", () => {
   void copyReport();
 });
-downloadBtn.addEventListener("click", downloadReport);
+downloadBtn.addEventListener("click", () => {
+  void downloadReport();
+});

--- a/crates/bdinfo-rs-wasm/web/src/worker.ts
+++ b/crates/bdinfo-rs-wasm/web/src/worker.ts
@@ -1,10 +1,12 @@
 /// <reference lib="webworker" />
 // The scan Worker: hosts the WebAssembly module OFF the main thread. It serves
 // every request in `analyze.ts` over the same module instance:
-//   - `inspect` / `inspect-iso`: the fast STRUCTURAL scan → the whole disc model.
+//   - `inspect` / `inspect-iso`: the STRUCTURAL scan (optionally deepened to
+//     the bounded codec pass by `options.codecs`) → the whole disc model.
 //   - `scan` / `scan-iso`: the FULL measured scan → the rendered report and the
 //     disc model, from one demux.
 //   - `render`: re-render the report from a disc model — no media touched.
+//   - `file-name`: the sanitized report save-file name for a disc label.
 // The wasm reads each file's bytes synchronously at byte offsets through
 // `FileReaderSync` (the reason this must be a Worker — that API exists only in a
 // Worker scope), so a multi-GB stream never has to fit in memory. Progress is
@@ -19,6 +21,7 @@ import init, {
   inspect_files,
   inspect_iso,
   render_report,
+  report_file_name,
   type ScanOptions,
   scan_files,
   scan_iso,
@@ -70,7 +73,19 @@ interface RenderRequest extends WithOptions {
   disc: Disc;
 }
 
-type Request = InspectRequest | InspectIsoRequest | ScanRequest | ScanIsoRequest | RenderRequest;
+/** The sanitized report save-file name for a disc label. */
+interface FileNameRequest extends WithOptions {
+  kind: "file-name";
+  label: string;
+}
+
+type Request =
+  | InspectRequest
+  | InspectIsoRequest
+  | ScanRequest
+  | ScanIsoRequest
+  | RenderRequest
+  | FileNameRequest;
 
 let ready: Promise<unknown> | null = null;
 
@@ -87,18 +102,16 @@ self.onmessage = async (event: MessageEvent<Request>) => {
       self.postMessage({ type: "progress", file, done, total });
     };
     switch (data.kind) {
-      // The two structural calls take the classification threshold on its own:
-      // a scan that reads no packets is unaffected by every other option.
       case "inspect":
         self.postMessage({
           type: "disc",
-          disc: inspect_files(data.paths, data.files, data.options.shortPlaylistSeconds),
+          disc: inspect_files(data.paths, data.files, data.options),
         });
         break;
       case "inspect-iso":
         self.postMessage({
           type: "disc",
-          disc: inspect_iso(data.file, data.options.shortPlaylistSeconds),
+          disc: inspect_iso(data.file, data.options),
         });
         break;
       case "scan":
@@ -117,6 +130,12 @@ self.onmessage = async (event: MessageEvent<Request>) => {
         self.postMessage({
           type: "done",
           report: render_report(data.disc, data.options),
+        });
+        break;
+      case "file-name":
+        self.postMessage({
+          type: "file-name",
+          name: report_file_name(data.label),
         });
         break;
     }

--- a/crates/bdinfo-rs-wasm/web/test/harness.html
+++ b/crates/bdinfo-rs-wasm/web/test/harness.html
@@ -6,17 +6,18 @@
     <title>bdinfo-rs wasm parity harness</title>
   </head>
   <body>
-    <!-- Headless-Chrome parity harness: exposes the package's three public calls
-         on the window so the Playwright test can hand them File objects (a folder
+    <!-- Headless-Chrome parity harness: exposes the package's public calls on
+         the window so the Playwright test can hand them File objects (a folder
          pick, and a single `.iso`) built from the committed Big Buck Bunny
          fixture, compare each report to its golden, drive the playlist
          classification through the real Worker, and round-trip a disc model back
          into a report. -->
     <script type="module">
-      import { inspect, renderReport, scan } from "/dist/analyze.js";
+      import { inspect, renderReport, reportFileName, scan } from "/dist/analyze.js";
       window.__inspect = inspect;
       window.__scan = scan;
       window.__renderReport = renderReport;
+      window.__reportFileName = reportFileName;
       window.__ready = true;
     </script>
   </body>

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -109,6 +109,7 @@ async function main() {
 
   let listings;
   let structured;
+  let surface;
   let isoStructured;
   let demo;
   try {
@@ -190,6 +191,24 @@ async function main() {
         report: scanned.report,
         reRendered: await window.__renderReport(scanned.disc),
         trimmed: await window.__renderReport(scanned.disc, { streamDiagnostics: false }),
+      };
+    });
+
+    // The rest of the option/API surface through the real Worker: an
+    // out-of-domain threshold rejects instead of defaulting, a codecs inspect
+    // deepens the stream descriptions while staying unmeasured, and the report
+    // save-file name comes back through the core sanitizer.
+    surface = await page.evaluate(async () => {
+      const rejected = await window.__inspect(window.__files, { shortPlaylistSeconds: -1 }).then(
+        () => null,
+        (error) => String(error.message ?? error),
+      );
+      const codecs = await window.__inspect(window.__files, { codecs: true });
+      return {
+        rejected,
+        codecsMeasured: codecs.measured,
+        codecsVideo: codecs.playlists[0].streams[0].fullDescription,
+        fileName: await window.__reportFileName("a/b:c"),
       };
     });
 
@@ -418,6 +437,18 @@ async function main() {
     // no request at all and leave everything the page holds where it is.
     await demoPage.click("#opt-keep-partial");
     const retentionOff = await readDemo();
+
+    // The threshold input accepts 0 — the committed "rule off" value: one more
+    // inspect re-classifies the table (nothing is short under 0 s either) and
+    // the stored setting becomes 0.
+    await demoPage.fill("#opt-short-seconds", "0");
+    await demoPage.locator("#opt-short-seconds").blur();
+    await demoPage.waitForFunction(
+      (want) => window.__calls.length === want,
+      retentionOff.calls.length + 1,
+      { timeout: 30000 },
+    );
+    const zeroThreshold = await readDemo();
     await demoPage.click("#settings-close");
 
     // A phone-width viewport must not scroll the page sideways — wide tables
@@ -464,6 +495,7 @@ async function main() {
       afterRenders,
       thresholdApplied,
       retentionOff,
+      zeroThreshold,
       pageScrolls,
       persisted,
     };
@@ -549,6 +581,19 @@ async function main() {
     console.error(
       `FAIL — scan/renderReport: measured ${structured.measured}, first stream rate ${structured.rate}, trimmed ${structured.trimmed.length} B.`,
     );
+  }
+
+  // The new-surface checks: rejection, codecs depth, and the sanitized name.
+  const surfaceOk =
+    typeof surface.rejected === "string" &&
+    surface.rejected.includes("shortPlaylistSeconds") &&
+    surface.codecsMeasured === false &&
+    surface.codecsVideo.includes("High Profile 4.1") &&
+    surface.fileName === "BDINFO.a_b_c.txt";
+  if (surfaceOk) {
+    console.log("PASS — Worker rejection, codecs inspect and reportFileName behave.");
+  } else {
+    console.error(`FAIL — option/API surface: ${JSON.stringify(surface)}`);
   }
 
   // The same two calls handed a single `File` instead of a list, which is what
@@ -766,11 +811,25 @@ async function main() {
     "00002.MPLS",
   ]);
 
+  // The zero threshold: accepted as a committed value (one more inspect), and
+  // nothing on the disc is short under it.
+  demoOk &= demoEq("a zero threshold costs one inspect", demo.zeroThreshold.calls, [
+    ...demo.retentionOff.calls,
+    "inspect",
+  ]);
+  demoOk &= demoEq("a zero threshold leaves nothing short", demo.zeroThreshold.names, [
+    "00001.MPLS [02 Chapters]",
+    "00000.MPLS",
+    "00002.MPLS",
+  ]);
+  demoOk &= demoEq("a zero threshold shows no short hint", demo.zeroThreshold.hintHidden, true);
+
   demoOk &= demoEq("no sideways page scroll at phone width", demo.pageScrolls, false);
   // Retention was switched off above, so the reload proves the stored `false`
-  // is read back rather than defaulted to on like an absent setting.
+  // is read back rather than defaulted to on like an absent setting; the
+  // stored 0 threshold likewise comes back as the committed 0, not the default.
   demoOk &= demoEq("settings survive a reload", demo.persisted, {
-    seconds: "5",
+    seconds: "0",
     short: false,
     looping: false,
     human: true,
@@ -781,7 +840,7 @@ async function main() {
   });
   demoOk = Boolean(demoOk);
 
-  process.exit(listOk && inspectOk && scanOk && isoStructuredOk && demoOk ? 0 : 1);
+  process.exit(listOk && inspectOk && scanOk && surfaceOk && isoStructuredOk && demoOk ? 0 : 1);
 }
 
 main().catch((err) => {

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -94,8 +94,15 @@ function shortPlaylist(mpls) {
 async function main() {
   const golden = await readFile(goldenPath);
 
-  const { initSync, scan_files, scan_iso, inspect_files, inspect_iso, render_report } =
-    await import("../pkg/bdinfo_rs_wasm.js");
+  const {
+    initSync,
+    scan_files,
+    scan_iso,
+    inspect_files,
+    inspect_iso,
+    render_report,
+    report_file_name,
+  } = await import("../pkg/bdinfo_rs_wasm.js");
   initSync({ module: await readFile(wasmPath) });
 
   const paths = [];
@@ -174,7 +181,7 @@ async function main() {
   const numbering = (playlists) =>
     JSON.stringify(playlists.map((playlist) => [playlist.group, playlist.position]));
   const standard = inspect_files(shortPaths, shortFiles).playlists;
-  const lowered = inspect_files(shortPaths, shortFiles, 5).playlists;
+  const lowered = inspect_files(shortPaths, shortFiles, { shortPlaylistSeconds: 5 }).playlists;
   const measuredShort = scan_files(shortPaths, shortFiles, [], undefined, {
     streamDiagnostics: true,
     quickSummary: true,
@@ -184,7 +191,7 @@ async function main() {
     classify(standard) === '["00000.MPLS:","00001.MPLS:short"]' &&
     // A zero threshold switches the short rule off: nothing is shorter than
     // zero seconds, so neither playlist is withheld.
-    classify(inspect_files(shortPaths, shortFiles, 0).playlists) ===
+    classify(inspect_files(shortPaths, shortFiles, { shortPlaylistSeconds: 0 }).playlists) ===
       '["00000.MPLS:","00001.MPLS:"]' &&
     classify(lowered) === '["00000.MPLS:","00001.MPLS:"]' &&
     numbering(standard) === "[[1,1],[1,2]]" &&
@@ -195,6 +202,52 @@ async function main() {
   if (!thresholdOk) {
     console.error(
       `FAIL — classification unexpected: standard ${classify(standard)}, lowered ${classify(lowered)}, numbering ${numbering(standard)}, measured ${classify(measuredShort.playlists)}.`,
+    );
+  }
+
+  // An out-of-domain threshold throws — from the structural and the measured
+  // export alike — instead of silently scanning with the 20 s default.
+  const rejects = (run) => {
+    try {
+      run();
+      return false;
+    } catch (error) {
+      return String(error.message ?? error).includes("shortPlaylistSeconds");
+    }
+  };
+  const rejectionOk =
+    rejects(() => inspect_files(paths, files, { shortPlaylistSeconds: -1 })) &&
+    rejects(() => inspect_files(paths, files, { shortPlaylistSeconds: 86401 })) &&
+    rejects(() => inspect_files(paths, files, { shortPlaylistSeconds: Number.NaN })) &&
+    rejects(() => scan_files(paths, files, [], undefined, { shortPlaylistSeconds: -1 }));
+  if (!rejectionOk) {
+    console.error("FAIL — an out-of-domain shortPlaylistSeconds did not throw.");
+  }
+
+  // The codecs depth: an inspect that reads each stream file's head. The video
+  // stream's description gains its profile/level while the disc stays
+  // unmeasured (the LPCM rate is parameter-declared, so it may fill in).
+  const codecsDisc = inspect_files(paths, files, { codecs: true });
+  const codecsVideo = codecsDisc.playlists[0].streams[0];
+  const plainVideo = inspected.playlists[0].streams[0];
+  const codecsOk =
+    codecsDisc.measured === false &&
+    codecsVideo.bitrateBps === 0 &&
+    codecsVideo.fullDescription.includes("High Profile 4.1") &&
+    !plainVideo.fullDescription.includes("Profile");
+  if (!codecsOk) {
+    console.error(
+      `FAIL — codecs inspect unexpected: measured ${codecsDisc.measured}, video "${codecsVideo.fullDescription}", plain "${plainVideo.fullDescription}".`,
+    );
+  }
+
+  // The report save-file name, sanitized by the core rule.
+  const fileNameOk =
+    report_file_name("WASMDISC") === "BDINFO.WASMDISC.txt" &&
+    report_file_name("a/b:c") === "BDINFO.a_b_c.txt";
+  if (!fileNameOk) {
+    console.error(
+      `FAIL — report_file_name unexpected: ${report_file_name("WASMDISC")}, ${report_file_name("a/b:c")}.`,
     );
   }
 
@@ -299,6 +352,9 @@ async function main() {
     inspectOk &&
     tableOk &&
     thresholdOk &&
+    rejectionOk &&
+    codecsOk &&
+    fileNameOk &&
     fullOk &&
     keepPartialOk &&
     isoOk &&
@@ -307,7 +363,7 @@ async function main() {
     isoFullOk
   ) {
     console.log(
-      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + selection + round trip + retention + .iso OK.`,
+      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + rejection + codecs + file name + selection + round trip + retention + .iso OK.`,
     );
     process.exit(0);
   }

--- a/crates/bdinfo-rs/build.rs
+++ b/crates/bdinfo-rs/build.rs
@@ -133,10 +133,12 @@ const LONG_HELP: [(&str, &str); 14] = [
     (
         "short_playlist_seconds",
         "The length in whole seconds below which a playlist counts as short, 20 by default. A \
-         playlist of exactly this length is not short. The cutoff decides what the selection \
-         table hides, what the hidden-playlist line names, and therefore what --whole scans; \
-         --show-short-playlists lists the short ones anyway. Playlists named with --mpls are \
-         never filtered, so the cutoff does not reach them.",
+         playlist of exactly this length is not short. Valid from 0 to 86400 (one day): 0 \
+         classifies nothing as short, and a value past the ceiling is rejected at argument \
+         parsing. The cutoff decides what the selection table hides, what the hidden-playlist \
+         line names, and therefore what --whole scans; --show-short-playlists lists the short \
+         ones anyway. Playlists named with --mpls are never filtered, so the cutoff does not \
+         reach them.",
     ),
     (
         "drop_partial",

--- a/crates/bdinfo-rs/src/cli.rs
+++ b/crates/bdinfo-rs/src/cli.rs
@@ -76,11 +76,19 @@ struct Cli {
     // `hide_default_value` keeps clap from appending its own `[default: 20]`:
     // the help card states the default inline instead, the way REPORT_DEST
     // does, and the appended form would push this line past 80 columns.
+    //
+    // The `86_400` ceiling (one day; `0` classifies nothing as short)
+    // duplicates `bdinfo_rs_core::bdrom::order::MAX_SHORT_PLAYLIST_SECONDS` by
+    // necessity: `build.rs` `include!`s this file and has no core
+    // build-dependency, so the constant cannot be named here. The test
+    // `the_cutoff_ceiling_matches_the_core_constant` in `tests/cli.rs` pins
+    // the two equal.
     #[arg(
         long,
         value_name = "SECONDS",
         default_value_t = 20,
         hide_default_value = true,
+        value_parser = clap::value_parser!(u32).range(..=86_400),
         help = "Short-playlist cutoff (default: 20)"
     )]
     short_playlist_seconds: u32,

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -515,10 +515,6 @@ fn a_zero_cutoff_classifies_nothing_as_short() {
 }
 
 #[test]
-#[expect(
-    clippy::expect_used,
-    reason = "end-to-end test driver; a failed spawn or conversion should abort the test loudly"
-)]
 fn the_cutoff_ceiling_matches_the_core_constant() {
     // `src/cli.rs` spells the 86_400 ceiling as a literal (`build.rs`
     // `include!`s that file without the library), so this is the check that

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -7,8 +7,8 @@
 //! all real code.
 #![expect(
     unused_crate_dependencies,
-    reason = "black-box CLI test spawns the built binary; it links the bin's \
-              deps (clap, bdinfo-rs-core) but uses neither directly"
+    reason = "black-box CLI test spawns the built binary; it links the bin's clap but never \
+              names it (bdinfo-rs-core IS named, but only for the shared threshold ceiling)"
 )]
 
 pub mod common;
@@ -496,6 +496,51 @@ fn the_short_playlist_cutoff_moves_what_the_table_hides_and_what_the_hint_names(
              with --show-short-playlists"
         ),
         "the hint judges against the given cutoff: {raised}"
+    );
+}
+
+#[test]
+fn a_zero_cutoff_classifies_nothing_as_short() {
+    let root = filtered_bd("cutoffzero");
+    let stdout = listing(&root, &["--short-playlist-seconds", "0"]);
+    let _ = std::fs::remove_dir_all(&root).is_ok();
+
+    // Nothing is strictly shorter than zero seconds: the 10 s playlist joins
+    // the table, the short hint disappears, and only the looping rule still
+    // withholds.
+    assert_eq!(table_row_lines(&stdout).len(), 2, "table: {stdout}");
+    assert!(stdout.contains("2   1      00002.MPLS     00:00:10"), "table: {stdout}");
+    assert!(!stdout.contains("(short)"), "nothing is short at 0 s: {stdout}");
+    assert!(stdout.contains(LOOPING_HINT), "the looping hint is unaffected: {stdout}");
+}
+
+#[test]
+#[expect(
+    clippy::expect_used,
+    reason = "end-to-end test driver; a failed spawn or conversion should abort the test loudly"
+)]
+fn the_cutoff_ceiling_matches_the_core_constant() {
+    // `src/cli.rs` spells the 86_400 ceiling as a literal (`build.rs`
+    // `include!`s that file without the library), so this is the check that
+    // keeps the two in step: the constant's own value parses…
+    let max = bdinfo_rs_core::bdrom::order::MAX_SHORT_PLAYLIST_SECONDS;
+    let root = filtered_bd("cutoffceiling");
+    let accepted = listing(&root, &["--short-playlist-seconds", &max.to_string()]);
+    let _ = std::fs::remove_dir_all(&root).is_ok();
+    assert!(table_row_lines(&accepted).is_empty(), "a day-long cutoff hides everything");
+
+    // …and one past it fails at argument parsing: exit 2 (an invalid
+    // argument), before any path is touched.
+    let over = u64::from(max).checked_add(1).expect("86_401 fits a u64");
+    let output = bdinfo_rs()
+        .args(["X", "--short-playlist-seconds", &over.to_string()])
+        .output()
+        .expect("spawn bdinfo-rs");
+    assert_eq!(output.status.code(), Some(2), "an out-of-range cutoff is a usage error");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("short-playlist-seconds") && stderr.contains(&over.to_string()),
+        "the error names the flag and the rejected value: {stderr}"
     );
 }
 


### PR DESCRIPTION
Unifies the short-playlist threshold contract across the four surfaces and completes the wasm API surface ahead of 3.0.0.

Threshold contract: the valid domain is 0 to 86400 seconds everywhere, and 0 disables the short rule. Programmatic surfaces reject out-of-range input; interactive surfaces clamp.

- core: new public constant MAX_SHORT_PLAYLIST_SECONDS (86400) beside PlaylistFilter documents the domain and the zero-disables rule. The filter itself still judges any value; holding input to the domain is each caller's job at its own boundary.
- gui: MAX_SHORT_SECONDS now derives from the core constant. The documented clamp semantics and the conf keys are unchanged.
- cli: --short-playlist-seconds is range-validated over 0 to 86400 at argument parsing; a value past the ceiling exits 2 before any path is touched, and 0 classifies nothing as short. The parser spells the ceiling as a literal because build.rs includes the CLI definition without the library; an end-to-end test pins the literal equal to the core constant. The man page states the range; the help card bytes are unchanged.
- wasm: a negative, non-finite or over-ceiling shortPlaylistSeconds now throws from every export instead of silently becoming the 20 s default; absent still means the default. inspect_files and inspect_iso take the same options object as the scan exports, replacing the bare positional threshold, and gain an optional codecs flag: true runs the bounded codec pass, so streams carry their full codec descriptions (profile, level, HDR) while measured stays false. A new report_file_name export wraps the core report-filename sanitizer and is exposed on the package entry as reportFileName.
- demo: the threshold input accepts 0 as the rule-off value (min moves to 0, the max stays), a stored or typed out-of-range value reverts instead of reaching the module, and the report download uses reportFileName. The demo holds no wasm instance on the main thread, so reportFileName runs as a request to the scan worker like every other package call - the worker round-trip wiring.

No report byte changes: the golden fixtures and the wasm round-trip goldens are untouched. New cases in the native tests and in the Node and headless-Chrome parity suites cover the rejection, the codecs depth, the sanitized file name, and the zero threshold end to end.
