### PR TITLE
docs: correct release-note wording and complete the release checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   opt back into discarding. (#285)
 * **core:** one short-playlist threshold contract on every surface: the valid domain is
   0 to 86400 seconds, and 0 switches the short rule off. Programmatic surfaces (CLI,
-  npm) reject out-of-domain values; interactive ones (GUI dialog, demo page) clamp.
-  (#286)
+  npm) reject out-of-domain values; the GUI dialog clamps, and the demo page reverts to
+  its default. (#286)
 * **wasm:** a codecs-depth inspect: `codecs: true` reads just each stream file's head,
   so every stream carries its full codec description — profile, level, HDR metadata —
   without the whole-file demux a measured scan costs. (#286)
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `selection` measures an explicit playlist set unfiltered. (#214)
 * **wasm:** the demo gains playlist-filter, report-section, and size-format settings.
   (#214, #223)
-* **wasm:** the structured model carries the encrypted-disc flag (`aacsEncrypted`).
+* **wasm:** the structured model carries the encrypted-disc flag (`isAacsEncrypted`).
   (#247)
 * **cli:** playlist visibility switches — `--show-short-playlists` and
   `--show-looping-playlists` with a hidden-playlist hint (#202) — plus

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,6 +234,7 @@ releases; only the tag does.
    | `SECURITY.md` | the supported-versions table |
    | `INSTALL.md` | the Docker pin example and the rolling-tag sentence |
    | `.github/ISSUE_TEMPLATE/bug_report.yml`, `gui_bug_report.yml`, `output_difference.yml` | the version-field placeholders |
+   | `crates/bdinfo-rs-wasm/Cargo.lock`, `crates/bdinfo-rs-gui/Cargo.lock`, `fuzz/Cargo.lock` | each sibling lockfile records the workspace crate versions; a `cargo check` in that workspace refreshes it |
 
    The npm tag guard cross-checks the workspace version, the wasm crate version and
    `package.json` against the pushed tag, so a missed one fails the release rather than shipping.

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -30,6 +30,7 @@ actually see on a normal disc.
 | [AC-3 low-sample-rate shift](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on non-BD input | Legacy `bsid` 9/10; conforming Blu-ray AC-3 is always `bsid` 8 |
 | [HEVC `profile_idc` recovery](#correctness-fixes-with-no-effect-on-a-normal-disc) | Edge case only | Malformed headers with `general_profile_idc == 0` |
 | [VC-1 interlaced-field picture type](#correctness-fixes-with-no-effect-on-a-normal-disc) | **No** — internal only | Never — the picture tag is counted, never printed |
+| [PAT `table_id` validation](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on malformed input | Never — no conforming disc carries a wrong PAT table id |
 | [AACS-encrypted discs are refused](#aacs-encrypted-discs-are-refused) | **Yes** — no report at all | Discs whose stream content is still encrypted |
 
 ---

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -241,7 +241,7 @@ cargo test
 
 The desktop app is `bdinfo-rs-gui`, released on its own
 [`gui-v*` tags](https://github.com/agentjp/bdinfo-rs/releases?q=%22native+desktop+GUI%22&expanded=true)
-and versioned independently of the command-line binary.
+and versioned in lock-step with the command-line binary.
 
 **Settings and log.** On every platform the app keeps its settings (`gui.conf`) and log
 (`gui.log`) in one per-user folder: `%APPDATA%\bdinfo-rs` on Windows,

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ fallback) — no webview and no bundled runtime.
 
 ```sh
 winget install agentjp.bdinfo-rs-gui              # Windows
-brew install --cask agentjp/tap/bdinfo-rs-gui     # macOS / Linux
+brew install --cask agentjp/tap/bdinfo-rs-gui     # macOS
 yay -S bdinfo-rs-gui-bin                          # Arch
 ```
 

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -21,7 +21,7 @@ Firefox.
 npm i @bdinfo-rs/wasm
 ```
 
-The published payload is **~497 KB of WebAssembly + ~44 KB of JS**. Only the
+The published payload is **~501 KB of WebAssembly + ~44 KB of JS**. Only the
 main-thread entry you import (~9 KB) loads up front; the scan Worker (~3 KB)
 and the wasm-bindgen glue (~32 KB) that hosts the `.wasm` are fetched lazily
 inside the Worker, and nothing past the entry loads at all until the first scan.


### PR DESCRIPTION
Pre-tag documentation review fixes, no code changes.

- CHANGELOG 3.0.0: the structured-model flag is isAacsEncrypted, not aacsEncrypted; the name ships in the generated release notes.
- CHANGELOG 3.0.0: the demo page reverts an out-of-domain threshold to its default; only the GUI dialog clamps.
- INSTALL: the desktop app is versioned in lock-step with the command-line binary, not independently.
- CONTRIBUTING: the release checklist now names the three sibling lockfiles (wasm, gui, fuzz) that record the workspace crate versions.
- DIFFERENCES: the at-a-glance table gains the PAT table_id validation row its correctness-fixes section already documents.
- npm README: the wasm payload figure is ~501 KB after the options-object visitor landed.
- README: the Homebrew cask is macOS-only.