### PR TITLE
ci: keep the komac version banner out of the returned binary path

### DIFF
--- a/.github/scripts/publish-gui-winget.ps1
+++ b/.github/scripts/publish-gui-winget.ps1
@@ -143,7 +143,9 @@ function Install-Komac {
     tar -xzf $tarball -C $dir komac
     if ($LASTEXITCODE -ne 0) { Stop-Leg 'could not extract komac' }
     $komac = Join-Path $dir 'komac'
-    & $komac --version
+    # Write-Host, not bare invocation: the version banner would join the
+    # function's output stream and corrupt the returned path into an array.
+    Write-Host (& $komac --version)
     if ($LASTEXITCODE -ne 0) { Stop-Leg 'komac does not run' }
     return $komac
 }


### PR DESCRIPTION
Install-Komac in publish-gui-winget.ps1 invoked komac --version bare, so the banner joined the function output stream and the returned binary path became a two-element array. The subsequent call-operator invocation then tried to execute a command named after the stringified array and failed. First surfaced on the gui-v3.0.0 publish run: the 2.0.0 run exited on the bootstrap-pending path before Install-Komac ran, so the return value was never consumed until now. The banner now goes through Write-Host, which keeps it in the log and out of the output stream.