### PR TITLE
docs(ci): correct the WINGET_TOKEN scope and the npm approve flow

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -27,7 +27,12 @@ name: packages
 #   - Scoop     -> the agentjp/scoop-bucket repo (Excavator auto-update bot)
 #
 # Secrets required (configure before the first release, or the jobs fail):
-#   WINGET_TOKEN       - classic PAT (public_repo) on the bot account that forked winget-pkgs
+#   WINGET_TOKEN       - classic PAT (public_repo + workflow) on the bot account that forked
+#                        winget-pkgs. `workflow` is required: komac syncs the fork before
+#                        submitting, and that CreateRef is rejected without it once upstream
+#                        winget-pkgs has changed .github/workflows past the fork's last sync.
+#                        Reads still work, so `komac list-versions` passes and only the
+#                        submit fails.
 #   AUR_SSH_KEY        - private SSH key whose public half is on the aur.archlinux.org account
 #   CLOUDSMITH_API_KEY - Cloudsmith API key (used by the linux-packages job)
 #

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -266,8 +266,9 @@ jobs:
           Write-Host "Staged $tag with provenance. It is NOT live until approved (2FA):"
           Write-Host "  npm stage view @bdinfo-rs/wasm"
           Write-Host "  npm stage download @bdinfo-rs/wasm"
-          Write-Host "  npm stage approve @bdinfo-rs/wasm     (or npm stage reject)"
+          Write-Host "  npm stage list @bdinfo-rs/wasm        (copy the stage UUID)"
+          Write-Host "  npm stage approve <stage-uuid>        (or npm stage reject <stage-uuid>)"
           Write-Host "Or approve at npmjs.com -> the package -> Staged."
           if ($env:GITHUB_STEP_SUMMARY) {
-            "@bdinfo-rs/wasm $tag is STAGED (not live). Approve with: npm stage approve @bdinfo-rs/wasm (2FA), or on npmjs.com." | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+            "@bdinfo-rs/wasm $tag is STAGED (not live). Approve with: npm stage list @bdinfo-rs/wasm -> npm stage approve <stage-uuid> (2FA), or on npmjs.com." | Add-Content -Path $env:GITHUB_STEP_SUMMARY
           }


### PR DESCRIPTION
Two stale statements in the publish workflows:

- packages.yml said WINGET_TOKEN needs only public_repo. komac syncs the fork before submitting, and that CreateRef is rejected without the workflow scope once upstream winget-pkgs has changed .github/workflows past the fork last sync; reads keep working, so the list-versions preflight passes while the submit fails. Documented the full required scope (public_repo + workflow) with the failure mode.
- publish-npm.yml printed "npm stage approve @bdinfo-rs/wasm" in the log and job summary. npm stage approve takes the stage UUID, not the package name. The reminder now prints the list-then-approve sequence.