### PR TITLE
ci: refresh the stale tool pins and tighten the release-status cloudsmith query

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -86,7 +86,7 @@ NPM=12.0.2
 
 # wrangler, invoked with npx to deploy the demo site. Pinned because it runs with
 # the Cloudflare Pages deploy token.
-WRANGLER=4.121.0
+WRANGLER=4.122.0
 
 # komac, fetched over curl to submit the WinGet manifests. winget-releaser wraps
 # the same tool but bootstraps it through cargo-bins/cargo-binstall@main, which
@@ -94,4 +94,4 @@ WRANGLER=4.121.0
 KOMAC=2.16.0
 
 # cloudsmith-cli, installed with pipx by the package push legs.
-CLOUDSMITH_CLI=1.21.0
+CLOUDSMITH_CLI=1.22.0

--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -137,11 +137,14 @@ jobs:
 
           # Cloudsmith deb/rpm — anonymous public API. Cloudsmith stores the packaging-
           # revisioned version (e.g. 1.2.0-1), so match the version BASE (strip -<revision>),
-          # NOT a bare version: query. Expect 4 (deb+rpm x2 arch). Retry a transient failure.
+          # NOT a bare version: query. The bdinfo-rs-gui packages share this repository and
+          # an unanchored name search matches by substring, so anchor the exact name
+          # (name:^bdinfo-rs$) and re-check it in jq, like the GUI row below. Expect 4
+          # (deb+rpm x2 arch). Retry a transient failure.
           cs="?"; i=0
           while [ "$i" -lt 3 ]; do
-            cs=$(curl -sS -G "https://api.cloudsmith.io/v1/packages/bdinfo-rs/bdinfo-rs/" --data-urlencode "query=version:$ver*" --data-urlencode "page_size=100" 2>/dev/null \
-              | jq --arg v "$ver" '[.[] | select((.version | sub("-[0-9]+$"; "")) == $v)] | length' 2>/dev/null || echo "?")
+            cs=$(curl -sS -G "https://api.cloudsmith.io/v1/packages/bdinfo-rs/bdinfo-rs/" --data-urlencode "query=name:^bdinfo-rs$ version:$ver*" --data-urlencode "page_size=100" 2>/dev/null \
+              | jq --arg v "$ver" '[.[] | select(.name == "bdinfo-rs") | select((.version | sub("-[0-9]+$"; "")) == $v)] | length' 2>/dev/null || echo "?")
             { [ "$cs" != "?" ] && [ -n "$cs" ]; } && break
             i=$((i+1)); sleep 2
           done

--- a/crates/bdinfo-rs-wasm/web/biome.json
+++ b/crates/bdinfo-rs-wasm/web/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
   "files": {
     "includes": [
       "**",

--- a/crates/bdinfo-rs-wasm/web/build.mjs
+++ b/crates/bdinfo-rs-wasm/web/build.mjs
@@ -25,9 +25,22 @@ execSync("cargo build --release --target wasm32-unknown-unknown --locked", {
 execSync(`wasm-bindgen --target web --out-dir "${pkg}" --out-name bdinfo_rs_wasm "${wasm}"`, {
   stdio: "inherit",
 });
-// `--all-features`: rustc's wasm32 output uses sign-ext / bulk-memory / etc., so
-// wasm-opt must accept those features or it rejects the module as invalid.
-execFileSync(process.execPath, [wasmOpt, "-Oz", "--all-features", bg, "-o", bg], {
+// rustc's wasm32-unknown-unknown output uses these target features (the
+// target's defaults), so wasm-opt must accept each or it rejects the module as
+// invalid. They are enabled individually, NOT with --all-features: that flag
+// also opts into new BINARY ENCODINGS engines may not parse yet — binaryen 132's
+// --all-features emits the compact import section (WebAssembly/binaryen#8926),
+// which Node 26 rejects at compile with "unknown import kind". A feature rustc
+// starts needing fails loudly at validation; add its --enable flag here.
+const features = [
+  "--enable-sign-ext",
+  "--enable-bulk-memory",
+  "--enable-mutable-globals",
+  "--enable-nontrapping-float-to-int",
+  "--enable-multivalue",
+  "--enable-reference-types",
+];
+execFileSync(process.execPath, [wasmOpt, "-Oz", ...features, bg, "-o", bg], {
   stdio: "inherit",
 });
 

--- a/crates/bdinfo-rs-wasm/web/package-lock.json
+++ b/crates/bdinfo-rs-wasm/web/package-lock.json
@@ -10,7 +10,7 @@
       "license": "LGPL-2.1-or-later",
       "devDependencies": {
         "@biomejs/biome": "^2",
-        "binaryen": "^131.0.0",
+        "binaryen": "^132.0.0",
         "playwright-core": "^1",
         "typescript": "^7"
       }
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/binaryen": {
-      "version": "131.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-131.0.0.tgz",
-      "integrity": "sha512-anblNezmBjfWGfOMvZq1j5MwhVnMs+gezqbDz4FBFwx6twDwOsQSed+E8i4UKmLYXb3r+f3HWmz7Lx5sx5qOyQ==",
+      "version": "132.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-132.0.0.tgz",
+      "integrity": "sha512-4Usg7yEvwO3FMso3Oov6qkOOHSod1IEv+boKkh77kTljM+eNBouqCTbqWswGzbG+vDNO/b/v2C4gfEh1WgB9Lg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/crates/bdinfo-rs-wasm/web/package.json
+++ b/crates/bdinfo-rs-wasm/web/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2",
-    "binaryen": "^131.0.0",
+    "binaryen": "^132.0.0",
     "playwright-core": "^1",
     "typescript": "^7"
   }


### PR DESCRIPTION
Closes #309.

- pins.env: wrangler 4.121.0 -> 4.122.0, cloudsmith-cli 1.21.0 -> 1.22.0.
- web/package.json + lockfile: binaryen ^131.0.0 -> ^132.0.0. The rebuilt optimized wasm is 522141 B of the 1048576 B budget (49.8%).
- web/biome.json: schema URL 2.5.6 -> 2.5.7, matching the installed @biomejs/biome.
- build.mjs: wasm-opt now enables the rustc wasm32 target features individually instead of --all-features. binaryen 132 under --all-features opportunistically emits the compact import section (WebAssembly/binaryen#8926), which Node 26 rejects at compile time with "unknown import kind"; the Node golden-parity check caught it. An explicit list keeps new binary encodings off by default and a newly-required feature fails loudly at validation.
- release-status.yml: the CLI Cloudsmith row queried version only, so the four bdinfo-rs-gui packages (substring name match, same repository) inflated its count to 8/4. The query now anchors the exact package name (name:^bdinfo-rs$) and re-checks it in jq, like the GUI row. Verified against the live API: 8 -> 4 for 3.0.0.

The wrangler pin is only exercised by deploy-pages and the cloudsmith-cli pin by the tag/dispatch publish lanes; PR CI validates their syntax, first live run is the next deploy/release.