### PR TITLE
fix(gui): keep the scan display live and log the scan through stalled reads

### DIFF
--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -369,6 +369,11 @@ enum Inner {
         /// The names being scanned, in table order — the report's selection
         /// order, carried into `Reported` for option-change re-renders.
         scanned: Vec<String>,
+        /// Whether progress events have gone quiet past the stall threshold
+        /// ([`crate::progress::stalled`]) — set by [`Flow::tick`], cleared by
+        /// every applied progress event. The status line then reads "still
+        /// reading" instead of implying normal progress.
+        stalled: bool,
     },
     Reported {
         listing: Listing,
@@ -548,7 +553,15 @@ impl Flow {
             {
                 listing.error = None;
                 let scanned = listing.scan_names();
-                Self { inner: Inner::Scanning { listing, generation, progress: None, scanned } }
+                Self {
+                    inner: Inner::Scanning {
+                        listing,
+                        generation,
+                        progress: None,
+                        scanned,
+                        stalled: false,
+                    },
+                }
             }
             other => Self { inner: other },
         }
@@ -558,6 +571,8 @@ impl Flow {
     /// byte counts, and the wall time elapsed since the scan started. Applied only
     /// while scanning **and** when `generation` matches the in-flight scan (a
     /// stale event is dropped); the pure progress math is [`ProgressModel`].
+    /// A real event is proof the read loop is moving, so it also clears the
+    /// stall flag [`Flow::tick`] may have raised.
     pub fn progress(
         &mut self,
         generation: u64,
@@ -566,10 +581,29 @@ impl Flow {
         total: u64,
         elapsed: Duration,
     ) {
-        if let Inner::Scanning { generation: active, progress, .. } = &mut self.inner
+        if let Inner::Scanning { generation: active, progress, stalled, .. } = &mut self.inner
             && *active == generation
         {
             *progress = Some(ProgressModel::compute(file, done, total, elapsed));
+            *stalled = false;
+        }
+    }
+
+    /// Advances the wall-clock readout while a scan is in flight — the shell's
+    /// ~1 s tick. `elapsed` (since the scan started) re-stamps the progress
+    /// model's elapsed seconds so the readout climbs even when no progress
+    /// event arrives (a read stuck in drive-firmware retries emits none), and
+    /// `since_progress` (since the last progress event) drives the stall flag
+    /// ([`crate::progress::stalled`]). The remaining estimate is untouched —
+    /// it is meaningful only against real progress. A no-op off
+    /// [`Stage::Scanning`], and before the first progress event only the
+    /// stall flag moves (there is no model to re-stamp).
+    pub fn tick(&mut self, elapsed: Duration, since_progress: Duration) {
+        if let Inner::Scanning { progress, stalled, .. } = &mut self.inner {
+            if let Some(model) = progress.as_mut() {
+                model.set_elapsed(elapsed);
+            }
+            *stalled = crate::progress::stalled(since_progress);
         }
     }
 
@@ -857,6 +891,15 @@ impl Flow {
             Inner::Scanning { progress, .. } => progress.as_ref(),
             _ => None,
         }
+    }
+
+    /// Whether the in-flight scan's progress events have gone quiet past the
+    /// stall threshold — the status line then says "still reading" so a read
+    /// stuck on damaged media looks like a struggling drive, not a dead app.
+    /// Always false off [`Stage::Scanning`].
+    #[must_use]
+    pub const fn scan_stalled(&self) -> bool {
+        matches!(self.inner, Inner::Scanning { stalled: true, .. })
     }
 
     /// Whether a report can be shown / saved / copied now — true whenever a disc
@@ -1271,6 +1314,59 @@ mod tests {
         assert_eq!(flow.selected_count(), 0);
         // Nothing checked does not block scanning — it is a whole-disc scan.
         assert!(flow.can_scan());
+    }
+
+    #[test]
+    fn a_tick_advances_elapsed_without_a_progress_event() {
+        let mut flow = listed().start_scanning(1);
+        flow.progress(1, "A.M2TS".to_owned(), 1, 2, Duration::from_secs(4));
+        let before = flow.progress_view().expect("a progress model");
+        assert_eq!(before.elapsed_hms(), "00:00:04");
+        assert_eq!(before.remaining_hms(), "00:00:04");
+        // The wall clock moves on with no progress event in between…
+        flow.tick(Duration::from_secs(65), Duration::from_secs(2));
+        let after = flow.progress_view().expect("the model survives the tick");
+        assert_eq!(after.elapsed_hms(), "00:01:05");
+        // …and only elapsed follows: the percent, the remaining estimate and
+        // the file hold, and 2 s of quiet is not yet a stall.
+        assert_eq!(after.percent, 50);
+        assert_eq!(after.remaining_hms(), "00:00:04");
+        assert_eq!(after.file(), "A.M2TS");
+        assert!(!flow.scan_stalled());
+    }
+
+    #[test]
+    fn quiet_ticks_flag_the_stall_and_a_progress_event_clears_it() {
+        let mut flow = listed().start_scanning(1);
+        flow.progress(1, "A.M2TS".to_owned(), 1, 2, Duration::from_secs(1));
+        assert!(!flow.scan_stalled());
+        // The threshold is 5 s inclusive; just under it is not a stall.
+        flow.tick(Duration::from_secs(6), Duration::from_millis(4_999));
+        assert!(!flow.scan_stalled());
+        flow.tick(Duration::from_secs(7), Duration::from_secs(5));
+        assert!(flow.scan_stalled());
+        // Well past the threshold reads stalled too (the flag is a range,
+        // not a single instant).
+        flow.tick(Duration::from_secs(8), Duration::from_secs(6));
+        assert!(flow.scan_stalled());
+        // A fresh progress event is proof of life and clears the flag.
+        flow.progress(1, "A.M2TS".to_owned(), 1, 2, Duration::from_secs(9));
+        assert!(!flow.scan_stalled());
+    }
+
+    #[test]
+    fn a_tick_before_any_progress_or_off_stage_is_harmless() {
+        // Scanning with no model yet: nothing to re-stamp, but the stall flag
+        // still tracks (the very first read can be the one that sticks).
+        let mut flow = listed().start_scanning(1);
+        flow.tick(Duration::from_secs(9), Duration::from_secs(9));
+        assert!(flow.progress_view().is_none());
+        assert!(flow.scan_stalled());
+        // Off Stage::Scanning a stray tick changes nothing.
+        let mut flow = listed();
+        flow.tick(Duration::from_secs(9), Duration::from_secs(9));
+        assert!(!flow.scan_stalled());
+        assert_eq!(flow.stage(), Stage::Listed);
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -594,7 +594,8 @@ impl Flow {
     /// model's elapsed seconds so the readout climbs even when no progress
     /// event arrives (a read stuck in drive-firmware retries emits none), and
     /// `since_progress` (since the last progress event) drives the stall flag
-    /// ([`crate::progress::stalled`]). The remaining estimate is untouched —
+    /// (its fixed threshold lives in [`crate::progress`], beside the model's
+    /// other display constants). The remaining estimate is untouched —
     /// it is meaningful only against real progress. A no-op off
     /// [`Stage::Scanning`], and before the first progress event only the
     /// stall flag moves (there is no model to re-stamp).

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -1282,13 +1282,7 @@ impl App {
                 Task::none()
             }
             Message::Tick => {
-                self.pulse = progress::pulse_advance(self.pulse);
-                if self.flow.stage() == Stage::Scanning {
-                    let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
-                    let since_progress =
-                        self.last_progress.map_or(Duration::ZERO, |at| at.elapsed());
-                    self.flow.tick(elapsed, since_progress);
-                }
+                self.on_tick();
                 Task::none()
             }
             Message::PaneResized(pane_grid::ResizeEvent { split, ratio }) => {
@@ -1676,6 +1670,19 @@ impl App {
         Task::none()
     }
 
+    /// Applies a display tick: advances the indeterminate bar's phase, and —
+    /// while the measured scan is in flight — re-reads the wall clock so the
+    /// elapsed readout and the stall hint move even when no progress event
+    /// arrives ([`Flow::tick`]).
+    fn on_tick(&mut self) {
+        self.pulse = progress::pulse_advance(self.pulse);
+        if self.flow.stage() == Stage::Scanning {
+            let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
+            let since_progress = self.last_progress.map_or(Duration::ZERO, |at| at.elapsed());
+            self.flow.tick(elapsed, since_progress);
+        }
+    }
+
     /// Cancels the in-flight measured scan for real: trips the worker's
     /// cooperative stop flag — the demux exits at its next read chunk, freeing
     /// CPU and IO — then returns the UI to the table. The worker's late "scan
@@ -1701,15 +1708,10 @@ impl App {
         playlists: Vec<PlaylistSummary>,
     ) -> Task<Message> {
         let was_scanning = self.flow.stage() == Stage::Scanning;
-        self.flow = std::mem::take(&mut self.flow).finished(
-            generation,
-            report,
-            Arc::clone(&errors),
-            playlists,
-        );
+        self.flow = std::mem::take(&mut self.flow).finished(generation, report, errors, playlists);
         if was_scanning && self.flow.stage() == Stage::Reported {
-            log::info!("scan finished: {} error(s) recorded", errors.len());
-            for error in errors.iter() {
+            log::info!("scan finished: {} error(s) recorded", self.flow.report_errors().len());
+            for error in self.flow.report_errors() {
                 log::info!("scan error: {error}");
             }
             self.notice = Some(flow::scan_notice(self.flow.report_errors().len()));

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -150,7 +150,8 @@ fn run_window(open: Option<PathBuf>) -> ExitCode {
     // exactly like the theme chips.
     .scale_factor(App::ui_scale)
     // "Auto" tracks the desktop live; while the initial scan runs, also drive
-    // the indeterminate progress-bar animation.
+    // the indeterminate progress-bar animation, and while the measured scan
+    // runs, the 1 s liveness tick.
     .subscription(App::subscription)
     .default_font(ui::UI)
     .font(
@@ -759,6 +760,10 @@ struct App {
     scan_cancel: Option<Arc<AtomicBool>>,
     /// When the current measured scan started.
     scan_start: Option<Instant>,
+    /// When the in-flight scan's last progress event arrived (the scan start
+    /// until the first one) — what the 1 s scanning tick measures the stall
+    /// hint against ([`Flow::tick`]).
+    last_progress: Option<Instant>,
     /// A one-line status (e.g. `Report saved to: …`), shown in the bottom bar.
     status: Option<String>,
     /// Whether the report view (over the panes) is showing.
@@ -818,6 +823,7 @@ impl Default for App {
             generation: 0,
             scan_cancel: None,
             scan_start: None,
+            last_progress: None,
             status: None,
             showing_report: false,
             notice: None,
@@ -1062,7 +1068,9 @@ enum Message {
     SettingsCancel,
     /// The OS reported (or changed) its light/dark setting.
     OsTheme(iced::theme::Mode),
-    /// An animation frame — advances the indeterminate "scanning" bar.
+    /// A display tick with no payload: per-frame while listing (advances the
+    /// indeterminate bar), ~1 s while scanning (re-reads the wall clock for
+    /// the elapsed readout and the stall hint).
     Tick,
     /// A pane splitter was dragged — resize the two panes it divides.
     PaneResized(pane_grid::ResizeEvent),
@@ -1227,6 +1235,7 @@ impl App {
             Message::ScanSelected => self.start_scan(),
             Message::Progress { generation, file, done, total } => {
                 let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
+                self.last_progress = Some(Instant::now());
                 self.flow.progress(generation, file, done, total, elapsed);
                 Task::none()
             }
@@ -1234,6 +1243,10 @@ impl App {
                 self.on_finished(generation, report, errors, playlists)
             }
             Message::ScanFailed { generation, error } => {
+                // Logged whether or not the flow applies it: a late failure
+                // from a cancelled worker ("scan cancelled") is the log's
+                // only record that the blocked thread finally returned.
+                log::info!("scan failed: {error}");
                 self.flow = std::mem::take(&mut self.flow).scan_failed(generation, error);
                 Task::none()
             }
@@ -1270,6 +1283,12 @@ impl App {
             }
             Message::Tick => {
                 self.pulse = progress::pulse_advance(self.pulse);
+                if self.flow.stage() == Stage::Scanning {
+                    let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
+                    let since_progress =
+                        self.last_progress.map_or(Duration::ZERO, |at| at.elapsed());
+                    self.flow.tick(elapsed, since_progress);
+                }
                 Task::none()
             }
             Message::PaneResized(pane_grid::ResizeEvent { split, ratio }) => {
@@ -1483,8 +1502,10 @@ impl App {
 
     /// The live subscriptions: the OS light/dark change feed, plus — only while
     /// the initial scan is in flight — a per-frame tick that animates the
-    /// indeterminate progress bar. The tick is off in every other state, so the
-    /// window is not redrawing continuously when idle.
+    /// indeterminate progress bar, and — only while the measured scan is — a
+    /// ~1 s wall-clock tick that keeps the elapsed readout and the stall hint
+    /// moving. The ticks are off in every other state, so the window is not
+    /// redrawing continuously when idle.
     fn subscription(&self) -> iced::Subscription<Message> {
         let mut subs = vec![iced::system::theme_changes().map(Message::OsTheme)];
         // Debug auto-open (`BDINFO_GUI_OPEN`/`_ISO`) rides a SUBSCRIPTION,
@@ -1539,6 +1560,15 @@ impl App {
         }));
         if self.flow.stage() == Stage::Listing {
             subs.push(iced::window::frames().map(|_| Message::Tick));
+        }
+        // The measured scan can run for hours, so its liveness tick is a 1 Hz
+        // wall-clock subscription — NOT the per-frame ticker above, whose ~60
+        // redraws a second are only acceptable for the brief listing stage.
+        // Each tick re-reads the clock in the Tick arm, so elapsed climbs and
+        // the stall hint appears even when a read stuck in drive-firmware
+        // retries emits no progress event for minutes.
+        if self.flow.stage() == Stage::Scanning {
+            subs.push(iced::time::every(Duration::from_secs(1)).map(|_| Message::Tick));
         }
         // While a column divider is held, follow the mouse globally — even off the
         // grab zone — so the drag tracks the cursor and ends on button release.
@@ -1653,6 +1683,7 @@ impl App {
     /// flow is no longer Scanning), so nothing else changes.
     fn cancel_scan(&mut self) -> Task<Message> {
         if let Some(cancel) = self.scan_cancel.take() {
+            log::info!("scan cancelled");
             cancel.store(true, Ordering::Relaxed);
         }
         self.flow = std::mem::take(&mut self.flow).cancel();
@@ -1670,12 +1701,25 @@ impl App {
         playlists: Vec<PlaylistSummary>,
     ) -> Task<Message> {
         let was_scanning = self.flow.stage() == Stage::Scanning;
-        self.flow = std::mem::take(&mut self.flow).finished(generation, report, errors, playlists);
+        self.flow = std::mem::take(&mut self.flow).finished(
+            generation,
+            report,
+            Arc::clone(&errors),
+            playlists,
+        );
         if was_scanning && self.flow.stage() == Stage::Reported {
+            log::info!("scan finished: {} error(s) recorded", errors.len());
+            for error in errors.iter() {
+                log::info!("scan error: {error}");
+            }
             self.notice = Some(flow::scan_notice(self.flow.report_errors().len()));
             if self.persisted.autosave_report {
                 self.autosave_report();
             }
+        } else {
+            // A completion the generation guard dropped — the user cancelled
+            // or restarted; the log still records the old worker returning.
+            log::info!("stale scan completion dropped");
         }
         Task::none()
     }
@@ -1787,6 +1831,16 @@ impl App {
         self.generation = self.generation.wrapping_add(1);
         let generation = self.generation;
         self.scan_start = Some(Instant::now());
+        self.last_progress = self.scan_start;
+        // The scan's opening log line: with the per-file lines and the
+        // terminal line below, gui.log can now place a field report's hang
+        // inside the scan (and name the file) rather than only before it.
+        log::info!(
+            "scan started: {} playlist(s), {} stream file(s), input {}",
+            selection.len(),
+            scan_files.len(),
+            input.display()
+        );
         self.status = None;
         self.showing_report = false;
         self.notice = None;
@@ -1828,6 +1882,9 @@ impl App {
                 }
                 last_sent = Some(Instant::now());
                 if file_changed {
+                    // One log line per stream file, from the worker thread —
+                    // after a freeze, the last of these names the stuck file.
+                    log::info!("scanning {}", progress.file);
                     progress.file.clone_into(&mut last_file);
                 }
                 let _ = sender.unbounded_send(Message::Progress {
@@ -2503,6 +2560,13 @@ impl App {
             "Drop to open the disc folder or .iso image.".to_owned()
         } else {
             self.status.clone().unwrap_or_else(|| match self.flow.stage() {
+                // A stalled scan (no progress event past the threshold —
+                // [`Flow::scan_stalled`]) says the drive is struggling with
+                // the named file; classic BDInfo's bar just freezes silently.
+                Stage::Scanning if self.flow.scan_stalled() => progress.map_or_else(
+                    || "Starting scan…".to_owned(),
+                    |pr| format!("Still reading {}…", pr.file()),
+                ),
                 Stage::Scanning => progress.map_or_else(
                     || "Starting scan…".to_owned(),
                     |pr| format!("Scanning {}…", pr.file()),
@@ -3646,6 +3710,7 @@ mod harness {
 mod interaction {
     use std::path::PathBuf;
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     use bdinfo_rs_gui::flow::Stage;
     use bdinfo_rs_gui::model::{Sort, SortColumn};
@@ -3758,6 +3823,32 @@ mod interaction {
             app.flow.progress_view().map(bdinfo_rs_gui::progress::ProgressModel::fraction);
         assert_eq!(fraction, Some(0.5));
         assert!(sees(&app, "Scanning A.M2TS…"), "the lead line names the demuxing file");
+    }
+
+    #[test]
+    fn a_tick_keeps_elapsed_climbing_and_flags_a_stalled_read() {
+        let mut app = listed_app();
+        click(&mut app, "Scan Bitrates");
+        let _ = app.update(Message::Progress {
+            generation: app.generation,
+            file: "A.M2TS".to_owned(),
+            done: 1,
+            total: 2,
+        });
+        assert!(sees(&app, "Scanning A.M2TS…"));
+        // Re-date the scan start and the last progress event into the past —
+        // the wall time a stuck ReadFile would let pass with no event at all.
+        app.scan_start = Instant::now().checked_sub(Duration::from_secs(90));
+        app.last_progress = Instant::now().checked_sub(Duration::from_secs(30));
+        let _ = app.update(Message::Tick);
+        // One tick re-reads the clock: elapsed climbs with no progress event,
+        // and the quiet 30 s turn the lead line into the stall hint.
+        assert_eq!(
+            app.flow.progress_view().map(bdinfo_rs_gui::progress::ProgressModel::elapsed_hms),
+            Some("00:01:30".to_owned())
+        );
+        assert!(app.flow.scan_stalled());
+        assert!(sees(&app, "Still reading A.M2TS…"), "the stall hint names the stuck file");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/progress.rs
+++ b/crates/bdinfo-rs-gui/src/progress.rs
@@ -40,6 +40,21 @@ pub fn pulse_fraction(phase: u16) -> f32 {
 /// coalescing interval.
 const EMIT_EVERY: Duration = Duration::from_millis(100);
 
+/// How long the scan may go without a progress event before the display calls
+/// the current read stalled. Progress normally arrives many times a second
+/// (one event per read chunk, coalesced to [`EMIT_EVERY`]), so a multi-second
+/// silence means one read syscall has not returned — damaged optical media
+/// held in drive-firmware retries, which can block for minutes with no error.
+const STALL_AFTER: Duration = Duration::from_secs(5);
+
+/// Whether `since_progress` — the time since the last progress event — has
+/// crossed the stall threshold ([`STALL_AFTER`], inclusive), so the status
+/// line should say the drive is struggling rather than imply normal progress.
+#[must_use]
+pub(crate) fn stalled(since_progress: Duration) -> bool {
+    since_progress >= STALL_AFTER
+}
+
 /// Whether a scan-progress event should become a UI message.
 ///
 /// The scan fires its callback every few MB — tens of thousands of times on a
@@ -74,6 +89,15 @@ impl ProgressModel {
     pub(crate) fn compute(file: String, done: u64, total: u64, elapsed: Duration) -> Self {
         let (percent, elapsed_seconds, remaining_seconds) = progress_stats(done, total, elapsed);
         Self { file, percent, elapsed_seconds, remaining_seconds }
+    }
+
+    /// Re-stamps the elapsed wall time from the clock, leaving `file`,
+    /// `percent` and `remaining_seconds` at their last computed values — the
+    /// remaining estimate is meaningful only against real progress, so a
+    /// wall-clock tick may never touch it. Whole seconds, truncated, like
+    /// every displayed time.
+    pub(crate) const fn set_elapsed(&mut self, elapsed: Duration) {
+        self.elapsed_seconds = elapsed.as_secs();
     }
 
     /// The bar fill, a fraction in `0.0..=1.0` (the progress bar's value over a
@@ -143,6 +167,26 @@ mod tests {
         assert_eq!(model.file(), "00000.M2TS");
         assert_eq!(model.elapsed_hms(), "00:00:04");
         assert_eq!(model.remaining_hms(), "00:00:12");
+    }
+
+    #[test]
+    fn set_elapsed_restamps_only_the_wall_clock() {
+        let mut model =
+            ProgressModel::compute("00000.M2TS".to_owned(), 50, 200, Duration::from_secs(4));
+        // 65.999 s truncates to 00:01:05; percent, remaining and the file
+        // hold their last computed values.
+        model.set_elapsed(Duration::from_millis(65_999));
+        assert_eq!(model.elapsed_hms(), "00:01:05");
+        assert_eq!(model.percent, 25);
+        assert_eq!(model.remaining_hms(), "00:00:12");
+        assert_eq!(model.file(), "00000.M2TS");
+    }
+
+    #[test]
+    fn the_stall_threshold_is_five_seconds_inclusive() {
+        assert!(!super::stalled(Duration::from_millis(4_999)));
+        assert!(super::stalled(Duration::from_secs(5)));
+        assert!(super::stalled(Duration::from_secs(6)));
     }
 
     #[test]


### PR DESCRIPTION
During the measured scan the window repainted only when a progress event arrived, and a read blocked in drive-firmware retries on damaged media emits none — elapsed froze, the window stopped painting, and the app was indistinguishable from a hang. gui.log also carried no scan lines at all, so a field log could not place a freeze inside the scan.

- A ~1 s `iced::time::every` tick subscription while scanning (not the listing stage's per-frame ticker) re-reads the wall clock each tick: elapsed keeps climbing and the window keeps painting through a stalled read. The remaining estimate is deliberately untouched — it is only meaningful against real progress.
- Once no progress event has arrived for 5 s, the status line switches to "Still reading <file>…", so a stall reads as a struggling drive rather than a dead app.
- gui.log gains Info lines for scan start (playlist/file counts and input), each stream-file transition, scan finish with every recorded ScanError, scan failure, cancellation, and late completions from a superseded worker. Listing start/end lines already existed.

Tier-A coverage stays at 100% lines/regions/functions; the in-diff mutation pass catches 9/9.

Fixes #326
Refs #319