### PR TITLE
fix(core): shrink demux reads to bound stalls and cancel latency

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -32,6 +32,7 @@ actually see on a normal disc.
 | [VC-1 interlaced-field picture type](#correctness-fixes-with-no-effect-on-a-normal-disc) | **No** — internal only | Never — the picture tag is counted, never printed |
 | [PAT `table_id` validation](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on malformed input | Never — no conforming disc carries a wrong PAT table id |
 | [AACS-encrypted discs are refused](#aacs-encrypted-discs-are-refused) | **Yes** — no report at all | Discs whose stream content is still encrypted |
+| [Damaged-media read granularity](#damaged-media-read-granularity) | Only on damaged media — partial scans retain more | Discs with unreadable spans |
 
 ---
 
@@ -192,6 +193,28 @@ when asked, which is what keeps the decision with the caller.
 
 <sub>Source: `crates/bdinfo-rs-core/src/bdrom/disc.rs` (the encryption probe),
 `crates/bdinfo-rs/src/main.rs` (exit code 4).</sub>
+
+### Damaged-media read granularity
+
+BDInfo 0.8 reads stream files in 5 MiB requests in both measurement passes (raised from
+0.7.5.6's 16 KiB by a throughput change with no correctness motive). bdinfo-rs reads
+256 KiB per request in the full pass and 16 KiB in the quick codec pass; the browser
+package keeps 5 MiB for both, since its file reads each cost one synchronous round trip.
+Healthy discs produce byte-identical reports either way — the packet state machine carries
+its state across chunk boundaries, so the request size cannot change a measured value.
+
+On damaged media the request size is the failure granularity, and there the outputs
+deliberately diverge from BDInfo 0.8:
+
+- a failed request discards only its own bytes, so a partial scan retains up to ~5 MiB
+  more measured data per damaged file than 0.8 would (toward 0.7.5.6's loss profile) —
+  chapter rows and stream tallies fill further before the zero rows begin;
+- cancellation, polled once per request, takes effect within 256 KiB of reading instead
+  of 5 MiB;
+- one unreadable span stalls a 256 KiB (listing: 16 KiB) request inside the drive's
+  retry storm rather than a 5 MiB one.
+
+<sub>Source: `crates/bdinfo-rs-core/src/bdrom/m2ts.rs` (`DATA_SIZE`, `QUICK_DATA_SIZE`).</sub>
 
 ---
 

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -211,10 +211,19 @@ deliberately diverge from BDInfo 0.8:
   chapter rows and stream tallies fill further before the zero rows begin;
 - cancellation, polled once per request, takes effect within 256 KiB of reading instead
   of 5 MiB;
-- one unreadable span stalls a 256 KiB (listing: 16 KiB) request inside the drive's
-  retry storm rather than a 5 MiB one.
+- one unreadable span stalls one small request inside the drive's retry storm rather
+  than a 5 MiB one — 16 KiB in the quick codec pass (which runs first in every
+  measurement scan and alone in a codec-only browse), 256 KiB in the full pass.
 
-<sub>Source: `crates/bdinfo-rs-core/src/bdrom/m2ts.rs` (`DATA_SIZE`, `QUICK_DATA_SIZE`).</sub>
+A damaged scan of a bare Windows drive root also keeps a degraded disc label: once
+stream read errors are recorded, the raw-device read that recovers the UDF volume label
+is skipped — one more sector-by-sector grind of a failing drive for a cosmetic string —
+so the report and its file name carry the bare drive letter. Classic BDInfo shows the
+OS-reported volume label there (it reads it through the filesystem before scanning and
+has no raw-device read to skip).
+
+<sub>Source: `crates/bdinfo-rs-core/src/bdrom/m2ts.rs` (`DATA_SIZE`, `QUICK_DATA_SIZE`),
+`crates/bdinfo-rs-core/src/vfs/volume.rs` (the label-read gate).</sub>
 
 ---
 

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -540,9 +540,9 @@ pub struct ScanProgress<'a> {
 }
 
 /// The live bookkeeping of one packet scan: the running byte count over the
-/// full pass's total, reported through the caller's callback after every
-/// demux read and at every file boundary, plus the caller's cooperative
-/// cancel flag the demux polls per read chunk.
+/// full pass's total, reported through the caller's callback before and
+/// after every demux read and at every file boundary, plus the caller's
+/// cooperative cancel flag the demux polls per read chunk.
 struct Progress<'a> {
     /// The caller's observer; a no-op for the plain `open`s.
     callback: &'a mut dyn FnMut(ScanProgress<'_>),
@@ -559,6 +559,16 @@ impl Progress<'_> {
     /// Advances the counter by `bytes` demuxed from `file` and reports.
     fn advance(&mut self, file: &str, bytes: u64) {
         self.done = self.done.saturating_add(bytes).min(self.total);
+        (self.callback)(ScanProgress { file, done: self.done, total: self.total });
+    }
+
+    /// Reports the current count against `file` without advancing it — the
+    /// pre-read heartbeat. [`CountingReader`] fires it before every physical
+    /// read, so a consumer watching for staleness knows a read is in flight
+    /// (and in which file) rather than seeing plain silence: on damaged media
+    /// one blocking read can stall for minutes, and the heartbeat is the last
+    /// event before that gap opens.
+    fn heartbeat(&mut self, file: &str) {
         (self.callback)(ScanProgress { file, done: self.done, total: self.total });
     }
 
@@ -584,6 +594,7 @@ struct CountingReader<'a, 'b> {
 
 impl Read for CountingReader<'_, '_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.progress.heartbeat(&self.name);
         let bytes = self.inner.read(buf)?;
         self.progress.advance(&self.name, u64::try_from(bytes).unwrap_or(u64::MAX));
         Ok(bytes)
@@ -2385,15 +2396,15 @@ mod tests {
     use proptest::prelude::{ProptestConfig, prop_assert, prop_assert_eq, proptest};
 
     use super::{
-        ALIGNED_UNIT_BYTES, BdError, BdRom, ClipMeta, ClipSummary, MAX_METADATA_BYTES, MVC_PID,
-        PlaylistFilter, PlaylistSummary, Progress, SOURCE_PACKET_BYTES, ScanMode, ScanOptions,
-        ScanProgress, ScanReport, ScanStage, Sink, TsPlaylistFile, TsStreamFile,
-        backup_subdir_files, build_chapter_summaries, build_clip_summaries, build_sorted_streams,
-        clear_measurements, clip_has_50hz_video, clip_stem, collect_backups, directory_size,
-        fixtures, has_aacs_key_file, merge_stream, rate_over, read_disc_title, read_file,
-        read_file_capped, resolve_playlist_streams, scan_stream_files, scan_total,
-        select_reference, stream_content_encrypted, stream_summary, unit_shows_encryption,
-        walked_disc_root,
+        ALIGNED_UNIT_BYTES, BdError, BdRom, ClipMeta, ClipSummary, CountingReader,
+        MAX_METADATA_BYTES, MVC_PID, PlaylistFilter, PlaylistSummary, Progress,
+        SOURCE_PACKET_BYTES, ScanMode, ScanOptions, ScanProgress, ScanReport, ScanStage, Sink,
+        TsPlaylistFile, TsStreamFile, backup_subdir_files, build_chapter_summaries,
+        build_clip_summaries, build_sorted_streams, clear_measurements, clip_has_50hz_video,
+        clip_stem, collect_backups, directory_size, fixtures, has_aacs_key_file, merge_stream,
+        rate_over, read_disc_title, read_file, read_file_capped, resolve_playlist_streams,
+        scan_stream_files, scan_total, select_reference, stream_content_encrypted, stream_summary,
+        unit_shows_encryption, walked_disc_root,
     };
     use crate::bdrom::clpi::TsStreamClip;
     use crate::bdrom::clpi::clips::build_clpi;
@@ -5096,7 +5107,7 @@ mod tests {
     /// FILES bitrate while every chapter row and the stream diagnostics stay
     /// empty. Retention must change nothing when switched off.
     const DAMAGED_OFF_REPORT: &str = r"Disc Label:     disc
-Disc Size:      5,243,712 bytes
+Disc Size:      263,040 bytes
 Protection:     AACS
 BDInfo:         0.8.0.1
 
@@ -5125,13 +5136,13 @@ PLAYLIST: 00000.MPLS
                                                                                                                       Total        Video                                                                           
 Title                                                           Codec   Length    Movie Size        Disc Size         Bitrate      Bitrate      Main Audio Track                          Secondary Audio Track    
 -----                                                           ------  -------   --------------    ----------------  -----------  -----------  ------------------                        ---------------------    
-00000.MPLS                                                      AVC     00:01:40  960               5,243,712         0.00 Mbps    0.00 Mbps                                                                       
+00000.MPLS                                                      AVC     00:01:40  960               263,040           0.00 Mbps    0.00 Mbps                                                                       
 [/code]
 
 [code]
 DISC INFO:
 Disc Label:     disc
-Disc Size:      5,243,712 bytes
+Disc Size:      263,040 bytes
 Protection:     AACS
 BDInfo:         0.8.0.1b
 
@@ -5174,7 +5185,7 @@ File            PID             Type            Codec           Language        
 QUICK SUMMARY:
 
 Disc Label:     disc
-Disc Size:      5,243,712 bytes
+Disc Size:      263,040 bytes
 Protection:     AACS
 Playlist:       00000.MPLS
 Size:           960 bytes
@@ -5261,11 +5272,13 @@ Total Bitrate:  0.00 Mbps
         /// panics or hangs the resilient scan, and the chapter table keeps
         /// its shape: one row per mark, each with its mark's own time and
         /// length, rates finite and non-negative. (24 cases — each scans a
-        /// >5 MiB two-chunk fixture twice; the deterministic boundary
-        /// offsets 0 and `DATA_SIZE` are pinned by the tests above.)
+        /// two-chunk fixture just past `DATA_SIZE` twice; the range runs
+        /// beyond the fixture so some cases never trip, and the
+        /// deterministic boundary offsets 0 and `DATA_SIZE` are pinned by
+        /// the tests above.)
         #[test]
         fn a_tripped_reader_yields_a_total_scan_with_one_chapter_row_per_mark(
-            serve in 0_usize..5_400_000,
+            serve in 0_usize..crate::bdrom::m2ts::DATA_SIZE.saturating_add(10_000),
         ) {
             let m2ts = two_chunk_m2ts(&[(0x1B, 0x1011)], &[1, 2, 3], &[46, 47]);
             let report =
@@ -5465,6 +5478,8 @@ Total Bitrate:  0.00 Mbps
                 cancel: &AtomicBool::new(false),
             };
             progress.advance("A.M2TS", 30);
+            // A heartbeat reports without moving the count.
+            progress.heartbeat("A.M2TS");
             // An over-read clamps at the total instead of overshooting.
             progress.advance("A.M2TS", 90);
             // A snap target below the current count never moves it backwards…
@@ -5473,6 +5488,7 @@ Total Bitrate:  0.00 Mbps
         assert_eq!(
             events,
             [
+                ("A.M2TS".to_owned(), 30, 100),
                 ("A.M2TS".to_owned(), 30, 100),
                 ("A.M2TS".to_owned(), 100, 100),
                 ("A.M2TS".to_owned(), 100, 100),
@@ -5494,6 +5510,42 @@ Total Bitrate:  0.00 Mbps
             progress.finish_file("B.M2TS", 60);
         }
         assert_eq!(events, [("B.M2TS".to_owned(), 10, 100), ("B.M2TS".to_owned(), 60, 100)]);
+    }
+
+    #[test]
+    fn a_counting_reader_heartbeats_before_every_read_and_advances_after() {
+        // Two reads through the counting seam: one serving bytes, one at EOF.
+        // Each is bracketed by a heartbeat (same count) and an advance, so a
+        // consumer's last event before a blocking read names the file being
+        // read — the signal a stalled read leaves behind.
+        let mut events: Vec<(String, u64, u64)> = Vec::new();
+        {
+            let mut callback =
+                |p: ScanProgress<'_>| events.push((p.file.to_owned(), p.done, p.total));
+            let mut progress = Progress {
+                callback: &mut callback,
+                done: 0,
+                total: 5,
+                cancel: &AtomicBool::new(false),
+            };
+            let mut reader = CountingReader {
+                inner: Box::new(Cursor::new(vec![0_u8; 5])),
+                name: "A.M2TS".to_owned(),
+                progress: &mut progress,
+            };
+            let mut sink = [0_u8; 8];
+            assert_eq!(reader.read(&mut sink).expect("serving read"), 5);
+            assert_eq!(reader.read(&mut sink).expect("EOF read"), 0);
+        }
+        assert_eq!(
+            events,
+            [
+                ("A.M2TS".to_owned(), 0, 5),
+                ("A.M2TS".to_owned(), 5, 5),
+                ("A.M2TS".to_owned(), 5, 5),
+                ("A.M2TS".to_owned(), 5, 5),
+            ]
+        );
     }
 
     /// A cancel flag that never trips — the default scan extras of every test
@@ -5532,6 +5584,9 @@ Total Bitrate:  0.00 Mbps
         .expect("scan with progress");
         assert_eq!(bd.playlists.len(), 2);
         assert!(!events.is_empty());
+        // The pre-read heartbeat precedes the first byte: the pass's first
+        // event reports a zero count, naming the file about to be read.
+        assert_eq!(events.first().map(|(_, done, _)| *done), Some(0));
         assert!(events.iter().all(|(_, _, total)| *total == 1000 + 500));
         assert!(events.windows(2).all(|pair| {
             pair.first().is_none_or(|(_, a, _)| pair.get(1).is_none_or(|(_, b, _)| a <= b))
@@ -5649,7 +5704,10 @@ Total Bitrate:  0.00 Mbps
         .expect_err("the cancelled scan errors");
         assert_eq!(err.to_string(), "scan cancelled");
         assert!(events.len() < baseline.len(), "the cancelled scan must stop early");
-        assert!(events.len() <= 3, "the event trail stops at the in-flight chunk");
+        // The in-flight chunk still completes (the flag is polled per chunk),
+        // emitting at most a heartbeat + advance pair for its serving read
+        // and another for its EOF read; nothing follows.
+        assert!(events.len() <= 4, "the event trail stops at the in-flight chunk");
 
         // The resilient scan aborts identically: cancellation is the caller's
         // abort, not disc damage to collect, so no partial report escapes.

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -832,7 +832,7 @@ impl BdRom {
     /// their metadata-only summaries (zero measured rates). `None` scans
     /// every stream file.
     ///
-    /// `progress` is called after every demux read and at every file boundary
+    /// `progress` is called before and after every demux read and at every file boundary
     /// with the running [`ScanProgress`]; it never fires without the packet
     /// scan.
     ///

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -195,7 +195,9 @@ pub struct TsStreamDiagnostics {
     pub bytes: u64,
     /// Transport packets in this window.
     pub packets: u64,
-    /// Window start time in seconds (`PTS / 90000`).
+    /// Time in seconds (`PTS / 90000`) of the frame that closed this window:
+    /// one entry is emitted per completed window, stamped with its closing
+    /// frame's time, not its start.
     pub marker: f64,
     /// Window length in seconds (the PTS delta `/ 90000`).
     pub interval: f64,

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -57,11 +57,25 @@ use crate::error::BdError;
 use crate::primitives::Pid;
 use crate::stream::{StreamKind, TsStream, TsStreamType};
 
-/// Read-chunk size (5 MiB) for each underlying read. The packet state machine
-/// is chunk-boundary-agnostic, so the value affects only read granularity
-/// (tests drive a small size to exercise the cross-chunk deferral paths) —
-/// plus failure granularity: a read error voids only its own chunk, so the
-/// demux keeps everything up to the last completed chunk boundary.
+/// Read-chunk size (256 KiB) for each underlying full-pass read. The packet
+/// state machine is chunk-boundary-agnostic, so the value changes no healthy
+/// output byte (tests drive a small size to exercise the cross-chunk deferral
+/// paths) — it sets read granularity, and with it three damaged-media bounds:
+/// how long one blocking read can stall (a stalled optical request spans the
+/// chunk's 128 optical sectors of in-device retries), how stale the per-chunk cancel
+/// poll ([`fill_buffer`]) can get, and how many bytes a failed read discards
+/// (a read error voids only its own chunk, so the demux keeps everything up
+/// to the last completed chunk boundary). Tunable within those trade-offs.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const DATA_SIZE: usize = 262_144;
+
+/// Read-chunk size (5 MiB) for each underlying full-pass read on
+/// `wasm32-unknown-unknown`. The browser read seam pays one synchronous
+/// `FileReaderSync` round trip per read call, so the wasm build keeps the
+/// large chunk (20× fewer calls than the native 256 KiB); browser reads of
+/// damaged media return promptly (a thrown exception, not an in-device
+/// retry), so the native chunk's stall/cancel/loss bounds buy nothing there.
+#[cfg(target_arch = "wasm32")]
 pub(crate) const DATA_SIZE: usize = 5_242_880;
 
 /// Size of the fixed `PAT`/`PMT` section-assembly buffers.
@@ -2965,7 +2979,8 @@ mod tests {
     fn a_mid_scan_cancel_stops_at_the_next_chunk_boundary() {
         // A stream one byte longer than a read chunk; serving the first chunk
         // trips the flag, so the scan aborts with `ScanCancelled` before the
-        // second chunk and the tail is never read.
+        // second chunk and the tail is never read — a cancel raised while a
+        // chunk is in flight takes effect within that one chunk's bytes.
         let cancel = AtomicBool::new(false);
         let bytes = vec![0_u8; DATA_SIZE.wrapping_add(1)];
         let mut reader = TripAfterServing { inner: Cursor::new(bytes), cancel: &cancel };
@@ -2974,7 +2989,46 @@ mod tests {
         let err = file.scan_cancellable(&mut reader, &mut pls, true, &cancel).unwrap_err();
         assert_eq!(err.to_string(), "scan cancelled");
         let consumed = usize::try_from(reader.inner.position()).expect("position fits");
-        assert!(consumed < reader.inner.get_ref().len(), "the tail is never read");
+        assert!(consumed <= DATA_SIZE, "at most the in-flight chunk is read after the trip");
+    }
+
+    /// A reader recording the destination length of each read call — how the
+    /// chunk size a scan entry selected reaches the underlying source.
+    struct SizeRecorder {
+        inner: Cursor<Vec<u8>>,
+        sizes: Vec<usize>,
+    }
+
+    impl Read for SizeRecorder {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            self.sizes.push(buf.len());
+            self.inner.read(buf)
+        }
+    }
+
+    #[test]
+    fn the_default_scan_entries_read_the_full_pass_in_data_size_chunks() {
+        // The payload does not matter here — only the destination length the
+        // demux hands the reader, which for a fresh chunk is the whole chunk.
+        // Both default entries (`scan` and `scan_cancellable`) must select the
+        // same size: the disc-level open drives the cancellable one, and the
+        // plain one must not diverge from it.
+        let bytes = vec![0_u8; 4096];
+        let first_size = |cancellable: bool| {
+            let mut recorder =
+                SizeRecorder { inner: Cursor::new(bytes.clone()), sizes: Vec::new() };
+            let mut file = TsStreamFile::new("00000.m2ts");
+            let mut pls = [empty_playlist()];
+            if cancellable {
+                file.scan_cancellable(&mut recorder, &mut pls, true, &AtomicBool::new(false))
+                    .expect("scan");
+            } else {
+                file.scan(&mut recorder, &mut pls, true).expect("scan");
+            }
+            recorder.sizes.first().copied()
+        };
+        assert_eq!(first_size(false), Some(DATA_SIZE));
+        assert_eq!(first_size(true), Some(DATA_SIZE));
     }
 
     // ── the sequential scan strategy (the wasm32 build's path) ──────────────

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -66,6 +66,8 @@ use crate::stream::{StreamKind, TsStream, TsStreamType};
 /// poll ([`fill_buffer`]) can get, and how many bytes a failed read discards
 /// (a read error voids only its own chunk, so the demux keeps everything up
 /// to the last completed chunk boundary). Tunable within those trade-offs.
+/// The size is a deliberate divergence from classic `BDInfo` 0.8's 5 MiB —
+/// see DIFFERENCES.md, "Damaged-media read granularity".
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) const DATA_SIZE: usize = 262_144;
 
@@ -83,7 +85,9 @@ pub(crate) const DATA_SIZE: usize = 5_242_880;
 /// registered stream's codec detail is initialised, so its chunk size bounds
 /// the read-ahead past that point — and on a file whose head is unreadable,
 /// how many bytes one blocking read can stall on before the failure is
-/// recorded and the pass moves to the next file.
+/// recorded and the pass moves to the next file. Diverges deliberately from
+/// classic `BDInfo` 0.8 (5 MiB for both passes) — see DIFFERENCES.md,
+/// "Damaged-media read granularity".
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) const QUICK_DATA_SIZE: usize = 16_384;
 
@@ -197,7 +201,10 @@ pub struct TsStreamDiagnostics {
     pub packets: u64,
     /// Time in seconds (`PTS / 90000`) of the frame that closed this window:
     /// one entry is emitted per completed window, stamped with its closing
-    /// frame's time, not its start.
+    /// frame's time, not its start. Exception: the end-of-scan flush closing
+    /// each stream's final window stamps it with the running maximum video
+    /// timestamp across streams, so on an interleaved (MVC) scan a dependent
+    /// view's last entry can carry the base view's time and interval.
     pub marker: f64,
     /// Window length in seconds (the PTS delta `/ 90000`).
     pub interval: f64,

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -78,6 +78,27 @@ pub(crate) const DATA_SIZE: usize = 262_144;
 #[cfg(target_arch = "wasm32")]
 pub(crate) const DATA_SIZE: usize = 5_242_880;
 
+/// Read-chunk size (16 KiB) for each underlying quick-pass read. The quick
+/// codec pass stops at the first completed access unit past which every
+/// registered stream's codec detail is initialised, so its chunk size bounds
+/// the read-ahead past that point — and on a file whose head is unreadable,
+/// how many bytes one blocking read can stall on before the failure is
+/// recorded and the pass moves to the next file.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const QUICK_DATA_SIZE: usize = 16_384;
+
+/// Quick-pass read-chunk size on `wasm32-unknown-unknown`: [`DATA_SIZE`]'s
+/// 5 MiB, for the same per-read round-trip economy.
+#[cfg(target_arch = "wasm32")]
+pub(crate) const QUICK_DATA_SIZE: usize = DATA_SIZE;
+
+/// The read-chunk size the default scan entries select for a pass: the full
+/// measurement pass reads [`DATA_SIZE`] chunks, the quick codec pass
+/// [`QUICK_DATA_SIZE`].
+const fn default_chunk_size(is_full_scan: bool) -> usize {
+    if is_full_scan { DATA_SIZE } else { QUICK_DATA_SIZE }
+}
+
 /// Size of the fixed `PAT`/`PMT` section-assembly buffers.
 const SECTION_SIZE: usize = 1024;
 
@@ -593,7 +614,13 @@ impl TsStreamFile {
         playlists: &mut [TsPlaylistFile],
         is_full_scan: bool,
     ) -> Result<(), BdError> {
-        self.scan_chunked(reader, playlists, is_full_scan, DATA_SIZE, &mut |_, _| {})
+        self.scan_chunked(
+            reader,
+            playlists,
+            is_full_scan,
+            default_chunk_size(is_full_scan),
+            &mut |_, _| {},
+        )
     }
 
     /// [`scan`](Self::scan) with a cooperative `cancel` flag — the demux entry
@@ -607,7 +634,14 @@ impl TsStreamFile {
         is_full_scan: bool,
         cancel: &AtomicBool,
     ) -> Result<(), BdError> {
-        self.scan_chunked_with(reader, playlists, is_full_scan, DATA_SIZE, cancel, &mut |_, _| {})
+        self.scan_chunked_with(
+            reader,
+            playlists,
+            is_full_scan,
+            default_chunk_size(is_full_scan),
+            cancel,
+            &mut |_, _| {},
+        )
     }
 
     /// [`scan`](Self::scan) with an explicit read-chunk size and a codec-seam
@@ -1932,7 +1966,8 @@ mod tests {
         pes_pts_padded, pes_variable, pmt_payload, pmt_payload_es, pmt_section,
     };
     use super::{
-        DATA_SIZE, TsInterleavedFile, TsStreamDiagnostics, TsStreamFile, pts_to_f64, round_long,
+        DATA_SIZE, QUICK_DATA_SIZE, TsInterleavedFile, TsStreamDiagnostics, TsStreamFile,
+        pts_to_f64, round_long,
     };
     use crate::bdrom::clpi::TsStreamClip;
     use crate::bdrom::interleaved::MemBdFile;
@@ -3007,28 +3042,30 @@ mod tests {
     }
 
     #[test]
-    fn the_default_scan_entries_read_the_full_pass_in_data_size_chunks() {
+    fn the_default_scan_entries_select_the_chunk_size_by_pass() {
         // The payload does not matter here — only the destination length the
         // demux hands the reader, which for a fresh chunk is the whole chunk.
         // Both default entries (`scan` and `scan_cancellable`) must select the
-        // same size: the disc-level open drives the cancellable one, and the
-        // plain one must not diverge from it.
+        // same size per pass: the disc-level open drives the cancellable one,
+        // and the plain one must not diverge from it.
         let bytes = vec![0_u8; 4096];
-        let first_size = |cancellable: bool| {
+        let first_size = |cancellable: bool, full: bool| {
             let mut recorder =
                 SizeRecorder { inner: Cursor::new(bytes.clone()), sizes: Vec::new() };
             let mut file = TsStreamFile::new("00000.m2ts");
             let mut pls = [empty_playlist()];
             if cancellable {
-                file.scan_cancellable(&mut recorder, &mut pls, true, &AtomicBool::new(false))
+                file.scan_cancellable(&mut recorder, &mut pls, full, &AtomicBool::new(false))
                     .expect("scan");
             } else {
-                file.scan(&mut recorder, &mut pls, true).expect("scan");
+                file.scan(&mut recorder, &mut pls, full).expect("scan");
             }
             recorder.sizes.first().copied()
         };
-        assert_eq!(first_size(false), Some(DATA_SIZE));
-        assert_eq!(first_size(true), Some(DATA_SIZE));
+        assert_eq!(first_size(false, true), Some(DATA_SIZE));
+        assert_eq!(first_size(true, true), Some(DATA_SIZE));
+        assert_eq!(first_size(false, false), Some(QUICK_DATA_SIZE));
+        assert_eq!(first_size(true, false), Some(QUICK_DATA_SIZE));
     }
 
     // ── the sequential scan strategy (the wasm32 build's path) ──────────────

--- a/crates/bdinfo-rs-core/src/scan.rs
+++ b/crates/bdinfo-rs-core/src/scan.rs
@@ -29,9 +29,11 @@ use crate::vfs::volume;
 /// ([`FsDir::take_errors`]) — a directory that could not be read is damage the
 /// scan itself never sees.
 ///
-/// The label is [`volume::resolve_folder_label`]'s: a folder scan names the
-/// disc after its root directory, which a bare Windows drive root (`J:\`) does
-/// not have.
+/// The label is the [`volume`] repair's: a folder scan names the disc after
+/// its root directory, which a bare Windows drive root (`J:\`) does not have.
+/// When the scan recorded stream read failures the repair skips its
+/// raw-device read — the drive just failed mid-stream, and another raw read
+/// could stall — so the label degrades to the bare drive letter there.
 ///
 /// `mode`, `options`, `scan_files`, `progress` and `cancel` are
 /// [`BdRom::open_resilient_with`]'s, passed through unchanged.
@@ -51,7 +53,8 @@ pub fn open_folder(
     let mut report =
         BdRom::open_resilient_with(&root, mode, options, scan_files, progress, cancel)?;
     report.errors.extend(root.take_errors());
-    report.bdrom.volume_label = volume::resolve_folder_label(&report.bdrom.volume_label);
+    report.bdrom.volume_label =
+        volume::resolve_folder_label_after_scan(&report.bdrom.volume_label, &report.errors);
     Ok(report)
 }
 

--- a/crates/bdinfo-rs-core/src/vfs/volume.rs
+++ b/crates/bdinfo-rs-core/src/vfs/volume.rs
@@ -19,11 +19,14 @@
 //! uses, the identical string Windows Explorer and classic `BDInfo` show —
 //! falling back to the drive letter when that read is unavailable. A folder
 //! backend's caller applies it to the scanned label; an `.iso` scan already
-//! reads the genuine UDF label and needs no repair.
+//! reads the genuine UDF label and needs no repair. A scan that recorded
+//! stream read failures resolves through `resolve_folder_label_after_scan`
+//! instead, which skips the raw-device read outright.
 
 #[cfg(any(windows, test))]
 use std::io::{self, Read, Seek, SeekFrom};
 
+use crate::error::{ScanError, ScanStage};
 #[cfg(any(windows, test))]
 use crate::vfs::ReadSeek;
 #[cfg(windows)]
@@ -64,6 +67,34 @@ fn resolve_with(scanned: &str, read: impl FnOnce(char) -> Option<String>) -> Str
         || scanned.to_owned(),
         |letter| read(letter).unwrap_or_else(|| letter.to_string()),
     )
+}
+
+/// [`resolve_folder_label`] for a scan that may have recorded failures: when
+/// `errors` records a stream read failure ([`ScanStage::StreamFile`]), the
+/// raw-device read is skipped and a bare drive-root label degrades straight
+/// to the drive letter. The label read grinds the same device that just
+/// failed mid-stream, sector by sector, and on damaged media one raw read
+/// can stall for minutes inside the drive's retries — a cosmetic label is
+/// not worth that after a scan that already recorded failures. A real name
+/// resolves to itself either way.
+#[must_use]
+pub(crate) fn resolve_folder_label_after_scan(scanned: &str, errors: &[ScanError]) -> String {
+    resolve_after_scan_with(scanned, errors, real_volume_label)
+}
+
+/// The pure core of [`resolve_folder_label_after_scan`], with the raw-device
+/// read injected as `read` so the failure gate is exercised without a real
+/// device.
+fn resolve_after_scan_with(
+    scanned: &str,
+    errors: &[ScanError],
+    read: impl FnOnce(char) -> Option<String>,
+) -> String {
+    if errors.iter().any(|e| e.stage == ScanStage::StreamFile) {
+        resolve_with(scanned, |_| None)
+    } else {
+        resolve_with(scanned, read)
+    }
 }
 
 /// How many times to attempt the raw-device read — an optical drive can fail the
@@ -266,8 +297,11 @@ mod tests {
     use std::io::{Cursor, Read as _, Seek as _, SeekFrom};
 
     use super::{
-        AlignedReader, SECTOR, add_signed, drive_root_letter, resolve_folder_label, resolve_with,
+        AlignedReader, SECTOR, ScanError, ScanStage, add_signed, drive_root_letter,
+        resolve_after_scan_with, resolve_folder_label, resolve_folder_label_after_scan,
+        resolve_with,
     };
+    use crate::error::BdError;
 
     #[test]
     fn drive_root_letter_matches_every_bare_drive_root_spelling() {
@@ -306,6 +340,57 @@ mod tests {
         // A real folder name never touches the device — exercises the public
         // wrapper (the drive-root path is validated end-to-end on real hardware).
         assert_eq!(resolve_folder_label("BigBuckBunny"), "BigBuckBunny");
+    }
+
+    /// A recorded failure at `stage`, for driving the post-scan gate.
+    fn error_at(stage: ScanStage) -> ScanError {
+        ScanError {
+            file: "00000.m2ts".to_owned(),
+            stage,
+            reason: BdError::Io(std::io::Error::other("read failed")),
+        }
+    }
+
+    #[test]
+    fn a_recorded_stream_read_failure_skips_the_device_read() {
+        // One injected reader for every shape: consulted only when no stream
+        // read failure is on record, so its label wins exactly there.
+        let read = |letter: char| Some(format!("VOL{letter}"));
+        // A stream read failure degrades a drive root straight to the letter…
+        assert_eq!(resolve_after_scan_with(r"J:\", &[error_at(ScanStage::StreamFile)], read), "J");
+        // …also when failures at other stages surround it…
+        assert_eq!(
+            resolve_after_scan_with(
+                r"J:\",
+                &[error_at(ScanStage::Discovery), error_at(ScanStage::StreamFile)],
+                read
+            ),
+            "J"
+        );
+        // …while non-stream failures alone leave the device read in play…
+        assert_eq!(
+            resolve_after_scan_with(r"J:\", &[error_at(ScanStage::Discovery)], read),
+            "VOLJ"
+        );
+        // …as does a clean scan.
+        assert_eq!(resolve_after_scan_with(r"J:\", &[], read), "VOLJ");
+        // A real name resolves to itself whatever is on record.
+        assert_eq!(
+            resolve_after_scan_with("BigBuckBunny", &[error_at(ScanStage::StreamFile)], read),
+            "BigBuckBunny"
+        );
+    }
+
+    #[test]
+    fn resolve_folder_label_after_scan_leaves_a_real_name_untouched() {
+        // The wrapper with the real device read behind it, on the shapes that
+        // never touch a device — a real name on both sides of the gate (the
+        // drive-root road is validated end-to-end on real hardware).
+        assert_eq!(resolve_folder_label_after_scan("BigBuckBunny", &[]), "BigBuckBunny");
+        assert_eq!(
+            resolve_folder_label_after_scan("BigBuckBunny", &[error_at(ScanStage::StreamFile)]),
+            "BigBuckBunny"
+        );
     }
 
     /// An inner reader that fails any read whose current position or length is

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -1870,10 +1870,11 @@ impl App {
             debug_worker_panic();
             #[cfg(debug_assertions)]
             debug_scan_delay();
-            // The scan fires its progress callback every few MB — tens of thousands
-            // of times on a feature disc. Coalesce to one message per ~100 ms (plus
-            // every file boundary) so the UI re-renders a few times a second, not
-            // thousands; the CLI throttles its terminal redraw the same way.
+            // The scan fires its progress callback before and after every read —
+            // several per 256 KiB chunk, hundreds of thousands of times on a
+            // feature disc. Coalesce to one message per ~100 ms (plus every file
+            // boundary) so the UI re-renders a few times a second, not thousands;
+            // the CLI throttles its terminal redraw the same way.
             let mut last_sent: Option<Instant> = None;
             let mut last_file = String::new();
             let mut on_progress = |progress: ScanProgress<'_>| {

--- a/crates/bdinfo-rs-gui/src/progress.rs
+++ b/crates/bdinfo-rs-gui/src/progress.rs
@@ -42,9 +42,10 @@ const EMIT_EVERY: Duration = Duration::from_millis(100);
 
 /// How long the scan may go without a progress event before the display calls
 /// the current read stalled. Progress normally arrives many times a second
-/// (one event per read chunk, coalesced to [`EMIT_EVERY`]), so a multi-second
-/// silence means one read syscall has not returned — damaged optical media
-/// held in drive-firmware retries, which can block for minutes with no error.
+/// (a heartbeat before and a count after every read, coalesced to
+/// [`EMIT_EVERY`]), so a multi-second silence means one read syscall has not
+/// returned — damaged optical media held in drive-firmware retries, which can
+/// block for minutes with no error.
 const STALL_AFTER: Duration = Duration::from_secs(5);
 
 /// Whether `since_progress` — the time since the last progress event — has
@@ -57,8 +58,8 @@ pub(crate) fn stalled(since_progress: Duration) -> bool {
 
 /// Whether a scan-progress event should become a UI message.
 ///
-/// The scan fires its callback every few MB — tens of thousands of times on a
-/// feature disc — so the worker coalesces to one message per `EMIT_EVERY`
+/// The scan fires its callback before and after every read — hundreds of
+/// thousands of times on a feature disc — so the worker coalesces to one message per `EMIT_EVERY`
 /// (100 ms), plus every file boundary and the final event, exactly like the
 /// CLI throttles its terminal redraw. `since_last` is the time since the last
 /// emitted message (`None` before the first, which always emits).

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -33,8 +33,10 @@ pub enum Input {
     /// A disc folder: the disc root, its `BDMV` directory, or any directory
     /// inside it (the scan walks up to the disc root). The label is the
     /// directory name — or, when the disc root is a nameless Windows drive
-    /// root, the real UDF label
-    /// [`bdinfo_rs_core::vfs::volume::resolve_folder_label`] recovers.
+    /// root, the real UDF label the [`bdinfo_rs_core::vfs::volume`] repair
+    /// recovers; after a scan that recorded stream read errors the repair
+    /// skips its raw-device read and the label degrades to the bare drive
+    /// letter.
     Folder(PathBuf),
     /// A single `.iso` image. The label is the real UDF volume label.
     Iso(PathBuf),

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -1092,8 +1092,9 @@ pub fn render_report(disc: Disc, options: Option<ScanOptions>) -> String {
 /// demux, so a consumer that wants the report and the model never reads a
 /// multi-GB disc twice.
 ///
-/// When `on_progress` is supplied it is called as `(file, done, total)` after
-/// each demux read. A non-empty `selection` names the playlists to measure (CLI
+/// When `on_progress` is supplied it is called as `(file, done, total)` before
+/// and after each demux read. A non-empty `selection` names the playlists to
+/// measure (CLI
 /// `--mpls` semantics — unfiltered, in order); an empty `selection` measures the
 /// standard `--whole` set. `options` carries the rest: the optional report
 /// sections, the short-playlist threshold `disc.playlists` is classified against

--- a/fuzz/fuzz_targets/m2ts_differential.rs
+++ b/fuzz/fuzz_targets/m2ts_differential.rs
@@ -77,10 +77,10 @@ use libfuzzer_sys::fuzz_target;
 /// chunk boundary is a point the two strategies must agree at, and the demux
 /// carries its packet state across them: 192 is one BDAV packet, 448 always
 /// lands mid-packet, 4096 is a page, and 32,768 is larger than most units so
-/// the whole stream arrives as a single chunk. The production size (`scan`
-/// passes 5 MiB) is deliberately absent: it would make every unit
-/// single-chunk — which 32,768 already does — at the cost of zeroing 5 MiB per
-/// scan.
+/// the whole stream arrives as a single chunk. The production sizes (`scan`
+/// selects per pass: 256 KiB full / 16 KiB quick natively, 5 MiB on wasm32)
+/// are deliberately absent: each would make every unit single-chunk — which
+/// 32,768 already does — at a larger per-scan zeroing cost.
 const CHUNK_SIZES: [usize; 4] = [192, 448, 4096, 32_768];
 
 /// The stream reader, optionally failing part-way through.


### PR DESCRIPTION
The demux read 5 MiB per blocking request in both measurement passes — upstream BDInfo 0.8 behavior (commit 9ff60e8, a throughput change) that multiplies every damaged-media failure mode: one stalled request spans 2560 optical sectors of in-device retries, the per-request cancel poll goes that whole read stale, a failed request discards up to 5 MiB of good bytes, and the listing pass pulls 5 MiB out of every file just to identify codecs.

- The full pass reads 256 KiB per request on native targets; wasm32 keeps 5 MiB (its reads each cost one synchronous `FileReaderSync` round trip, and they return promptly on damage). The packet state machine is chunk-boundary-agnostic, so healthy reports are byte-identical — the goldens are untouched. The damaged-disc pins move deliberately: the failure boundary is finer, so partial scans retain more; recorded in DIFFERENCES.md.
- The quick codec pass reads 16 KiB per request (BDInfo 0.7.5.6's size for both passes), so a head-damaged file stalls the listing at 16 KiB granularity instead of 5 MiB.
- Scan progress fires a zero-delta heartbeat before each physical read, so a consumer can tell a stalled in-flight read (and the file it is stuck in) from silence. The existing consumers throttle by time, so the higher event rate reaches no UI unthrottled.
- A folder scan that recorded stream read errors skips the raw-volume label read — a second stall site on a drive that just failed — and the label degrades to the bare drive letter.

Cancellation needs no new machinery: the existing per-request poll now fires per 256 KiB, and a mid-file cancel taking effect within one chunk is pinned by test. Scan throughput over the committed fixtures is unchanged-to-better (median whole-disc scan, folder fixture 24.8 ms to 18.5 ms, iso 20.1 ms to 15.1 ms — the smaller zeroed read buffers win), with reports byte-identical between the two builds.

Fixes #319. Refs #324.
