### PR TITLE
fix(wasm): render over the scanned selection and surface iso read errors

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -33,6 +33,7 @@ actually see on a normal disc.
 | [PAT `table_id` validation](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on malformed input | Never — no conforming disc carries a wrong PAT table id |
 | [AACS-encrypted discs are refused](#aacs-encrypted-discs-are-refused) | **Yes** — no report at all | Discs whose stream content is still encrypted |
 | [Damaged-media read granularity](#damaged-media-read-granularity) | Only on damaged media — partial scans retain more | Discs with unreadable spans |
+| [Read errors: folder input vs `.iso` input](#read-errors-folder-input-vs-iso-input) | Only on damaged media — the same disc measures differently through the two inputs | Damaged discs and damaged disc images |
 
 ---
 
@@ -224,6 +225,34 @@ has no raw-device read to skip).
 
 <sub>Source: `crates/bdinfo-rs-core/src/bdrom/m2ts.rs` (`DATA_SIZE`, `QUICK_DATA_SIZE`),
 `crates/bdinfo-rs-core/src/vfs/volume.rs` (the label-read gate).</sub>
+
+### Read errors: folder input vs `.iso` input
+
+A read that fails is handled at a different layer for the two inputs, so the same damaged
+disc measures differently depending on which one it is scanned through. Both are
+deliberate; neither has a BDInfo counterpart, which reads folders only.
+
+- **Folder input** — the failing read aborts that stream file. Everything demuxed before
+  it is kept (unless the retention switch discards it) and everything after it is never
+  read, so the file's chapter rows and tallies stop at the failure and stay zero past it.
+  The failure is recorded against the file and printed in the report `WARNING:` block.
+- **`.iso` input** — the UDF reader sits under the demux and is resilient there: it records
+  the unreadable sectors and serves that span **as zeros**, so the demux reads on to the
+  end of the file. The damage shows up as depressed rates across the affected span rather
+  than as a truncated file, the values after it are measured normally, and the retention
+  switch has nothing to decide. The reader's recordings are drained into the scan and
+  printed in the same `WARNING:` block. Only file data degrades this way: the volume
+  structures stay strict, since a damaged filesystem descriptor has no readable rest to
+  degrade to, so an image damaged there does not open at all.
+
+Zero-fill is what lets one bad sector cost its own sector rather than the rest of a 30 GB
+stream file, which is why the `.iso` path keeps it. Every surface that takes an `.iso`
+drains those recordings — the command line, the desktop app and the browser package alike
+— so an unreadable image is never reported as a clean scan.
+
+<sub>Source: `crates/bdinfo-rs-core/src/vfs/udf/source.rs` (`UdfSource::open_resilient`,
+`take_errors`), `crates/bdinfo-rs-core/src/scan.rs` (`open_iso`),
+`crates/bdinfo-rs-wasm/src/lib.rs` (`scan_iso`, `run_iso_report`).</sub>
 
 ---
 

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -66,7 +66,7 @@ use bdinfo_rs_core::bdrom::order::{
 };
 #[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::discovery::BdmvDir;
-use bdinfo_rs_core::error::BdError;
+use bdinfo_rs_core::error::{BdError, ScanError};
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 #[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::vfs::fs::glob_ci;
@@ -195,22 +195,46 @@ struct WebReader {
 
 /// Renders a `JsValue` error to a short message for an [`io::Error`].
 ///
-/// A thrown string comes back directly; an `Error`/`DOMException` is an object
-/// whose `message` property carries the human-readable text (e.g. a
-/// `NotFoundError` from a revoked `File`), so reach for that before falling
-/// back to a generic label.
+/// JavaScript can throw any value at all, and this message is all a user of a
+/// damaged disc gets, so it walks down four steps and only names the type when
+/// every one of them comes back with nothing:
+///
+/// 1. a thrown string comes back directly;
+/// 2. an `Error`/`DOMException` is an object whose `message` property carries the human-readable
+///    text (e.g. a `NotFoundError` from a revoked `File`);
+/// 3. an exotic throw with no `message` may still be classified by its `name` (a `DOMException`
+///    subclass thrown with an empty message);
+/// 4. anything else is rendered as the value itself, `JSON.stringify`, so a thrown payload reaches
+///    the report instead of being flattened away;
+/// 5. and only a value that renders as nothing at all — `undefined`, a symbol, a function, an
+///    object whose serialization throws — falls back to a placeholder, which at least names its
+///    type.
+///
+/// The literal placeholder is the last resort rather than the second step: a
+/// browser scan of a damaged disc was observed reporting nothing but that
+/// placeholder, which threw away the only diagnostic the failure carried.
 #[cfg(target_arch = "wasm32")]
 fn js_message(value: &JsValue) -> String {
     if let Some(text) = value.as_string() {
         return text;
     }
-    if let Ok(message) = js_sys::Reflect::get(value, &JsValue::from_str("message"))
-        && let Some(text) = message.as_string()
+    for property in ["message", "name"] {
+        if let Ok(found) = js_sys::Reflect::get(value, &JsValue::from_str(property))
+            && let Some(text) = found.as_string()
+            && !text.is_empty()
+        {
+            return text;
+        }
+    }
+    if let Ok(json) = js_sys::JSON::stringify(value)
+        && let Some(text) = json.as_string()
         && !text.is_empty()
     {
         return text;
     }
-    "JavaScript exception".to_owned()
+    // `typeof` is what is left to say about it.
+    let kind = value.js_typeof().as_string().unwrap_or_default();
+    format!("JavaScript exception ({kind})")
 }
 
 /// The byte window `[start, end)` a [`WebReader`] read of `buf_len` bytes at
@@ -692,7 +716,9 @@ fn inspect_disc(
     filter: &PlaylistFilter,
 ) -> Result<Disc, BdError> {
     let report = BdRom::open_resilient(root, mode)?;
-    Ok(Disc::from_scan(&report.bdrom, &report.errors, false, filter))
+    // No report was rendered, so the mirror carries no report order and a later
+    // render of it falls back to the whole-disc presentation order.
+    Ok(Disc::from_scan(&report.bdrom, &report.errors, false, filter, None))
 }
 
 /// Why a by-name [`scan_selection`] could not produce a report.
@@ -803,6 +829,34 @@ impl Scan {
     fn render(&self, options: RenderOptions) -> String {
         text::render_with(&self.report.bdrom, &self.order, &self.report.errors, options)
     }
+
+    /// The playlists this scan renders, by name and in rendered order.
+    ///
+    /// Only the mirror needs them, so this shares its gate.
+    ///
+    /// The [`order`](Self::order) spelled the way a mirror can hold it: names
+    /// survive the round trip through JavaScript that indices into a rebuilt
+    /// disc could not be trusted to. This is what [`Disc::report_order`] takes,
+    /// so a re-render of the mirror prints the blocks this scan printed.
+    #[cfg(any(target_arch = "wasm32", test))]
+    fn playlist_names(&self) -> Vec<String> {
+        self.order
+            .iter()
+            .filter_map(|&index| self.report.bdrom.playlists.get(index))
+            .map(|playlist| playlist.name.clone())
+            .collect()
+    }
+
+    /// Merges failures a source recorded itself into this scan's.
+    ///
+    /// The `.iso` reader records a bad sector and serves the unreadable span as
+    /// zeros, so the demux above it succeeds and the scan records nothing —
+    /// draining the reader is the only way that damage reaches the report
+    /// `WARNING:` block (the composition [`bdinfo_rs_core::scan::open_iso`]
+    /// makes for the command line).
+    fn merge_errors(&mut self, errors: Vec<ScanError>) {
+        self.report.errors.extend(errors);
+    }
 }
 
 /// Runs the full **measured** scan over `root`, in the CLI's `--whole` playlist
@@ -863,6 +917,25 @@ fn render_options(options: Option<&ScanOptions>) -> RenderOptions {
     }
 }
 
+/// The playlist order a [`Disc`] renders in — indices into `bdrom`'s playlists.
+///
+/// `names` is the mirror's [`Disc::report_order`]: the playlists the scan that
+/// produced it printed, in printed order, which map back to indices in that
+/// same order (a name no playlist on the disc carries is skipped, exactly as a
+/// by-name scan skips it). Rendering over them is what keeps a re-render inside
+/// the scanned selection — the whole-disc presentation order below would print
+/// every never-scanned playlist as a block of zeros beside the measured ones.
+///
+/// Their absence is a disc no report was rendered from ([`inspect_files`],
+/// [`inspect_iso`]), which renders as the standard filtered whole-disc set.
+#[cfg(any(target_arch = "wasm32", test))]
+fn render_order(bdrom: &BdRom, names: Option<&[String]>) -> Vec<usize> {
+    names.map_or_else(
+        || bdrom.presentation_order(&PlaylistFilter::default()),
+        |names| selection_order(&bdrom.playlists, names),
+    )
+}
+
 /// The scan switches `options` asks for. An absent `keepPartial` — or no options
 /// object at all — leaves [`CoreScanOptions::default`] in force, which keeps the
 /// measured state of a stream file whose read fails partway.
@@ -887,8 +960,16 @@ fn scan_options(options: Option<&ScanOptions>) -> CoreScanOptions {
 fn measured_result(scan: &Scan, options: RenderOptions, filter: &PlaylistFilter) -> ScanResult {
     ScanResult {
         report: scan.render(options),
-        // A `Scan` is always the packet scan, so the mirror says measured.
-        disc: Disc::from_scan(&scan.report.bdrom, &scan.report.errors, true, filter),
+        // A `Scan` is always the packet scan, so the mirror says measured. It
+        // carries the scan's own playlist order too, so re-rendering the mirror
+        // reproduces the report beside it rather than the whole disc.
+        disc: Disc::from_scan(
+            &scan.report.bdrom,
+            &scan.report.errors,
+            true,
+            filter,
+            Some(scan.playlist_names()),
+        ),
     }
 }
 
@@ -949,13 +1030,23 @@ pub fn run_report(data: &[u8]) -> String {
 /// `wasm_bindgen` export that adds progress, selection, and error reporting
 /// around the same wiring.
 ///
+/// The reader's own bad-sector recordings are drained into the scan's failures
+/// before the render, so an unreadable span — which the reader serves as zeros,
+/// leaving the demux above it none the wiser — reaches the report's `WARNING:`
+/// block. Draining inside keeps the signature a plain image in, report out.
+///
 /// An image that is not a readable UDF volume, or that opens but holds no
 /// `BDMV` structure, renders as the empty string — matching [`run_report`]'s
 /// resilient-open absence path.
 #[must_use]
 pub fn run_iso_report(reader: Box<dyn IsoReader>) -> String {
     let Ok(source) = UdfSource::open_resilient(reader) else { return String::new() };
-    render_disc(&source.root(), RenderOptions::default(), &mut |_| {}).unwrap_or_default()
+    scan_whole(&source.root(), CoreScanOptions::default(), &mut |_| {})
+        .map(|mut scan| {
+            scan.merge_errors(source.take_errors());
+            scan.render(RenderOptions::default())
+        })
+        .unwrap_or_default()
 }
 
 /// The in-memory entry point: feed it BDMV bytes (the six `u32`-BE
@@ -1067,18 +1158,20 @@ pub fn inspect_iso(file: web_sys::File, options: Option<ScanOptions>) -> Result<
 /// [`Disc`] into report text. Formatting the model by hand produces something
 /// that merely resembles the locked format.
 ///
-/// The playlists print in the disc's presentation order — the standard
-/// `--whole` set, grouped by shared clip files and longest first, the same
-/// order a whole-disc scan renders. Any disc renders, including one whose
-/// values were never measured: a disc from a by-name scan holds every playlist
-/// but measured values only for the ones that scan named, and one from
-/// [`inspect_files`] holds none at all, so both print the rest at zero.
+/// The playlists print in the order the scan that produced the disc printed
+/// them — its `reportOrder`, so a disc from a by-name scan re-renders as that
+/// scan reported it and a playlist it never measured never appears. A disc from
+/// [`inspect_files`] or [`inspect_iso`] carries no such order and prints in the
+/// disc's presentation order instead — the standard `--whole` set, grouped by
+/// shared clip files and longest first — every value of it zero, because an
+/// inspect measures none.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 #[must_use]
-pub fn render_report(disc: Disc, options: Option<ScanOptions>) -> String {
+pub fn render_report(mut disc: Disc, options: Option<ScanOptions>) -> String {
+    let printed = disc.report_order.take();
     let (bdrom, errors) = disc.into_scan();
-    let order = bdrom.presentation_order(&PlaylistFilter::default());
+    let order = render_order(&bdrom, printed.as_deref());
     text::render_with(&bdrom, &order, &errors, render_options(options.as_ref()))
 }
 
@@ -1140,6 +1233,13 @@ pub fn scan_files(
 /// behaves exactly as [`scan_files`] — one demux, both results, and the same
 /// meaning for every parameter it shares.
 ///
+/// One failure mode is the `.iso` path's own: a sector the image cannot serve
+/// is recorded by the UDF reader and served to the demux as zeros, so the scan
+/// itself sees no error. Those recordings are merged into the result, so they
+/// reach `result.disc.errors` and the report's `WARNING:` block like any other
+/// read failure. A folder scan has no such layer — a failing read aborts that
+/// file instead (see `DIFFERENCES.md`).
+///
 /// # Errors
 /// Returns a `JsValue` if the image is not a readable UDF `.iso`, no readable
 /// Blu-ray structure is found inside it, or a non-empty `selection` names no
@@ -1158,9 +1258,14 @@ pub fn scan_iso(
     let length = file.size() as u64;
     let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
         .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
-    let scan = scan_root(&source.root(), &selection, scan_options(options.as_ref()), &mut |p| {
-        notify(on_progress.as_ref(), &p);
-    })?;
+    let mut scan =
+        scan_root(&source.root(), &selection, scan_options(options.as_ref()), &mut |p| {
+            notify(on_progress.as_ref(), &p);
+        })?;
+    // The reader's bad sectors, which it zero-filled past — invisible to the
+    // demux, and reported nowhere unless drained here (as `run_iso_report` and
+    // the command line's `open_iso` both drain them).
+    scan.merge_errors(source.take_errors());
     Ok(measured_result(&scan, render_options(options.as_ref()), &filter))
 }
 
@@ -1474,6 +1579,68 @@ mod tests {
         assert_eq!(result.disc.volume_label, "WASMDISC");
     }
 
+    #[test]
+    fn a_re_render_of_the_mirror_prints_the_playlists_the_scan_printed() {
+        use bdinfo_rs_core::bdrom::disc::ScanProgress;
+        use bdinfo_rs_core::report::text;
+
+        use super::{CoreScanOptions, measured_result, render_order, scan_whole};
+
+        let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
+        let scan = scan_whole(&framed_tree(&fixture_blob()), CoreScanOptions::default(), &mut sink)
+            .expect("the fixture opens");
+        let filter = super::classification_filter(None).expect("an absent threshold is valid");
+        let result = measured_result(&scan, RenderOptions::default(), &filter);
+
+        // The mirror carries the scan's own playlist order, by name.
+        assert_eq!(result.disc.report_order.as_deref(), Some(scan.playlist_names().as_slice()));
+
+        // Re-rendering the mirror over that order — the three lines the browser
+        // `render_report` export is — reproduces the scan's report byte for
+        // byte. On this one-playlist fixture the two orders agree; the browser
+        // harness drives the subset scan where they do not.
+        let mut disc = result.disc;
+        let printed = disc.report_order.take();
+        let (bdrom, errors) = disc.into_scan();
+        let order = render_order(&bdrom, printed.as_deref());
+        let rendered = text::render_with(&bdrom, &order, &errors, RenderOptions::default());
+        assert_eq!(rendered, result.report);
+    }
+
+    #[test]
+    fn a_render_follows_the_scans_order_and_falls_back_to_the_presentation_one() {
+        use bdinfo_rs_core::bdrom::disc::{PlaylistSummary, ScanProgress};
+
+        use super::{CoreScanOptions, render_order, scan_whole};
+
+        // Two playlists off the scanned fixture, long enough that neither is
+        // withheld as short: the shorter one sorts SECOND in presentation order
+        // (longest first), so an order that follows the scan is visibly not the
+        // presentation one.
+        let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
+        let scan = scan_whole(&framed_tree(&fixture_blob()), CoreScanOptions::default(), &mut sink)
+            .expect("the fixture opens");
+        let mut bdrom = scan.report.bdrom;
+        let one = bdrom.playlists.first().expect("the fixture has a playlist").clone();
+        bdrom.playlists = vec![
+            PlaylistSummary { name: "00000.MPLS".to_owned(), total_length: 30.0, ..one.clone() },
+            PlaylistSummary { name: "00001.MPLS".to_owned(), total_length: 100.0, ..one },
+        ];
+
+        // No order recorded: the whole disc, longest first.
+        assert_eq!(render_order(&bdrom, None), vec![1, 0]);
+        // A scan of one playlist prints that playlist and nothing else.
+        assert_eq!(render_order(&bdrom, Some(&["00000.MPLS".to_owned()])), vec![0]);
+        // Several print in the order the scan named them, not the table's.
+        let named = ["00000.MPLS".to_owned(), "00001.MPLS".to_owned()];
+        assert_eq!(render_order(&bdrom, Some(&named)), vec![0, 1]);
+        // A name the disc does not carry is skipped, as a by-name scan skips
+        // it; an order that names nothing prints nothing.
+        let nothing: Vec<usize> = Vec::new();
+        assert_eq!(render_order(&bdrom, Some(&["NOSUCH.MPLS".to_owned()])), nothing);
+        assert_eq!(render_order(&bdrom, Some(&[])), nothing);
+    }
+
     /// An options object with every option left out — the base each test below
     /// sets the one option it is about on.
     fn no_options() -> super::ScanOptions {
@@ -1640,6 +1807,71 @@ mod tests {
             run_iso_report(Box::new(MemIso(Arc::from(vec![0_u8; 1 << 16])))).is_empty(),
             "a non-UDF image renders as the empty string"
         );
+    }
+
+    #[test]
+    fn an_unreadable_iso_sector_reaches_the_report_warning_block() {
+        use std::io::{Cursor, Read, Seek};
+        use std::sync::Arc;
+
+        use bdinfo_rs_core::vfs::ReadSeek;
+        use bdinfo_rs_core::vfs::udf::source::IsoReader;
+
+        use super::run_iso_report;
+
+        /// The unreadable window: one 2 KiB sector deep inside the image, which
+        /// is 11 of its 12.3 MiB of stream file. Reading it is what the browser
+        /// cannot do on a damaged disc.
+        const BAD_AT: u64 = 8 << 20;
+        const BAD_LEN: u64 = 2048;
+
+        /// An [`IsoReader`] over an image with one unreadable window — the
+        /// `.iso` analogue of the core reader tests' `FaultyIso`. Every cursor
+        /// it opens fails any read overlapping `[BAD_AT, BAD_AT + BAD_LEN)`,
+        /// which is what a bad sector does to a `FileReaderSync` read.
+        #[derive(Debug)]
+        struct FaultyIso(Arc<[u8]>);
+
+        struct FaultyCursor(Cursor<Arc<[u8]>>);
+
+        impl Read for FaultyCursor {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                let start = self.0.position();
+                let end = start.saturating_add(buf.len() as u64);
+                if start < BAD_AT.saturating_add(BAD_LEN) && end > BAD_AT {
+                    return Err(std::io::Error::other("simulated bad sector"));
+                }
+                self.0.read(buf)
+            }
+        }
+
+        impl Seek for FaultyCursor {
+            fn seek(&mut self, from: std::io::SeekFrom) -> std::io::Result<u64> {
+                self.0.seek(from)
+            }
+        }
+
+        impl IsoReader for FaultyIso {
+            fn open(&self) -> std::io::Result<Box<dyn ReadSeek>> {
+                Ok(Box::new(FaultyCursor(Cursor::new(Arc::clone(&self.0)))))
+            }
+        }
+
+        const ISO: &[u8] = include_bytes!("../../bdinfo-rs/tests/fixtures/BigBuckBunny.iso");
+
+        // The resilient UDF reader records the bad sector and serves the span
+        // as zeros, so the demux above it succeeds and records nothing: without
+        // the drain the report would come back clean and the damage would be
+        // reported nowhere at all.
+        let report = run_iso_report(Box::new(FaultyIso(Arc::from(ISO))));
+        assert!(
+            report.contains("WARNING: File errors were encountered during scan:"),
+            "a bad sector must reach the report:\n{report}"
+        );
+        assert!(report.contains("00000.M2TS"), "the WARNING must name the file:\n{report}");
+        // The rest of the disc still rendered — one unreadable window is not a
+        // failed scan.
+        assert!(report.contains("PLAYLIST: 00000.MPLS"), "the report still renders:\n{report}");
     }
 
     #[test]

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -4,7 +4,7 @@
 //!
 //! | Mirror | Core |
 //! |---|---|
-//! | [`Disc`] | [`BdRom`] plus the scan mode and the recorded failures |
+//! | [`Disc`] | [`BdRom`] plus the scan mode, the recorded failures and the report order |
 //! | [`Playlist`] | [`PlaylistSummary`] |
 //! | [`Clip`] | [`ClipSummary`] |
 //! | [`Stream`] | [`StreamSummary`] |
@@ -220,6 +220,21 @@ pub struct Disc {
     /// Per-file failures the scan recorded and continued past. Empty for a
     /// scan of healthy media.
     pub errors: Vec<ScanError>,
+    /// The playlists the scan that produced this disc printed, in printed
+    /// order, naming each one as its `name` does.
+    ///
+    /// `renderReport` prints exactly these, so re-rendering a disc from a scan
+    /// of a named selection reproduces that scan report rather than the whole
+    /// disc — a playlist the scan never measured cannot reappear as a block of
+    /// zeros. Absent on a disc that no report was rendered from (`inspectFiles`
+    /// and `inspectIso` return one), where `renderReport` falls back to the disc
+    /// presentation order: the standard whole-disc set, grouped by shared clip
+    /// files and longest first.
+    ///
+    /// This is an order over the playlists, not a filter on them: `playlists`
+    /// still holds every playlist the disc declares, measured or not.
+    #[tsify(optional)]
+    pub report_order: Option<Vec<String>>,
 }
 
 /// One playlist (`*.MPLS`) with its streams, clips and chapters.
@@ -593,12 +608,17 @@ impl Disc {
     /// `filter` supplies the short-playlist threshold each playlist is
     /// classified against for its `hiddenBy`; its two switches are not read,
     /// because no playlist is ever dropped here.
+    ///
+    /// `report_order` is the playlist order the scan rendered its report in, by
+    /// name — [`report_order`](Self::report_order), which a re-render prints.
+    /// `None` for a scan that rendered no report.
     #[must_use]
     pub fn from_scan(
         bdrom: &BdRom,
         errors: &[error::ScanError],
         measured: bool,
         filter: &PlaylistFilter,
+        report_order: Option<Vec<String>>,
     ) -> Self {
         // The table numbering describes the disc, not a view of it, so it is
         // taken over every playlist: a group or a position that shifted when a
@@ -640,6 +660,7 @@ impl Disc {
                 .collect(),
             measured,
             errors: errors.iter().map(ScanError::from).collect(),
+            report_order,
         }
     }
 }
@@ -877,9 +898,11 @@ impl Disc {
     /// Rebuilds the disc this mirror describes: the [`BdRom`] and the per-file
     /// failures, the two halves a report is rendered from.
     ///
-    /// The inverse of [`from_scan`](Self::from_scan) but for `measured`, which
-    /// describes how the values were obtained rather than being one of them —
-    /// a disc carries no such flag, so it is dropped here.
+    /// The inverse of [`from_scan`](Self::from_scan) but for `measured` and
+    /// [`report_order`](Self::report_order), which describe how the values were
+    /// obtained and how they were printed rather than being values of the disc
+    /// — a disc carries neither, so both are dropped here. A caller rendering
+    /// this mirror reads the order off the [`Disc`] before taking it apart.
     #[must_use]
     pub fn into_scan(self) -> (BdRom, Vec<error::ScanError>) {
         let bdrom = BdRom {
@@ -1296,6 +1319,7 @@ mod tests {
             playlists: vec![a_playlist()],
             measured: true,
             errors: vec![a_scan_error()],
+            report_order: Some(vec!["00000.MPLS".to_owned()]),
         }
     }
 
@@ -1317,6 +1341,7 @@ mod tests {
             "playlists": [a_playlist_json()],
             "measured": true,
             "errors": [a_scan_error_json()],
+            "reportOrder": ["00000.MPLS"],
         })
     }
 
@@ -1378,6 +1403,21 @@ mod tests {
     }
 
     #[test]
+    fn an_absent_report_order_may_be_left_out_of_the_wire_form() {
+        // The key simply missing is what makes the field additive: a `Disc`
+        // built before it existed still crosses, and reads as the disc having
+        // no report order rather than as a malformed object.
+        let mut wire = a_disc_json();
+        wire.as_object_mut().expect("the wire form is an object").remove("reportOrder");
+        let back: Disc = serde_json::from_value(wire).expect("deserialize a disc with no order");
+        assert_eq!(back, Disc { report_order: None, ..a_disc() });
+
+        // Going back out it is an explicit null, as an absent disc title is.
+        let out = serde_json::to_value(&back).expect("serialize a disc with no order");
+        assert_eq!(out.get("reportOrder"), Some(&Value::Null));
+    }
+
+    #[test]
     fn the_encrypted_flag_crosses_and_rebuilds_at_both_values() {
         // Both values, both directions. The whole-fields fixtures pin the flag
         // set; an unencrypted disc is the value a consumer sees on nearly every
@@ -1385,7 +1425,7 @@ mod tests {
         // there.
         for encrypted in [false, true] {
             let bdrom = BdRom { is_aacs_encrypted: encrypted, ..a_core_bdrom() };
-            let disc = Disc::from_scan(&bdrom, &[], false, &PlaylistFilter::default());
+            let disc = Disc::from_scan(&bdrom, &[], false, &PlaylistFilter::default(), None);
             assert_eq!(disc.is_aacs_encrypted, encrypted);
 
             let wire = serde_json::to_value(&disc).expect("serialize the mirror");
@@ -1616,6 +1656,7 @@ mod tests {
             &report.errors,
             mode == ScanMode::Full,
             &PlaylistFilter::default(),
+            None,
         )
     }
 
@@ -1626,7 +1667,8 @@ mod tests {
                 &a_core_bdrom(),
                 &[a_core_scan_error()],
                 true,
-                &PlaylistFilter::default()
+                &PlaylistFilter::default(),
+                a_disc().report_order,
             ),
             a_disc()
         );
@@ -1636,10 +1678,17 @@ mod tests {
     fn the_scan_mode_alone_decides_the_measured_flag() {
         // Same disc, same values: only the flag differs, and it says whether a
         // zero below was measured or never looked at.
-        let unmeasured = Disc::from_scan(&a_core_bdrom(), &[], false, &PlaylistFilter::default());
+        let unmeasured =
+            Disc::from_scan(&a_core_bdrom(), &[], false, &PlaylistFilter::default(), None);
         assert!(!unmeasured.measured);
         assert!(unmeasured.errors.is_empty(), "a scan with no failures mirrors none");
-        assert_eq!(Disc { measured: true, ..unmeasured }, Disc { errors: Vec::new(), ..a_disc() });
+        assert!(unmeasured.report_order.is_none(), "a scan that rendered nothing carries no order");
+        // The three fields that describe the scan rather than the disc are set
+        // aside; everything the disc itself has must match.
+        assert_eq!(
+            Disc { measured: true, report_order: a_disc().report_order, ..unmeasured },
+            Disc { errors: Vec::new(), ..a_disc() }
+        );
     }
 
     #[test]
@@ -1649,7 +1698,7 @@ mod tests {
         // the filter only ever decides what `hiddenBy` names.
         let bdrom = a_mixed_core_bdrom();
         for filter in [PlaylistFilter::default(), PlaylistFilter::everything()] {
-            let disc = Disc::from_scan(&bdrom, &[a_core_scan_error()], true, &filter);
+            let disc = Disc::from_scan(&bdrom, &[a_core_scan_error()], true, &filter, None);
             assert_eq!(names(&disc), ["00000.MPLS", "00001.MPLS", "00002.MPLS"], "{filter:?}");
             assert_eq!(disc.errors, vec![a_scan_error()], "the failures are not filtered");
         }
@@ -1659,7 +1708,7 @@ mod tests {
     fn every_playlist_carries_the_rules_that_withhold_it() {
         let bdrom = a_mixed_core_bdrom();
         let rules = |filter: &PlaylistFilter| {
-            Disc::from_scan(&bdrom, &[], false, filter)
+            Disc::from_scan(&bdrom, &[], false, filter, None)
                 .playlists
                 .into_iter()
                 .map(|playlist| playlist.hidden_by)
@@ -1679,7 +1728,7 @@ mod tests {
         // A playlist that is both short and looping names both, Short first.
         let both =
             BdRom { playlists: vec![filtered_playlist("00003.MPLS", 5.0, true)], ..a_core_bdrom() };
-        let disc = Disc::from_scan(&both, &[], false, &PlaylistFilter::default());
+        let disc = Disc::from_scan(&both, &[], false, &PlaylistFilter::default(), None);
         let playlist = disc.playlists.first().expect("the one playlist");
         assert_eq!(playlist.hidden_by, [HiddenRule::Short, HiddenRule::Looping]);
     }
@@ -1717,7 +1766,7 @@ mod tests {
         // The standard filter would withhold the 5 s playlist; the numbering
         // must not notice, since it describes the disc rather than a view.
         let numbering = |filter: &PlaylistFilter| {
-            Disc::from_scan(&bdrom, &[], true, filter)
+            Disc::from_scan(&bdrom, &[], true, filter, None)
                 .playlists
                 .into_iter()
                 .map(|playlist| (playlist.name, playlist.group, playlist.position))

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -144,9 +144,10 @@ const trimmed = await renderReport(disc, { streamDiagnostics: false });
 ```
 
 `streamDiagnostics` and `quickSummary` both default to on, which is the report
-the CLI writes. A `disc` from a `scan` with a `selection` holds every playlist
-but measured values only for the ones that scan named, so re-rendering it prints
-the rest at zero — scan again to measure them.
+the CLI writes. A `disc` from a `scan` with a `selection` re-renders as that scan
+reported it: `disc.reportOrder` records the playlists it printed, so a playlist
+the scan never measured cannot reappear as a block of zeros. The model still
+holds every playlist on the disc — scan again to measure more of them.
 
 ### Stream files that cannot be read to the end
 
@@ -162,6 +163,13 @@ const { disc } = await scan(picked, undefined, { keepPartial: false });
 `keepPartial: false` discards that measured span instead, leaving those values
 zero throughout. The failure is reported in `disc.errors` either way, and a
 disc that reads cleanly produces the same bytes under both settings.
+
+An `.iso` behaves differently one layer down, deliberately: a sector the image
+cannot serve is recorded by the UDF reader and served to the scan as zeros, so
+the scan reads on through the gap and the file is measured to its end. Those
+recordings reach `disc.errors` and the report `WARNING:` block like any other
+read failure — a damaged span shows up as depressed rates rather than as a
+truncated file, and `keepPartial` does not apply to it.
 
 ### Saving the report
 

--- a/crates/bdinfo-rs-wasm/web/src/analyze.ts
+++ b/crates/bdinfo-rs-wasm/web/src/analyze.ts
@@ -368,11 +368,14 @@ export function scan(
  * formatting the model by hand produces something that merely resembles the
  * locked format.
  *
- * The playlists print in the disc's presentation order: the standard `--whole`
- * set, grouped by shared clip files and longest first. A `disc` from a
- * {@link scan} with a `selection` holds every playlist but measured values only
- * for the ones that scan named, so re-rendering it prints the rest at zero —
- * scan again to measure them.
+ * The playlists print in the order the scan that produced the `disc` printed
+ * them ({@link Disc.reportOrder}), so a `disc` from a {@link scan} with a
+ * `selection` re-renders as that scan reported it — a playlist it never
+ * measured cannot reappear as a block of zeros. The model still holds every
+ * playlist on the disc; scan again to measure more of them. A `disc` from
+ * {@link inspect} was never rendered from and prints in the disc's presentation
+ * order instead — the standard `--whole` set, grouped by shared clip files and
+ * longest first — with every measured value zero.
  */
 export function renderReport(disc: Disc, options?: ScanOptions): Promise<string> {
   return request(

--- a/crates/bdinfo-rs-wasm/web/test/faults.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/faults.node.mjs
@@ -338,16 +338,35 @@ async function main() {
     }
   }
 
-  // Re-rendering the disc model of a damaged subset scan is NOT the scan's own
-  // report. The scan renders the selection the caller named; the re-render walks
-  // every playlist the disc declares, in the presentation order of the selection
-  // table (longest first, 00002 before 00000 here) — so the two playlists the
-  // caller never selected come back as blocks of zeros beside the one it did.
-  const rerendered = reportBlocks(render_report(subsetDisc));
-  if (rerendered.join(",") !== "00002,00000,00001") {
+  // Re-rendering the disc model of a damaged subset scan IS the scan's own
+  // report: the model carries the playlists the scan printed (`reportOrder`),
+  // so the re-render prints those and only those — byte for byte, the two
+  // playlists the caller never selected absent rather than blocks of zeros.
+  // Before this was fixed the re-render walked every playlist the disc
+  // declares, in selection-table order (`00002,00000,00001` here).
+  const rerendered = render_report(subsetDisc);
+  if (reportBlocks(rerendered).join(",") !== "00002") {
     failures.push(
-      `re-render blocks were ${rerendered.join(",")}, not the whole disc in table order`,
+      `re-render blocks were ${reportBlocks(rerendered).join(",")}, not the scanned selection`,
     );
+  }
+  if (rerendered !== reports.get("twoClips/defectiveOnly")) {
+    failures.push("re-rendering the subset scan model did not reproduce its own report");
+  }
+
+  // A read that throws a value with no message and no name still reports what
+  // it threw: the seam renders the thrown payload itself rather than collapsing
+  // every exotic throw to one literal, which is what a field report of a
+  // damaged disc came back carrying.
+  const thrown = reports
+    .get("sharedClip/all")
+    .split("\r\n")
+    .filter((line) => line.includes("io error:"));
+  if (!thrown.every((line) => line.includes("unreadable from byte 40000"))) {
+    failures.push(`the WARNING lines lost the thrown value: ${JSON.stringify(thrown)}`);
+  }
+  if (thrown.some((line) => line.includes("JavaScript exception"))) {
+    failures.push(`a WARNING line fell back to the placeholder: ${JSON.stringify(thrown)}`);
   }
 
   // Damage deep inside a multi-chunk clip is named ONCE per file, not twice.

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -267,6 +267,9 @@ async function main() {
   const fullOk =
     full.disc.measured === true &&
     full.disc.playlists[0].streams[0].bitrateBps > 0 &&
+    // The playlists the scan printed travel with the model, which is what makes
+    // the re-render reproduce THIS report rather than the whole disc.
+    JSON.stringify(full.disc.reportOrder) === JSON.stringify(["00000.MPLS"]) &&
     reRendered.equals(golden) &&
     !noDiagnostics.includes("STREAM DIAGNOSTICS:") &&
     noDiagnostics.includes("QUICK SUMMARY:") &&
@@ -309,6 +312,9 @@ async function main() {
   const isoInspected = inspect_iso(isoFile);
   const isoInspectOk =
     isoInspected.measured === false &&
+    // An inspect rendered no report, so it records no order and a render of it
+    // falls back to the disc presentation order.
+    isoInspected.reportOrder === undefined &&
     isoInspected.volumeLabel === "Blu-Ray" &&
     isoInspected.playlists.length === 1 &&
     isoInspected.playlists[0].name === "00000.MPLS" &&

--- a/crates/bdinfo-rs-wasm/web/test/shims.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/shims.mjs
@@ -60,11 +60,12 @@ export function readLog() {
 /**
  * The value a failing read throws.
  *
- * Deliberately not an `Error` and deliberately without a `message`: the wasm
- * side reads `.message` off the thrown value and falls back to the literal
- * string `JavaScript exception` when there is none, which is what a browser
- * scan of a damaged disc has been observed to report. Throwing an `Error` here
- * would pin the fallback out of the harness.
+ * Deliberately not an `Error` and deliberately without a `message` or a `name`:
+ * a browser scan of a damaged disc was observed reporting nothing but the wasm
+ * side's placeholder, so the harness throws the value that reaches the very end
+ * of its fallback chain. What the report says about this object is therefore
+ * the weakest message the seam can produce — `faults.node.mjs` asserts it still
+ * carries the payload below.
  *
  * @param {string} why
  * @param {string} name


### PR DESCRIPTION
Three browser-side defects, all visible only on damaged media or a narrowed selection.

**Re-rendering a disc model printed the whole disc.** scan_files and scan_iso render the playlists the caller selected, but the model they return carried no record of that, so render_report fell back to the disc presentation order and printed every never-scanned playlist as a block of zeros beside the measured ones. The model now carries reportOrder - the playlists the scan printed, by name, in printed order - and a render follows it, so re-rendering a subset scan reproduces that scan report byte for byte. A model from an inspect records none and still renders the presentation order. The field is optional on the wire, so the npm surface stays additive.

**scan_iso never drained the UDF reader own bad-sector recordings.** The reader serves an unreadable span as zeros, so the demux above it succeeds and the scan records nothing: a browser scan of a damaged image came back looking clean. Both .iso entries now merge those recordings before rendering, as scan::open_iso has always done for the command line and the desktop app. A new faulting-IsoReader test proves the WARNING block appears.

**js_message collapsed every non-Error throw to the literal "JavaScript exception".** It now walks a chain - thrown string, message, name, JSON.stringify, and only then a placeholder naming the type - so a thrown payload reaches the report instead of being flattened away.

DIFFERENCES.md documents the folder-vs-iso read-error split the second fix makes visible: a folder read failure aborts that stream file, while the UDF reader zero-fills and records, so the same damaged disc measures differently through the two inputs. Both are deliberate.

Evidence for the first fix: #329 proved the core aggregation selection-independent over a partially readable multi-playlist disc, and #331 pinned the divergence end to end through the real exports (the scan renders the selection; handing its model back to render_report printed all three playlists in table order). That pinned assertion is updated here to the new behaviour, and the harness now also asserts the re-render is byte-identical to the scan report and that a thrown value with no message and no name still reaches the WARNING line.

Verification: root gate green on the committed branch (the wasm sibling gate auto-chains on the diff paths) - coverage 100.00% lines (1762/1762), regions and functions; mutants 12 found, 9 caught, 3 unviable, 0 missed; Node golden parity plus the 21-run read-failure matrix; headless browser and Playwright Worker parity.

Fixes #320
Fixes #321
Fixes #323
Fixes #328
