### PR TITLE
ci: bump wrangler pin to 4.123.0

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -86,7 +86,7 @@ NPM=12.0.2
 
 # wrangler, invoked with npx to deploy the demo site. Pinned because it runs with
 # the Cloudflare Pages deploy token.
-WRANGLER=4.122.0
+WRANGLER=4.123.0
 
 # komac, fetched over curl to submit the WinGet manifests. winget-releaser wraps
 # the same tool but bootstraps it through cargo-bins/cargo-binstall@main, which


### PR DESCRIPTION
Bumps the `WRANGLER` pin in `.github/pins.env` from 4.122.0 to 4.123.0.

wrangler is invoked with npx only by `deploy-pages.yml`, so this pin is not exercised by pull-request CI.

Closes #337