### PR TITLE
fix(gui): make the listing pass cancellable and show its progress

### DIFF
--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -357,10 +357,18 @@ pub struct Flow {
 #[derive(Debug, Clone)]
 enum Inner {
     Idle,
-    /// Idle, but with last session's source remembered — shown in the Source
-    /// field with "Rescan" live, opened only when the user asks.
+    /// Idle, but with the source remembered — shown in the Source field with
+    /// "Rescan" live, opened only when the user asks. Reached from a boot
+    /// that recalls last session's path, and from a cancelled listing (the
+    /// input stays one click from a retry).
     Recalled(Input),
-    Listing(Input),
+    Listing {
+        input: Input,
+        /// The structural scan's live progress — `None` until the quick codec
+        /// pass's first event (the metadata open that precedes the pass
+        /// reports nothing, and an AACS-encrypted disc never runs the pass).
+        progress: Option<ProgressModel>,
+    },
     Listed(Listing),
     Scanning {
         listing: Listing,
@@ -416,7 +424,7 @@ impl Flow {
     /// A folder/`.iso` was picked — begin its structural scan.
     #[must_use]
     pub const fn start_listing(input: Input) -> Self {
-        Self { inner: Inner::Listing(input) }
+        Self { inner: Inner::Listing { input, progress: None } }
     }
 
     /// The structural scan for `input` finished. Applied only when this flow is
@@ -431,7 +439,7 @@ impl Flow {
         view: ViewSettings,
     ) -> Self {
         match &self.inner {
-            Inner::Listing(pending) if pending == input => match result {
+            Inner::Listing { input: pending, .. } if pending == input => match result {
                 Ok(structural) => {
                     Self { inner: Inner::Listed(Listing::build(input.clone(), structural, view)) }
                 }
@@ -484,7 +492,7 @@ impl Flow {
     #[must_use]
     pub fn open_failed(self, message: String) -> Self {
         match self.inner {
-            Inner::Listing(_) | Inner::Scanning { .. } => self,
+            Inner::Listing { .. } | Inner::Scanning { .. } => self,
             _ => Self { inner: Inner::Failed(message) },
         }
     }
@@ -589,6 +597,18 @@ impl Flow {
         }
     }
 
+    /// Records a structural-scan progress event — the stream file the quick
+    /// codec pass is reading, its `done`/`total` byte counts, and the wall
+    /// time elapsed since the listing started. Applied only while listing;
+    /// the shell keeps events from a superseded listing worker away from
+    /// here (its listing messages carry a generation stamp), so this needs
+    /// no generation of its own.
+    pub fn list_progress(&mut self, file: String, done: u64, total: u64, elapsed: Duration) {
+        if let Inner::Listing { progress, .. } = &mut self.inner {
+            *progress = Some(ProgressModel::compute(file, done, total, elapsed));
+        }
+    }
+
     /// Advances the wall-clock readout while a scan is in flight — the shell's
     /// ~1 s tick. `elapsed` (since the scan started) re-stamps the progress
     /// model's elapsed seconds so the readout climbs even when no progress
@@ -647,17 +667,23 @@ impl Flow {
         }
     }
 
-    /// Cancels the in-flight scan, returning to the table. The shell trips the
-    /// worker's cooperative stop flag alongside this transition, so the demux
-    /// aborts within moments; the worker's late "cancelled" failure message is
-    /// ignored — a Listed flow is no longer Scanning, so `scan_failed` (and any
-    /// straggling progress) drops it. Starting a new scan immediately is safe:
-    /// it gets a fresh generation and its own cancel flag, and the old worker
-    /// only ever reads the disc.
+    /// Cancels the in-flight scan. A measured scan returns to the table; a
+    /// structural scan (the listing) returns to the source prompt with the
+    /// input remembered, so a retry is one "Rescan" click. The shell trips
+    /// the worker's cooperative stop flag alongside this transition, so the
+    /// read loop aborts within moments — and this transition never waits for
+    /// it: a cancelled listing can produce no further event at all (the
+    /// cancel flag is polled before each read), so teardown is driven from
+    /// here, with the worker's late result message ignored — a Listed or
+    /// Recalled flow is no longer scanning or listing, so `scan_failed` /
+    /// `listed` (and any straggling progress) drop it. Starting a new scan
+    /// immediately is safe: it gets a fresh generation and its own cancel
+    /// flag, and the old worker only ever reads the disc.
     #[must_use]
     pub fn cancel(self) -> Self {
         match self.inner {
             Inner::Scanning { listing, .. } => Self { inner: Inner::Listed(listing) },
+            Inner::Listing { input, .. } => Self { inner: Inner::Recalled(input) },
             other => Self { inner: other },
         }
     }
@@ -669,7 +695,7 @@ impl Flow {
     pub const fn stage(&self) -> Stage {
         match &self.inner {
             Inner::Idle | Inner::Recalled(_) => Stage::Idle,
-            Inner::Listing(_) => Stage::Listing,
+            Inner::Listing { .. } => Stage::Listing,
             Inner::Listed(_) => Stage::Listed,
             Inner::Scanning { .. } => Stage::Scanning,
             Inner::Reported { .. } => Stage::Reported,
@@ -682,7 +708,7 @@ impl Flow {
     #[must_use]
     pub fn input_display(&self) -> Option<String> {
         self.any_listing().map(|listing| listing.input.display()).or_else(|| match &self.inner {
-            Inner::Listing(input) | Inner::Recalled(input) => Some(input.display()),
+            Inner::Listing { input, .. } | Inner::Recalled(input) => Some(input.display()),
             _ => None,
         })
     }
@@ -693,7 +719,7 @@ impl Flow {
     #[must_use]
     pub fn current_input(&self) -> Option<&Input> {
         match &self.inner {
-            Inner::Listing(input) | Inner::Recalled(input) => Some(input),
+            Inner::Listing { input, .. } | Inner::Recalled(input) => Some(input),
             _ => self.any_listing().map(|listing| &listing.input),
         }
     }
@@ -885,11 +911,12 @@ impl Flow {
         })
     }
 
-    /// The latest progress snapshot, while scanning.
+    /// The latest progress snapshot, while a measured scan — or the listing's
+    /// quick codec pass — is in flight.
     #[must_use]
     pub const fn progress_view(&self) -> Option<&ProgressModel> {
         match &self.inner {
-            Inner::Scanning { progress, .. } => progress.as_ref(),
+            Inner::Scanning { progress, .. } | Inner::Listing { progress, .. } => progress.as_ref(),
             _ => None,
         }
     }
@@ -1633,6 +1660,51 @@ mod tests {
         // A finish from the cancelled scan's generation must not reach Reported.
         let flow = flow.finished(7, "R".to_owned(), Arc::new(Vec::new()), Vec::new());
         assert_eq!(flow.stage(), Stage::Listed);
+    }
+
+    #[test]
+    fn cancelling_a_listing_recalls_the_input_and_drops_the_stray_result() {
+        let flow = Flow::start_listing(input()).cancel();
+        // Back to the source prompt, with the input one "Rescan" click away.
+        assert_eq!(flow.stage(), Stage::Idle);
+        assert_eq!(flow.current_input(), Some(&input()));
+        assert_eq!(flow.input_display(), Some("disc".to_owned()));
+        assert!(flow.table().is_empty());
+        // The cancelled worker still returns — successfully if the cancel
+        // landed after the last read, with the cancellation error otherwise.
+        // Neither outcome may apply.
+        let stray_ok = flow.clone().listed(&input(), Ok(structural()), ViewSettings::default());
+        assert_eq!(stray_ok.stage(), Stage::Idle, "a late success must not resurface the table");
+        assert!(stray_ok.table().is_empty());
+        let stray_err =
+            flow.listed(&input(), Err("scan cancelled".to_owned()), ViewSettings::default());
+        assert_eq!(stray_err.stage(), Stage::Idle, "a late failure must not turn fatal");
+        assert_eq!(stray_err.error_message(), None);
+    }
+
+    #[test]
+    fn listing_progress_projects_only_while_listing() {
+        let mut flow = Flow::start_listing(input());
+        assert!(flow.progress_view().is_none(), "no event yet — nothing to project");
+        flow.list_progress("A.M2TS".to_owned(), 1, 4, Duration::from_secs(2));
+        let model = flow.progress_view().expect("the listing projects its progress");
+        assert_eq!(model.file(), "A.M2TS");
+        assert!((model.fraction() - 0.25).abs() < f32::EPSILON);
+        assert_eq!(model.elapsed_hms(), "00:00:02");
+        // A later event replaces the snapshot.
+        flow.list_progress("B.M2TS".to_owned(), 4, 4, Duration::from_secs(3));
+        assert_eq!(
+            flow.progress_view().map(|model| model.file().to_owned()),
+            Some("B.M2TS".to_owned())
+        );
+        // Cancelling drops the snapshot with the listing…
+        let mut flow = flow.cancel();
+        flow.list_progress("A.M2TS".to_owned(), 1, 4, Duration::ZERO);
+        assert!(flow.progress_view().is_none(), "a cancelled listing projects nothing");
+        // …and off the listing stage the event is dropped entirely.
+        let mut flow = listed();
+        flow.list_progress("A.M2TS".to_owned(), 1, 4, Duration::ZERO);
+        assert!(flow.progress_view().is_none(), "a listed table has no listing progress");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -751,16 +751,18 @@ struct App {
     theme_pref: ThemePref,
     /// The last light/dark setting reported by the OS.
     os_mode: iced::theme::Mode,
-    /// Bumped on each "Scan selected"; the in-flight scan's id.
+    /// Bumped at each listing and each "Scan selected"; the in-flight
+    /// worker's id, stamped on its messages so a stale worker's are ignored.
     generation: u64,
-    /// The in-flight measured scan's cooperative cancel flag — a fresh one per
-    /// scan (so cancelling an old scan can never touch a newer one), shared
-    /// with the worker thread, set by the Cancel button. The demux polls it
-    /// per read chunk and aborts, so Cancel really frees the machine.
+    /// The in-flight worker's cooperative cancel flag — listing and measured
+    /// scan alike, a fresh one per worker (so cancelling an old worker can
+    /// never touch a newer one), shared with its thread, set by the Cancel
+    /// button. The read loop polls it per chunk and aborts, so Cancel really
+    /// frees the machine.
     scan_cancel: Option<Arc<AtomicBool>>,
-    /// When the current measured scan started.
+    /// When the current worker (listing or measured scan) started.
     scan_start: Option<Instant>,
-    /// When the in-flight scan's last progress event arrived (the scan start
+    /// When the in-flight worker's last progress event arrived (the start
     /// until the first one) — what the 1 s scanning tick measures the stall
     /// hint against ([`Flow::tick`]).
     last_progress: Option<Instant>,
@@ -986,8 +988,13 @@ enum Message {
     FileDropped(PathBuf),
     /// The hovered file(s) left the window without dropping.
     FilesHoveredLeft,
+    /// A streamed progress event from the listing worker's quick codec pass.
+    ListProgress { generation: u64, file: String, done: u64, total: u64 },
     /// The structural scan for `input` finished (or failed with a message).
-    Listed { input: Input, result: Result<Structural, String> },
+    /// `generation` is the stamp [`App::begin_listing`] issued the worker —
+    /// the flow's input match alone cannot drop a cancelled worker's late
+    /// result once the same input is picked again.
+    Listed { generation: u64, input: Input, result: Result<Structural, String> },
     /// A table row's scan checkbox toggled (0-based table position).
     RowToggled(usize),
     /// A table row clicked — make it the active (highlighted) playlist that the
@@ -1209,7 +1216,13 @@ impl App {
                     Task::none()
                 }
             }
-            Message::Listed { input, result } => self.on_listed(&input, result),
+            Message::ListProgress { generation, file, done, total } => {
+                self.on_list_progress(generation, file, done, total);
+                Task::none()
+            }
+            Message::Listed { generation, input, result } => {
+                self.on_listed(generation, &input, result)
+            }
             Message::RowToggled(index) => {
                 self.flow.toggle(index);
                 Task::none()
@@ -1643,17 +1656,42 @@ impl App {
         })
     }
 
+    /// Applies a listing worker's progress event — only the current worker's
+    /// (`generation` is the stamp `begin_listing` issued it; the flow holds no
+    /// listing generation of its own, so a cancelled worker's stragglers are
+    /// dropped here, before they could touch a re-pick of the same input).
+    fn on_list_progress(&mut self, generation: u64, file: String, done: u64, total: u64) {
+        if generation == self.generation {
+            let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
+            self.last_progress = Some(Instant::now());
+            self.flow.list_progress(file, done, total, elapsed);
+        }
+    }
+
     /// Applies a finished structural scan. A successful listing becomes the
     /// remembered last path (saved now — `BDInfo` keeps `LastPath` the same
     /// way). In a debug build it also honours the capture harness's auto-scan
     /// hook (`BDINFO_GUI_SCAN=all`), selecting and scanning every playlist so
     /// a screenshot can show measured data.
-    fn on_listed(&mut self, input: &Input, result: Result<Structural, String>) -> Task<Message> {
-        // The listing outcome, next to begin_listing's start line.
+    fn on_listed(
+        &mut self,
+        generation: u64,
+        input: &Input,
+        result: Result<Structural, String>,
+    ) -> Task<Message> {
+        // The listing outcome, next to begin_listing's start line. A stale
+        // worker's outcome is logged too, then dropped: after a cancel it is
+        // the record that the blocked thread finally returned.
         match &result {
             Ok(_) => log::info!("listed {}", input.display()),
             Err(error) => log::info!("listing failed: {error}"),
         }
+        if generation != self.generation {
+            log::info!("stale listing result dropped");
+            return Task::none();
+        }
+        // The worker has returned; its cancel flag can no longer do anything.
+        self.scan_cancel = None;
         let view = ViewSettings::from_settings(&self.persisted);
         self.flow = std::mem::take(&mut self.flow).listed(input, result, view);
         // Only when THIS input just became the listing (not a superseded or
@@ -1683,14 +1721,20 @@ impl App {
         }
     }
 
-    /// Cancels the in-flight measured scan for real: trips the worker's
-    /// cooperative stop flag — the demux exits at its next read chunk, freeing
-    /// CPU and IO — then returns the UI to the table. The worker's late "scan
-    /// failed (cancelled)" message is dropped by the generation guard (the
-    /// flow is no longer Scanning), so nothing else changes.
+    /// Cancels the in-flight scan for real — the measured scan back to the
+    /// table, the listing back to the source prompt: trips the worker's
+    /// cooperative stop flag (the read loop exits at its next chunk, freeing
+    /// CPU and IO), then moves the UI on immediately — never waiting on the
+    /// worker, which a stuck read can hold for minutes with no further
+    /// message. The worker's late result is dropped by the generation guards
+    /// (the flow is no longer Scanning / Listing), so nothing else changes.
     fn cancel_scan(&mut self) -> Task<Message> {
         if let Some(cancel) = self.scan_cancel.take() {
-            log::info!("scan cancelled");
+            if self.flow.stage() == Stage::Listing {
+                log::info!("listing cancelled");
+            } else {
+                log::info!("scan cancelled");
+            }
             cancel.store(true, Ordering::Relaxed);
         }
         self.flow = std::mem::take(&mut self.flow).cancel();
@@ -1788,11 +1832,14 @@ impl App {
         }
     }
 
-    /// Begins the initial scan of `input` on iced's executor — the bounded
-    /// `Codecs` pass, which reads each stream file's head to fill the codec
-    /// detail. It runs off the UI thread, so the "scanning" overlay animates while
-    /// it works; the input is carried back so a superseded pick's result is
-    /// discarded.
+    /// Begins the initial scan of `input` — the bounded `Codecs` pass, which
+    /// reads each stream file's head to fill the codec detail — on a worker
+    /// thread, streaming its progress + result back as messages, exactly like
+    /// the measured scan below: a progress stream needs more than the one
+    /// message a one-shot task can deliver, and on damaged media the listing
+    /// can block inside a single read for minutes, which must not park one of
+    /// iced's executor threads. The generation stamp on the messages is what
+    /// discards a superseded or cancelled worker's stragglers.
     fn begin_listing(&mut self, input: Input) -> Task<Message> {
         self.status = None;
         self.showing_report = false;
@@ -1801,24 +1848,68 @@ impl App {
         self.hovered_header = None;
         self.pane_selection = None;
         self.pulse = 0;
+        self.generation = self.generation.wrapping_add(1);
+        let generation = self.generation;
+        self.scan_start = Some(Instant::now());
+        self.last_progress = self.scan_start;
         // The one log line per open: pins down whether a scan ever started
         // when a report or listing seems to be missing in the field.
         log::info!("listing {}", input.display());
         self.flow = Flow::start_listing(input.clone());
-        Task::perform(
-            async move {
-                #[cfg(debug_assertions)]
-                debug_scan_delay();
-                // The core is fuzz-held no-panic, but the exposure is exactly
-                // this untrusted-disc path — an escaped panic would lose the
-                // Listed message and stick the non-dismissable "scanning"
-                // modal, so it is caught onto the same friendly failure road
-                // a bad disc takes.
-                let result = scan::catch_scan_panic(|| scan::scan_structural(&input));
-                (input, result)
-            },
-            |(input, result)| Message::Listed { input, result },
-        )
+        // A fresh flag per listing — see the `scan_cancel` field.
+        let cancel = Arc::new(AtomicBool::new(false));
+        self.scan_cancel = Some(Arc::clone(&cancel));
+
+        let (sender, receiver) = iced::futures::channel::mpsc::unbounded();
+        std::thread::spawn(move || {
+            #[cfg(debug_assertions)]
+            debug_scan_delay();
+            // The same ~100 ms coalescing as the measured worker below — the
+            // codec pass fires its callback around every read too.
+            let mut last_sent: Option<Instant> = None;
+            let mut last_file = String::new();
+            let progress_sender = sender.clone();
+            // The core is fuzz-held no-panic, but the exposure is exactly
+            // this untrusted-disc path — an escaped panic would lose the
+            // Listed message and stick the non-dismissable "scanning"
+            // modal, so it is caught onto the same friendly failure road
+            // a bad disc takes.
+            let result = scan::catch_scan_panic(|| {
+                scan::scan_structural(
+                    &input,
+                    &mut |progress: ScanProgress<'_>| {
+                        let file_changed = progress.file != last_file;
+                        let since_last = last_sent.map(|at| at.elapsed());
+                        if !progress::emit_due(
+                            file_changed,
+                            progress.done,
+                            progress.total,
+                            since_last,
+                        ) {
+                            return;
+                        }
+                        last_sent = Some(Instant::now());
+                        if file_changed {
+                            // One log line per stream file — after a pre-scan
+                            // freeze, the last of these names the stuck file.
+                            log::info!("listing {}", progress.file);
+                            progress.file.clone_into(&mut last_file);
+                        }
+                        let _ = progress_sender.unbounded_send(Message::ListProgress {
+                            generation,
+                            file: progress.file.to_owned(),
+                            done: progress.done,
+                            total: progress.total,
+                        });
+                    },
+                    &cancel,
+                )
+            });
+            let _ = sender.unbounded_send(Message::Listed { generation, input, result });
+        });
+        // The receiver stream ends when the worker drops its sender, completing
+        // this task; each item arrives as a `Message`.
+        Task::stream(receiver)
     }
 
     /// Spawns the measured scan on a worker thread (so native demux keeps its
@@ -2056,7 +2147,7 @@ impl App {
 
         let base = container(content).width(Length::Fill).height(Length::Fill).into();
         if self.flow.stage() == Stage::Listing {
-            return scanning_modal(base, scanning_card(p));
+            return scanning_modal(base, scanning_card(p, self.pulse, self.flow.progress_view()));
         }
         if let Some(draft) = &self.settings_draft {
             return modal(base, settings_card(p, draft), Message::SettingsCancel);
@@ -2551,8 +2642,10 @@ impl App {
         let fraction = match self.flow.stage() {
             Stage::Scanning => progress.map_or(0.0, ProgressModel::fraction),
             Stage::Reported => 1.0,
-            // The initial scan has no measurable %, so the bar breathes.
-            Stage::Listing => progress::pulse_fraction(self.pulse),
+            // The listing has no measurable % until the codec pass's first
+            // event, so the bar breathes, then tracks the pass.
+            Stage::Listing => progress
+                .map_or_else(|| progress::pulse_fraction(self.pulse), ProgressModel::fraction),
             _ => 0.0,
         };
 
@@ -2574,7 +2667,10 @@ impl App {
                     || "Starting scan…".to_owned(),
                     |pr| format!("Scanning {}…", pr.file()),
                 ),
-                Stage::Listing => "Scanning disc…".to_owned(),
+                Stage::Listing => progress.map_or_else(
+                    || "Scanning disc…".to_owned(),
+                    |pr| format!("Reading {}…", pr.file()),
+                ),
                 Stage::Reported => "Report ready.".to_owned(),
                 Stage::Listed if self.flow.selected_count() > 0 => "Ready to scan.".to_owned(),
                 // Nothing checked still scans — the whole disc, like BDInfo.
@@ -3186,9 +3282,19 @@ fn scanning_modal<'a>(
 }
 
 /// The "please wait" scan overlay card: the brand mark over the same message
-/// `BDInfo` shows while it reads a disc.
-fn scanning_card<'a>(p: Palette) -> Element<'a, Message> {
-    let card = Column::new()
+/// `BDInfo` shows while it reads a disc — plus what `BDInfo`'s modal lacks
+/// and a damaged disc needs: the codec pass's live progress (the bar breathes
+/// indeterminately until its first event) and a Cancel that works, because
+/// this pre-scan pass reads every stream file's head and can stall on a bad
+/// sector exactly like the measured scan.
+fn scanning_card<'a>(
+    p: Palette,
+    pulse: u16,
+    progress: Option<&ProgressModel>,
+) -> Element<'a, Message> {
+    let fraction =
+        progress.map_or_else(|| progress::pulse_fraction(pulse), ProgressModel::fraction);
+    let mut card = Column::new()
         .align_x(Horizontal::Center)
         .spacing(ui::GAP_4)
         .push(brand_mark_large(p))
@@ -3197,7 +3303,27 @@ fn scanning_card<'a>(p: Palette) -> Element<'a, Message> {
                 .size(ui::TEXT_MD)
                 .color(p.text)
                 .align_x(Horizontal::Center),
+        )
+        .push(
+            progress_bar(0.0..=1.0, fraction)
+                .length(Length::Fixed(320.0))
+                .girth(Length::Fixed(8.0))
+                .style(ui::progress(p)),
         );
+    if let Some(pr) = progress {
+        card = card.push(
+            text(format!("Reading {}…", pr.file()))
+                .size(ui::TEXT_SM)
+                .color(p.text_muted)
+                .align_x(Horizontal::Center),
+        );
+    }
+    card = card.push(
+        button(text("Cancel").size(ui::TEXT_SM).font(ui::UI_MEDIUM))
+            .padding([ui::GAP_2, ui::GAP_4])
+            .style(ui::secondary_button(p))
+            .on_press(Message::Cancel),
+    );
     container(card).padding(ui::GAP_6).max_width(440.0).style(ui::hero_card(p)).into()
 }
 
@@ -3810,6 +3936,82 @@ mod interaction {
         assert_eq!(app.flow.stage(), Stage::Listed);
         // The cooperative stop flag was taken and tripped.
         assert!(app.scan_cancel.is_none());
+    }
+
+    #[test]
+    fn cancel_returns_the_listing_to_the_source_prompt() {
+        let mut app = App::default();
+        let _ = app.update(Message::FolderPicked(Some(PathBuf::from("disc"))));
+        assert_eq!(app.flow.stage(), Stage::Listing);
+        assert!(app.scan_cancel.is_some(), "the listing worker owns a cancel flag");
+        let generation = app.generation;
+        // The "please wait" modal offers Cancel; clicking it returns to the
+        // source prompt without waiting on the (possibly stuck) worker.
+        click(&mut app, "Cancel");
+        assert_eq!(app.flow.stage(), Stage::Idle);
+        assert!(app.scan_cancel.is_none(), "the flag was taken and tripped");
+        assert!(sees(&app, "disc"), "the source field keeps the input for a one-click Rescan");
+        // The cancelled worker's late return applies nothing — and must not
+        // turn the idle prompt into the fatal failure screen.
+        let _ = app.update(Message::Listed {
+            generation,
+            input: bdinfo_rs_gui::scan::Input::Folder("disc".into()),
+            result: Err("scan cancelled".to_owned()),
+        });
+        assert_eq!(app.flow.stage(), Stage::Idle);
+    }
+
+    #[test]
+    fn a_cancelled_workers_result_never_resolves_a_relisting_of_the_same_input() {
+        let mut app = App::default();
+        let _ = app.update(Message::FolderPicked(Some(PathBuf::from("disc"))));
+        let stale = app.generation;
+        click(&mut app, "Cancel");
+        // Rescan the SAME input: the flow's input match alone could not tell
+        // the old worker's result from the new one's — the generation stamp
+        // is what drops it.
+        let _ = app.update(Message::Rescan);
+        assert_eq!(app.flow.stage(), Stage::Listing);
+        assert_ne!(app.generation, stale);
+        let _ = app.update(Message::Listed {
+            generation: stale,
+            input: bdinfo_rs_gui::scan::Input::Folder("disc".into()),
+            result: Ok(structural()),
+        });
+        assert_eq!(app.flow.stage(), Stage::Listing, "the old worker's table must not surface");
+        // The new worker's result lands normally.
+        let _ = app.update(Message::Listed {
+            generation: app.generation,
+            input: bdinfo_rs_gui::scan::Input::Folder("disc".into()),
+            result: Ok(structural()),
+        });
+        assert_eq!(app.flow.stage(), Stage::Listed);
+    }
+
+    #[test]
+    fn a_listing_progress_event_reaches_the_modal_and_the_bar() {
+        let mut app = App::default();
+        let _ = app.update(Message::FolderPicked(Some(PathBuf::from("disc"))));
+        assert!(sees(&app, "Please wait while we scan the disc..."));
+        let _ = app.update(Message::ListProgress {
+            generation: app.generation,
+            file: "A.M2TS".to_owned(),
+            done: 1,
+            total: 2,
+        });
+        let fraction =
+            app.flow.progress_view().map(bdinfo_rs_gui::progress::ProgressModel::fraction);
+        assert_eq!(fraction, Some(0.5));
+        assert!(sees(&app, "Reading A.M2TS…"), "the modal names the file being read");
+        // An event from a superseded worker is dropped before the flow.
+        let _ = app.update(Message::ListProgress {
+            generation: app.generation.wrapping_add(1),
+            file: "B.M2TS".to_owned(),
+            done: 2,
+            total: 2,
+        });
+        assert!(sees(&app, "Reading A.M2TS…"), "the stale event must not repaint");
+        assert!(!sees(&app, "Reading B.M2TS…"));
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -1217,8 +1217,7 @@ impl App {
                 }
             }
             Message::ListProgress { generation, file, done, total } => {
-                self.on_list_progress(generation, file, done, total);
-                Task::none()
+                self.on_list_progress(generation, file, done, total)
             }
             Message::Listed { generation, input, result } => {
                 self.on_listed(generation, &input, result)
@@ -1660,12 +1659,19 @@ impl App {
     /// (`generation` is the stamp `begin_listing` issued it; the flow holds no
     /// listing generation of its own, so a cancelled worker's stragglers are
     /// dropped here, before they could touch a re-pick of the same input).
-    fn on_list_progress(&mut self, generation: u64, file: String, done: u64, total: u64) {
+    fn on_list_progress(
+        &mut self,
+        generation: u64,
+        file: String,
+        done: u64,
+        total: u64,
+    ) -> Task<Message> {
         if generation == self.generation {
             let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
             self.last_progress = Some(Instant::now());
             self.flow.list_progress(file, done, total, elapsed);
         }
+        Task::none()
     }
 
     /// Applies a finished structural scan. A successful listing becomes the

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -8,9 +8,10 @@
 //! module is the thin IO glue, verified by the golden-tie parity test (byte-exact
 //! report over the committed fixture) rather than line coverage.
 //!
-//! The long, blocking measured scan ([`scan_measured`]) is what the iced shell
-//! runs on a worker thread, forwarding its [`ScanProgress`] callback over a
-//! channel; the structural scan ([`scan_structural`]) is fast (no demux).
+//! Both scans block for as long as the disc makes them (a damaged sector can
+//! hold one read for minutes), so the iced shell runs each on a worker thread,
+//! forwarding its [`ScanProgress`] callback over a channel; the structural
+//! scan ([`scan_structural`]) merely reads far less (no full demux).
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -156,24 +157,37 @@ fn error_lines(errors: &[ScanError]) -> Vec<String> {
 
 /// The no-op progress sink.
 ///
-/// [`scan_structural`] always uses it, and a [`scan_measured`] caller that
-/// wants no live progress — the golden ties — passes it too.
+/// For any [`scan_structural`] / [`scan_measured`] caller that wants no live
+/// progress — the golden ties pass it to both.
 pub const fn no_progress(_: ScanProgress<'_>) {}
 
-/// Runs the **structural** scan over `input` (fast — no M2TS demux) and returns
+/// Runs the **structural** scan over `input` (no full M2TS demux) and returns
 /// the playlist list + label for the selection table.
+///
+/// `progress` observes the quick codec pass ([`ScanMode::Codecs`]), which
+/// climbs to 100% of the selected byte total in per-file jumps; the metadata
+/// open that precedes it reports nothing, so the first event can arrive only
+/// after that open completes. `cancel` aborts the codec pass at its next read
+/// chunk — the flag is polled **before** each read, so a cancel honoured
+/// before the first read produces no progress event at all; a caller must
+/// never wait on one to conclude a cancelled listing is over.
 ///
 /// # Errors
 /// A short message when the input holds no readable Blu-ray structure (no
-/// `BDMV`/`CLIPINF`/`PLAYLIST`, or a `.iso` that is not a readable UDF volume).
-pub fn scan_structural(input: &Input) -> Result<Structural, String> {
+/// `BDMV`/`CLIPINF`/`PLAYLIST`, or a `.iso` that is not a readable UDF
+/// volume), or when `cancel` was set mid-listing.
+pub fn scan_structural(
+    input: &Input,
+    progress: &mut dyn FnMut(ScanProgress<'_>),
+    cancel: &AtomicBool,
+) -> Result<Structural, String> {
     let (bdrom, errors) = listing_scan(|mode| {
         // Always the default (retain), never the user's setting: the
         // partial-retention toggle scopes to the measured scan, which is the
         // one that renders a report. A listing open that hits a mid-file read
         // error therefore keeps that file's partial codec detail whatever the
         // setting says, so the panes stay as full as the disc allows.
-        open(input, mode, ScanOptions::default(), None, &mut no_progress, &AtomicBool::new(false))
+        open(input, mode, ScanOptions::default(), None, progress, cancel)
             .map_err(|err: BdError| err.to_string())
     })?;
     let features = bdrom.extra_features().into_iter().map(str::to_owned).collect();
@@ -192,14 +206,16 @@ pub fn scan_structural(input: &Input) -> Result<Structural, String> {
 /// disc.
 ///
 /// For every other disc the `Codecs` open gives the panes their full codec
-/// detail (profile / HDR / Dolby Vision) right away, like `BDInfo`, without the
-/// whole-file bitrate scan; on readable streams it ends at codec init, so it
-/// carries no cancel affordance. Reaching it costs a second parse of the clip
-/// metadata the first open just read, which the filesystem cache serves.
+/// detail (profile / HDR / Dolby Vision) right away, like `BDInfo`, without
+/// the whole-file bitrate scan; on readable streams it ends at codec init,
+/// but damaged media can hold a single read for minutes, which is why the
+/// pass is observable and cancellable through [`scan_structural`]'s
+/// parameters. Reaching it costs a second parse of the clip metadata the
+/// first open just read, which the filesystem cache serves.
 ///
 /// # Errors
 /// Whatever `open` reports, from either call.
-fn listing_scan(open: impl Fn(ScanMode) -> Opened) -> Opened {
+fn listing_scan(mut open: impl FnMut(ScanMode) -> Opened) -> Opened {
     let cheap = open(ScanMode::Metadata)?;
     if cheap.0.is_aacs_encrypted { Ok(cheap) } else { open(ScanMode::Codecs) }
 }
@@ -308,10 +324,18 @@ impl<F: FnOnce()> Drop for PanicAlarm<F> {
 mod tests {
     use std::cell::RefCell;
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::AtomicBool;
 
     use bdinfo_rs_core::vfs::fs::FsDir;
 
-    use super::{BdRom, Input, ScanMode, ScanOptions};
+    use super::{BdRom, Input, ScanMode, ScanOptions, Structural};
+
+    /// [`super::scan_structural`] with the silent sink and a never-set cancel
+    /// flag — every test that only cares about the scan's result goes through
+    /// this.
+    fn scan_structural(input: &Input) -> Result<Structural, String> {
+        super::scan_structural(input, &mut super::no_progress, &AtomicBool::new(false))
+    }
 
     /// A scratch directory under the crate's target dir (unique per test).
     fn scratch(name: &str) -> PathBuf {
@@ -409,7 +433,7 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("the scratch dir creates");
         let iso = dir.join("garbage.iso");
         std::fs::write(&iso, b"not a udf volume at all").expect("the scratch iso writes");
-        let message = super::scan_structural(&Input::Iso(iso)).expect_err("no UDF volume to open");
+        let message = scan_structural(&Input::Iso(iso)).expect_err("no UDF volume to open");
         assert!(!message.is_empty(), "the failure carries a user-facing message");
     }
 
@@ -434,8 +458,8 @@ mod tests {
             at = start.checked_add(1).expect("offset fits");
         }
         std::fs::write(&iso, bytes).expect("the scratch iso writes");
-        let message = super::scan_structural(&Input::Iso(iso))
-            .expect_err("a volume with no BDMV cannot list");
+        let message =
+            scan_structural(&Input::Iso(iso)).expect_err("a volume with no BDMV cannot list");
         assert!(!message.is_empty(), "the failure carries a user-facing message");
     }
 
@@ -446,7 +470,7 @@ mod tests {
         let dir = scratch("empty");
         std::fs::create_dir_all(&dir).expect("the scratch dir creates");
         let message =
-            super::scan_structural(&Input::Folder(dir)).expect_err("no Blu-ray structure to open");
+            scan_structural(&Input::Folder(dir)).expect_err("no Blu-ray structure to open");
         assert!(!message.is_empty(), "the failure carries a user-facing message");
     }
 
@@ -590,8 +614,8 @@ mod tests {
         // file to EOF — tens of gigabytes off an optical drive, for detail no
         // key can recover. The listing must stop at the metadata pass instead.
         let root = encrypted_fixture("aacs-listing");
-        let listed = super::scan_structural(&Input::Folder(root.clone()))
-            .expect("an encrypted disc still lists");
+        let listed =
+            scan_structural(&Input::Folder(root.clone())).expect("an encrypted disc still lists");
         assert!(listed.bdrom.is_aacs_encrypted);
         assert!(!listed.bdrom.playlists.is_empty(), "the structure still lists");
 
@@ -616,12 +640,50 @@ mod tests {
         // scanned codec detail the panes show, so the listing has to be the
         // deeper pass rather than the metadata one.
         let root = fixture("BigBuckBunny");
-        let listed =
-            super::scan_structural(&Input::Folder(root.clone())).expect("the fixture lists");
+        let listed = scan_structural(&Input::Folder(root.clone())).expect("the fixture lists");
         assert!(!listed.bdrom.is_aacs_encrypted);
         let codecs =
             BdRom::open(&FsDir::new(&root), ScanMode::Codecs).expect("the codec pass opens");
         assert_eq!(listed.bdrom.playlists, codecs.playlists, "the listing skipped the codec pass");
+    }
+
+    #[test]
+    fn the_listing_reports_the_codec_pass_to_completion() {
+        // The quick codec pass reports through the caller's callback (the
+        // metadata open that precedes it reports nothing): first event at
+        // zero, one fixed byte total throughout, monotonic, closing exactly
+        // on the total — the shape the shell's progress bar projects.
+        let mut events: Vec<(String, u64, u64)> = Vec::new();
+        let listed = super::scan_structural(
+            &Input::Folder(fixture("BigBuckBunny")),
+            &mut |progress| events.push((progress.file.to_owned(), progress.done, progress.total)),
+            &AtomicBool::new(false),
+        )
+        .expect("the fixture lists");
+        assert!(!listed.bdrom.playlists.is_empty());
+        let (file, first_done, total) = events.first().expect("the codec pass reports").clone();
+        assert_eq!(file, "00000.M2TS", "the fixture's one stream file is what the pass reads");
+        assert_eq!(first_done, 0, "the pass opens at zero");
+        assert!(events.iter().all(|(_, _, each)| *each == total), "one fixed byte total");
+        assert!(events.windows(2).all(|pair| pair[0].1 <= pair[1].1), "done never regresses");
+        assert_eq!(events.last().map(|(_, done, _)| *done), Some(total), "the pass closes full");
+    }
+
+    #[test]
+    fn a_preset_cancel_flag_aborts_the_listing_before_any_progress() {
+        // The cancel flag is polled before each read, so a cancel honoured
+        // before the first read produces NO progress event at all — a caller
+        // waiting on one to conclude a cancelled listing is over would wait
+        // forever.
+        let mut events: Vec<u64> = Vec::new();
+        let message = super::scan_structural(
+            &Input::Folder(fixture("BigBuckBunny")),
+            &mut |progress| events.push(progress.done),
+            &AtomicBool::new(true),
+        )
+        .expect_err("a cancelled listing yields no table");
+        assert_eq!(message, "scan cancelled");
+        assert!(events.is_empty(), "no event precedes the cancel poll");
     }
 
     #[test]
@@ -635,7 +697,7 @@ mod tests {
         std::fs::write(root.join("BDMV/PLAYLIST/00000.mpls"), b"garbage")
             .expect("the playlist corrupts");
         let structural =
-            super::scan_structural(&Input::Folder(root)).expect("the resilient scan still opens");
+            scan_structural(&Input::Folder(root)).expect("the resilient scan still opens");
         assert!(!structural.warnings.is_empty(), "the corrupt playlist is recorded");
         assert!(
             structural.warnings.iter().any(|warning| warning.contains("00000.mpls")),

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -665,7 +665,7 @@ mod tests {
         assert_eq!(file, "00000.M2TS", "the fixture's one stream file is what the pass reads");
         assert_eq!(first_done, 0, "the pass opens at zero");
         assert!(events.iter().all(|(_, _, each)| *each == total), "one fixed byte total");
-        assert!(events.windows(2).all(|pair| pair[0].1 <= pair[1].1), "done never regresses");
+        assert!(events.is_sorted_by_key(|(_, done, _)| *done), "done never regresses");
         assert_eq!(events.last().map(|(_, done, _)| *done), Some(total), "the pass closes full");
     }
 

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -676,14 +676,24 @@ mod tests {
         // waiting on one to conclude a cancelled listing is over would wait
         // forever.
         let mut events: Vec<u64> = Vec::new();
+        let mut on_progress = |progress: bdinfo_rs_core::bdrom::disc::ScanProgress<'_>| {
+            events.push(progress.done);
+        };
+        // One direct priming call — the scan itself must never add to it, so
+        // the assertion below counts exactly this call and nothing more.
+        on_progress(bdinfo_rs_core::bdrom::disc::ScanProgress {
+            file: "00000.M2TS",
+            done: 7,
+            total: 9,
+        });
         let message = super::scan_structural(
             &Input::Folder(fixture("BigBuckBunny")),
-            &mut |progress| events.push(progress.done),
+            &mut on_progress,
             &AtomicBool::new(true),
         )
         .expect_err("a cancelled listing yields no table");
         assert_eq!(message, "scan cancelled");
-        assert!(events.is_empty(), "no event precedes the cancel poll");
+        assert_eq!(events, [7], "no event beyond the priming call precedes the cancel poll");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/tests/golden.rs
+++ b/crates/bdinfo-rs-gui/tests/golden.rs
@@ -33,7 +33,9 @@ const ISO_GOLDEN: &str = include_str!("../../bdinfo-rs/tests/fixtures/golden/iso
 /// Lists `input`, selects every row, and runs the measured scan — the exact
 /// Tier-A flow the shell drives, returning the rendered report + disc label.
 fn list_select_all_and_measure(input: &Input) -> (String, String) {
-    let structural: Structural = scan::scan_structural(input).expect("the fixture lists");
+    let structural: Structural =
+        scan::scan_structural(input, &mut scan::no_progress, &AtomicBool::new(false))
+            .expect("the fixture lists");
     // Default view settings — the byte contract holds for a fresh config.
     let mut flow =
         Flow::start_listing(input.clone()).listed(input, Ok(structural), ViewSettings::default());
@@ -57,7 +59,8 @@ fn a_cancelled_measured_scan_yields_no_report() {
     // The shell's Cancel trips the flag; a scan that observes it must return
     // the cancelled error — never a partial (or empty) report.
     let input = Input::Folder(fixture("BigBuckBunny"));
-    let structural = scan::scan_structural(&input).expect("the fixture lists");
+    let structural = scan::scan_structural(&input, &mut scan::no_progress, &AtomicBool::new(false))
+        .expect("the fixture lists");
     let mut flow =
         Flow::start_listing(input.clone()).listed(&input, Ok(structural), ViewSettings::default());
     flow.select_all();
@@ -96,7 +99,8 @@ fn a_report_toggle_rerender_reproduces_the_worker_bytes() {
     // renders from the RETAINED disc, not the worker's) must reproduce the
     // worker's report byte-for-byte.
     let input = Input::Folder(fixture("BigBuckBunny"));
-    let structural = scan::scan_structural(&input).expect("the fixture lists");
+    let structural = scan::scan_structural(&input, &mut scan::no_progress, &AtomicBool::new(false))
+        .expect("the fixture lists");
     let mut flow =
         Flow::start_listing(input.clone()).listed(&input, Ok(structural), ViewSettings::default());
     flow.select_all();
@@ -132,8 +136,12 @@ fn a_report_toggle_rerender_reproduces_the_worker_bytes() {
 fn a_missing_disc_fails_the_structural_scan_with_a_message() {
     // The pick flow's hard-error road, driven through the same public seam:
     // a path with no disc yields a user-facing message, never a panic.
-    let message = scan::scan_structural(&Input::Folder(fixture("does-not-exist")))
-        .expect_err("nothing to list");
+    let message = scan::scan_structural(
+        &Input::Folder(fixture("does-not-exist")),
+        &mut scan::no_progress,
+        &AtomicBool::new(false),
+    )
+    .expect_err("nothing to list");
     assert!(!message.is_empty(), "the failure carries a user-facing message");
 }
 
@@ -148,7 +156,12 @@ fn a_broken_iso_fails_the_structural_scan_with_a_message() {
     std::fs::create_dir_all(&dir).expect("the scratch dir creates");
     let garbage = dir.join("garbage.iso");
     std::fs::write(&garbage, b"not a udf volume at all").expect("the scratch iso writes");
-    let message = scan::scan_structural(&Input::Iso(garbage)).expect_err("no UDF volume to open");
+    let message = scan::scan_structural(
+        &Input::Iso(garbage),
+        &mut scan::no_progress,
+        &AtomicBool::new(false),
+    )
+    .expect_err("no UDF volume to open");
     assert!(!message.is_empty(), "the failure carries a user-facing message");
 
     let renamed = dir.join("renamed.iso");
@@ -164,7 +177,12 @@ fn a_broken_iso_fails_the_structural_scan_with_a_message() {
         at = start.checked_add(1).expect("offset fits");
     }
     std::fs::write(&renamed, bytes).expect("the scratch iso writes");
-    let message = scan::scan_structural(&Input::Iso(renamed)).expect_err("a volume with no BDMV");
+    let message = scan::scan_structural(
+        &Input::Iso(renamed),
+        &mut scan::no_progress,
+        &AtomicBool::new(false),
+    )
+    .expect_err("a volume with no BDMV");
     assert!(!message.is_empty(), "the failure carries a user-facing message");
 }
 
@@ -173,7 +191,8 @@ fn the_structural_scan_lists_the_disc_playlist() {
     // The Listed-state projection the table renders: the fast structural scan
     // populates exactly the one filtered feature playlist.
     let input = Input::Folder(fixture("BigBuckBunny"));
-    let structural = scan::scan_structural(&input).expect("the fixture lists");
+    let structural = scan::scan_structural(&input, &mut scan::no_progress, &AtomicBool::new(false))
+        .expect("the fixture lists");
     assert!(structural.warnings.is_empty(), "the fixture lists cleanly");
     let flow =
         Flow::start_listing(input.clone()).listed(&input, Ok(structural), ViewSettings::default());
@@ -195,7 +214,8 @@ fn the_pre_scan_report_matches_the_disc_but_reads_zero_bitrate() {
     // the structural scan, rendered from the disc with zero (unmeasured)
     // bitrates. Nothing is selected, so it covers the whole disc.
     let input = Input::Folder(fixture("BigBuckBunny"));
-    let structural = scan::scan_structural(&input).expect("the fixture lists");
+    let structural = scan::scan_structural(&input, &mut scan::no_progress, &AtomicBool::new(false))
+        .expect("the fixture lists");
     let flow =
         Flow::start_listing(input.clone()).listed(&input, Ok(structural), ViewSettings::default());
     assert!(flow.report_available(), "View Report is offered before the scan");


### PR DESCRIPTION
The GUI's structural listing ran as one blocking call on an iced executor thread, behind a "please wait" modal with no progress, no cancel, and a freshly constructed never-set cancel flag — on damaged media a single stuck read could hold the pre-scan stage indefinitely with no exit but killing the app.

The listing now runs on a worker thread with a message channel, exactly like the measured scan:

- `scan::scan_structural` takes the caller's progress callback and cancel flag and forwards both into the core opens. The quick codec pass reports to 100% of the selected byte total; the metadata open reports nothing.
- The modal shows a live progress bar (indeterminate until the first event), the file being read, and a working Cancel button; the bottom bar tracks the same fraction and file.
- Cancelling returns to the source prompt with the input remembered, so a retry is one Rescan click. Teardown is driven from the Cancel press itself — a cancelled pass polls its flag before the first read and can emit no progress event at all, so nothing waits on the worker.
- Listing messages carry a generation stamp: a cancelled or superseded worker's late result or progress is dropped even when the same input was picked again, where the flow's input match alone could not tell the workers apart.
- gui.log gains one line per stream file during the listing and a `listing cancelled` line, so a field log can name the file a pre-scan hang is stuck on.

New tests: flow-level cancel-during-listing (returns to the prompt, stray completion and progress apply nothing), listing-progress projection, the interaction roads for the modal's Cancel / stale-generation drops / progress rendering, and scan-seam pins that the codec pass reports monotonically to completion and that a pre-set cancel aborts with zero progress events.

Fixes #324
