### PR TITLE
fix(core): gate the raw-volume label read on io errors from any stage

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -216,12 +216,14 @@ deliberately diverge from BDInfo 0.8:
   than a 5 MiB one — 16 KiB in the quick codec pass (which runs first in every
   measurement scan and alone in a codec-only browse), 256 KiB in the full pass.
 
-A damaged scan of a bare Windows drive root also keeps a degraded disc label: once
-stream read errors are recorded, the raw-device read that recovers the UDF volume label
-is skipped — one more sector-by-sector grind of a failing drive for a cosmetic string —
-so the report and its file name carry the bare drive letter. Classic BDInfo shows the
-OS-reported volume label there (it reads it through the filesystem before scanning and
-has no raw-device read to skip).
+A damaged scan of a bare Windows drive root also keeps a degraded disc label: once any
+io error is recorded — at any scan stage, so a metadata-only browse counts too — the
+raw-device read that recovers the UDF volume label is skipped — one more sector-by-sector
+grind of a failing drive for a cosmetic string — so the report and its file name carry
+the bare drive letter. A failure blaming the disc's bytes rather than the device (a
+malformed playlist, a missing clip file) leaves the label read in place. Classic BDInfo
+shows the OS-reported volume label there (it reads it through the filesystem before
+scanning and has no raw-device read to skip).
 
 <sub>Source: `crates/bdinfo-rs-core/src/bdrom/m2ts.rs` (`DATA_SIZE`, `QUICK_DATA_SIZE`),
 `crates/bdinfo-rs-core/src/vfs/volume.rs` (the label-read gate).</sub>

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -569,11 +569,12 @@ impl Progress<'_> {
     /// Advances the counter by `bytes` demuxed from `file` and reports.
     fn advance(&mut self, file: &str, bytes: u64) {
         self.done = self.done.saturating_add(bytes).min(self.total);
-        (self.callback)(ScanProgress { file, done: self.done, total: self.total });
+        self.heartbeat(file);
     }
 
     /// Reports the current count against `file` without advancing it — the
-    /// pre-read heartbeat. [`CountingReader`] fires it before every physical
+    /// pre-read heartbeat, and the single emission point the two counter
+    /// updates end in. [`CountingReader`] fires it before every physical
     /// read, so a consumer watching for staleness knows a read is in flight
     /// (and in which file) rather than seeing plain silence: on damaged media
     /// one blocking read can stall for minutes, and the heartbeat is the last
@@ -587,7 +588,7 @@ impl Progress<'_> {
     /// percentage of the files after it.
     fn finish_file(&mut self, file: &str, target: u64) {
         self.done = self.done.max(target).min(self.total);
-        (self.callback)(ScanProgress { file, done: self.done, total: self.total });
+        self.heartbeat(file);
     }
 }
 

--- a/crates/bdinfo-rs-core/src/scan.rs
+++ b/crates/bdinfo-rs-core/src/scan.rs
@@ -31,9 +31,10 @@ use crate::vfs::volume;
 ///
 /// The label is the [`volume`] repair's: a folder scan names the disc after
 /// its root directory, which a bare Windows drive root (`J:\`) does not have.
-/// When the scan recorded stream read failures the repair skips its
-/// raw-device read — the drive just failed mid-stream, and another raw read
-/// could stall — so the label degrades to the bare drive letter there.
+/// When the scan recorded an io failure at any stage the repair skips its
+/// raw-device read — the device just demonstrated read errors, and another
+/// raw read could stall — so the label degrades to the bare drive letter
+/// there.
 ///
 /// `mode`, `options`, `scan_files`, `progress` and `cancel` are
 /// [`BdRom::open_resilient_with`]'s, passed through unchanged.

--- a/crates/bdinfo-rs-core/src/vfs/volume.rs
+++ b/crates/bdinfo-rs-core/src/vfs/volume.rs
@@ -19,14 +19,14 @@
 //! uses, the identical string Windows Explorer and classic `BDInfo` show —
 //! falling back to the drive letter when that read is unavailable. A folder
 //! backend's caller applies it to the scanned label; an `.iso` scan already
-//! reads the genuine UDF label and needs no repair. A scan that recorded
-//! stream read failures resolves through `resolve_folder_label_after_scan`
-//! instead, which skips the raw-device read outright.
+//! reads the genuine UDF label and needs no repair. A scan that recorded io
+//! failures resolves through `resolve_folder_label_after_scan` instead, which
+//! skips the raw-device read outright.
 
 #[cfg(any(windows, test))]
 use std::io::{self, Read, Seek, SeekFrom};
 
-use crate::error::{ScanError, ScanStage};
+use crate::error::{BdError, ScanError};
 #[cfg(any(windows, test))]
 use crate::vfs::ReadSeek;
 #[cfg(windows)]
@@ -57,11 +57,11 @@ fn drive_root_letter(label: &str) -> Option<char> {
 /// a `J:\` scan.
 #[must_use]
 pub fn resolve_folder_label(scanned: &str) -> String {
-    resolve_with(scanned, real_volume_label)
+    resolve_folder_label_after_scan(scanned, &[])
 }
 
-/// The pure core of [`resolve_folder_label`], with the raw-device read injected
-/// as `read` so the decision logic is exercised without a real device.
+/// The label resolution both entry points end in, with the raw-device read
+/// injected as `read` so the decision logic is exercised without a real device.
 fn resolve_with(scanned: &str, read: impl FnOnce(char) -> Option<String>) -> String {
     drive_root_letter(scanned).map_or_else(
         || scanned.to_owned(),
@@ -70,12 +70,14 @@ fn resolve_with(scanned: &str, read: impl FnOnce(char) -> Option<String>) -> Str
 }
 
 /// [`resolve_folder_label`] for a scan that may have recorded failures: when
-/// `errors` records a stream read failure ([`ScanStage::StreamFile`]), the
+/// `errors` carries an io failure ([`BdError::Io`]) from any stage, the
 /// raw-device read is skipped and a bare drive-root label degrades straight
 /// to the drive letter. The label read grinds the same device that just
-/// failed mid-stream, sector by sector, and on damaged media one raw read
-/// can stall for minutes inside the drive's retries — a cosmetic label is
-/// not worth that after a scan that already recorded failures. A real name
+/// failed, sector by sector, and on damaged media one raw read can stall for
+/// minutes inside the drive's retries — a cosmetic label is not worth that
+/// after the device has demonstrated read errors. Every other [`BdError`]
+/// describes the disc's *bytes* — malformed or missing metadata — which is no
+/// evidence against the device, so those leave the read in play. A real name
 /// resolves to itself either way.
 #[must_use]
 pub(crate) fn resolve_folder_label_after_scan(scanned: &str, errors: &[ScanError]) -> String {
@@ -90,7 +92,7 @@ fn resolve_after_scan_with(
     errors: &[ScanError],
     read: impl FnOnce(char) -> Option<String>,
 ) -> String {
-    if errors.iter().any(|e| e.stage == ScanStage::StreamFile) {
+    if errors.iter().any(|e| matches!(e.reason, BdError::Io(_))) {
         resolve_with(scanned, |_| None)
     } else {
         resolve_with(scanned, read)
@@ -297,11 +299,11 @@ mod tests {
     use std::io::{Cursor, Read as _, Seek as _, SeekFrom};
 
     use super::{
-        AlignedReader, SECTOR, ScanError, ScanStage, add_signed, drive_root_letter,
+        AlignedReader, BdError, SECTOR, ScanError, add_signed, drive_root_letter,
         resolve_after_scan_with, resolve_folder_label, resolve_folder_label_after_scan,
         resolve_with,
     };
-    use crate::error::BdError;
+    use crate::error::ScanStage;
 
     #[test]
     fn drive_root_letter_matches_every_bare_drive_root_spelling() {
@@ -342,8 +344,8 @@ mod tests {
         assert_eq!(resolve_folder_label("BigBuckBunny"), "BigBuckBunny");
     }
 
-    /// A recorded failure at `stage`, for driving the post-scan gate.
-    fn error_at(stage: ScanStage) -> ScanError {
+    /// A recorded device failure at `stage` — the reason that closes the gate.
+    fn io_error_at(stage: ScanStage) -> ScanError {
         ScanError {
             file: "00000.m2ts".to_owned(),
             stage,
@@ -351,32 +353,48 @@ mod tests {
         }
     }
 
+    /// A recorded failure at `stage` blaming the disc's bytes rather than the
+    /// device, which leaves the gate open.
+    fn parse_error_at(stage: ScanStage) -> ScanError {
+        ScanError { file: "00000.clpi".to_owned(), stage, reason: BdError::UnexpectedEof }
+    }
+
     #[test]
-    fn a_recorded_stream_read_failure_skips_the_device_read() {
-        // One injected reader for every shape: consulted only when no stream
-        // read failure is on record, so its label wins exactly there.
+    fn a_recorded_io_failure_at_any_stage_skips_the_device_read() {
+        // One injected reader for every shape: consulted only when the gate is
+        // open, so its label wins exactly there.
         let read = |letter: char| Some(format!("VOL{letter}"));
-        // A stream read failure degrades a drive root straight to the letter…
-        assert_eq!(resolve_after_scan_with(r"J:\", &[error_at(ScanStage::StreamFile)], read), "J");
-        // …also when failures at other stages surround it…
+        // An io failure degrades a drive root straight to the letter, whatever
+        // stage recorded it — a stream read is what a damaged disc trips first,
+        // but a metadata-only scan never reaches that stage at all.
+        for stage in [
+            ScanStage::Discovery,
+            ScanStage::ClipInfo,
+            ScanStage::Playlist,
+            ScanStage::StreamFile,
+            ScanStage::SectorRead,
+        ] {
+            assert_eq!(resolve_after_scan_with(r"J:\", &[io_error_at(stage)], read), "J");
+        }
+        // A parse failure is no evidence against the device, so it leaves the
+        // read in play — as does a clean scan.
+        assert_eq!(
+            resolve_after_scan_with(r"J:\", &[parse_error_at(ScanStage::ClipInfo)], read),
+            "VOLJ"
+        );
+        assert_eq!(resolve_after_scan_with(r"J:\", &[], read), "VOLJ");
+        // One io failure among parse failures still closes the gate.
         assert_eq!(
             resolve_after_scan_with(
                 r"J:\",
-                &[error_at(ScanStage::Discovery), error_at(ScanStage::StreamFile)],
+                &[parse_error_at(ScanStage::ClipInfo), io_error_at(ScanStage::Playlist)],
                 read
             ),
             "J"
         );
-        // …while non-stream failures alone leave the device read in play…
-        assert_eq!(
-            resolve_after_scan_with(r"J:\", &[error_at(ScanStage::Discovery)], read),
-            "VOLJ"
-        );
-        // …as does a clean scan.
-        assert_eq!(resolve_after_scan_with(r"J:\", &[], read), "VOLJ");
         // A real name resolves to itself whatever is on record.
         assert_eq!(
-            resolve_after_scan_with("BigBuckBunny", &[error_at(ScanStage::StreamFile)], read),
+            resolve_after_scan_with("BigBuckBunny", &[io_error_at(ScanStage::StreamFile)], read),
             "BigBuckBunny"
         );
     }
@@ -388,7 +406,7 @@ mod tests {
         // drive-root road is validated end-to-end on real hardware).
         assert_eq!(resolve_folder_label_after_scan("BigBuckBunny", &[]), "BigBuckBunny");
         assert_eq!(
-            resolve_folder_label_after_scan("BigBuckBunny", &[error_at(ScanStage::StreamFile)]),
+            resolve_folder_label_after_scan("BigBuckBunny", &[io_error_at(ScanStage::StreamFile)]),
             "BigBuckBunny"
         );
     }

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -35,9 +35,8 @@ pub enum Input {
     /// inside it (the scan walks up to the disc root). The label is the
     /// directory name — or, when the disc root is a nameless Windows drive
     /// root, the real UDF label the [`bdinfo_rs_core::vfs::volume`] repair
-    /// recovers; after a scan that recorded stream read errors the repair
-    /// skips its raw-device read and the label degrades to the bare drive
-    /// letter.
+    /// recovers; after a scan that recorded an io error the repair skips its
+    /// raw-device read and the label degrades to the bare drive letter.
     Folder(PathBuf),
     /// A single `.iso` image. The label is the real UDF volume label.
     Iso(PathBuf),

--- a/crates/bdinfo-rs/Cargo.toml
+++ b/crates/bdinfo-rs/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 keywords = ["bluray", "bdmv", "m2ts", "cli", "video"]
 categories = ["command-line-utilities", "multimedia::video"]
 
-# Keep the ~6 MB real-disc test fixtures out of the published crate — they exist
+# Keep the ~30 MB real-disc test fixtures out of the published crate — they exist
 # only for the repo's CI (the end-to-end scan in tests/cli.rs) and are useless to
 # anyone installing from crates.io. `cargo install`/`publish` build the binary, not
 # the integration tests, so excluding them doesn't affect the build; tests/cli.rs


### PR DESCRIPTION
The post-scan label gate skipped the raw-volume read only when a recorded failure carried `ScanStage::StreamFile`. Its rationale — never grind a raw volume that just demonstrated device errors — covers io failures recorded at the discovery, clip-info, playlist and sector stages just as well, and a metadata-only scan records no stream failure at all, so it reached the raw read unconditionally.

The gate now keys on the `BdError::Io` reason at any stage. A failure blaming the disc bytes (a malformed playlist, a missing clip file) is no evidence against the device and leaves the label read in play, so a damaged-metadata disc in a healthy drive still recovers its real UDF label. `DIFFERENCES.md` and the folder-scan docs follow the sharper predicate.

Two cleanups in the same code:

- `resolve_folder_label` delegates to the after-scan entry point with no recorded failures, so one predicate serves both.
- `Progress::advance` and `Progress::finish_file` emit through `Progress::heartbeat` — one emission path, three callers.

Plus one stale number: the published-crate `exclude` comment called the fixture set ~6 MB; it is ~30 MB.

Verified: `pwsh scripts/compliance.ps1 -All` green on the first run — root 1045 tests, coverage 100,00% lines (23509) / regions / functions, branches 97,64% (floor 97%), `mt` 6 mutants all caught, `semver` no update required; wasm and gui gates pass. Teeth check both directions: restoring the stage-only gate fails the newly gated stages, and widening to any-error-any-stage fails the parse-error case.

Refs #319