### PR TITLE
fix(gui): extend the stall hint to the listing pass

### DIFF
--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -368,6 +368,12 @@ enum Inner {
         /// pass's first event (the metadata open that precedes the pass
         /// reports nothing, and an AACS-encrypted disc never runs the pass).
         progress: Option<ProgressModel>,
+        /// Whether progress events have gone quiet past the stall threshold —
+        /// the same slot, threshold and wording the measured scan uses
+        /// (`Scanning::stalled`). The listing reads the head of every stream
+        /// file, so on damaged media it is the FIRST place a read sticks,
+        /// minutes before any measured scan starts.
+        stalled: bool,
     },
     Listed(Listing),
     Scanning {
@@ -424,7 +430,7 @@ impl Flow {
     /// A folder/`.iso` was picked — begin its structural scan.
     #[must_use]
     pub const fn start_listing(input: Input) -> Self {
-        Self { inner: Inner::Listing { input, progress: None } }
+        Self { inner: Inner::Listing { input, progress: None, stalled: false } }
     }
 
     /// The structural scan for `input` finished. Applied only when this flow is
@@ -602,25 +608,36 @@ impl Flow {
     /// time elapsed since the listing started. Applied only while listing;
     /// the shell keeps events from a superseded listing worker away from
     /// here (its listing messages carry a generation stamp), so this needs
-    /// no generation of its own.
+    /// no generation of its own. Like the measured scan's [`Flow::progress`],
+    /// a real event is proof the read loop is moving, so it also clears the
+    /// stall flag [`Flow::tick`] may have raised.
     pub fn list_progress(&mut self, file: String, done: u64, total: u64, elapsed: Duration) {
-        if let Inner::Listing { progress, .. } = &mut self.inner {
+        if let Inner::Listing { progress, stalled, .. } = &mut self.inner {
             *progress = Some(ProgressModel::compute(file, done, total, elapsed));
+            *stalled = false;
         }
     }
 
     /// Advances the wall-clock readout while a scan is in flight — the shell's
-    /// ~1 s tick. `elapsed` (since the scan started) re-stamps the progress
+    /// display tick. `elapsed` (since the scan started) re-stamps the progress
     /// model's elapsed seconds so the readout climbs even when no progress
     /// event arrives (a read stuck in drive-firmware retries emits none), and
     /// `since_progress` (since the last progress event) drives the stall flag
     /// (its fixed threshold lives in [`crate::progress`], beside the model's
     /// other display constants). The remaining estimate is untouched —
-    /// it is meaningful only against real progress. A no-op off
-    /// [`Stage::Scanning`], and before the first progress event only the
-    /// stall flag moves (there is no model to re-stamp).
+    /// it is meaningful only against real progress.
+    ///
+    /// Both in-flight stages take it, on identical terms: the measured scan
+    /// ([`Stage::Scanning`]) and the structural listing ([`Stage::Listing`]),
+    /// which reads every stream file's head and stalls on damaged media the
+    /// same way. A no-op in every other stage, and before the first progress
+    /// event only the stall flag moves (there is no model to re-stamp) — the
+    /// listing's clock therefore runs from its start, since a cancelled or
+    /// pre-cancelled listing can emit no event at all.
     pub fn tick(&mut self, elapsed: Duration, since_progress: Duration) {
-        if let Inner::Scanning { progress, stalled, .. } = &mut self.inner {
+        if let Inner::Scanning { progress, stalled, .. }
+        | Inner::Listing { progress, stalled, .. } = &mut self.inner
+        {
             if let Some(model) = progress.as_mut() {
                 model.set_elapsed(elapsed);
             }
@@ -924,10 +941,16 @@ impl Flow {
     /// Whether the in-flight scan's progress events have gone quiet past the
     /// stall threshold — the status line then says "still reading" so a read
     /// stuck on damaged media looks like a struggling drive, not a dead app.
-    /// Always false off [`Stage::Scanning`].
+    /// One flag for both reading stages, the structural listing
+    /// ([`Stage::Listing`]) and the measured scan ([`Stage::Scanning`]), so
+    /// they share one stall vocabulary; always false in the stages that read
+    /// nothing.
     #[must_use]
     pub const fn scan_stalled(&self) -> bool {
-        matches!(self.inner, Inner::Scanning { stalled: true, .. })
+        matches!(
+            self.inner,
+            Inner::Scanning { stalled: true, .. } | Inner::Listing { stalled: true, .. }
+        )
     }
 
     /// Whether a report can be shown / saved / copied now — true whenever a disc
@@ -1395,6 +1418,47 @@ mod tests {
         flow.tick(Duration::from_secs(9), Duration::from_secs(9));
         assert!(!flow.scan_stalled());
         assert_eq!(flow.stage(), Stage::Listed);
+    }
+
+    #[test]
+    fn quiet_ticks_flag_a_stalled_listing_and_an_event_clears_it() {
+        let mut flow = Flow::start_listing(input());
+        assert!(!flow.scan_stalled(), "a listing starts with the flag down");
+        flow.list_progress("A.M2TS".to_owned(), 1, 4, Duration::from_secs(1));
+        assert!(!flow.scan_stalled());
+        // The listing takes the measured scan's threshold unchanged — 5 s,
+        // inclusive — so one silence means the same thing in both stages.
+        flow.tick(Duration::from_secs(6), Duration::from_millis(4_999));
+        assert!(!flow.scan_stalled());
+        flow.tick(Duration::from_secs(7), Duration::from_secs(5));
+        assert!(flow.scan_stalled());
+        flow.tick(Duration::from_secs(8), Duration::from_secs(6));
+        assert!(flow.scan_stalled());
+        // The listing's readout climbs across those ticks, and nothing else
+        // in its snapshot moves.
+        let model = flow.progress_view().expect("the listing keeps its snapshot");
+        assert_eq!(model.elapsed_hms(), "00:00:08");
+        assert_eq!(model.file(), "A.M2TS");
+        assert_eq!(model.percent, 25);
+        // A fresh event is proof the read loop is moving.
+        flow.list_progress("A.M2TS".to_owned(), 2, 4, Duration::from_secs(9));
+        assert!(!flow.scan_stalled());
+    }
+
+    #[test]
+    fn a_listing_stalls_before_its_first_progress_event() {
+        // The listing's stall clock runs from its start, never from a first
+        // event: the metadata open reports nothing, and a listing cancelled
+        // early emits no event at all — so the flag must rise with no
+        // snapshot to re-stamp and no file to name.
+        let mut flow = Flow::start_listing(input());
+        flow.tick(Duration::from_secs(9), Duration::from_secs(9));
+        assert!(flow.progress_view().is_none());
+        assert!(flow.scan_stalled());
+        // Cancelling out of the stalled listing leaves nothing flagged.
+        let flow = flow.cancel();
+        assert_eq!(flow.stage(), Stage::Idle);
+        assert!(!flow.scan_stalled());
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -763,8 +763,9 @@ struct App {
     /// When the current worker (listing or measured scan) started.
     scan_start: Option<Instant>,
     /// When the in-flight worker's last progress event arrived (the start
-    /// until the first one) — what the 1 s scanning tick measures the stall
-    /// hint against ([`Flow::tick`]).
+    /// until the first one, so the clock runs even for a worker that emits
+    /// nothing at all) — what the display tick measures the stall hint
+    /// against ([`Flow::tick`]), for the listing and the measured scan alike.
     last_progress: Option<Instant>,
     /// A one-line status (e.g. `Report saved to: …`), shown in the bottom bar.
     status: Option<String>,
@@ -1075,9 +1076,10 @@ enum Message {
     SettingsCancel,
     /// The OS reported (or changed) its light/dark setting.
     OsTheme(iced::theme::Mode),
-    /// A display tick with no payload: per-frame while listing (advances the
-    /// indeterminate bar), ~1 s while scanning (re-reads the wall clock for
-    /// the elapsed readout and the stall hint).
+    /// A display tick with no payload, at two cadences: per-frame while
+    /// listing (which also advances the indeterminate bar), ~1 s while
+    /// scanning. Either way it re-reads the wall clock for the elapsed
+    /// readout and the stall hint.
     Tick,
     /// A pane splitter was dragged — resize the two panes it divides.
     PaneResized(pane_grid::ResizeEvent),
@@ -1506,11 +1508,11 @@ impl App {
         }
     }
 
-    /// The live subscriptions: the OS light/dark change feed, plus — only while
-    /// the initial scan is in flight — a per-frame tick that animates the
-    /// indeterminate progress bar, and — only while the measured scan is — a
-    /// ~1 s wall-clock tick that keeps the elapsed readout and the stall hint
-    /// moving. The ticks are off in every other state, so the window is not
+    /// The live subscriptions: the OS light/dark change feed, plus the display
+    /// tick that keeps the elapsed readout and the stall hint moving — at two
+    /// cadences, per-frame while the initial scan is in flight (it animates
+    /// the indeterminate progress bar too) and ~1 s while the measured scan
+    /// is. The ticks are off in every other state, so the window is not
     /// redrawing continuously when idle.
     fn subscription(&self) -> iced::Subscription<Message> {
         let mut subs = vec![iced::system::theme_changes().map(Message::OsTheme)];
@@ -1714,17 +1716,17 @@ impl App {
         Task::none()
     }
 
-    /// Applies a display tick: advances the indeterminate bar's phase, and —
-    /// while the measured scan is in flight — re-reads the wall clock so the
-    /// elapsed readout and the stall hint move even when no progress event
-    /// arrives ([`Flow::tick`]).
+    /// Applies a display tick: advances the indeterminate bar's phase, then
+    /// re-reads the wall clock so the elapsed readout and the stall hint move
+    /// even when no progress event arrives. The listing and the measured scan
+    /// are fed the same two durations off the same two fields — the stage
+    /// gate is [`Flow::tick`]'s own, which ignores a tick from any other
+    /// stage.
     fn on_tick(&mut self) {
         self.pulse = progress::pulse_advance(self.pulse);
-        if self.flow.stage() == Stage::Scanning {
-            let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
-            let since_progress = self.last_progress.map_or(Duration::ZERO, |at| at.elapsed());
-            self.flow.tick(elapsed, since_progress);
-        }
+        let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
+        let since_progress = self.last_progress.map_or(Duration::ZERO, |at| at.elapsed());
+        self.flow.tick(elapsed, since_progress);
     }
 
     /// Cancels the in-flight scan for real — the measured scan back to the
@@ -2153,7 +2155,9 @@ impl App {
 
         let base = container(content).width(Length::Fill).height(Length::Fill).into();
         if self.flow.stage() == Stage::Listing {
-            return scanning_modal(base, scanning_card(p, self.pulse, self.flow.progress_view()));
+            let card =
+                scanning_card(p, self.pulse, self.flow.progress_view(), self.flow.scan_stalled());
+            return scanning_modal(base, card);
         }
         if let Some(draft) = &self.settings_draft {
             return modal(base, settings_card(p, draft), Message::SettingsCancel);
@@ -2672,6 +2676,12 @@ impl App {
                 Stage::Scanning => progress.map_or_else(
                     || "Starting scan…".to_owned(),
                     |pr| format!("Scanning {}…", pr.file()),
+                ),
+                // The listing reads every stream file's head, so it stalls on
+                // damaged media the same way and says so in the same words.
+                Stage::Listing if self.flow.scan_stalled() => progress.map_or_else(
+                    || "Scanning disc…".to_owned(),
+                    |pr| format!("Still reading {}…", pr.file()),
                 ),
                 Stage::Listing => progress.map_or_else(
                     || "Scanning disc…".to_owned(),
@@ -3290,13 +3300,18 @@ fn scanning_modal<'a>(
 /// The "please wait" scan overlay card: the brand mark over the same message
 /// `BDInfo` shows while it reads a disc — plus what `BDInfo`'s modal lacks
 /// and a damaged disc needs: the codec pass's live progress (the bar breathes
-/// indeterminately until its first event) and a Cancel that works, because
-/// this pre-scan pass reads every stream file's head and can stall on a bad
-/// sector exactly like the measured scan.
+/// indeterminately until its first event), the stall hint when `stalled`, and
+/// a Cancel that works, because this pre-scan pass reads every stream file's
+/// head and can stall on a bad sector exactly like the measured scan.
+///
+/// A stall before the first event has no file to name, so it leaves the card's
+/// wording alone rather than inventing a readout — the breathing bar and the
+/// live Cancel are the liveness proof there.
 fn scanning_card<'a>(
     p: Palette,
     pulse: u16,
     progress: Option<&ProgressModel>,
+    stalled: bool,
 ) -> Element<'a, Message> {
     let fraction =
         progress.map_or_else(|| progress::pulse_fraction(pulse), ProgressModel::fraction);
@@ -3317,12 +3332,13 @@ fn scanning_card<'a>(
                 .style(ui::progress(p)),
         );
     if let Some(pr) = progress {
-        card = card.push(
-            text(format!("Reading {}…", pr.file()))
-                .size(ui::TEXT_SM)
-                .color(p.text_muted)
-                .align_x(Horizontal::Center),
-        );
+        let line = if stalled {
+            format!("Still reading {}…", pr.file())
+        } else {
+            format!("Reading {}…", pr.file())
+        };
+        card =
+            card.push(text(line).size(ui::TEXT_SM).color(p.text_muted).align_x(Horizontal::Center));
     }
     card = card.push(
         button(text("Cancel").size(ui::TEXT_SM).font(ui::UI_MEDIUM))
@@ -4018,6 +4034,44 @@ mod interaction {
         });
         assert!(sees(&app, "Reading A.M2TS…"), "the stale event must not repaint");
         assert!(!sees(&app, "Reading B.M2TS…"));
+    }
+
+    #[test]
+    fn a_quiet_listing_turns_both_progress_lines_into_the_stall_hint() {
+        let mut app = App::default();
+        let _ = app.update(Message::FolderPicked(Some(PathBuf::from("disc"))));
+        let _ = app.update(Message::ListProgress {
+            generation: app.generation,
+            file: "A.M2TS".to_owned(),
+            done: 1,
+            total: 2,
+        });
+        assert!(sees(&app, "Reading A.M2TS…"));
+        // Re-date the listing's start and its last event into the past — the
+        // wall time a stuck ReadFile would let pass with no event at all.
+        app.scan_start = Instant::now().checked_sub(Duration::from_secs(90));
+        app.last_progress = Instant::now().checked_sub(Duration::from_secs(30));
+        let _ = app.update(Message::Tick);
+        assert!(app.flow.scan_stalled());
+        assert!(sees(&app, "Still reading A.M2TS…"), "the stall hint names the stuck file");
+        // The modal card and the bottom bar both carry this line, and `sees`
+        // matches either — so the absence of the plain wording is what proves
+        // BOTH switched, not just whichever the search reaches first.
+        assert!(!sees(&app, "Reading A.M2TS…"), "the plain wording is replaced, not doubled");
+        // The listing's elapsed readout climbs off the same tick.
+        assert_eq!(
+            app.flow.progress_view().map(bdinfo_rs_gui::progress::ProgressModel::elapsed_hms),
+            Some("00:01:30".to_owned())
+        );
+        // The next real event is proof of life: the hint goes away again.
+        let _ = app.update(Message::ListProgress {
+            generation: app.generation,
+            file: "A.M2TS".to_owned(),
+            done: 2,
+            total: 2,
+        });
+        assert!(!app.flow.scan_stalled());
+        assert!(sees(&app, "Reading A.M2TS…"));
     }
 
     #[test]


### PR DESCRIPTION
The stall hint was Stage::Scanning-only. A listing stalled on a bad sector
kept repainting and stayed cancellable, but its progress line froze at the
last event with no change of wording. The listing reads every stream file's
head, so on damaged media it is the first place a read sticks - minutes
before any measured scan starts.

Inner::Listing gains a stalled slot, Flow::tick drives it on the same terms
as the measured scan's (5 s inclusive, cleared by every applied progress
event), and the shell feeds both stages the same two durations off
scan_start / last_progress. The listing modal card and the bottom bar both
read "Still reading <file>..." while the flag is up - one stall vocabulary
across both reading stages.

The listing's stall clock runs from the listing's start rather than from a
first event: a cancelled or pre-cancelled listing emits none, and a stall
before the first event has no file to name, so only the flag moves there.

Refs #324
