### PR TITLE
feat: surface short-stream notices in the CLI, GUI and web UI

### DIFF
--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 
 use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, ScanOptions};
 use bdinfo_rs_core::bdrom::order::{PlaylistFilter, selection_order, selection_stream_files};
+use bdinfo_rs_core::bdrom::shortfall::ShortStreamFile;
 use bdinfo_rs_core::error::ScanError;
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 
@@ -323,6 +324,24 @@ pub fn scan_notice(errors: usize) -> String {
     } else {
         format!("Scan completed with {errors} error(s).\nThe report below was still written.")
     }
+}
+
+/// The notice for one stream file the demux measured shorter than the disc
+/// declares — raised beside the report, because the locked report format has no
+/// line for it ([`bdinfo_rs_core::bdrom::shortfall`]).
+///
+/// The wording is shared with the other surfaces' copies of this format
+/// (the `bdinfo-rs` CLI's `short_stream_notice`, `bdinfo-rs-wasm`'s
+/// `mirror::short_stream_notice`); each copy is pinned by an identical test, so
+/// a change here reworks all three together or fails a sibling gate.
+fn short_stream_notice(short: &ShortStreamFile) -> String {
+    format!(
+        "{} is shorter than declared: measured {:.1} s of {:.1} s ({:.1} s missing)",
+        short.file(),
+        short.measured_seconds(),
+        short.declared_seconds(),
+        short.missing_seconds()
+    )
 }
 
 /// What a measured scan needs, read from the [`Flow`] before spawning the worker.
@@ -824,6 +843,22 @@ impl Flow {
     #[must_use]
     pub fn warnings(&self) -> &[String] {
         self.any_listing().map_or(&[], |listing| listing.warnings.as_slice())
+    }
+
+    /// The short-stream notices — one sentence per stream file the measured
+    /// scan demuxed materially less of than the disc declares
+    /// ([`BdRom::short_stream_files`]), banner material beside the structural
+    /// warnings. Empty before a measured scan: an unmeasured disc carries no
+    /// per-stream tallies, so the derivation stays silent.
+    ///
+    /// Derived from the retained disc on every call rather than stored, so a
+    /// later scan that replaces the measured playlists can never leave a stale
+    /// notice behind.
+    #[must_use]
+    pub fn short_stream_notices(&self) -> Vec<String> {
+        self.any_listing().map_or_else(Vec::new, |listing| {
+            listing.bdrom.short_stream_files().iter().map(short_stream_notice).collect()
+        })
     }
 
     /// The selectable table rows (empty unless a disc is loaded).
@@ -1871,6 +1906,41 @@ mod tests {
         assert!(
             rows.first().is_some_and(|row| row.hidden && row.codec == "MPEG-4 AVC Video"),
             "the codec row carries the name and the hidden flag: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn a_measured_short_stream_file_surfaces_the_notice_with_the_shared_wording() {
+        use bdinfo_rs_core::bdrom::disc::ClipStreamTally;
+        use bdinfo_rs_core::primitives::Pid;
+        use bdinfo_rs_core::stream::TsStreamType;
+
+        // No disc, and an unmeasured (structural) disc: silent.
+        assert!(Flow::idle().short_stream_notices().is_empty());
+        let flow = listed().start_scanning(1);
+        assert!(flow.short_stream_notices().is_empty(), "unmeasured clips raise no notice");
+
+        // The measured result comes back with the first clip demuxed to 500 of
+        // its declared 1640 seconds, carrying the per-stream tally that marks
+        // the file as measured.
+        let mut measured = structural().bdrom.playlists;
+        let clip = measured.first_mut().and_then(|p| p.clips.first_mut()).expect("the first clip");
+        clip.length = 1640.0;
+        clip.packet_seconds = 500.0;
+        clip.streams = vec![ClipStreamTally {
+            pid: Pid::new(0x1011),
+            stream_type: TsStreamType::AvcVideo,
+            codec_short_name: "AVC".to_owned(),
+            payload_bytes: 1024,
+            packet_count: 8,
+        }];
+        let flow = flow.finished(1, "R".to_owned(), Arc::new(Vec::new()), measured);
+        // The exact sentence, pinned: the CLI and wasm crates carry the same
+        // format and pin the same bytes, which is what keeps the three
+        // surfaces' wording identical.
+        assert_eq!(
+            flow.short_stream_notices(),
+            ["A.M2TS is shorter than declared: measured 500.0 s of 1640.0 s (1140.0 s missing)"]
         );
     }
 

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -2315,6 +2315,12 @@ impl App {
         for warning in self.flow.warnings() {
             content = content.push(banner(p, p.warning, warning.as_str()));
         }
+        // Stream files a measured scan found shorter than the disc declares:
+        // a truncated file reads to a clean end of file, so this banner is the
+        // only place the loss shows (the report has no line for it).
+        for notice in self.flow.short_stream_notices() {
+            content = content.push(banner(p, p.warning, notice.as_str()));
+        }
 
         content =
             content.push(container(self.disc_panes(p)).width(Length::Fill).height(Length::Fill));

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -4,7 +4,7 @@
 //!
 //! | Mirror | Core |
 //! |---|---|
-//! | [`Disc`] | [`BdRom`] plus the scan mode, the recorded failures and the report order |
+//! | [`Disc`] | [`BdRom`] plus the scan mode, the recorded failures, the report order and the short-stream notices |
 //! | [`Playlist`] | [`PlaylistSummary`] |
 //! | [`Clip`] | [`ClipSummary`] |
 //! | [`Stream`] | [`StreamSummary`] |
@@ -60,6 +60,7 @@ use bdinfo_rs_core::bdrom::disc::{
     BdRom, ClipStreamTally, ClipSummary, PlaylistSummary, StreamSummary,
 };
 use bdinfo_rs_core::bdrom::order::{self, PlaylistFilter, table_rows};
+use bdinfo_rs_core::bdrom::shortfall::ShortStreamFile;
 use bdinfo_rs_core::error;
 use bdinfo_rs_core::primitives::Pid;
 use bdinfo_rs_core::stream::TsStreamType;
@@ -235,6 +236,20 @@ pub struct Disc {
     /// still holds every playlist the disc declares, measured or not.
     #[tsify(optional)]
     pub report_order: Option<Vec<String>>,
+    /// The short-stream notices of the scan that produced this disc — one
+    /// sentence per stream file the measured scan demuxed materially less of
+    /// than the disc declares, sorted by file name. Such a file reads to a
+    /// clean end of file: nothing lands in `errors`, the report carries no
+    /// `WARNING:` line for it, and every value measured from it is silently
+    /// smaller than the disc says — this field is where that shows. Absent
+    /// when no file is short, which includes every unmeasured disc: an
+    /// inspect measures nothing, so it can name nothing short.
+    ///
+    /// The sentences match the `bdinfo-rs` command line's stderr notices and
+    /// the desktop app's banner word for word; the numbers behind them are in
+    /// `playlists` (each clip's `length` against its `packetSeconds`).
+    #[tsify(optional)]
+    pub short_stream_notices: Option<Vec<String>>,
 }
 
 /// One playlist (`*.MPLS`) with its streams, clips and chapters.
@@ -661,8 +676,35 @@ impl Disc {
             measured,
             errors: errors.iter().map(ScanError::from).collect(),
             report_order,
+            short_stream_notices: short_stream_notices(bdrom),
         }
     }
+}
+
+/// The notice for one stream file the demux measured shorter than the disc
+/// declares — raised beside the report, because the locked report format has no
+/// line for it ([`bdinfo_rs_core::bdrom::shortfall`]).
+///
+/// The wording is shared with the other surfaces' copies of this format
+/// (the `bdinfo-rs` CLI's `short_stream_notice`, `bdinfo-rs-gui`'s
+/// `flow::short_stream_notice`); each copy is pinned by an identical test, so
+/// a change here reworks all three together or fails a sibling gate.
+fn short_stream_notice(short: &ShortStreamFile) -> String {
+    format!(
+        "{} is shorter than declared: measured {:.1} s of {:.1} s ({:.1} s missing)",
+        short.file(),
+        short.measured_seconds(),
+        short.declared_seconds(),
+        short.missing_seconds()
+    )
+}
+
+/// [`Disc::short_stream_notices`] for a scanned disc: the notice sentences, or
+/// `None` when no stream file is short — the field's "nothing to say" spelling,
+/// so a healthy disc's wire form carries no empty list.
+fn short_stream_notices(bdrom: &BdRom) -> Option<Vec<String>> {
+    let notices: Vec<String> = bdrom.short_stream_files().iter().map(short_stream_notice).collect();
+    (!notices.is_empty()).then_some(notices)
 }
 
 impl Playlist {
@@ -898,10 +940,12 @@ impl Disc {
     /// Rebuilds the disc this mirror describes: the [`BdRom`] and the per-file
     /// failures, the two halves a report is rendered from.
     ///
-    /// The inverse of [`from_scan`](Self::from_scan) but for `measured` and
-    /// [`report_order`](Self::report_order), which describe how the values were
-    /// obtained and how they were printed rather than being values of the disc
-    /// — a disc carries neither, so both are dropped here. A caller rendering
+    /// The inverse of [`from_scan`](Self::from_scan) but for `measured`,
+    /// [`report_order`](Self::report_order) and
+    /// [`short_stream_notices`](Self::short_stream_notices), which describe how
+    /// the values were obtained, how they were printed and what the scan
+    /// noticed about them rather than being values of the disc — a disc
+    /// carries none of the three, so all are dropped here. A caller rendering
     /// this mirror reads the order off the [`Disc`] before taking it apart.
     #[must_use]
     pub fn into_scan(self) -> (BdRom, Vec<error::ScanError>) {
@@ -1320,6 +1364,11 @@ mod tests {
             measured: true,
             errors: vec![a_scan_error()],
             report_order: Some(vec!["00000.MPLS".to_owned()]),
+            // Derived, not injectable: [`a_core_clip`] measures past its
+            // declared span, so its scan has nothing short to notice. The
+            // populated form is pinned where a genuinely short clip builds it
+            // (`a_short_stream_file_crosses_as_the_shared_notice_wording`).
+            short_stream_notices: None,
         }
     }
 
@@ -1342,6 +1391,7 @@ mod tests {
             "measured": true,
             "errors": [a_scan_error_json()],
             "reportOrder": ["00000.MPLS"],
+            "shortStreamNotices": null,
         })
     }
 
@@ -1415,6 +1465,65 @@ mod tests {
         // Going back out it is an explicit null, as an absent disc title is.
         let out = serde_json::to_value(&back).expect("serialize a disc with no order");
         assert_eq!(out.get("reportOrder"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn absent_short_stream_notices_may_be_left_out_of_the_wire_form() {
+        // The key simply missing is what makes the field additive: a `Disc`
+        // built before it existed still crosses, and reads as the scan having
+        // noticed nothing rather than as a malformed object.
+        let mut wire = a_disc_json();
+        wire.as_object_mut().expect("the wire form is an object").remove("shortStreamNotices");
+        let back: Disc = serde_json::from_value(wire).expect("deserialize a disc with no notices");
+        assert_eq!(back, a_disc());
+
+        // Going back out it is an explicit null, as an absent report order is.
+        let out = serde_json::to_value(&back).expect("serialize a disc with no notices");
+        assert_eq!(out.get("shortStreamNotices"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn a_short_stream_file_crosses_as_the_shared_notice_wording() {
+        // A clip demuxed to 500 of its declared 1640 seconds, carrying the
+        // per-stream tally that marks its file as measured.
+        let clip = ClipSummary {
+            packet_seconds: 500.0,
+            streams: vec![a_core_clip_stream()],
+            ..fixtures::clip("00011.M2TS", 1640.0)
+        };
+        let bdrom = BdRom {
+            playlists: vec![fixtures::playlist("00000.MPLS", 1640.0, vec![clip])],
+            ..a_core_bdrom()
+        };
+        let disc = Disc::from_scan(&bdrom, &[], true, &PlaylistFilter::default(), None);
+        // The exact sentence, pinned: the CLI and GUI crates carry the same
+        // format and pin the same bytes, which is what keeps the three
+        // surfaces' wording identical.
+        assert_eq!(
+            disc.short_stream_notices.as_deref(),
+            Some(
+                &["00011.M2TS is shorter than declared: measured 500.0 s of 1640.0 s (1140.0 s \
+                   missing)"
+                    .to_owned()][..]
+            )
+        );
+
+        // The wire carries the sentences as a plain array, and they survive
+        // the round trip.
+        let wire = serde_json::to_value(&disc).expect("serialize the mirror");
+        assert_eq!(
+            wire.get("shortStreamNotices"),
+            Some(&json!([
+                "00011.M2TS is shorter than declared: measured 500.0 s of 1640.0 s (1140.0 s \
+                 missing)"
+            ]))
+        );
+        let back: Disc = serde_json::from_value(wire).expect("deserialize the mirror");
+        assert_eq!(back, disc);
+
+        // Rebuilding drops the derived notices and nothing else: the disc
+        // comes back exactly, short clip included.
+        assert_eq!(back.into_scan().0, bdrom);
     }
 
     #[test]
@@ -1683,8 +1792,9 @@ mod tests {
         assert!(!unmeasured.measured);
         assert!(unmeasured.errors.is_empty(), "a scan with no failures mirrors none");
         assert!(unmeasured.report_order.is_none(), "a scan that rendered nothing carries no order");
-        // The three fields that describe the scan rather than the disc are set
-        // aside; everything the disc itself has must match.
+        // The fields that describe the scan rather than the disc are set aside
+        // (`shortStreamNotices` is derived and already `None` on both sides —
+        // nothing here is short); everything the disc itself has must match.
         assert_eq!(
             Disc { measured: true, report_order: a_disc().report_order, ..unmeasured },
             Disc { errors: Vec::new(), ..a_disc() }
@@ -1842,6 +1952,7 @@ mod tests {
         assert_eq!(disc.volume_label, "WASMDISC");
         assert_eq!(disc.size_bytes, 11_146_324);
         assert!(disc.errors.is_empty(), "the fixture is healthy media");
+        assert!(disc.short_stream_notices.is_none(), "healthy media measures its declared span");
 
         let playlist = disc.playlists.first().expect("the fixture has one playlist");
         assert_eq!(names(&disc), ["00000.MPLS"]);

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -171,6 +171,15 @@ recordings reach `disc.errors` and the report `WARNING:` block like any other
 read failure — a damaged span shows up as depressed rates rather than as a
 truncated file, and `keepPartial` does not apply to it.
 
+A stream file whose bytes simply **stop** before the span the disc declares is
+different again: it reads to a clean end of file, so nothing lands in
+`disc.errors`, the report carries no `WARNING:` line, and every value measured
+from it is silently smaller than the disc says. A `scan` names such files in
+`disc.shortStreamNotices` — one sentence per short file, worded exactly as the
+`bdinfo-rs` CLI's stderr notices and the desktop app's banner; the field is
+absent when nothing is short. The report bytes never change for it: raise the
+notices beside the report, the way the demo shows them above it.
+
 ### Saving the report
 
 `reportFileName` gives the name a report is saved under — `BDINFO.<label>.txt`,

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -34,6 +34,7 @@
         --accent-strong: #2aa8f0;
         --accent-dim: rgba(76, 194, 255, 0.12);
         --danger: #ff6b6b;
+        --warn: #f7b955;
         --ok: #46d18a;
         --radius: 12px;
         --mono: ui-monospace, "Cascadia Code", "JetBrains Mono", "SF Mono", Consolas, monospace;
@@ -643,6 +644,28 @@
       .error svg {
         color: var(--danger);
       }
+      /* The error strip's warning-tinted sibling — same shape, amber. */
+      .warning {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+        padding: 0.8rem 1rem;
+        margin-bottom: 0.9rem;
+        font-size: 0.88rem;
+        color: #ffe6bd;
+        background: rgba(247, 185, 85, 0.08);
+        border: 1px solid rgba(247, 185, 85, 0.35);
+        border-radius: 10px;
+      }
+      .warning svg {
+        flex-shrink: 0;
+        color: var(--warn);
+      }
+      .warning ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
 
       /* ── footer ──────────────────────────────────────────────── */
       .footer {
@@ -872,6 +895,17 @@
                 Download
               </button>
             </div>
+          </div>
+          <!-- Stream files the scan measured shorter than the disc declares:
+               such a file reads to a clean end of file, so this strip is the
+               only place the loss shows (the report bytes never change). -->
+          <div id="short-streams" class="warning" hidden>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+              <line x1="12" x2="12" y1="9" y2="13" />
+              <line x1="12" x2="12.01" y1="17" y2="17" />
+            </svg>
+            <ul id="short-streams-list"></ul>
           </div>
           <pre class="report" id="report"></pre>
         </section>

--- a/crates/bdinfo-rs-wasm/web/src/analyze.ts
+++ b/crates/bdinfo-rs-wasm/web/src/analyze.ts
@@ -336,6 +336,11 @@ export function inspect(source: DiscSource, options?: ScanOptions): Promise<Disc
  * `result.disc` and {@link renderReport} re-renders the report from it with
  * other sections, without reading the disc again.
  *
+ * {@link Disc.shortStreamNotices} names any stream file measured shorter than
+ * the disc declares. Such a file reads to a clean end of file — no entry in
+ * `disc.errors`, no report `WARNING:` line — so the field is the scan's only
+ * trace of the loss; show it beside the report.
+ *
  * Everything runs locally: no bytes leave the page.
  */
 export function scan(

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -113,6 +113,8 @@ const copyLabel = el("copy-label");
 const downloadBtn = el<HTMLButtonElement>("download-btn");
 const errorBox = el("error");
 const errorText = el("error-text");
+const shortStreams = el("short-streams");
+const shortStreamsList = el("short-streams-list");
 const mainEl = el("main");
 const listingBox = el("listing");
 const settingsBtn = el<HTMLButtonElement>("settings-btn");
@@ -411,6 +413,17 @@ function adoptDisc(next: Disc, threshold: number): void {
   playlists = next.playlists;
   allRows = playlistRows(next.playlists);
   encryptedNote.hidden = !next.isAacsEncrypted;
+  // Only a measured scan can carry short-stream notices, so a re-inspected
+  // (structural) disc clears the strip along with everything else measured.
+  const notices = next.shortStreamNotices ?? [];
+  shortStreamsList.replaceChildren(
+    ...notices.map((notice) => {
+      const item = document.createElement("li");
+      item.textContent = notice;
+      return item;
+    }),
+  );
+  shortStreams.hidden = notices.length === 0;
   renderRows();
 }
 

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -270,6 +270,8 @@ async function main() {
     // The playlists the scan printed travel with the model, which is what makes
     // the re-render reproduce THIS report rather than the whole disc.
     JSON.stringify(full.disc.reportOrder) === JSON.stringify(["00000.MPLS"]) &&
+    // Healthy media measures its declared span, so the scan notices nothing.
+    full.disc.shortStreamNotices === undefined &&
     reRendered.equals(golden) &&
     !noDiagnostics.includes("STREAM DIAGNOSTICS:") &&
     noDiagnostics.includes("QUICK SUMMARY:") &&
@@ -292,6 +294,39 @@ async function main() {
   if (!fullOk) {
     console.error(
       `FAIL — scan_files/render_report round trip: report ${full.report.length} B, re-rendered ${reRendered.length} B, golden ${golden.length} B, measured ${full.disc.measured}.`,
+    );
+  }
+
+  // A truncated stream file. Cutting the clip's bytes reads to a clean end of
+  // file: no error is recorded and the report carries no WARNING block — the
+  // scan's only trace of the loss is `disc.shortStreamNotices`, one sentence
+  // per short file in the wording the CLI prints on stderr (the clip declares
+  // 30.1 s; the measured seconds depend on where the cut lands, so the notice
+  // is shape-checked rather than byte-pinned).
+  const truncFiles = await Promise.all(
+    LAYOUT.map(async (item) => {
+      const bytes =
+        item.file === null ? new Uint8Array(0) : new Uint8Array(await readFile(item.file));
+      const name = item.path.split("/").pop();
+      return new ShimFile(
+        item.path.endsWith("00000.m2ts") ? bytes.slice(0, 3_000_000) : bytes,
+        name,
+      );
+    }),
+  );
+  const truncated = scan_files(paths, truncFiles, []);
+  const notices = truncated.disc.shortStreamNotices;
+  const truncatedOk =
+    truncated.disc.errors.length === 0 &&
+    !truncated.report.includes("WARNING") &&
+    Array.isArray(notices) &&
+    notices.length === 1 &&
+    /^00000\.M2TS is shorter than declared: measured \d+\.\d s of 30\.1 s \(\d+\.\d s missing\)$/.test(
+      notices[0],
+    );
+  if (!truncatedOk) {
+    console.error(
+      `FAIL — truncated-clip scan unexpected: errors ${truncated.disc.errors.length}, notices ${JSON.stringify(notices)}.`,
     );
   }
 
@@ -369,13 +404,14 @@ async function main() {
     fileNameOk &&
     fullOk &&
     keepPartialOk &&
+    truncatedOk &&
     isoOk &&
     isoSelOk &&
     isoInspectOk &&
     isoFullOk
   ) {
     console.log(
-      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + rejection + codecs + size vectors + file name + selection + round trip + retention + .iso OK.`,
+      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + rejection + codecs + size vectors + file name + selection + round trip + retention + short-stream notices + .iso OK.`,
     );
     process.exit(0);
   }

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -34,7 +34,10 @@
 //! the readable rest is still reported (the failures land in the report's
 //! WARNING block and are summarized on stderr), and the live scan progress
 //! draws on stderr; the flow narration (table, picker, analysis preamble,
-//! classic epilogue, saved-report message) prints on stdout.
+//! classic epilogue, saved-report message) prints on stdout. A stream file
+//! measured shorter than the disc declares (a truncated file reads to a clean
+//! end of file, so it records no error) gets a stderr notice after the report
+//! is saved; the report bytes and the exit code are unchanged by it.
 //!
 //! `-h`/`--help` and a bare invocation all print the same one-screen help
 //! card, headed by a banner, a colour chip or a plain line depending on what
@@ -86,6 +89,7 @@ use bdinfo_rs_core::bdrom::order::{
     selection_stream_files, table_rows,
 };
 use bdinfo_rs_core::bdrom::progress::{hms, progress_stats};
+use bdinfo_rs_core::bdrom::shortfall::ShortStreamFile;
 use bdinfo_rs_core::error::{BdError, ScanError};
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 use bdinfo_rs_core::{report, scan};
@@ -218,6 +222,36 @@ fn report_errors(errors: &[ScanError]) {
     eprintln!("warning: scan completed with {} error(s):", errors.len());
     for err in errors {
         eprintln!("warning:   {err}");
+    }
+}
+
+/// The notice for one stream file the demux measured shorter than the disc
+/// declares — raised beside the report, because the locked report format has no
+/// line for it ([`bdinfo_rs_core::bdrom::shortfall`]).
+///
+/// The wording is shared with the other surfaces' copies of this format
+/// (`bdinfo-rs-gui`'s `flow::short_stream_notice`, `bdinfo-rs-wasm`'s
+/// `mirror::short_stream_notice`); each copy is pinned by an identical test, so
+/// a change here reworks all three together or fails a sibling gate.
+fn short_stream_notice(short: &ShortStreamFile) -> String {
+    format!(
+        "{} is shorter than declared: measured {:.1} s of {:.1} s ({:.1} s missing)",
+        short.file(),
+        short.measured_seconds(),
+        short.declared_seconds(),
+        short.missing_seconds()
+    )
+}
+
+/// Prints the short-stream notices on stderr, one line per affected file —
+/// nothing for a disc with none.
+///
+/// Notices are advisory: unlike [`report_errors`] they carry no exit code,
+/// because the scan itself completed cleanly (a truncated file reads to a
+/// clean end of file).
+fn report_short_streams(bdrom: &BdRom) {
+    for short in bdrom.short_stream_files() {
+        eprintln!("warning: {}", short_stream_notice(&short));
     }
 }
 
@@ -376,6 +410,7 @@ fn scan_and_report(
                 return code;
             }
             println!("Report saved to: {}", dest.display());
+            report_short_streams(&bdrom);
             finish_early(&errors)
         }
         Err(BdError::ScanCancelled) => {
@@ -1024,10 +1059,14 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::time::{Duration, Instant};
 
-    use bdinfo_rs_core::bdrom::disc::{PlaylistSummary, ScanProgress, fixtures};
+    use bdinfo_rs_core::bdrom::disc::{
+        BdRom, ClipStreamTally, PlaylistSummary, ScanProgress, fixtures,
+    };
     use bdinfo_rs_core::bdrom::order::{PlaylistFilter, table_rows};
     use bdinfo_rs_core::error::{BdError, ScanError, ScanStage};
+    use bdinfo_rs_core::primitives::Pid;
     use bdinfo_rs_core::report::text::RenderOptions;
+    use bdinfo_rs_core::stream::TsStreamType;
     use clap::Parser;
     use clap::error::ErrorKind;
 
@@ -2056,6 +2095,65 @@ Options:
             reason: BdError::StructureNotFound,
         }];
         assert_eq!(finish_early(&errors), 3);
+    }
+
+    /// A scanned disc whose one stream file was demuxed to 500 of its declared
+    /// 1640 seconds — past both shortfall thresholds — with the per-stream
+    /// tally that marks the file as measured.
+    fn short_disc() -> BdRom {
+        let clip = bdinfo_rs_core::bdrom::disc::ClipSummary {
+            packet_seconds: 500.0,
+            streams: vec![ClipStreamTally {
+                pid: Pid::new(0x1011),
+                stream_type: TsStreamType::AvcVideo,
+                codec_short_name: "AVC".to_owned(),
+                payload_bytes: 1024,
+                packet_count: 8,
+            }],
+            ..fixtures::clip("00011.M2TS", 1640.0)
+        };
+        BdRom {
+            volume_label: "DISC".to_owned(),
+            disc_title: None,
+            size: 0,
+            interleaved_size: 0,
+            is_3d: false,
+            is_50hz: false,
+            is_uhd: false,
+            is_aacs_encrypted: false,
+            is_bd_plus: false,
+            is_bd_java: false,
+            is_dbox: false,
+            is_psp: false,
+            playlists: vec![fixtures::playlist("00000.MPLS", 1640.0, vec![clip])],
+        }
+    }
+
+    #[test]
+    fn the_short_stream_notice_spells_the_shared_wording() {
+        // The exact sentence, pinned: the GUI and wasm crates carry the same
+        // format and pin the same bytes, which is what keeps the three
+        // surfaces' wording identical.
+        let shorts = short_disc().short_stream_files();
+        let short = shorts.first().expect("the truncated file is reported");
+        assert_eq!(
+            super::short_stream_notice(short),
+            "00011.M2TS is shorter than declared: measured 500.0 s of 1640.0 s (1140.0 s missing)"
+        );
+    }
+
+    #[test]
+    fn a_clean_scan_with_a_short_stream_file_still_exits_0() {
+        // The notice is advisory: the scan recorded no error, so the report is
+        // written and the exit code stays the clean 0.
+        let dest = TempDest::new();
+        let code = super::scan_and_report(
+            &mut |_, _| Ok((short_disc(), Vec::new())),
+            &dest.root,
+            &["00000.MPLS".to_owned()],
+            RenderOptions::default(),
+        );
+        assert_eq!(code, 0);
     }
 
     #[test]

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -976,6 +976,60 @@ fn the_multi_playlist_disc_lists_three_playlists_and_scans_them_clean() {
 }
 
 #[test]
+fn a_truncated_stream_file_scans_clean_and_raises_the_stderr_notice() {
+    // A copy of the disc with its shared clip cut to 500 of its declared
+    // 1640 seconds (the fixture's cadence is exactly 3840 bytes per clip
+    // second). Truncation reads to a clean end of file — no io error, no
+    // WARNING block, exit 0 — so the stderr notice is the only place the
+    // loss shows.
+    fn copy_tree(from: &Path, to: &Path) {
+        std::fs::create_dir_all(to).expect("create copy dir");
+        for entry in std::fs::read_dir(from).expect("list fixture") {
+            let entry = entry.expect("fixture entry");
+            let target = to.join(entry.file_name());
+            if entry.file_type().expect("entry type").is_dir() {
+                copy_tree(&entry.path(), &target);
+            } else {
+                std::fs::copy(entry.path(), &target).expect("copy fixture file");
+            }
+        }
+    }
+    let parent = std::env::temp_dir().join(format!("bdinfo-rs-short-{}", std::process::id()));
+    let root = parent.join("MultiPlaylist");
+    copy_tree(&real_fixture("MultiPlaylist"), &root);
+    let clip = root.join("BDMV").join("STREAM").join("00011.M2TS");
+    let bytes = std::fs::read(&clip).expect("read the stream file");
+    // 1,920,000 bytes = 500 clip seconds at the fixture's 3840 bytes/second.
+    let kept = bytes.get(..1_920_000).expect("the clip is 6,297,600 bytes");
+    std::fs::write(&clip, kept).expect("truncate the stream file");
+
+    let output =
+        bdinfo_rs().args([root.as_os_str(), "-w".as_ref()]).output().expect("spawn bdinfo-rs");
+    let report =
+        std::fs::read_to_string(root.join("BDINFO.MultiPlaylist.txt")).expect("read the report");
+    let _ = std::fs::remove_dir_all(&parent).is_ok();
+
+    // Clean exit: the truncation records no scan error.
+    assert_eq!(output.status.code(), Some(0), "{}", String::from_utf8_lossy(&output.stderr));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning: 00011.M2TS is shorter than declared: measured "),
+        "the notice names the truncated file: {stderr}"
+    );
+    assert!(stderr.contains(" of 1640.0 s ("), "the notice carries the declared span: {stderr}");
+    // One entry per file: two playlists play the truncated clip, one notice.
+    assert_eq!(
+        stderr.matches("is shorter than declared").count(),
+        1,
+        "one notice per affected file: {stderr}"
+    );
+    // The report itself is untouched by the feature: no WARNING block (nothing
+    // errored) and no notice wording (the locked format has no line for it).
+    assert!(!report.contains("WARNING"), "a clean scan reports no warnings: {report}");
+    assert!(!report.contains("shorter than declared"), "the notice never enters the report");
+}
+
+#[test]
 fn a_real_list_shows_the_filtered_table_without_writing_a_report() {
     let disc = real_fixture("BigBuckBunny");
     let output =

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -997,7 +997,10 @@ fn a_truncated_stream_file_scans_clean_and_raises_the_stderr_notice() {
     let parent = std::env::temp_dir().join(format!("bdinfo-rs-short-{}", std::process::id()));
     let root = parent.join("MultiPlaylist");
     copy_tree(&real_fixture("MultiPlaylist"), &root);
-    let clip = root.join("BDMV").join("STREAM").join("00011.M2TS");
+    // The committed file name is lower-case; only the report and the notice
+    // upper-case it. A case-insensitive filesystem forgives a wrong case here,
+    // Linux does not.
+    let clip = root.join("BDMV").join("STREAM").join("00011.m2ts");
     let bytes = std::fs::read(&clip).expect("read the stream file");
     // 1,920,000 bytes = 500 clip seconds at the fixture's 3840 bytes/second.
     let kept = bytes.get(..1_920_000).expect("the clip is 6,297,600 bytes");


### PR DESCRIPTION
A stream file whose bytes stop before the span the disc declares reads to a clean end of file: nothing is recorded, the report carries no WARNING block, and every value measured from the file is silently smaller than the disc says. The locked report format has no line for this, so the loss is raised in the surface chrome instead, one shared sentence per affected file, building on the detection landed with BdRom::short_stream_files.

- CLI: warning lines on stderr after the report is saved; stdout and exit codes unchanged.
- GUI: warning-tinted banners beside the structural-warning banners, derived from the retained measured disc so a later scan cannot leave a stale notice.
- Web: an additive optional Disc.shortStreamNotices field on the wasm mirror (absent when nothing is short, dropped on rebuild), rendered by the demo as a warning strip above the report.

The wording is defined once per crate and pinned byte-identical by a test in each, so a reword moves all three surfaces together. End-to-end: a truncated copy of the MultiPlaylist fixture scans clean (exit 0), raises exactly one stderr notice, and leaves the report bytes free of any new wording; the Node parity harness pins the same shape through the wasm exports.

Fixes #322