### PR TITLE
feat(gui): tick measured sizes and bitrates in the grids during a scan

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -270,8 +270,7 @@ Not carried over:
   per-frame measurements; bdinfo-rs keeps only the aggregate statistics the report prints, so
   there is nothing to plot. The chart-tied image-prefix setting is absent with them.
 - **Custom playlist builder.** Playlists are selected from the disc's own table, not assembled.
-- **Taskbar progress and live in-grid numbers.** Progress is shown in the window, not painted into
-  the taskbar button or streamed into the playlist grid mid-scan.
+- **Taskbar progress.** Progress is shown in the window, not painted into the taskbar button.
 - **The `KeepStreamOrder`, `EnableSSIF`, and `ExtendedStreamDiagnostics` toggles.**
 - **Selectable report text.** The text widgets in use cannot span-select; *Copy report* and
   *Save report…* cover the same need.

--- a/crates/bdinfo-rs-core/src/scan.rs
+++ b/crates/bdinfo-rs-core/src/scan.rs
@@ -55,10 +55,12 @@ pub fn open_folder(
     open_folder_observed(path, mode, options, scan_files, ScanObservers::new(progress, cancel))
 }
 
-/// Opens the Blu-ray folder at `path` like [`open_folder`], taking its progress
-/// callback and cancel flag as a [`ScanObservers`] bundle — the form that can
-/// carry a measured observer too ([`ScanObservers::with_measured`]), so a
-/// path-driven surface can watch the tallies build up during the scan.
+/// Opens the Blu-ray folder at `path` like [`open_folder`], observed.
+///
+/// Takes the progress callback and cancel flag as a [`ScanObservers`] bundle —
+/// the form that can carry a measured observer too
+/// ([`ScanObservers::with_measured`]), so a path-driven surface can watch the
+/// tallies build up during the scan.
 ///
 /// # Errors
 /// As [`open_folder`].
@@ -103,9 +105,10 @@ pub fn open_iso(
     open_iso_observed(path, mode, options, scan_files, ScanObservers::new(progress, cancel))
 }
 
-/// Opens the Blu-ray `.iso` image at `path` like [`open_iso`], taking its
-/// progress callback and cancel flag as a [`ScanObservers`] bundle — the `.iso`
-/// twin of [`open_folder_observed`].
+/// Opens the Blu-ray `.iso` image at `path` like [`open_iso`], observed.
+///
+/// Takes the progress callback and cancel flag as a [`ScanObservers`] bundle —
+/// the `.iso` twin of [`open_folder_observed`].
 ///
 /// # Errors
 /// As [`open_iso`].

--- a/crates/bdinfo-rs-core/src/scan.rs
+++ b/crates/bdinfo-rs-core/src/scan.rs
@@ -3,10 +3,12 @@
 //! [`BdRom::open_resilient_with`] reads through the [`crate::vfs`] seam and
 //! knows nothing about paths. A caller holding one must pick the backend, open
 //! it, and merge that backend's own recorded failures into the scan's — and for
-//! a folder repair the label the scan derived. These two functions are that
-//! composition, so every path-driven surface shares one implementation of it.
+//! a folder repair the label the scan derived. These functions are that
+//! composition, so every path-driven surface shares one implementation of it —
+//! one pair per backend: the plain form and an `_observed` one for a caller that
+//! also watches the measured tallies build up.
 //! A browser caller has no paths and builds its [`BdDir`](crate::vfs::BdDir)
-//! itself, so it uses neither.
+//! itself, so it uses none of them.
 //!
 //! How deep to read stays the caller's choice: `mode` is passed through
 //! untouched.
@@ -15,7 +17,7 @@ use std::collections::BTreeSet;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
-use crate::bdrom::disc::{BdRom, ScanMode, ScanOptions, ScanProgress, ScanReport};
+use crate::bdrom::disc::{BdRom, ScanMode, ScanObservers, ScanOptions, ScanProgress, ScanReport};
 use crate::error::BdError;
 use crate::vfs::fs::FsDir;
 use crate::vfs::udf::source::{PathIso, UdfSource};
@@ -50,9 +52,25 @@ pub fn open_folder(
     progress: &mut dyn FnMut(ScanProgress<'_>),
     cancel: &AtomicBool,
 ) -> Result<ScanReport, BdError> {
+    open_folder_observed(path, mode, options, scan_files, ScanObservers::new(progress, cancel))
+}
+
+/// Opens the Blu-ray folder at `path` like [`open_folder`], taking its progress
+/// callback and cancel flag as a [`ScanObservers`] bundle — the form that can
+/// carry a measured observer too ([`ScanObservers::with_measured`]), so a
+/// path-driven surface can watch the tallies build up during the scan.
+///
+/// # Errors
+/// As [`open_folder`].
+pub fn open_folder_observed(
+    path: &Path,
+    mode: ScanMode,
+    options: ScanOptions,
+    scan_files: Option<&BTreeSet<String>>,
+    observers: ScanObservers<'_>,
+) -> Result<ScanReport, BdError> {
     let root = FsDir::new(path);
-    let mut report =
-        BdRom::open_resilient_with(&root, mode, options, scan_files, progress, cancel)?;
+    let mut report = BdRom::open_resilient_observed(&root, mode, options, scan_files, observers)?;
     report.errors.extend(root.take_errors());
     report.bdrom.volume_label =
         volume::resolve_folder_label_after_scan(&report.bdrom.volume_label, &report.errors);
@@ -82,9 +100,25 @@ pub fn open_iso(
     progress: &mut dyn FnMut(ScanProgress<'_>),
     cancel: &AtomicBool,
 ) -> Result<ScanReport, BdError> {
+    open_iso_observed(path, mode, options, scan_files, ScanObservers::new(progress, cancel))
+}
+
+/// Opens the Blu-ray `.iso` image at `path` like [`open_iso`], taking its
+/// progress callback and cancel flag as a [`ScanObservers`] bundle — the `.iso`
+/// twin of [`open_folder_observed`].
+///
+/// # Errors
+/// As [`open_iso`].
+pub fn open_iso_observed(
+    path: &Path,
+    mode: ScanMode,
+    options: ScanOptions,
+    scan_files: Option<&BTreeSet<String>>,
+    observers: ScanObservers<'_>,
+) -> Result<ScanReport, BdError> {
     let source = UdfSource::open_resilient(Box::new(PathIso::new(path)))?;
     let mut report =
-        BdRom::open_resilient_with(&source.root(), mode, options, scan_files, progress, cancel)?;
+        BdRom::open_resilient_observed(&source.root(), mode, options, scan_files, observers)?;
     report.errors.extend(source.take_errors());
     Ok(report)
 }
@@ -94,7 +128,11 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
-    use super::{BdError, ScanMode, ScanOptions, ScanReport, open_folder, open_iso};
+    use super::{
+        BdError, ScanMode, ScanObservers, ScanOptions, ScanProgress, ScanReport, open_folder,
+        open_folder_observed, open_iso, open_iso_observed,
+    };
+    use crate::bdrom::measured::MeasuredSnapshot;
 
     /// The committed real-disc fixtures, one crate over: `BigBuckBunny` (a BDMV
     /// folder) and `BigBuckBunny.iso` (the same disc as a UDF image, whose UDF
@@ -157,6 +195,64 @@ mod tests {
         );
         assert_eq!(reported != 0, report.is_ok() && mode != ScanMode::Metadata);
         report
+    }
+
+    /// Asserts that the last snapshot an observed open delivered carries the
+    /// very numbers the finished scan reports: same stream file, same playlist,
+    /// same measured bytes. A display that ticks the snapshots and then takes
+    /// the summaries therefore never jumps at the handover.
+    fn assert_the_live_tallies_land_on_the_summaries(
+        report: &ScanReport,
+        snapshots: &[MeasuredSnapshot],
+    ) {
+        let playlist = report.bdrom.playlists.first().expect("the fixture lists one playlist");
+        let last = snapshots.last().expect("the measurement pass reported");
+        assert_eq!(last.file, "00000.M2TS", "the fixture's one stream file");
+        let measured = last.playlists.first().expect("the playlist plays that file");
+        assert_eq!(measured.name, playlist.name);
+        assert_eq!(measured.measured_bytes, playlist.total_angle_packet_size());
+    }
+
+    #[test]
+    fn an_observed_folder_open_streams_the_measured_tallies() {
+        // The bundle form is what a live display opens through — the same scan
+        // as `open_folder`, plus the snapshots.
+        let mut snapshots: Vec<MeasuredSnapshot> = Vec::new();
+        let cancel = AtomicBool::new(false);
+        let mut quiet = |_: ScanProgress<'_>| {};
+        let report = {
+            let mut watch = |snapshot| snapshots.push(snapshot);
+            open_folder_observed(
+                &fixture("BigBuckBunny"),
+                ScanMode::Full,
+                ScanOptions::default(),
+                None,
+                ScanObservers::new(&mut quiet, &cancel).with_measured(&mut watch),
+            )
+        }
+        .expect("the fixture folder opens");
+        assert_eq!(report.bdrom.volume_label, "BigBuckBunny", "the label repair still runs");
+        assert_the_live_tallies_land_on_the_summaries(&report, &snapshots);
+    }
+
+    #[test]
+    fn an_observed_iso_open_streams_the_measured_tallies() {
+        let mut snapshots: Vec<MeasuredSnapshot> = Vec::new();
+        let cancel = AtomicBool::new(false);
+        let mut quiet = |_: ScanProgress<'_>| {};
+        let report = {
+            let mut watch = |snapshot| snapshots.push(snapshot);
+            open_iso_observed(
+                &fixture("BigBuckBunny.iso"),
+                ScanMode::Full,
+                ScanOptions::default(),
+                None,
+                ScanObservers::new(&mut quiet, &cancel).with_measured(&mut watch),
+            )
+        }
+        .expect("the fixture image opens");
+        assert_eq!(report.bdrom.volume_label, "Blu-Ray", "the UDF volume label still reads");
+        assert_the_live_tallies_land_on_the_summaries(&report, &snapshots);
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -16,7 +16,7 @@
 //! late message can drive the UI into an inconsistent state. That invariant is
 //! proptested.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -26,6 +26,7 @@ use bdinfo_rs_core::bdrom::shortfall::ShortStreamFile;
 use bdinfo_rs_core::error::ScanError;
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 
+use crate::live::LivePlaylist;
 use crate::model::{
     self, HiddenPlaylists, PlaylistRow, SelectableRow, Sort, SortColumn, ViewSettings,
 };
@@ -407,6 +408,14 @@ enum Inner {
         /// every applied progress event. The status line then reads "still
         /// reading" instead of implying normal progress.
         stalled: bool,
+        /// The measured cells the scan has reported so far, by playlist name —
+        /// what the table's `Measured Bytes` column and the two panes show
+        /// while the scan runs ([`crate::live`]). Merged per playlist by
+        /// [`Flow::measured`] and read only here: the rows, their order and the
+        /// retained report never see it, and the finished scan's summaries
+        /// replace it rather than adding to it. Empty until the first snapshot,
+        /// so an unreported playlist keeps showing the summaries' zeros.
+        live: BTreeMap<String, LivePlaylist>,
     },
     Reported {
         listing: Listing,
@@ -593,6 +602,7 @@ impl Flow {
                         progress: None,
                         scanned,
                         stalled: false,
+                        live: BTreeMap::new(),
                     },
                 }
             }
@@ -619,6 +629,26 @@ impl Flow {
         {
             *progress = Some(ProgressModel::compute(file, done, total, elapsed));
             *stalled = false;
+        }
+    }
+
+    /// Records the measured cells a scan in flight has reported — one entry per
+    /// playlist the snapshot covered ([`crate::live::updates`]). Applied only
+    /// while scanning **and** when `generation` matches the in-flight scan, like
+    /// [`Flow::progress`].
+    ///
+    /// **Cells only.** Each entry replaces that playlist's previous one and
+    /// nothing else moves: the row set, the sort order, the checked set, the
+    /// active row and the retained report are all untouched, so the table the
+    /// user is watching cannot reorder or rebuild under a running scan. A
+    /// playlist no snapshot has covered yet keeps showing the (zero) summary
+    /// values, and the scan's completion ([`Flow::finished`]) replaces every
+    /// cell with the measured summaries.
+    pub fn measured(&mut self, generation: u64, playlists: Vec<(String, LivePlaylist)>) {
+        if let Inner::Scanning { generation: active, live, .. } = &mut self.inner
+            && *active == generation
+        {
+            live.extend(playlists);
         }
     }
 
@@ -818,24 +848,31 @@ impl Flow {
     }
 
     /// The "Stream Files" pane rows for the active playlist (empty when none),
-    /// their size cells rendered under the human-readable toggle.
+    /// their size cells rendered under the human-readable toggle — and, while a
+    /// scan is reporting that playlist, its measured sizes as of the last
+    /// snapshot.
     #[must_use]
     pub fn stream_file_rows(&self) -> Vec<StreamFileRow> {
         self.any_listing()
             .and_then(|listing| {
                 listing.active_playlist().map(|playlist| {
-                    panes::stream_file_rows(playlist, listing.view.human_readable_sizes)
+                    panes::stream_file_rows(
+                        playlist,
+                        listing.view.human_readable_sizes,
+                        self.live_playlist(&playlist.name),
+                    )
                 })
             })
             .unwrap_or_default()
     }
 
-    /// The "Streams" (codec) pane rows for the active playlist (empty when none).
+    /// The "Streams" (codec) pane rows for the active playlist (empty when
+    /// none), their rates ticking with the scan like the sizes above.
     #[must_use]
     pub fn codec_rows(&self) -> Vec<CodecRow> {
         self.any_listing()
             .and_then(Listing::active_playlist)
-            .map(panes::codec_rows)
+            .map(|playlist| panes::codec_rows(playlist, self.live_playlist(&playlist.name)))
             .unwrap_or_default()
     }
 
@@ -862,18 +899,29 @@ impl Flow {
     }
 
     /// The selectable table rows (empty unless a disc is loaded).
+    ///
+    /// A row whose playlist a scan in flight has reported shows that scan's
+    /// running `Measured Bytes` count in place of the summary's; every other
+    /// cell, and the row order, is the same one a settled table renders.
     #[must_use]
     pub fn table(&self) -> Vec<SelectableRow> {
         let Some(listing) = self.any_listing() else { return Vec::new() };
         model::display_rows(&listing.rows, listing.view)
             .into_iter()
             .enumerate()
-            .map(|(index, cells)| SelectableRow {
-                index,
-                selected: listing.selection.is_checked(index),
-                active: index == listing.active,
-                has_hidden: listing.rows.get(index).is_some_and(|row| row.has_hidden_streams),
-                cells,
+            .map(|(index, mut cells)| {
+                let row = listing.rows.get(index);
+                if let Some(live) = row.and_then(|row| self.live_playlist(&row.name)) {
+                    cells.measured_bytes =
+                        model::byte_cell(live.measured_bytes, listing.view.human_readable_sizes);
+                }
+                SelectableRow {
+                    index,
+                    selected: listing.selection.is_checked(index),
+                    active: index == listing.active,
+                    has_hidden: row.is_some_and(|row| row.has_hidden_streams),
+                    cells,
+                }
             })
             .collect()
     }
@@ -1050,6 +1098,17 @@ impl Flow {
         }
     }
 
+    /// The named playlist's cells as the in-flight scan last reported them, or
+    /// `None` outside a scan and for a playlist no snapshot has covered yet.
+    /// Only [`Stage::Scanning`] answers: a settled table's numbers come from
+    /// the summaries themselves.
+    fn live_playlist(&self, name: &str) -> Option<&LivePlaylist> {
+        match &self.inner {
+            Inner::Scanning { live, .. } => live.get(name),
+            _ => None,
+        }
+    }
+
     /// The listing behind an **editable** state (Listed / Reported) — the
     /// read side of [`editable_listing_mut`](Self::editable_listing_mut).
     const fn editable_listing(&self) -> Option<&Listing> {
@@ -1074,11 +1133,51 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, fixtures};
+    use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, StreamSummary, fixtures};
+    use bdinfo_rs_core::primitives::Pid;
+    use bdinfo_rs_core::stream::TsStreamType;
 
     use super::{Flow, Stage};
+    use crate::live::{LivePlaylist, LiveStream};
     use crate::model::{Sort, SortColumn, ViewSettings};
     use crate::scan::{Input, Structural};
+
+    /// A presented video stream on camera angle `angle_index`, unmeasured — the
+    /// fields the Streams pane reads, and the `(pid, angle_index)` pair a live
+    /// rate is keyed on.
+    fn stream_summary(pid: Pid, angle_index: usize) -> StreamSummary {
+        StreamSummary {
+            pid,
+            stream_type: TsStreamType::default(),
+            codec_short_name: String::new(),
+            codec_name: "MPEG-4 AVC Video".to_owned(),
+            codec_alt_name: "",
+            bitrate: 0,
+            active_bitrate: 0,
+            language_name: String::new(),
+            language_code: String::new(),
+            description: String::new(),
+            full_description: "1080p / 23.976 fps / 16:9".to_owned(),
+            channel_description: String::new(),
+            sample_rate: 0,
+            bit_depth: 0,
+            channel_count: 0,
+            height: 0,
+            angle_index,
+            is_hidden: false,
+            ssif_only: false,
+        }
+    }
+
+    /// The Stream Files pane's `Measured Size` cells, in row order.
+    fn pane_sizes(flow: &Flow) -> Vec<String> {
+        flow.stream_file_rows().into_iter().map(|row| row.measured).collect()
+    }
+
+    /// The Streams pane's `Bit Rate` cells, in row order.
+    fn pane_rates(flow: &Flow) -> Vec<String> {
+        flow.codec_rows().into_iter().map(|row| row.bitrate).collect()
+    }
 
     fn playlist(name: &str, length: f64, clips: &[&str]) -> PlaylistSummary {
         playlist_sized(name, length, 1000, clips)
@@ -1737,6 +1836,130 @@ mod tests {
         assert_eq!(sizes, ["192,000"]);
     }
 
+    /// The live cells one snapshot carries for a playlist: its total, its
+    /// per-clip counts, and one presented stream's rate on the main angle.
+    fn live_cells(
+        name: &str,
+        measured_bytes: u64,
+        clips: &[u64],
+        bitrate: i64,
+    ) -> (String, LivePlaylist) {
+        (
+            name.to_owned(),
+            LivePlaylist {
+                measured_bytes,
+                clips: clips.to_vec(),
+                streams: vec![LiveStream { pid: Pid::new(0x1011), angle_index: 0, bitrate }],
+            },
+        )
+    }
+
+    /// The table's `Measured Bytes` cells, in row order.
+    fn measured_cells(flow: &Flow) -> Vec<String> {
+        flow.table().into_iter().map(|row| row.cells.measured_bytes).collect()
+    }
+
+    #[test]
+    fn a_measured_update_ticks_the_cells_and_moves_nothing_else() {
+        let mut flow = listed3();
+        flow.toggle(0);
+        flow.set_active(1);
+        let mut flow = flow.start_scanning(1);
+        let before = flow.report().expect("the pre-scan report").to_owned();
+        assert_eq!(measured_cells(&flow), ["0", "0", "0"], "nothing measured yet");
+
+        flow.measured(1, vec![live_cells("00001.MPLS", 960, &[960], 19_000)]);
+
+        // The reported playlist's cell ticks; the others hold their zeros.
+        assert_eq!(measured_cells(&flow), ["0", "960", "0"]);
+        // Everything else about the table is exactly as it was: the same rows
+        // in the same order, the same checked row, the same highlight, the same
+        // frozen state and the same retained report.
+        assert_eq!(row_names(&flow), ["00000.MPLS", "00001.MPLS", "00002.MPLS"]);
+        assert_eq!(flow.selected_count(), 1);
+        assert!(flow.table().first().is_some_and(|row| row.selected));
+        assert_eq!(flow.active_index(), Some(1));
+        assert_eq!(flow.stage(), Stage::Scanning);
+        assert!(!flow.editable());
+        assert_eq!(flow.report(), Some(before.as_str()), "the report is not regenerated");
+
+        // A later snapshot replaces that playlist's cell and still leaves the
+        // playlists it did not cover alone.
+        flow.measured(1, vec![live_cells("00001.MPLS", 1_920, &[1_920], 19_000)]);
+        assert_eq!(measured_cells(&flow), ["0", "1,920", "0"]);
+    }
+
+    #[test]
+    fn the_active_playlists_panes_tick_with_the_scan() {
+        // The active playlist plays two clips and presents one stream, so both
+        // panes have a cell to move.
+        let mut structural = structural();
+        let feature = structural.bdrom.playlists.first_mut().expect("the feature playlist");
+        feature.clips = fixtures::clips(&["A.M2TS", "B.M2TS"], 50.0);
+        feature.streams = vec![stream_summary(Pid::new(0x1011), 0)];
+        let flow =
+            Flow::start_listing(input()).listed(&input(), Ok(structural), ViewSettings::default());
+        let mut flow = flow.start_scanning(1);
+        assert_eq!(pane_sizes(&flow), ["-", "-"], "nothing demuxed yet");
+        assert_eq!(pane_rates(&flow), ["-"]);
+
+        flow.measured(1, vec![live_cells("00000.MPLS", 960, &[768, 192], 19_000)]);
+        assert_eq!(pane_sizes(&flow), ["768", "192"], "one cell per clip row, in clip order");
+        assert_eq!(pane_rates(&flow), ["19 kbps"]);
+
+        // A playlist the snapshot did not cover keeps showing its own (unread)
+        // tallies — the panes never borrow another playlist's numbers.
+        let mut other = listed();
+        other.set_active(1);
+        let mut other = other.start_scanning(1);
+        other.measured(1, vec![live_cells("00000.MPLS", 960, &[768, 192], 19_000)]);
+        assert_eq!(pane_sizes(&other), ["-"]);
+    }
+
+    #[test]
+    fn measured_cells_reach_only_the_scan_they_belong_to() {
+        // A snapshot from a superseded scan is dropped, like a stale progress
+        // event…
+        let mut flow = listed3().start_scanning(5);
+        flow.measured(4, vec![live_cells("00001.MPLS", 960, &[960], 19_000)]);
+        assert_eq!(measured_cells(&flow), ["0", "0", "0"], "stale cells ignored");
+        // …and so is one that arrives when no scan is running at all, in either
+        // stage that shows the table.
+        let mut listed = listed3();
+        listed.measured(5, vec![live_cells("00001.MPLS", 960, &[960], 19_000)]);
+        assert_eq!(measured_cells(&listed), ["0", "0", "0"]);
+        let mut reported = listed3().start_scanning(5).finished(
+            5,
+            "R".to_owned(),
+            Arc::new(Vec::new()),
+            structural3().bdrom.playlists,
+        );
+        reported.measured(5, vec![live_cells("00001.MPLS", 960, &[960], 19_000)]);
+        assert_eq!(measured_cells(&reported), ["0", "0", "0"]);
+    }
+
+    #[test]
+    fn the_scans_end_takes_the_live_cells_off_the_grids() {
+        // Finishing swaps in the measured summaries — the live cells are a
+        // display of the same numbers on their way there, never an addition to
+        // them.
+        let mut flow = listed().start_scanning(1);
+        flow.measured(1, vec![live_cells("00000.MPLS", 960, &[960], 19_000)]);
+        assert_eq!(measured_cells(&flow), ["960", "0"]);
+        let mut measured = structural().bdrom.playlists;
+        measured
+            .first_mut()
+            .and_then(|playlist| playlist.clips.first_mut())
+            .expect("the first clip")
+            .packet_count = 1000; // 1000 * 192 = 192,000 bytes
+        let done = flow.clone().finished(1, "R".to_owned(), Arc::new(Vec::new()), measured);
+        assert_eq!(measured_cells(&done), ["192,000", "0"]);
+        // Cancelling ends the scan without measured summaries to show, so the
+        // table returns to the pre-scan zeros rather than keeping the numbers
+        // of a scan that never completed.
+        assert_eq!(measured_cells(&flow.cancel()), ["0", "0"]);
+    }
+
     #[test]
     fn a_stale_generation_never_advances_the_state() {
         let mut flow = listed();
@@ -1862,37 +2085,13 @@ mod tests {
 
     #[test]
     fn warnings_hidden_streams_and_codec_rows_surface_through_the_flow() {
-        use bdinfo_rs_core::bdrom::disc::StreamSummary;
-        use bdinfo_rs_core::primitives::Pid;
-        use bdinfo_rs_core::stream::TsStreamType;
-
         // A disc whose structural scan recorded a warning and whose feature
         // playlist presents one HIDDEN stream: all three accessors the shell
         // banners/marks from must surface it.
         let mut structural = structural();
         structural.warnings = vec!["BDMV/PLAYLIST/00000.mpls: unreadable".to_owned()];
         structural.bdrom.playlists.first_mut().expect("the feature playlist").streams =
-            vec![StreamSummary {
-                pid: Pid::new(0x1011),
-                stream_type: TsStreamType::default(),
-                codec_short_name: String::new(),
-                codec_name: "MPEG-4 AVC Video".to_owned(),
-                codec_alt_name: "",
-                bitrate: 0,
-                active_bitrate: 0,
-                language_name: String::new(),
-                language_code: String::new(),
-                description: String::new(),
-                full_description: "1080p / 23.976 fps / 16:9".to_owned(),
-                channel_description: String::new(),
-                sample_rate: 0,
-                bit_depth: 0,
-                channel_count: 0,
-                height: 0,
-                angle_index: 0,
-                is_hidden: true,
-                ssif_only: false,
-            }];
+            vec![StreamSummary { is_hidden: true, ..stream_summary(Pid::new(0x1011), 0) }];
         let flow =
             Flow::start_listing(input()).listed(&input(), Ok(structural), ViewSettings::default());
         // The structural warning reaches the banner accessor verbatim.
@@ -1912,8 +2111,6 @@ mod tests {
     #[test]
     fn a_measured_short_stream_file_surfaces_the_notice_with_the_shared_wording() {
         use bdinfo_rs_core::bdrom::disc::ClipStreamTally;
-        use bdinfo_rs_core::primitives::Pid;
-        use bdinfo_rs_core::stream::TsStreamType;
 
         // No disc, and an unmeasured (structural) disc: silent.
         assert!(Flow::idle().short_stream_notices().is_empty());

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -632,10 +632,11 @@ impl Flow {
         }
     }
 
-    /// Records the measured cells a scan in flight has reported — one entry per
-    /// playlist the snapshot covered ([`crate::live::updates`]). Applied only
-    /// while scanning **and** when `generation` matches the in-flight scan, like
-    /// [`Flow::progress`].
+    /// Records the measured cells a scan in flight has reported.
+    ///
+    /// `playlists` is one entry per playlist the snapshot covered
+    /// ([`crate::live::updates`]). Applied only while scanning **and** when
+    /// `generation` matches the in-flight scan, like [`Flow::progress`].
     ///
     /// **Cells only.** Each entry replaces that playlist's previous one and
     /// nothing else moves: the row set, the sort order, the checked set, the
@@ -848,9 +849,10 @@ impl Flow {
     }
 
     /// The "Stream Files" pane rows for the active playlist (empty when none),
-    /// their size cells rendered under the human-readable toggle — and, while a
-    /// scan is reporting that playlist, its measured sizes as of the last
-    /// snapshot.
+    /// their size cells rendered under the human-readable toggle.
+    ///
+    /// While a scan is reporting that playlist, the measured column carries its
+    /// sizes as of the last snapshot.
     #[must_use]
     pub fn stream_file_rows(&self) -> Vec<StreamFileRow> {
         self.any_listing()

--- a/crates/bdinfo-rs-gui/src/lib.rs
+++ b/crates/bdinfo-rs-gui/src/lib.rs
@@ -3,7 +3,8 @@
 //! Holds the pure logic — the argv surface and attended-session evidence
 //! ([`args`]), the playlist view-model ([`model`]), the
 //! master-detail pane view-models ([`panes`]), the selection model (`selection`),
-//! the live-progress model ([`progress`]), the flow state machine ([`flow`]),
+//! the live-progress model ([`progress`]), the mid-scan measured cells
+//! ([`live`]), the flow state machine ([`flow`]),
 //! the copy-path helpers ([`paths`]), the clipboard sanitizer ([`clipboard`]),
 //! the column-weight math ([`columns`]), the persistent configuration
 //! ([`settings`]), the best-effort diagnostics log ([`diagnostics`]), the
@@ -28,6 +29,7 @@ pub mod columns;
 pub mod diagnostics;
 pub mod flow;
 pub mod icon;
+pub mod live;
 pub mod model;
 pub mod panes;
 pub mod paths;

--- a/crates/bdinfo-rs-gui/src/live.rs
+++ b/crates/bdinfo-rs-gui/src/live.rs
@@ -1,0 +1,149 @@
+//! The measured cells a scan in flight ticks into the grids.
+//!
+//! A measured scan installs an observer
+//! ([`ScanObservers::with_measured`](bdinfo_rs_core::bdrom::disc::ScanObservers::with_measured))
+//! and is handed an owned [`MeasuredSnapshot`] as each demuxed chunk lands. The
+//! worker thread turns each one into the per-playlist [`updates`] below and
+//! sends them to the shell, which merges them into the state the playlist table
+//! and the two panes read while `Stage::Scanning`
+//! ([`crate::flow`]). Only the cells: nothing here changes which rows exist,
+//! their order, or the rendered report — the finished scan's summaries replace
+//! these values wholesale.
+//!
+//! A snapshot covers only the playlists that play the stream file it was taken
+//! over, so the merge is per playlist and every other playlist keeps its last
+//! known values. The tallies only grow within one pass, so a cell never walks
+//! backwards.
+
+use bdinfo_rs_core::bdrom::measured::MeasuredSnapshot;
+use bdinfo_rs_core::primitives::Pid;
+
+/// One playlist's live cells, as one snapshot left them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LivePlaylist {
+    /// Packet-derived bytes over every clip the playlist sequences, angle clips
+    /// included — the playlist table's `Measured Bytes` cell.
+    pub measured_bytes: u64,
+    /// The same count per sequenced clip, in the playlist's own clip order
+    /// (angle clips included, one entry per play item) — the Stream Files
+    /// pane's `Measured Size` column, whose rows are in that same order.
+    pub clips: Vec<u64>,
+    /// The presented streams' measured rates — the Streams pane's `Bit Rate`
+    /// column. The pane has no active-rate column, so the snapshot's
+    /// active-bitrate half is dropped here rather than carried unread.
+    pub streams: Vec<LiveStream>,
+}
+
+/// One presented stream's live rate, tagged with what names its row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LiveStream {
+    /// The stream's packet identifier.
+    pub pid: Pid,
+    /// The camera angle whose copy of the stream this is: `0` for the main
+    /// presentation row, `1..` for a video stream's per-angle copies. With
+    /// `pid` it names exactly one row of the Streams pane.
+    pub angle_index: usize,
+    /// Bits per second over the pass's demuxed seconds so far.
+    pub bitrate: i64,
+}
+
+impl LivePlaylist {
+    /// The live measured bytes of the clip the Stream Files pane shows at
+    /// `index`, or `None` when this playlist's snapshot carries no such row
+    /// (nothing has been measured for it yet).
+    #[must_use]
+    pub fn clip_bytes(&self, index: usize) -> Option<u64> {
+        self.clips.get(index).copied()
+    }
+
+    /// The live rate of the stream `pid` presents on camera angle
+    /// `angle_index`, or `None` when the pass has not resolved that row yet.
+    ///
+    /// Looked up by the pair, never by position: the snapshot orders its
+    /// streams main-presentation-first and then per angle, which is not the
+    /// order the pane's rows are in.
+    #[must_use]
+    pub fn bitrate(&self, pid: Pid, angle_index: usize) -> Option<i64> {
+        self.streams
+            .iter()
+            .find(|stream| stream.pid == pid && stream.angle_index == angle_index)
+            .map(|stream| stream.bitrate)
+    }
+}
+
+/// The per-playlist cells `snapshot` carries, each under its playlist name.
+///
+/// The shell's worker thread runs this, so what crosses the channel is the
+/// handful of numbers the grids draw rather than the whole snapshot.
+#[must_use]
+pub fn updates(snapshot: MeasuredSnapshot) -> Vec<(String, LivePlaylist)> {
+    snapshot
+        .playlists
+        .into_iter()
+        .map(|playlist| {
+            let live = LivePlaylist {
+                measured_bytes: playlist.measured_bytes,
+                clips: playlist.clips.into_iter().map(|clip| clip.measured_bytes).collect(),
+                streams: playlist
+                    .streams
+                    .into_iter()
+                    .map(|stream| LiveStream {
+                        pid: stream.pid,
+                        angle_index: stream.angle_index,
+                        bitrate: stream.bitrate,
+                    })
+                    .collect(),
+            };
+            (playlist.name, live)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use bdinfo_rs_core::primitives::Pid;
+
+    use super::{LivePlaylist, LiveStream};
+
+    /// A playlist carrying one clip row and two stream rows of the same PID on
+    /// different angles.
+    fn live() -> LivePlaylist {
+        LivePlaylist {
+            measured_bytes: 960,
+            clips: vec![768, 192],
+            streams: vec![
+                LiveStream { pid: Pid::new(0x1011), angle_index: 0, bitrate: 19_000 },
+                LiveStream { pid: Pid::new(0x1011), angle_index: 1, bitrate: 7_000 },
+                LiveStream { pid: Pid::new(0x1100), angle_index: 0, bitrate: 640_000 },
+            ],
+        }
+    }
+
+    #[test]
+    fn clip_bytes_reads_by_row_position() {
+        let live = live();
+        assert_eq!(live.clip_bytes(0), Some(768));
+        assert_eq!(live.clip_bytes(1), Some(192));
+        assert_eq!(live.clip_bytes(2), None, "a row the snapshot does not carry");
+    }
+
+    #[test]
+    fn a_rate_is_found_by_pid_and_angle_together() {
+        // Same PID, different angles: keying on the PID alone would hand the
+        // main row an extra angle's rate.
+        let live = live();
+        assert_eq!(live.bitrate(Pid::new(0x1011), 0), Some(19_000));
+        assert_eq!(live.bitrate(Pid::new(0x1011), 1), Some(7_000));
+        assert_eq!(live.bitrate(Pid::new(0x1100), 0), Some(640_000));
+        assert_eq!(live.bitrate(Pid::new(0x1100), 1), None, "that PID has no angle copy");
+        assert_eq!(live.bitrate(Pid::new(0x1234), 0), None, "an unresolved stream");
+    }
+
+    #[test]
+    fn an_empty_playlist_answers_nothing() {
+        let empty = LivePlaylist::default();
+        assert_eq!(empty.measured_bytes, 0);
+        assert_eq!(empty.clip_bytes(0), None);
+        assert_eq!(empty.bitrate(Pid::new(0x1011), 0), None);
+    }
+}

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -33,11 +33,15 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use bdinfo_rs_core::bdrom::disc::{HIDDEN_STREAMS_NOTE, PlaylistSummary, ScanProgress};
+use bdinfo_rs_core::bdrom::disc::{
+    HIDDEN_STREAMS_NOTE, PlaylistSummary, ScanObservers, ScanProgress,
+};
+use bdinfo_rs_core::bdrom::measured::MeasuredSnapshot;
 use bdinfo_rs_core::error::ScanError;
 use bdinfo_rs_core::report;
 use bdinfo_rs_gui::diagnostics::{self, LogErr as _};
 use bdinfo_rs_gui::flow::{self, Flow, ScanRequest, Stage};
+use bdinfo_rs_gui::live::{self, LivePlaylist};
 use bdinfo_rs_gui::model::{SelectableRow, Sort, SortColumn, ViewSettings, format_file_size};
 use bdinfo_rs_gui::panes::{CodecRow, StreamFileRow};
 use bdinfo_rs_gui::progress::{self, ProgressModel};
@@ -1030,6 +1034,10 @@ enum Message {
     ScanSelected,
     /// A streamed scan-progress event from the worker thread.
     Progress { generation: u64, file: String, done: u64, total: u64 },
+    /// The measured cells the running scan has tallied, one entry per playlist
+    /// the worker's latest snapshot covered — the grids' live numbers, sent at
+    /// most once a second ([`bdinfo_rs_gui::progress::measure_due`]).
+    Measured { generation: u64, playlists: Vec<(String, LivePlaylist)> },
     /// The worker's measured scan finished. The errors are typed (shared —
     /// `ScanError` is not `Clone`) so the flow can re-render the report when
     /// a report-section toggle changes.
@@ -1253,6 +1261,7 @@ impl App {
                 self.flow.progress(generation, file, done, total, elapsed);
                 Task::none()
             }
+            Message::Measured { generation, playlists } => self.on_measured(generation, playlists),
             Message::Finished { generation, report, errors, playlists } => {
                 self.on_finished(generation, report, errors, playlists)
             }
@@ -1716,6 +1725,19 @@ impl App {
         Task::none()
     }
 
+    /// Applies the running scan's measured cells to the grids. A pure flow
+    /// transition — the generation guard and the cells-only rule are
+    /// [`Flow::measured`]'s — so the only shell-side effect is the repaint the
+    /// returned (empty) task lets iced do.
+    fn on_measured(
+        &mut self,
+        generation: u64,
+        playlists: Vec<(String, LivePlaylist)>,
+    ) -> Task<Message> {
+        self.flow.measured(generation, playlists);
+        Task::none()
+    }
+
     /// Applies a display tick: advances the indeterminate bar's phase, then
     /// re-reads the wall clock so the elapsed readout and the stall hint move
     /// even when no progress event arrives. The listing and the measured scan
@@ -1996,14 +2018,29 @@ impl App {
                     total: progress.total,
                 });
             };
+            // The measured tallies arrive once per demuxed read chunk — many a
+            // second on a fast source. Each message re-renders three grids, so
+            // they tick on a wall clock (the rate classic BDInfo samples its
+            // own live grids at) rather than per chunk, and only the numbers the
+            // grids draw cross the channel.
+            let mut last_measured: Option<Instant> = None;
+            let mut on_measured = |snapshot: MeasuredSnapshot| {
+                if !progress::measure_due(last_measured.map(|at| at.elapsed())) {
+                    return;
+                }
+                last_measured = Some(Instant::now());
+                let _ = sender.unbounded_send(Message::Measured {
+                    generation,
+                    playlists: live::updates(snapshot),
+                });
+            };
             let result = scan::scan_measured(
                 &input,
                 &selection,
                 &scan_files,
                 options,
                 scan_options,
-                &mut on_progress,
-                &cancel,
+                ScanObservers::new(&mut on_progress, &cancel).with_measured(&mut on_measured),
             );
             let outcome = match result {
                 Ok(measured) => Message::Finished {
@@ -4094,6 +4131,40 @@ mod interaction {
             app.flow.progress_view().map(bdinfo_rs_gui::progress::ProgressModel::fraction);
         assert_eq!(fraction, Some(0.5));
         assert!(sees(&app, "Scanning A.M2TS…"), "the lead line names the demuxing file");
+    }
+
+    #[test]
+    fn the_workers_measured_cells_tick_the_table_and_the_panes() {
+        use bdinfo_rs_gui::live::LivePlaylist;
+
+        let mut app = listed_app();
+        click(&mut app, "Scan Bitrates");
+        assert_eq!(app.flow.stage(), Stage::Scanning);
+        assert!(!sees(&app, "1,234,560"), "nothing is measured before the first snapshot");
+
+        let cells = |bytes: u64| {
+            vec![(
+                "00000.MPLS".to_owned(),
+                LivePlaylist { measured_bytes: bytes, clips: vec![bytes], streams: Vec::new() },
+            )]
+        };
+        let _ = app
+            .update(Message::Measured { generation: app.generation, playlists: cells(1_234_560) });
+        assert!(sees(&app, "1,234,560"), "the row's Measured Bytes cell carries the count");
+        // The same count reaches the active playlist's Stream Files pane. Both
+        // grids draw the identical string, so the pane is read through the
+        // view-model rather than searched for on screen.
+        assert_eq!(
+            app.flow.stream_file_rows().first().map(|row| row.measured.clone()),
+            Some("1,234,560".to_owned())
+        );
+        // A snapshot from a superseded scan is dropped before the flow.
+        let _ = app.update(Message::Measured {
+            generation: app.generation.wrapping_add(1),
+            playlists: cells(9_999_999),
+        });
+        assert!(!sees(&app, "9,999,999"), "the stale cells must not repaint");
+        assert!(sees(&app, "1,234,560"));
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -1256,10 +1256,7 @@ impl App {
             }
             Message::ScanSelected => self.start_scan(),
             Message::Progress { generation, file, done, total } => {
-                let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
-                self.last_progress = Some(Instant::now());
-                self.flow.progress(generation, file, done, total, elapsed);
-                Task::none()
+                self.on_progress(generation, file, done, total)
             }
             Message::Measured { generation, playlists } => self.on_measured(generation, playlists),
             Message::Finished { generation, report, errors, playlists } => {
@@ -1722,6 +1719,24 @@ impl App {
             self.flow.select_all();
             return self.start_scan();
         }
+        Task::none()
+    }
+
+    /// Applies a measured worker's progress event.
+    ///
+    /// The stale-event guard is [`Flow::progress`]'s own generation match; the
+    /// two shell-side fields here are the wall clock the elapsed readout and
+    /// the stall hint are computed from.
+    fn on_progress(
+        &mut self,
+        generation: u64,
+        file: String,
+        done: u64,
+        total: u64,
+    ) -> Task<Message> {
+        let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
+        self.last_progress = Some(Instant::now());
+        self.flow.progress(generation, file, done, total, elapsed);
         Task::none()
     }
 

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -1034,9 +1034,9 @@ enum Message {
     ScanSelected,
     /// A streamed scan-progress event from the worker thread.
     Progress { generation: u64, file: String, done: u64, total: u64 },
-    /// The measured cells the running scan has tallied, one entry per playlist
-    /// the worker's latest snapshot covered — the grids' live numbers, sent at
-    /// most once a second ([`bdinfo_rs_gui::progress::measure_due`]).
+    /// The measured cells the running scan has tallied — the grids' live
+    /// numbers, one entry per playlist the worker's latest snapshot covered,
+    /// sent at most once a second.
     Measured { generation: u64, playlists: Vec<(String, LivePlaylist)> },
     /// The worker's measured scan finished. The errors are typed (shared —
     /// `ScanError` is not `Clone`) so the flow can re-render the report when
@@ -1725,10 +1725,11 @@ impl App {
         Task::none()
     }
 
-    /// Applies the running scan's measured cells to the grids. A pure flow
-    /// transition — the generation guard and the cells-only rule are
-    /// [`Flow::measured`]'s — so the only shell-side effect is the repaint the
-    /// returned (empty) task lets iced do.
+    /// Applies the running scan's measured cells to the grids.
+    ///
+    /// A pure flow transition — the generation guard and the cells-only rule
+    /// are [`Flow::measured`]'s — so the only shell-side effect is the repaint
+    /// the returned (empty) task lets iced do.
     fn on_measured(
         &mut self,
         generation: u64,

--- a/crates/bdinfo-rs-gui/src/panes.rs
+++ b/crates/bdinfo-rs-gui/src/panes.rs
@@ -12,6 +12,7 @@ use bdinfo_rs_core::bdrom::chapters::seconds_to_ticks;
 use bdinfo_rs_core::bdrom::disc::{ClipSummary, PlaylistSummary, StreamSummary};
 use bdinfo_rs_core::report::text;
 
+use crate::live::LivePlaylist;
 use crate::model::byte_cell;
 
 /// One "Stream File" pane row: a clip of the selected playlist, pre-formatted.
@@ -61,23 +62,38 @@ pub struct CodecRow {
 /// `human_sizes` switches the size cells to the human-readable form —
 /// `BDInfo` applies its `SizeFormatHR` setting to this grid exactly as to the
 /// playlist table.
+///
+/// `live` is the playlist's cells as a scan in flight last reported them
+/// ([`crate::live`]): present, its per-clip counts fill the `Measured Size`
+/// column instead of the summaries', which stay at zero until the scan ends.
 #[must_use]
-pub fn stream_file_rows(playlist: &PlaylistSummary, human_sizes: bool) -> Vec<StreamFileRow> {
+pub fn stream_file_rows(
+    playlist: &PlaylistSummary,
+    human_sizes: bool,
+    live: Option<&LivePlaylist>,
+) -> Vec<StreamFileRow> {
     let mut rows = Vec::new();
     let mut index: usize = 0;
-    for clip in &playlist.clips {
+    for (position, clip) in playlist.clips.iter().enumerate() {
         if clip.angle_index == 0 {
             index = index.saturating_add(1);
         }
-        rows.push(stream_file_row(clip, index, human_sizes));
+        let measured = live.and_then(|live| live.clip_bytes(position));
+        rows.push(stream_file_row(clip, index, human_sizes, measured));
     }
     rows
 }
 
 /// Formats one clip into its stream-file row, mirroring `BDInfo`: an extra-angle
 /// clip gets a ` (N)` suffix, and a size that is not yet known (no file /
-/// nothing demuxed) shows as `-`.
-fn stream_file_row(clip: &ClipSummary, index: usize, human_sizes: bool) -> StreamFileRow {
+/// nothing demuxed) shows as `-`. `measured` is the live count for this row when
+/// a scan is reporting one, else the clip's own tally is used.
+fn stream_file_row(
+    clip: &ClipSummary,
+    index: usize,
+    human_sizes: bool,
+    measured: Option<u64>,
+) -> StreamFileRow {
     let file = if clip.angle_index > 0 {
         format!("{} ({})", clip.display_name, clip.angle_index)
     } else {
@@ -88,7 +104,7 @@ fn stream_file_row(clip: &ClipSummary, index: usize, human_sizes: bool) -> Strea
         index: index.to_string(),
         length: text::time_hh_short(seconds_to_ticks(clip.length)),
         estimated: size_cell(clip.estimated_bytes().unwrap_or(0), human_sizes),
-        measured: size_cell(clip.packet_size(), human_sizes),
+        measured: size_cell(measured.unwrap_or_else(|| clip.packet_size()), human_sizes),
     }
 }
 
@@ -100,19 +116,29 @@ fn size_cell(bytes: u64, human: bool) -> String {
 
 /// Builds the "Streams" (codec) rows for `playlist` — one per presented stream,
 /// in the playlist's own stream order.
+///
+/// `live` is the playlist's cells as a scan in flight last reported them
+/// ([`crate::live`]): present, the rate it carries for a row fills that row's
+/// `Bit Rate` cell instead of the summary's.
 #[must_use]
-pub fn codec_rows(playlist: &PlaylistSummary) -> Vec<CodecRow> {
-    playlist.streams.iter().map(codec_row).collect()
+pub fn codec_rows(playlist: &PlaylistSummary, live: Option<&LivePlaylist>) -> Vec<CodecRow> {
+    playlist.streams.iter().map(|stream| codec_row(stream, live)).collect()
 }
 
 /// Formats one stream into its codec row. Uses `full_description` — the same
 /// string the locked report prints (video profile/level, audio kbps / bit depth
 /// / embedded core) — so the pane matches the report and the original `BDInfo`.
-fn codec_row(stream: &StreamSummary) -> CodecRow {
+/// The description is left as the scan last built it: only the rate ticks during
+/// a scan, and a rate folded into an audio description settles when the scan
+/// finishes.
+fn codec_row(stream: &StreamSummary, live: Option<&LivePlaylist>) -> CodecRow {
+    let bitrate = live
+        .and_then(|live| live.bitrate(stream.pid, stream.angle_index))
+        .unwrap_or(stream.bitrate);
     CodecRow {
         codec: stream.codec_name.clone(),
         language: stream.language_name.clone(),
-        bitrate: bitrate_cell(stream.bitrate),
+        bitrate: bitrate_cell(bitrate),
         description: stream.full_description.clone(),
         hidden: stream.is_hidden,
     }
@@ -136,6 +162,7 @@ mod tests {
     use bdinfo_rs_core::stream::TsStreamType;
 
     use super::{CodecRow, StreamFileRow, bitrate_cell, codec_rows, stream_file_rows};
+    use crate::live::{LivePlaylist, LiveStream};
 
     /// A clip carrying the fields the stream-file row reads.
     fn clip(name: &str, angle_index: i32, length: f64, packet_count: u64) -> ClipSummary {
@@ -208,7 +235,7 @@ mod tests {
 
     #[test]
     fn stream_files_carry_index_length_and_both_sizes() {
-        let rows = stream_file_rows(&playlist(), false);
+        let rows = stream_file_rows(&playlist(), false, None);
         assert_eq!(
             rows,
             [
@@ -239,7 +266,7 @@ mod tests {
         // An extra-angle clip with both a plain and an interleaved size: the row
         // shows the interleaved size and a ` (2)` angle suffix.
         p.clips = vec![sized_clip("00007.M2TS", 2, 40.0, 0, 700_000, 900_000)];
-        let rows = stream_file_rows(&p, false);
+        let rows = stream_file_rows(&p, false, None);
         assert_eq!(
             rows,
             [StreamFileRow {
@@ -262,7 +289,7 @@ mod tests {
             clip("00002.M2TS", 0, 50.0, 0),
         ];
         let indices: Vec<_> =
-            stream_file_rows(&p, false).into_iter().map(|row| row.index).collect();
+            stream_file_rows(&p, false, None).into_iter().map(|row| row.index).collect();
         assert_eq!(indices, ["1", "1", "2"]);
     }
 
@@ -270,7 +297,7 @@ mod tests {
     fn the_human_readable_toggle_reaches_the_size_cells() {
         // The same grid BDInfo formats with SizeFormatHR: known sizes switch
         // to the short form, the unknown `-` stays a dash.
-        let rows = stream_file_rows(&playlist(), true);
+        let rows = stream_file_rows(&playlist(), true, None);
         let cells: Vec<_> = rows.into_iter().map(|row| (row.estimated, row.measured)).collect();
         assert_eq!(
             cells,
@@ -280,7 +307,7 @@ mod tests {
 
     #[test]
     fn codec_rows_carry_codec_language_bitrate_description() {
-        let rows = codec_rows(&playlist());
+        let rows = codec_rows(&playlist(), None);
         assert_eq!(
             rows,
             [
@@ -300,6 +327,43 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn live_counts_fill_the_measured_column_while_a_scan_reports() {
+        // Mid-scan the summaries still carry the pre-scan tallies, so the cells
+        // come from the live counts — including the row whose summary has none
+        // (`-` until the scan reaches it).
+        let live = LivePlaylist { clips: vec![384, 192], ..LivePlaylist::default() };
+        let cells: Vec<_> = stream_file_rows(&playlist(), false, Some(&live))
+            .into_iter()
+            .map(|row| row.measured)
+            .collect();
+        assert_eq!(cells, ["384", "192"]);
+        // A live playlist that carries no row for a clip leaves that clip's own
+        // tally showing (1000 packets * 192 bytes), never a dash.
+        let partial = LivePlaylist::default();
+        let cells: Vec<_> = stream_file_rows(&playlist(), false, Some(&partial))
+            .into_iter()
+            .map(|row| row.measured)
+            .collect();
+        assert_eq!(cells, ["192,000", "-"]);
+    }
+
+    #[test]
+    fn a_live_rate_fills_the_bit_rate_cell_of_its_own_row() {
+        // Two rows share PID 0x1011 — the main presentation row and an angle
+        // copy — so a live rate keyed on the PID alone would land on both.
+        let mut p = playlist();
+        let video = p.streams.first().expect("the fixture presents a video stream").clone();
+        p.streams.push(StreamSummary { angle_index: 1, ..video });
+        let live = LivePlaylist {
+            streams: vec![LiveStream { pid: Pid::new(0x1011), angle_index: 1, bitrate: 7_000_000 }],
+            ..LivePlaylist::default()
+        };
+        let cells: Vec<_> =
+            codec_rows(&p, Some(&live)).into_iter().map(|row| row.bitrate).collect();
+        assert_eq!(cells, ["-", "3,948 kbps", "7,000 kbps"]);
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/progress.rs
+++ b/crates/bdinfo-rs-gui/src/progress.rs
@@ -77,9 +77,10 @@ pub fn emit_due(file_changed: bool, done: u64, total: u64, since_last: Option<Du
 /// second is the rate classic `BDInfo` samples its live grids at.
 const MEASURE_EVERY: Duration = Duration::from_secs(1);
 
-/// Whether a measured snapshot should become a UI message. `since_last` is the
-/// time since the last emitted one (`None` before the first, which always
-/// emits).
+/// Whether a measured snapshot should become a UI message.
+///
+/// `since_last` is the time since the last emitted one (`None` before the
+/// first, which always emits).
 #[must_use]
 pub fn measure_due(since_last: Option<Duration>) -> bool {
     since_last.is_none_or(|elapsed| elapsed >= MEASURE_EVERY)

--- a/crates/bdinfo-rs-gui/src/progress.rs
+++ b/crates/bdinfo-rs-gui/src/progress.rs
@@ -68,6 +68,23 @@ pub fn emit_due(file_changed: bool, done: u64, total: u64, since_last: Option<Du
     file_changed || done == total || since_last.is_none_or(|elapsed| elapsed >= EMIT_EVERY)
 }
 
+/// How often the measured tallies are worth a UI message — the worker's
+/// grid-tick interval.
+///
+/// The scan reports them once per demuxed read chunk, which on a fast source is
+/// many times a second and on a stalled one not for minutes; the grids are
+/// re-rendered per message, so the cells tick on a wall clock instead. One
+/// second is the rate classic `BDInfo` samples its live grids at.
+const MEASURE_EVERY: Duration = Duration::from_secs(1);
+
+/// Whether a measured snapshot should become a UI message. `since_last` is the
+/// time since the last emitted one (`None` before the first, which always
+/// emits).
+#[must_use]
+pub fn measure_due(since_last: Option<Duration>) -> bool {
+    since_last.is_none_or(|elapsed| elapsed >= MEASURE_EVERY)
+}
+
 /// A live-progress snapshot: the current file, the percent, and the estimates.
 ///
 /// The iced shell stores the latest of these while a scan is in flight and
@@ -232,6 +249,16 @@ mod tests {
         // A file boundary and the final byte always emit, however recent.
         assert!(super::emit_due(true, 4, 100, Some(Duration::ZERO)));
         assert!(super::emit_due(false, 100, 100, Some(Duration::ZERO)));
+    }
+
+    #[test]
+    fn measured_snapshots_tick_once_a_second() {
+        // The first snapshot of a scan always emits; the rest wait out the
+        // interval, whose boundary is inclusive.
+        assert!(super::measure_due(None));
+        assert!(!super::measure_due(Some(Duration::from_millis(999))));
+        assert!(super::measure_due(Some(Duration::from_secs(1))));
+        assert!(super::measure_due(Some(Duration::from_secs(5))));
     }
 
     // The projection runs over hostile-shaped byte counts and durations, so

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -18,7 +18,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, ScanMode, ScanOptions, ScanProgress};
+use bdinfo_rs_core::bdrom::disc::{
+    BdRom, PlaylistSummary, ScanMode, ScanObservers, ScanOptions, ScanProgress,
+};
 use bdinfo_rs_core::bdrom::order::selection_order;
 use bdinfo_rs_core::error::{BdError, ScanError};
 use bdinfo_rs_core::report::text::{self, RenderOptions};
@@ -132,14 +134,15 @@ fn open(
     mode: ScanMode,
     options: ScanOptions,
     scan_files: Option<&BTreeSet<String>>,
-    progress: &mut dyn FnMut(ScanProgress<'_>),
-    cancel: &AtomicBool,
+    observers: ScanObservers<'_>,
 ) -> Result<(BdRom, Vec<ScanError>), BdError> {
     let report = match input {
         Input::Folder(path) => {
-            core_scan::open_folder(path, mode, options, scan_files, progress, cancel)
+            core_scan::open_folder_observed(path, mode, options, scan_files, observers)
         }
-        Input::Iso(path) => core_scan::open_iso(path, mode, options, scan_files, progress, cancel),
+        Input::Iso(path) => {
+            core_scan::open_iso_observed(path, mode, options, scan_files, observers)
+        }
     }?;
     Ok((report.bdrom, report.errors))
 }
@@ -186,7 +189,10 @@ pub fn scan_structural(
         // one that renders a report. A listing open that hits a mid-file read
         // error therefore keeps that file's partial codec detail whatever the
         // setting says, so the panes stay as full as the disc allows.
-        open(input, mode, ScanOptions::default(), None, progress, cancel)
+        //
+        // A fresh bundle per open: the listing makes two of them, and the
+        // observers hold the callback exclusively for one call.
+        open(input, mode, ScanOptions::default(), None, ScanObservers::new(&mut *progress, cancel))
             .map_err(|err: BdError| err.to_string())
     })?;
     let features = bdrom.extra_features().into_iter().map(str::to_owned).collect();
@@ -221,7 +227,7 @@ fn listing_scan(mut open: impl FnMut(ScanMode) -> Opened) -> Opened {
 
 /// Runs the **measured** scan over `input`, narrowed to the selected clips.
 ///
-/// Streams progress through `progress` and renders the classic report in
+/// Streams progress through `observers` and renders the classic report in
 /// `selection` order — the GUI equivalent of `bdinfo-rs <disc> --mpls A,B`.
 ///
 /// `selection` is the chosen playlist names in table order, and `scan_files` the
@@ -234,28 +240,30 @@ fn listing_scan(mut open: impl FnMut(ScanMode) -> Opened) -> Opened {
 /// iced shell's worker thread, where native demux keeps its `thread::scope`
 /// parallelism.
 ///
-/// `cancel` is the shell's Cancel affordance: set it (from the UI thread) and
-/// the demux aborts at its next read chunk, so the worker returns within
-/// moments instead of scanning a possibly-90-GB disc to completion.
+/// `observers` carries the scan's three seams: the progress callback, the
+/// cooperative cancel flag, and — when the caller installs one
+/// ([`ScanObservers::with_measured`]) — the measured-tally observer whose
+/// snapshots let a display tick its cells while the scan runs. The cancel flag
+/// is the shell's Cancel affordance: set it (from the UI thread) and the demux
+/// aborts at its next read chunk, so the worker returns within moments instead
+/// of scanning a possibly-90-GB disc to completion.
 ///
 /// # Errors
 /// A short message when the structure is too damaged to open at all — the same
 /// hard error [`scan_structural`] surfaces (it cannot occur in practice, since
 /// the structural scan just located the same structure, but the result is
-/// reported rather than panicked) — or when `cancel` was set mid-scan (the
-/// message is dropped by the shell's generation guard; no report escapes).
+/// reported rather than panicked) — or when the cancel flag was set mid-scan
+/// (the message is dropped by the shell's generation guard; no report escapes).
 pub fn scan_measured(
     input: &Input,
     selection: &[String],
     scan_files: &BTreeSet<String>,
     options: RenderOptions,
     scan_options: ScanOptions,
-    progress: &mut dyn FnMut(ScanProgress<'_>),
-    cancel: &AtomicBool,
+    observers: ScanObservers<'_>,
 ) -> Result<Measured, String> {
-    let (bdrom, errors) =
-        open(input, ScanMode::Full, scan_options, Some(scan_files), progress, cancel)
-            .map_err(|err| err.to_string())?;
+    let (bdrom, errors) = open(input, ScanMode::Full, scan_options, Some(scan_files), observers)
+        .map_err(|err| err.to_string())?;
     let order = selection_order(&bdrom.playlists, selection);
     let report = text::render_with(&bdrom, &order, &errors, options);
     Ok(Measured {
@@ -480,14 +488,14 @@ mod tests {
         // structure — but the result is a Result, not a hope).
         let dir = scratch("empty-measured");
         std::fs::create_dir_all(&dir).expect("the scratch dir creates");
+        let cancel = AtomicBool::new(false);
         let message = super::scan_measured(
             &Input::Folder(dir),
             &[],
             &std::collections::BTreeSet::new(),
             bdinfo_rs_core::report::text::RenderOptions::default(),
             ScanOptions::default(),
-            &mut super::no_progress,
-            &std::sync::atomic::AtomicBool::new(false),
+            super::ScanObservers::new(&mut super::no_progress, &cancel),
         )
         .expect_err("no Blu-ray structure to open");
         assert!(!message.is_empty(), "the failure carries a user-facing message");
@@ -717,6 +725,77 @@ mod tests {
         // disc's BDMV/BACKUP copy — resilience, not silence; the warning above
         // is the record of the primary's corruption.
         assert!(!structural.bdrom.playlists.is_empty());
+    }
+
+    #[test]
+    fn a_measured_scan_streams_live_cells_that_land_on_the_finished_summaries() {
+        // The whole point of the live cells: a grid that ticks them during the
+        // scan and takes the summaries at the end never jumps at the handover.
+        // The three-playlist fixture also shows the per-file scope — its middle
+        // playlist shares no clip, while one clip is played by two playlists.
+        use std::collections::BTreeMap;
+
+        use bdinfo_rs_core::bdrom::disc::ClipSummary;
+        use bdinfo_rs_core::bdrom::measured::MeasuredSnapshot;
+        use bdinfo_rs_core::bdrom::order::selection_stream_files;
+        use bdinfo_rs_core::report::text::RenderOptions;
+
+        use crate::live::{self, LivePlaylist};
+
+        let input = Input::Folder(fixture("MultiPlaylist"));
+        let listed = scan_structural(&input).expect("the fixture lists");
+        let selection: Vec<String> =
+            listed.bdrom.playlists.iter().map(|playlist| playlist.name.clone()).collect();
+        let scan_files = selection_stream_files(&listed.bdrom.playlists, &selection);
+        let cancel = AtomicBool::new(false);
+        let mut live: BTreeMap<String, LivePlaylist> = BTreeMap::new();
+        let mut covered: Vec<Vec<String>> = Vec::new();
+        let measured = {
+            let mut watch = |snapshot: MeasuredSnapshot| {
+                let updates = live::updates(snapshot);
+                covered.push(updates.iter().map(|(name, _)| name.clone()).collect());
+                live.extend(updates);
+            };
+            super::scan_measured(
+                &input,
+                &selection,
+                &scan_files,
+                RenderOptions::default(),
+                ScanOptions::default(),
+                super::ScanObservers::new(&mut super::no_progress, &cancel)
+                    .with_measured(&mut watch),
+            )
+        }
+        .expect("the fixture scans");
+
+        assert_eq!(measured.playlists.len(), 3);
+        for playlist in &measured.playlists {
+            let cells = live.get(&playlist.name).expect("every scanned playlist was reported");
+            assert!(cells.measured_bytes > 0, "{} measured nothing", playlist.name);
+            assert_eq!(cells.measured_bytes, playlist.total_angle_packet_size());
+            let clips: Vec<u64> = playlist.clips.iter().map(ClipSummary::packet_size).collect();
+            assert_eq!(cells.clips, clips, "{} clip rows", playlist.name);
+            for stream in &playlist.streams {
+                assert_eq!(
+                    cells.bitrate(stream.pid, stream.angle_index),
+                    Some(stream.bitrate),
+                    "{} stream {:?}",
+                    playlist.name,
+                    stream.pid
+                );
+            }
+        }
+        // One snapshot per demuxed chunk plus one per file boundary, each
+        // naming only the playlists that play the file it was taken over.
+        assert!(covered.len() >= scan_files.len(), "at least one snapshot per stream file");
+        assert!(
+            covered.iter().any(|names| names.len() == 2),
+            "the shared clip moves two playlists at once: {covered:?}"
+        );
+        assert!(
+            covered.iter().any(|names| names.len() == 1),
+            "a clip played by one playlist moves only it: {covered:?}"
+        );
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/tests/golden.rs
+++ b/crates/bdinfo-rs-gui/tests/golden.rs
@@ -14,6 +14,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
+use bdinfo_rs_core::bdrom::disc::ScanObservers;
 use bdinfo_rs_gui::flow::Flow;
 use bdinfo_rs_gui::model::ViewSettings;
 use bdinfo_rs_gui::scan::{self, Input, Structural};
@@ -47,8 +48,7 @@ fn list_select_all_and_measure(input: &Input) -> (String, String) {
         &request.scan_files,
         request.options,
         request.scan_options,
-        &mut scan::no_progress,
-        &AtomicBool::new(false),
+        ScanObservers::new(&mut scan::no_progress, &AtomicBool::new(false)),
     )
     .expect("the fixture scans");
     (measured.report, measured.label)
@@ -71,8 +71,7 @@ fn a_cancelled_measured_scan_yields_no_report() {
         &request.scan_files,
         request.options,
         request.scan_options,
-        &mut scan::no_progress,
-        &AtomicBool::new(true),
+        ScanObservers::new(&mut scan::no_progress, &AtomicBool::new(true)),
     )
     .expect_err("a cancelled scan yields no report");
     assert_eq!(err, "scan cancelled");
@@ -112,8 +111,7 @@ fn a_report_toggle_rerender_reproduces_the_worker_bytes() {
         &request.scan_files,
         request.options,
         request.scan_options,
-        &mut scan::no_progress,
-        &AtomicBool::new(false),
+        ScanObservers::new(&mut scan::no_progress, &AtomicBool::new(false)),
     )
     .expect("the fixture scans");
     let mut flow = flow.finished(1, measured.report, measured.errors, measured.playlists);


### PR DESCRIPTION
Restores the live grid updates classic BDInfo shows while it scans. During a
measured scan the playlist table's Measured Bytes column ticks, and the active
playlist's Stream Files and Streams panes tick with it, at most once a second.

The scan worker installs the core's measured observer and turns each snapshot
into the per-playlist cells the grids draw; the flow merges them per playlist
while scanning. Cells only: the row set, the sort order, the selection and the
retained report are untouched mid-scan, and the finished scan replaces every
cell with the measured summaries.

bdinfo-rs-core gains scan::open_folder_observed and scan::open_iso_observed,
the observed forms of the two path-based opens, with the plain pair delegating
through them. A path-driven surface can then install a measured observer
without reimplementing the backend dispatch, the recorded-failure merge and the
folder label repair.

DIFFERENCES.md no longer lists live in-grid numbers as not carried over.

Fixes #325
