### PR TITLE
feat(wasm): stream measured snapshots to the page

### DIFF
--- a/crates/bdinfo-rs-wasm/.cargo/mutants.toml
+++ b/crates/bdinfo-rs-wasm/.cargo/mutants.toml
@@ -22,6 +22,7 @@ exclude_re = [
     "build_web_tree", # &js_sys::Array -> Node<WebFile>
     "notify", # the wasm32 progress-callback shim -> js_sys::Function
     "scan_root", # the wasm32 whole-disc/by-name scan dispatch -> JsValue
+    "scan_observed", # the wasm32 observer bundle around scan_root (js_sys::Function callbacks)
     "scan_files", # the #[wasm_bindgen] measured streaming export
     "scan_iso", # the #[wasm_bindgen] measured .iso streaming export
     "inspect_files", # the #[wasm_bindgen] structural disc-model export

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -57,8 +57,13 @@ use std::sync::atomic::AtomicBool;
 // exports take, which carries the retention switch this type holds plus the
 // report and classification choices a disc open knows nothing about.
 use bdinfo_rs_core::bdrom::disc::{
-    BdRom, ScanMode, ScanOptions as CoreScanOptions, ScanProgress, ScanReport,
+    BdRom, ScanMode, ScanObservers, ScanOptions as CoreScanOptions, ScanProgress, ScanReport,
 };
+// The live tallies a measured observer is handed, named by the browser exports
+// that forward them to JavaScript (`notify_measured`) — wasm32-only, like the
+// callback plumbing itself.
+#[cfg(target_arch = "wasm32")]
+use bdinfo_rs_core::bdrom::measured::MeasuredSnapshot;
 use bdinfo_rs_core::bdrom::order::PlaylistFilter;
 #[cfg(any(target_arch = "wasm32", test))]
 use bdinfo_rs_core::bdrom::order::{
@@ -76,6 +81,11 @@ use bdinfo_rs_core::vfs::{BdDir, mem};
 use bdinfo_rs_core::vfs::{BdFile, SearchOption};
 #[cfg(target_arch = "wasm32")]
 use bdinfo_rs_core::vfs::{ReadSeek, extension_of_name};
+// `Tsify` is named for its `into_js`, which turns a mirror value into the
+// JavaScript object a callback takes — the conversion the `#[wasm_bindgen]`
+// return path performs implicitly for a value an export returns.
+#[cfg(target_arch = "wasm32")]
+use tsify::Tsify;
 use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::{JsCast, JsValue};
@@ -759,7 +769,9 @@ impl std::fmt::Display for SelectionError {
 /// selectable by name.
 ///
 /// `options` governs the measured scan alone: the structural scan reads no
-/// packets, so no switch it carries can change what that scan finds.
+/// packets, so no switch it carries can change what that scan finds — and it is
+/// unobserved for the same reason, so `observers` only ever sees the measured
+/// pass.
 ///
 /// # Errors
 /// [`SelectionError::Open`] if the structure is too damaged to scan, or
@@ -771,7 +783,7 @@ fn scan_selection(
     root: &dyn BdDir,
     selection: &[String],
     options: CoreScanOptions,
-    progress: &mut dyn FnMut(ScanProgress<'_>),
+    observers: ScanObservers<'_>,
 ) -> Result<Scan, SelectionError> {
     let structural = BdRom::open_resilient(root, ScanMode::Metadata)?;
     let names = named_selection(&structural.bdrom.playlists, selection);
@@ -784,16 +796,9 @@ fn scan_selection(
     // found, so it cannot hit the only hard error (`StructureNotFound`); on that
     // unreachable failure it degrades to the structural disc (zero measured
     // tallies) rather than erroring.
-    // The browser exports carry no cancel affordance: the flag is never set.
-    let measured = BdRom::open_resilient_with(
-        root,
-        ScanMode::Full,
-        options,
-        Some(&files),
-        progress,
-        &never_cancelled(),
-    )
-    .unwrap_or(structural);
+    let measured =
+        BdRom::open_resilient_observed(root, ScanMode::Full, options, Some(&files), observers)
+            .unwrap_or(structural);
     let order = selection_order(&measured.bdrom.playlists, &names);
     Ok(Scan { report: measured, order })
 }
@@ -863,28 +868,21 @@ impl Scan {
 /// order.
 ///
 /// This is the byte-for-byte core shared by every export and the native parity
-/// test: [`BdRom::open_resilient_with`] with the packet scan **on** and the
+/// test: [`BdRom::open_resilient_observed`] with the packet scan **on** and the
 /// scan's behaviour switches set by `options`, ordered by the standard filtered
 /// set ([`PlaylistFilter::default`], which drops playlists shorter than 20 s and
-/// looping ones). `progress` observes the demux.
+/// looping ones). `observers` watches the demux.
 ///
 /// # Errors
-/// Returns the [`BdError`] from [`BdRom::open_resilient_with`] when the
+/// Returns the [`BdError`] from [`BdRom::open_resilient_observed`] when the
 /// structure is too damaged to open at all (no `BDMV`/`CLIPINF`/`PLAYLIST`) —
 /// the caller decides whether that is an empty disc or an error to report.
 fn scan_whole(
     root: &dyn BdDir,
     options: CoreScanOptions,
-    progress: &mut dyn FnMut(ScanProgress<'_>),
+    observers: ScanObservers<'_>,
 ) -> Result<Scan, BdError> {
-    let report = BdRom::open_resilient_with(
-        root,
-        ScanMode::Full,
-        options,
-        None,
-        progress,
-        &never_cancelled(),
-    )?;
+    let report = BdRom::open_resilient_observed(root, ScanMode::Full, options, None, observers)?;
     let order = report.bdrom.presentation_order(&PlaylistFilter::default());
     Ok(Scan { report, order })
 }
@@ -893,7 +891,8 @@ fn scan_whole(
 ///
 /// The scan itself runs with [`CoreScanOptions::default`]: the report-only
 /// entries this serves ([`run_report`], [`run_iso_report`]) take no options, so
-/// they scan the way an unconfigured call does.
+/// they scan the way an unconfigured call does. It watches no measured tallies
+/// either — a caller that only wants the report text has nothing to tick.
 ///
 /// # Errors
 /// As [`scan_whole`].
@@ -902,7 +901,12 @@ fn render_disc(
     options: RenderOptions,
     progress: &mut dyn FnMut(ScanProgress<'_>),
 ) -> Result<String, BdError> {
-    Ok(scan_whole(root, CoreScanOptions::default(), progress)?.render(options))
+    let scan = scan_whole(
+        root,
+        CoreScanOptions::default(),
+        ScanObservers::new(progress, &never_cancelled()),
+    )?;
+    Ok(scan.render(options))
 }
 
 /// The report sections `options` asks for: each option switches its own section
@@ -987,15 +991,45 @@ fn scan_root(
     root: &dyn BdDir,
     selection: &[String],
     options: CoreScanOptions,
-    progress: &mut dyn FnMut(ScanProgress<'_>),
+    observers: ScanObservers<'_>,
 ) -> Result<Scan, JsValue> {
     if selection.is_empty() {
-        scan_whole(root, options, progress)
+        scan_whole(root, options, observers)
             .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))
     } else {
-        scan_selection(root, selection, options, progress)
+        scan_selection(root, selection, options, observers)
             .map_err(|err| JsValue::from_str(&err.to_string()))
     }
+}
+
+/// Runs a measured scan of `root` reporting to the caller's two callbacks — the
+/// whole plumbing the streaming exports share, so they differ only in how they
+/// obtain `root`.
+///
+/// The measured observer is installed only when `on_measured` is a callback:
+/// unobserved, the scan never builds a snapshot at all, so a caller that does
+/// not ask for live tallies pays nothing for them. The browser exports carry no
+/// cancel affordance (a worker-side scan ends with the page), so the flag they
+/// pass is never set.
+///
+/// # Errors
+/// As [`scan_root`].
+#[cfg(target_arch = "wasm32")]
+fn scan_observed(
+    root: &dyn BdDir,
+    selection: &[String],
+    options: CoreScanOptions,
+    on_progress: Option<&js_sys::Function>,
+    on_measured: Option<&js_sys::Function>,
+) -> Result<Scan, JsValue> {
+    let cancel = never_cancelled();
+    let mut observe = |progress: ScanProgress<'_>| notify(on_progress, &progress);
+    let mut watch = |snapshot: MeasuredSnapshot| notify_measured(on_measured, &snapshot);
+    let observers = ScanObservers::new(&mut observe, &cancel);
+    if on_measured.is_none() {
+        return scan_root(root, selection, options, observers);
+    }
+    scan_root(root, selection, options, observers.with_measured(&mut watch))
 }
 
 /// Calls the caller's progress `callback`, when it supplied one, as
@@ -1010,6 +1044,26 @@ fn notify(callback: Option<&js_sys::Function>, progress: &ScanProgress<'_>) {
             &JsValue::from_f64(progress.done as f64),
             &JsValue::from_f64(progress.total as f64),
         );
+    }
+}
+
+/// Calls the caller's measured `callback`, when it supplied one, with the
+/// snapshot as one [`mirror::MeasuredSnapshot`] object.
+///
+/// A snapshot that cannot be serialized, and a callback that throws, are both
+/// ignored — as in [`notify`], a scan is not abandoned because the page could
+/// not draw a cell.
+///
+/// This fires once per demuxed read chunk (5 MiB on this target), not once per
+/// read like [`notify`], so the wide payload is built at the chunk cadence and
+/// never at the read cadence. Turning that into a wall-clock rate is the
+/// caller's job — the Worker relay throttles it to one message per second.
+#[cfg(target_arch = "wasm32")]
+fn notify_measured(callback: Option<&js_sys::Function>, snapshot: &MeasuredSnapshot) {
+    if let Some(callback) = callback
+        && let Ok(value) = mirror::MeasuredSnapshot::from(snapshot).into_js()
+    {
+        let _ = callback.call1(&JsValue::NULL, value.as_ref());
     }
 }
 
@@ -1041,12 +1095,17 @@ pub fn run_report(data: &[u8]) -> String {
 #[must_use]
 pub fn run_iso_report(reader: Box<dyn IsoReader>) -> String {
     let Ok(source) = UdfSource::open_resilient(reader) else { return String::new() };
-    scan_whole(&source.root(), CoreScanOptions::default(), &mut |_| {})
-        .map(|mut scan| {
-            scan.merge_errors(source.take_errors());
-            scan.render(RenderOptions::default())
-        })
-        .unwrap_or_default()
+    let mut silent = |_: ScanProgress<'_>| {};
+    scan_whole(
+        &source.root(),
+        CoreScanOptions::default(),
+        ScanObservers::new(&mut silent, &never_cancelled()),
+    )
+    .map(|mut scan| {
+        scan.merge_errors(source.take_errors());
+        scan.render(RenderOptions::default())
+    })
+    .unwrap_or_default()
 }
 
 /// The in-memory entry point: feed it BDMV bytes (the six `u32`-BE
@@ -1186,8 +1245,11 @@ pub fn render_report(mut disc: Disc, options: Option<ScanOptions>) -> String {
 /// multi-GB disc twice.
 ///
 /// When `on_progress` is supplied it is called as `(file, done, total)` before
-/// and after each demux read. A non-empty `selection` names the playlists to
-/// measure (CLI
+/// and after each demux read. When `on_measured` is supplied it is called with
+/// one `MeasuredSnapshot` object per demuxed read chunk — the scan's tallies
+/// as they stand, so a page can tick its cells during the scan; omit it and the
+/// scan builds no snapshots at all. A non-empty `selection` names the playlists
+/// to measure (CLI
 /// `--mpls` semantics — unfiltered, in order); an empty `selection` measures the
 /// standard `--whole` set. `options` carries the rest: the optional report
 /// sections, the short-playlist threshold `disc.playlists` is classified against
@@ -1213,14 +1275,20 @@ pub fn scan_files(
     selection: Vec<String>,
     on_progress: Option<js_sys::Function>,
     options: Option<ScanOptions>,
+    on_measured: Option<js_sys::Function>,
 ) -> Result<ScanResult, JsValue> {
     // Validated before the scan: an out-of-domain threshold rejects up front
     // rather than after a multi-GB demux.
     let filter = classification_filter(options.and_then(|options| options.short_playlist_seconds))
         .map_err(|err| JsValue::from_str(&err.to_string()))?;
     let root = build_web_tree(&paths, &files)?;
-    let mut observe = |p: ScanProgress<'_>| notify(on_progress.as_ref(), &p);
-    let scan = scan_root(&root, &selection, scan_options(options.as_ref()), &mut observe)?;
+    let scan = scan_observed(
+        &root,
+        &selection,
+        scan_options(options.as_ref()),
+        on_progress.as_ref(),
+        on_measured.as_ref(),
+    )?;
     Ok(measured_result(&scan, render_options(options.as_ref()), &filter))
 }
 
@@ -1251,6 +1319,7 @@ pub fn scan_iso(
     selection: Vec<String>,
     on_progress: Option<js_sys::Function>,
     options: Option<ScanOptions>,
+    on_measured: Option<js_sys::Function>,
 ) -> Result<ScanResult, JsValue> {
     // Validated before the scan, as in `scan_files`.
     let filter = classification_filter(options.and_then(|options| options.short_playlist_seconds))
@@ -1258,10 +1327,13 @@ pub fn scan_iso(
     let length = file.size() as u64;
     let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
         .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
-    let mut scan =
-        scan_root(&source.root(), &selection, scan_options(options.as_ref()), &mut |p| {
-            notify(on_progress.as_ref(), &p);
-        })?;
+    let mut scan = scan_observed(
+        &source.root(),
+        &selection,
+        scan_options(options.as_ref()),
+        on_progress.as_ref(),
+        on_measured.as_ref(),
+    )?;
     // The reader's bad sectors, which it zero-filled past — invisible to the
     // demux, and reported nowhere unless drained here (as `run_iso_report` and
     // the command line's `open_iso` both drain them).
@@ -1561,15 +1633,19 @@ mod tests {
     fn one_measured_scan_yields_both_the_report_and_the_disc() {
         use bdinfo_rs_core::bdrom::disc::ScanProgress;
 
-        use super::{CoreScanOptions, measured_result, scan_whole};
+        use super::{CoreScanOptions, ScanObservers, measured_result, never_cancelled, scan_whole};
 
         /// The pinned report for the fixture disc — what the report-only
         /// exports render from the same scan.
         const GOLDEN: &[u8] = include_bytes!("../tests/golden_report.txt");
 
         let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
-        let scan = scan_whole(&framed_tree(&fixture_blob()), CoreScanOptions::default(), &mut sink)
-            .expect("the fixture opens");
+        let scan = scan_whole(
+            &framed_tree(&fixture_blob()),
+            CoreScanOptions::default(),
+            ScanObservers::new(&mut sink, &never_cancelled()),
+        )
+        .expect("the fixture opens");
         // One scan, both outputs: the report is the pinned bytes and the disc
         // is the same scan mirrored, neither derived from the other.
         let filter = super::classification_filter(None).expect("an absent threshold is valid");
@@ -1584,11 +1660,18 @@ mod tests {
         use bdinfo_rs_core::bdrom::disc::ScanProgress;
         use bdinfo_rs_core::report::text;
 
-        use super::{CoreScanOptions, measured_result, render_order, scan_whole};
+        use super::{
+            CoreScanOptions, ScanObservers, measured_result, never_cancelled, render_order,
+            scan_whole,
+        };
 
         let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
-        let scan = scan_whole(&framed_tree(&fixture_blob()), CoreScanOptions::default(), &mut sink)
-            .expect("the fixture opens");
+        let scan = scan_whole(
+            &framed_tree(&fixture_blob()),
+            CoreScanOptions::default(),
+            ScanObservers::new(&mut sink, &never_cancelled()),
+        )
+        .expect("the fixture opens");
         let filter = super::classification_filter(None).expect("an absent threshold is valid");
         let result = measured_result(&scan, RenderOptions::default(), &filter);
 
@@ -1611,15 +1694,19 @@ mod tests {
     fn a_render_follows_the_scans_order_and_falls_back_to_the_presentation_one() {
         use bdinfo_rs_core::bdrom::disc::{PlaylistSummary, ScanProgress};
 
-        use super::{CoreScanOptions, render_order, scan_whole};
+        use super::{CoreScanOptions, ScanObservers, never_cancelled, render_order, scan_whole};
 
         // Two playlists off the scanned fixture, long enough that neither is
         // withheld as short: the shorter one sorts SECOND in presentation order
         // (longest first), so an order that follows the scan is visibly not the
         // presentation one.
         let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
-        let scan = scan_whole(&framed_tree(&fixture_blob()), CoreScanOptions::default(), &mut sink)
-            .expect("the fixture opens");
+        let scan = scan_whole(
+            &framed_tree(&fixture_blob()),
+            CoreScanOptions::default(),
+            ScanObservers::new(&mut sink, &never_cancelled()),
+        )
+        .expect("the fixture opens");
         let mut bdrom = scan.report.bdrom;
         let one = bdrom.playlists.first().expect("the fixture has a playlist").clone();
         bdrom.playlists = vec![
@@ -2044,7 +2131,10 @@ mod tests {
             use bdinfo_rs_core::vfs::mem::MemFile;
 
             use super::mem_entries;
-            use crate::{CoreScanOptions, Node, assemble_tree, scan_selection};
+            use crate::{
+                CoreScanOptions, Node, ScanObservers, assemble_tree, never_cancelled,
+                scan_selection,
+            };
 
             const INDEX: &[u8] =
                 include_bytes!("../../bdinfo-rs/tests/fixtures/BigBuckBunny/BDMV/index.bdmv");
@@ -2089,7 +2179,7 @@ mod tests {
                 &tree,
                 &["00000.MPLS".to_owned()],
                 CoreScanOptions::default(),
-                &mut sink,
+                ScanObservers::new(&mut sink, &never_cancelled()),
             )
             .expect("scan the feature")
             .render(whole);
@@ -2098,10 +2188,14 @@ mod tests {
 
             // Selecting the short playlist by name keeps it — unfiltered, unlike
             // `--whole`; and only the named playlist is rendered.
-            let short_only =
-                scan_selection(&tree, &["00001".to_owned()], CoreScanOptions::default(), &mut sink)
-                    .expect("scan the short")
-                    .render(whole);
+            let short_only = scan_selection(
+                &tree,
+                &["00001".to_owned()],
+                CoreScanOptions::default(),
+                ScanObservers::new(&mut sink, &never_cancelled()),
+            )
+            .expect("scan the short")
+            .render(whole);
             assert!(short_only.contains("00001.MPLS"), "a by-name short playlist is kept");
             assert!(!short_only.contains("00000.MPLS"), "only the named playlist is rendered");
 
@@ -2113,7 +2207,7 @@ mod tests {
                 &empty,
                 &["00000.MPLS".to_owned()],
                 CoreScanOptions::default(),
-                &mut sink,
+                ScanObservers::new(&mut sink, &never_cancelled()),
             )
             .expect_err("a structure with no BDMV must error");
             assert!(
@@ -2127,7 +2221,7 @@ mod tests {
                 &tree,
                 &["99999.MPLS".to_owned()],
                 CoreScanOptions::default(),
-                &mut sink,
+                ScanObservers::new(&mut sink, &never_cancelled()),
             )
             .expect_err("an all-unknown selection must error");
             assert_eq!(no_match.to_string(), "No matching playlists found on BD");

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -14,6 +14,10 @@
 //! | [`ScanStage`] | [`ScanStage`](bdinfo_rs_core::error::ScanStage) |
 //! | [`ScanErrorReason`] | [`BdError`](bdinfo_rs_core::error::BdError) |
 //! | [`HiddenRule`] | [`HiddenRule`](bdinfo_rs_core::bdrom::order::HiddenRule) |
+//! | [`MeasuredSnapshot`] | [`MeasuredSnapshot`](core_measured::MeasuredSnapshot) |
+//! | [`MeasuredPlaylist`] | [`MeasuredPlaylist`](core_measured::MeasuredPlaylist) |
+//! | [`MeasuredClip`] | [`MeasuredClip`](core_measured::MeasuredClip) |
+//! | [`MeasuredStream`] | [`MeasuredStream`](core_measured::MeasuredStream) |
 //!
 //! ## Conventions
 //!
@@ -52,6 +56,11 @@
 //! the [`Disc`] it was rendered beside, for a scan that returns both. [`ScanOptions`] is the one
 //! type that crosses the other way — what a call takes rather than what it produces — so it is
 //! also the only one whose fields are all optional.
+//!
+//! The four `Measured*` types are the only ones that cross **during** a scan rather than at its
+//! end: a measured observer is handed one [`MeasuredSnapshot`] per demuxed read chunk, so a page
+//! can tick its cells while the scan runs. Their `From` impls are the only ones taking a core
+//! type that is not part of the disc model.
 
 use std::io;
 
@@ -59,6 +68,7 @@ use bdinfo_rs_core::bdrom::chapters::{ChapterSummary, seconds_to_ticks};
 use bdinfo_rs_core::bdrom::disc::{
     BdRom, ClipStreamTally, ClipSummary, PlaylistSummary, StreamSummary,
 };
+use bdinfo_rs_core::bdrom::measured as core_measured;
 use bdinfo_rs_core::bdrom::order::{self, PlaylistFilter, table_rows};
 use bdinfo_rs_core::bdrom::shortfall::ShortStreamFile;
 use bdinfo_rs_core::error;
@@ -503,6 +513,90 @@ pub struct Chapter {
     pub max_frame_time_seconds: f64,
 }
 
+/// What a measured scan has tallied so far, taken while it is still running.
+///
+/// A scan that was given a measured observer hands it one of these per demuxed
+/// read chunk, so a display can tick its cells during the scan instead of
+/// waiting for the report. Every value is one the finished scan reports too:
+/// `measuredBytes` lands on the same number the `Clip` packet counts give, and
+/// `bitrateBps` on the same rate the `Stream` carries, so a cell that ticks
+/// here never jumps at the handover.
+///
+/// Two properties make the snapshots composable into a live display: each
+/// covers only the playlists that play the stream file it was taken over, so a
+/// display keeps its last known numbers for every other playlist; and within
+/// one scan the byte tallies only grow, so a cell one snapshot raises is never
+/// walked back by a later one.
+#[derive(Tsify, Serialize, Debug, Clone, PartialEq, Eq)]
+#[tsify(into_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct MeasuredSnapshot {
+    /// The stream file the scan was demuxing when it took this snapshot, in
+    /// upper case, for example `00000.M2TS`.
+    pub file: String,
+    /// The playlists that sequence that file, by name. Empty when no playlist
+    /// plays it: a clip file no playlist references is still scanned, and moves
+    /// nothing.
+    pub playlists: Vec<MeasuredPlaylist>,
+}
+
+/// The tallies of one playlist within a `MeasuredSnapshot`.
+#[derive(Tsify, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MeasuredPlaylist {
+    /// The playlist file name in upper case, for example `00000.MPLS` — the
+    /// same `name` the disc model carries.
+    pub name: String,
+    /// Packet-derived bytes over every clip the playlist sequences, angle clips
+    /// included. The live form of the sum of the playlist `clips` packet counts
+    /// times 192.
+    pub measured_bytes: u64,
+    /// The sequenced clips, one entry per row of the playlist `clips` and in
+    /// that same order, so the two line up by position.
+    pub clips: Vec<MeasuredClip>,
+    /// The measured rates of the playlist presented streams, one entry per
+    /// packet identifier and camera angle. Empty until the scan resolves the
+    /// presented streams, and never ordered like the playlist `streams`: match
+    /// a row by its `pid` and `angleIndex`, never by position.
+    pub streams: Vec<MeasuredStream>,
+}
+
+/// The tallies of one sequenced clip within a `MeasuredSnapshot`.
+#[derive(Tsify, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MeasuredClip {
+    /// The clip stream-file name in upper case, for example `00000.M2TS`. Only
+    /// the clips carrying the snapshot `file` can have moved since the previous
+    /// snapshot; a playlist that plays one file twice has one entry per play
+    /// item.
+    pub name: String,
+    /// Which camera angle this clip belongs to; zero is the main angle.
+    pub angle_index: i32,
+    /// Packet-derived bytes measured for this clip — the live form of the clip
+    /// `packetCount` times 192.
+    pub measured_bytes: u64,
+}
+
+/// The measured rates of one presented stream within a `MeasuredSnapshot`.
+#[derive(Tsify, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MeasuredStream {
+    /// The packet identifier.
+    pub pid: u16,
+    /// Which camera angle this row carries: zero for the main presentation row,
+    /// and 1 upwards for the per-angle copies of a video stream. Together with
+    /// `pid` it names exactly one row of the playlist `streams`.
+    pub angle_index: usize,
+    /// The stream bitrate in bits per second so far — the live form of the
+    /// stream `bitrateBps`. A constant-rate stream carries its declared rate
+    /// from the start; a variable-rate one is recomputed as the scan proceeds.
+    pub bitrate_bps: i64,
+    /// The bitrate in bits per second over the region where the stream is
+    /// active — the live form of the stream `activeBitrateBps`, and filled in
+    /// for the same streams.
+    pub active_bitrate_bps: i64,
+}
+
 /// One file the scan could not read or parse, and continued past.
 ///
 /// A scan never stops on a bad file: it records the failure here and scans the
@@ -825,6 +919,47 @@ impl From<&ChapterSummary> for Chapter {
     }
 }
 
+impl From<&core_measured::MeasuredSnapshot> for MeasuredSnapshot {
+    fn from(snapshot: &core_measured::MeasuredSnapshot) -> Self {
+        Self {
+            file: snapshot.file.clone(),
+            playlists: snapshot.playlists.iter().map(MeasuredPlaylist::from).collect(),
+        }
+    }
+}
+
+impl From<&core_measured::MeasuredPlaylist> for MeasuredPlaylist {
+    fn from(playlist: &core_measured::MeasuredPlaylist) -> Self {
+        Self {
+            name: playlist.name.clone(),
+            measured_bytes: playlist.measured_bytes,
+            clips: playlist.clips.iter().map(MeasuredClip::from).collect(),
+            streams: playlist.streams.iter().map(MeasuredStream::from).collect(),
+        }
+    }
+}
+
+impl From<&core_measured::MeasuredClip> for MeasuredClip {
+    fn from(clip: &core_measured::MeasuredClip) -> Self {
+        Self {
+            name: clip.name.clone(),
+            angle_index: clip.angle_index,
+            measured_bytes: clip.measured_bytes,
+        }
+    }
+}
+
+impl From<&core_measured::MeasuredStream> for MeasuredStream {
+    fn from(stream: &core_measured::MeasuredStream) -> Self {
+        Self {
+            pid: stream.pid.get(),
+            angle_index: stream.angle_index,
+            bitrate_bps: stream.bitrate,
+            active_bitrate_bps: stream.active_bitrate,
+        }
+    }
+}
+
 impl From<&error::ScanError> for ScanError {
     fn from(failure: &error::ScanError) -> Self {
         Self {
@@ -1128,8 +1263,9 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::{
-        Chapter, Clip, ClipStream, Disc, HiddenRule, Playlist, ScanError, ScanErrorReason,
-        ScanOptions, ScanStage, Stream, borrowed_codec_alt_name, order,
+        Chapter, Clip, ClipStream, Disc, HiddenRule, MeasuredSnapshot, Playlist, ScanError,
+        ScanErrorReason, ScanOptions, ScanStage, Stream, borrowed_codec_alt_name, core_measured,
+        order,
     };
 
     // One fixture value and one hand-written wire form per mirror type, composed
@@ -1767,6 +1903,93 @@ mod tests {
             &PlaylistFilter::default(),
             None,
         )
+    }
+
+    /// Every snapshot a measured scan of the fixture disc takes, mirrored.
+    ///
+    /// The scan is the real one — the core types are `#[non_exhaustive]`, so a
+    /// snapshot cannot be built by hand — which is also what makes the
+    /// assertions below a comparison against the numbers the same scan then
+    /// reports, rather than against a fixture restating the mapping.
+    fn fixture_snapshots() -> (Vec<MeasuredSnapshot>, Disc) {
+        use std::sync::atomic::AtomicBool;
+
+        use bdinfo_rs_core::bdrom::disc::{ScanObservers, ScanOptions, ScanProgress};
+
+        let tree = crate::framed_tree(&crate::tests::fixture_blob());
+        let mut taken: Vec<MeasuredSnapshot> = Vec::new();
+        let mut progress = |_: ScanProgress<'_>| {};
+        let mut watch = |snapshot: core_measured::MeasuredSnapshot| {
+            taken.push(MeasuredSnapshot::from(&snapshot));
+        };
+        let cancel = AtomicBool::new(false);
+        let report = BdRom::open_resilient_observed(
+            &tree,
+            ScanMode::Full,
+            ScanOptions::default(),
+            None,
+            ScanObservers::new(&mut progress, &cancel).with_measured(&mut watch),
+        )
+        .expect("the fixture disc opens");
+        let disc =
+            Disc::from_scan(&report.bdrom, &report.errors, true, &PlaylistFilter::default(), None);
+        (taken, disc)
+    }
+
+    #[test]
+    fn a_live_snapshot_carries_the_numbers_the_finished_scan_reports() {
+        let (snapshots, disc) = fixture_snapshots();
+        let last = snapshots.last().expect("the measured pass takes at least one snapshot");
+        assert_eq!(last.file, "00000.M2TS", "the snapshot names the stream file it was taken over");
+
+        let playlist = disc.playlists.first().expect("the fixture disc has a playlist");
+        let live = last.playlists.first().expect("the fixture playlist plays the scanned clip");
+        assert_eq!(last.playlists.len(), 1, "only the playlists playing that file are covered");
+        assert_eq!(live.name, playlist.name);
+
+        // The playlist total, the per-clip rows and the per-stream rates all
+        // land on the finished summaries: the last snapshot of a scan IS the
+        // report, in the live spelling.
+        let clip_bytes = |clip: &Clip| clip.packet_count * 192;
+        assert_eq!(live.measured_bytes, playlist.clips.iter().map(clip_bytes).sum::<u64>());
+        assert!(live.measured_bytes > 0, "the packet scan measured the clip");
+        assert_eq!(live.clips.len(), playlist.clips.len());
+        for (measured, clip) in live.clips.iter().zip(&playlist.clips) {
+            assert_eq!((&measured.name, measured.angle_index), (&clip.name, clip.angle_index));
+            assert_eq!(measured.measured_bytes, clip_bytes(clip));
+        }
+
+        // Streams are keyed, never zipped: the snapshot orders them main map
+        // first and then per angle, which is not the report row order.
+        assert_eq!(live.streams.len(), playlist.streams.len());
+        for stream in &playlist.streams {
+            let measured = live
+                .streams
+                .iter()
+                .find(|live| (live.pid, live.angle_index) == (stream.pid, stream.angle_index))
+                .expect("every presented stream has a measured row");
+            assert_eq!(measured.bitrate_bps, stream.bitrate_bps, "pid {}", stream.pid);
+            assert_eq!(measured.active_bitrate_bps, stream.active_bitrate_bps);
+        }
+        assert!(
+            live.streams.iter().any(|stream| stream.bitrate_bps > 0),
+            "the measured rates reach the mirror"
+        );
+    }
+
+    #[test]
+    fn the_byte_tallies_only_grow_across_a_scan() {
+        // The property a live display leans on: a cell one snapshot raises is
+        // never walked back by a later one, so patching cells in arrival order
+        // cannot show a number going down.
+        let (snapshots, _) = fixture_snapshots();
+        assert!(snapshots.len() > 1, "the fixture clip spans several read chunks");
+        let totals: Vec<u64> = snapshots
+            .iter()
+            .map(|snapshot| snapshot.playlists.iter().map(|playlist| playlist.measured_bytes).sum())
+            .collect();
+        assert!(totals.is_sorted(), "byte tallies must be monotone: {totals:?}");
+        assert!(totals.first() < totals.last(), "and they must actually move: {totals:?}");
     }
 
     #[test]

--- a/crates/bdinfo-rs-wasm/wasm-size-budget.txt
+++ b/crates/bdinfo-rs-wasm/wasm-size-budget.txt
@@ -2,8 +2,10 @@
 # (web/pkg/bdinfo_rs_wasm_bg.wasm, after `wasm-opt -Oz`).
 #
 # A ceiling, not a target: the gate and CI (wasm.yml) fail if the optimized
-# .wasm exceeds it. Current optimized size is ~513,498 B (rustc 1.97.1 +
-# wasm-bindgen 0.2.126 + binaryen 131.0.0).
+# .wasm exceeds it. Current optimized size is ~540,482 B (rustc 1.97.1 +
+# wasm-bindgen 0.2.127 + binaryen 132.0.0); the same tree built ~513,498 B under
+# wasm-bindgen 0.2.126 + binaryen 131.0.0, so a few tens of kilobytes of the
+# figure are toolchain drift rather than code.
 #
 # The ceiling is 1 MiB, roughly double the current figure. It is deliberately
 # loose: a payload of this size is not a cost worth designing around for a tool
@@ -24,4 +26,7 @@
 # row serializer and the four exports that fed it took ~2,859 B back off.
 # Replacing the scanning calls' positional option tails with one deserialized
 # options object added ~5,126 B - one more visitor over four optional fields.
+# The live measured-snapshot mirror (four types serialized once per demuxed read
+# chunk) added ~4,468 B, measured against the same tree without it: `Serialize`
+# alone over small flat records is the cheap half of serde.
 1048576

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -228,6 +228,33 @@ call with an error rather than silently scanning with the default.
 Nothing else moves with it: which playlists a `Disc` holds, which ones a
 `selection` measures, and the rendered report are the same either way.
 
+### Live numbers while the scan runs
+
+`onProgress` says how far a scan has read; `options.onMeasured` says what it has
+measured so far, so a table can fill its measured cells during the scan instead
+of waiting for the report:
+
+```ts
+await scan(picked, undefined, {
+  onMeasured: ({ file, playlists }) => {
+    for (const playlist of playlists) {
+      // `measuredBytes` per playlist, `clips[]` per stream file, `streams[]`
+      // per (pid, angleIndex) — the live form of the same values `scan`
+      // resolves with.
+      cells.get(playlist.name).textContent = format(playlist.measuredBytes);
+    }
+  },
+});
+```
+
+Each snapshot covers only the playlists that play the stream file named by
+`file`, so keep your last known numbers for the rest; within one scan the byte
+tallies only grow. The values land exactly on the finished ones, so a cell that
+ticks does not jump when the scan ends. The callback is called **at most once a
+second** whatever the read speed — the scan produces snapshots far faster on a
+quick source and the extra ones are dropped — and a scan given no `onMeasured`
+builds no snapshots at all.
+
 ### Cancelling
 
 Pass an `AbortSignal`. Aborting it terminates the scan Worker and rejects the

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -803,6 +803,8 @@
                   <th data-sort="group">Group<span class="arrow"></span></th>
                   <th data-sort="length">Length<span class="arrow"></span></th>
                   <th class="num" data-sort="size">Est. Size<span class="arrow"></span></th>
+                  <!-- filled by the measured scan, and ticked while it runs -->
+                  <th class="num" data-sort="measured">Meas. Size<span class="arrow"></span></th>
                 </tr>
               </thead>
               <tbody id="playlist-body"></tbody>

--- a/crates/bdinfo-rs-wasm/web/package.json
+++ b/crates/bdinfo-rs-wasm/web/package.json
@@ -48,6 +48,8 @@
     "dist/analyze.js",
     "dist/analyze.d.ts",
     "dist/worker.js",
+    "dist/measured.js",
+    "dist/measured.d.ts",
     "pkg",
     "README.md",
     "LICENSE",
@@ -62,7 +64,7 @@
     "size": "node check-size.mjs",
     "check": "biome check .",
     "format": "biome check --write .",
-    "test:node": "node test/parity.node.mjs && node test/faults.node.mjs",
+    "test:node": "node test/parity.node.mjs && node test/faults.node.mjs && node test/measured.node.mjs",
     "test:chrome": "node test/parity.chrome.mjs"
   },
   "devDependencies": {

--- a/crates/bdinfo-rs-wasm/web/src/analyze.ts
+++ b/crates/bdinfo-rs-wasm/web/src/analyze.ts
@@ -18,7 +18,12 @@
 // files, and resolves with the result — the rendered classic disc report being
 // the very bytes the native CLI writes to `BDINFO.<label>.txt`.
 
-import type { Disc, ScanOptions as ModuleOptions, ScanResult } from "../pkg/bdinfo_rs_wasm.js";
+import type {
+  Disc,
+  MeasuredSnapshot,
+  ScanOptions as ModuleOptions,
+  ScanResult,
+} from "../pkg/bdinfo_rs_wasm.js";
 
 // The structured disc model is generated from the Rust types, so these
 // declarations and the values the WebAssembly module hands back have one source
@@ -30,6 +35,10 @@ export type {
   ClipStream,
   Disc,
   HiddenRule,
+  MeasuredClip,
+  MeasuredPlaylist,
+  MeasuredSnapshot,
+  MeasuredStream,
   Playlist,
   ScanError,
   ScanErrorReason,
@@ -62,6 +71,12 @@ export interface ScanProgress {
 
 /** A progress observer, called repeatedly as the scan demuxes. */
 export type ProgressFn = (progress: ScanProgress) => void;
+
+/**
+ * A live-tally observer, called as a measured scan raises its numbers — at most
+ * once a second, whatever the read speed.
+ */
+export type MeasuredFn = (measured: MeasuredSnapshot) => void;
 
 /**
  * Optional overrides for every call in this module. Each option documents which
@@ -142,6 +157,22 @@ export interface ScanOptions {
    */
   keepPartial?: boolean;
   /**
+   * An observer of the scan measured tallies as they build up, so a table can
+   * tick its measured cells during the scan instead of waiting for the report.
+   *
+   * It is called with one {@link MeasuredSnapshot} at most once a second — the
+   * scan produces them far faster on a quick source, and the extra ones are
+   * dropped rather than posted. Each snapshot covers only the playlists that
+   * play the stream file it was taken over, so keep your last known numbers for
+   * the rest; within one scan the byte tallies only grow. The values land
+   * exactly on the ones {@link scan} resolves with, so a cell that ticks here
+   * does not jump when the scan finishes.
+   *
+   * Read by {@link scan}. Omitting it costs nothing: a scan nobody watches
+   * builds no snapshots at all.
+   */
+  onMeasured?: MeasuredFn;
+  /**
    * An optional {@link AbortSignal} that cancels the call in progress: when it
    * aborts, the scan Worker is terminated and the returned promise rejects with
    * the signal's reason (an `AbortError`), so callers can tell a user cancel
@@ -155,6 +186,7 @@ export interface ScanOptions {
 /** Everything the scan Worker posts back; see `worker.ts` for who sends what. */
 type WorkerMessage =
   | ({ type: "progress" } & ScanProgress)
+  | { type: "measured"; measured: MeasuredSnapshot }
   | { type: "done"; report: string }
   | { type: "disc"; disc: Disc }
   | { type: "result"; result: ScanResult }
@@ -220,11 +252,11 @@ function cancelledError(signal?: AbortSignal): DOMException {
  * out of the reply that answers it.
  *
  * `request` is the shape every call in this module shares: spawn the Worker,
- * post one request, forward demux progress to `onProgress`, settle on the first
- * reply `take` accepts or on the first `error`, and terminate the Worker on
- * every exit — reply, failure, or cancel. `take` returns `null` for a message
- * that is not this request's answer, which is what keeps the message loop out of
- * the calls themselves.
+ * post one request, forward demux progress to `onProgress` and live tallies to
+ * `options.onMeasured`, settle on the first reply `take` accepts or on the first
+ * `error`, and terminate the Worker on every exit — reply, failure, or cancel.
+ * `take` returns `null` for a message that is not this request's answer, which
+ * is what keeps the message loop out of the calls themselves.
  *
  * `message` must be one of the request shapes `worker.ts` declares as `Request`;
  * that union is the contract, and it cannot be imported here because `worker.ts`
@@ -259,6 +291,10 @@ function request<T>(
       const reply = event.data;
       if (reply.type === "progress") {
         onProgress?.(reply);
+        return;
+      }
+      if (reply.type === "measured") {
+        options?.onMeasured?.(reply.measured);
         return;
       }
       if (reply.type === "error") {
@@ -324,7 +360,9 @@ export function inspect(source: DiscSource, options?: ScanOptions): Promise<Disc
  * UDF reader and read on demand at byte offsets, never loaded whole, so a
  * multi-GB image is fine.
  *
- * `onProgress`, if given, is called as the scan demuxes. `options.selection`
+ * `onProgress`, if given, is called as the scan demuxes, and
+ * `options.onMeasured` as its measured numbers climb — the two together are
+ * what a page needs to show a live scan. `options.selection`
  * measures only the named playlists (the CLI's `--mpls`), defaulting to the
  * standard `--whole` set. `options.streamDiagnostics` and
  * `options.quickSummary` choose the report's optional sections, both rendered

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -5,7 +5,10 @@
 // playlist table is the master of a master-detail flow: the active (highlighted)
 // row populates the two detail panes below it — the playlist's stream files and
 // its codecs — the same lower panes the bdinfo-rs desktop app and the classic
-// BDInfo window show. The settings dialog mirrors the desktop app's: the two
+// BDInfo window show. The measured cells of all three tables tick WHILE a scan
+// runs, from the snapshots the scan reports (`applyMeasured`): cells only, so
+// the row set and the sort the user set up never move under a running scan.
+// The settings dialog mirrors the desktop app's: the two
 // playlist-filter opt-outs, the size format and the chapter-count suffix are
 // pure re-projections of the model the page already holds; only the
 // short-playlist threshold (a fresh `inspect`) and the two report sections (a
@@ -18,6 +21,8 @@ import {
   type Disc,
   type HiddenRule,
   inspect,
+  type MeasuredPlaylist,
+  type MeasuredSnapshot,
   type Playlist,
   renderReport,
   reportFileName,
@@ -42,6 +47,11 @@ interface PlaylistRow {
   lengthTicks: number;
   /** Interleaved `*.ssif` size, else `*.m2ts` size, else null (the `—` cell). */
   estimatedBytes: number | null;
+  /**
+   * Packet-derived bytes over the playlist's clips — zero until a scan measures
+   * them, and the cell a running scan ticks (see {@link live}).
+   */
+  measuredBytes: number;
   /** Whether the playlist hides any stream (the CLI's `(*)` note). */
   hasHidden: boolean;
   hiddenBy: HiddenRule[];
@@ -51,6 +61,9 @@ interface PlaylistRow {
 
 /** The ticks in one second — the unit `totalLengthTicks` counts. */
 const TICKS_PER_SECOND = 10_000_000;
+
+/** Bytes per transport packet — what turns a packet count into a size cell. */
+const PACKET_BYTES = 192;
 
 /** A row per playlist, in the table order `position` records. */
 function playlistRows(playlists: Playlist[]): PlaylistRow[] {
@@ -62,6 +75,10 @@ function playlistRows(playlists: Playlist[]): PlaylistRow[] {
       length: tableLength(playlist.totalLengthTicks),
       lengthTicks: playlist.totalLengthTicks,
       estimatedBytes: playlist.interleavedFileSizeBytes || playlist.fileSizeBytes || null,
+      measuredBytes: playlist.clips.reduce(
+        (bytes, clip) => bytes + clip.packetCount * PACKET_BYTES,
+        0,
+      ),
       hasHidden: playlist.streams.some((stream) => stream.isHidden),
       hiddenBy: playlist.hiddenBy,
       chapterCount: playlist.chapterCount,
@@ -177,6 +194,20 @@ let allRows: PlaylistRow[] = [];
 let displayed: PlaylistRow[] = [];
 /** The playlists the user has unticked, by name — persists across a redraw. */
 const unchecked = new Set<string>();
+/**
+ * What the RUNNING scan has measured so far, by playlist name: the overlay the
+ * table and the panes prefer over the held disc while a scan is in flight, and
+ * the only place a mid-scan number lives.
+ *
+ * It is an overlay rather than a patch of the held disc for the reason the
+ * desktop app keeps one too: the disc the page holds is what the report, the
+ * sort keys and the row set are derived from, so writing half-measured numbers
+ * into it would make those disagree with the report beside them. Clearing the
+ * map is therefore all a scan's end takes — {@link adoptDisc} does it when the
+ * measured disc arrives, and a cancelled scan does it to return the cells to
+ * what the held disc knows.
+ */
+const live = new Map<string, MeasuredPlaylist>();
 /** The playlist whose details the panes show; null before the first draw. */
 let activeName: string | null = null;
 
@@ -408,6 +439,9 @@ async function loadSource(src: Source): Promise<void> {
  * what the user set up.
  */
 function adoptDisc(next: Disc, threshold: number): void {
+  // A new disc supersedes whatever a scan was ticking: its numbers are the
+  // final form of the very cells the overlay was raising.
+  live.clear();
   disc = next;
   discThreshold = threshold;
   playlists = next.playlists;
@@ -451,7 +485,7 @@ function isShown(row: PlaylistRow): boolean {
 // ── sorting ──────────────────────────────────────────────────────────────────
 
 /** A sortable playlist-table column; the sort key is the row's raw value. */
-type SortColumn = "position" | "name" | "group" | "length" | "size";
+type SortColumn = "position" | "name" | "group" | "length" | "size" | "measured";
 
 /** The playlist table's active sort — a column and a direction. */
 interface Sort {
@@ -484,7 +518,17 @@ function compareRows(a: PlaylistRow, b: PlaylistRow, by: Sort): number {
         return (a.estimatedBytes === null ? 1 : 0) - (b.estimatedBytes === null ? 1 : 0);
       }
       return dir(a.estimatedBytes - b.estimatedBytes);
+    case "measured":
+      // Unmeasured is a zero, not an absent value like the estimated size
+      // above: a scan measured nothing there yet, so it sorts as the smallest
+      // number rather than being pushed to the bottom in both directions.
+      return dir(measuredBytes(a) - measuredBytes(b));
   }
+}
+
+/** The measured bytes a row shows: the running scan's, else the held disc's. */
+function measuredBytes(row: PlaylistRow): number {
+  return live.get(row.name)?.measuredBytes ?? row.measuredBytes;
 }
 
 /** Whether `rows` already read ascending by `column` (ties allowed). */
@@ -637,6 +681,12 @@ function playlistRow(row: PlaylistRow, position: number, group: number): HTMLTab
   tr.appendChild(textCell(row.length));
   tr.appendChild(textCell(sizeCell(row.estimatedBytes), "num"));
 
+  // The measured cell a running scan ticks: tagged so a snapshot can find it
+  // without knowing the column order (see `applyMeasured`).
+  const measured = textCell(sizeCell(measuredBytes(row) || null), "num");
+  measured.dataset.cell = "measured";
+  tr.appendChild(measured);
+
   // The check cell toggles the tick; the rest of the row activates the
   // playlist and fills the detail panes, like the desktop table.
   tr.addEventListener("click", (event) => {
@@ -730,8 +780,9 @@ function renderPanes(): void {
   }
   show(panesBox);
   paneLabel.textContent = playlist.name;
-  filesBody.replaceChildren(...streamFileRows(playlist.clips));
-  codecsBody.replaceChildren(...playlist.streams.map(codecRow));
+  const measured = live.get(playlist.name);
+  filesBody.replaceChildren(...streamFileRows(playlist.clips, measured));
+  codecsBody.replaceChildren(...playlist.streams.map((stream) => codecRow(stream, measured)));
 }
 
 /**
@@ -740,10 +791,14 @@ function renderPanes(): void {
  * main clip's index and gets a ` (N)` angle suffix on the file name; the
  * estimated size prefers the interleaved `*.ssif` over the plain `*.m2ts`; a
  * size that is not yet known (no file on disk / nothing demuxed) shows as `—`.
+ *
+ * `measured` is the running scan's tallies for this playlist, whose per-clip
+ * rows line up with `clips` one for one; without it the cells come from the
+ * held disc.
  */
-function streamFileRows(clips: Clip[]): HTMLTableRowElement[] {
+function streamFileRows(clips: Clip[], measured?: MeasuredPlaylist): HTMLTableRowElement[] {
   let index = 0;
-  return clips.map((clip) => {
+  return clips.map((clip, position) => {
     if (clip.angleIndex === 0) {
       index += 1;
     }
@@ -758,8 +813,12 @@ function streamFileRows(clips: Clip[]): HTMLTableRowElement[] {
     // table-time rule every `hh:mm:ss` cell follows.
     tr.appendChild(textCell(tableLength(Math.trunc(clip.lengthSeconds * TICKS_PER_SECOND))));
     tr.appendChild(textCell(sizeCell(estimated > 0 ? estimated : null), "num"));
-    // The packet-derived size: 192 bytes per transport packet.
-    tr.appendChild(textCell(sizeCell(clip.packetCount > 0 ? clip.packetCount * 192 : null), "num"));
+    // The packet-derived size: 192 bytes per transport packet. Tagged like the
+    // table's measured cell, so a snapshot can patch it where it stands.
+    const bytes = measured?.clips.at(position)?.measuredBytes ?? clip.packetCount * PACKET_BYTES;
+    const packets = textCell(sizeCell(bytes > 0 ? bytes : null), "num");
+    packets.dataset.cell = "clip-measured";
+    tr.appendChild(packets);
     return tr;
   });
 }
@@ -768,9 +827,16 @@ function streamFileRows(clips: Clip[]): HTMLTableRowElement[] {
  * One "Streams" (codec) row, formatted like the desktop pane. The description
  * is `fullDescription` — the same string the locked report prints — so the
  * pane matches the report; a hidden stream's codec name is marked with `*`.
+ *
+ * The rate comes from `measured` — the running scan's tallies for this
+ * playlist — when it carries this row, and from the held disc otherwise. The
+ * row records the pair that names it, since the snapshot orders its streams
+ * differently and can only be matched by `(pid, angleIndex)`.
  */
-function codecRow(stream: Stream): HTMLTableRowElement {
+function codecRow(stream: Stream, measured?: MeasuredPlaylist): HTMLTableRowElement {
   const tr = document.createElement("tr");
+  tr.dataset.pid = String(stream.pid);
+  tr.dataset.angle = String(stream.angleIndex);
   const codecCell = cell();
   codecCell.textContent = stream.codecName;
   if (stream.isHidden) {
@@ -778,15 +844,75 @@ function codecRow(stream: Stream): HTMLTableRowElement {
   }
   tr.appendChild(codecCell);
   tr.appendChild(textCell(stream.languageName));
-  tr.appendChild(textCell(bitrateCell(stream.bitrateBps), "num"));
+  const rate = textCell(bitrateCell(liveRate(measured, stream) ?? stream.bitrateBps), "num");
+  rate.dataset.cell = "bitrate";
+  tr.appendChild(rate);
   tr.appendChild(textCell(stream.fullDescription));
   return tr;
+}
+
+/** `measured`'s rate for the row `(pid, angleIndex)` names, when it has one. */
+function liveRate(measured: MeasuredPlaylist | undefined, stream: Stream): number | undefined {
+  return measured?.streams.find(
+    (row) => row.pid === stream.pid && row.angleIndex === stream.angleIndex,
+  )?.bitrateBps;
 }
 
 /** The bit-rate cell: `N kbps` (thousands-grouped), or `—` while unmeasured. */
 function bitrateCell(bitsPerSecond: number): string {
   const kbps = Math.trunc(bitsPerSecond / 1000);
   return kbps > 0 ? `${kbps.toLocaleString("en-US")} kbps` : "—";
+}
+
+// ── live measured cells ──────────────────────────────────────────────────────
+
+/**
+ * Takes one snapshot of the running scan and writes the cells it moved, in
+ * place: the playlist table's measured column, and the two panes when the
+ * snapshot covers the active playlist.
+ *
+ * Cells only — no row is added, removed, re-sorted or re-numbered, and the
+ * report is not re-rendered. That is what makes ticking safe during a scan: the
+ * table the user set up (its sort, its ticks, its active row) is the same table
+ * a second later, with different numbers in it. A snapshot covers only the
+ * playlists that play the stream file it was taken over, so every other row
+ * keeps the number it already shows.
+ */
+function applyMeasured(snapshot: MeasuredSnapshot): void {
+  for (const playlist of snapshot.playlists) {
+    live.set(playlist.name, playlist);
+  }
+  for (const tr of playlistBody.querySelectorAll("tr")) {
+    const measured = live.get(tr.dataset.name ?? "");
+    const cell = tr.querySelector('[data-cell="measured"]');
+    if (measured !== undefined && cell !== null) {
+      cell.textContent = sizeCell(measured.measuredBytes || null);
+    }
+  }
+  const active = activeName === null ? undefined : live.get(activeName);
+  if (active !== undefined) {
+    patchPanes(active);
+  }
+}
+
+/** Writes `measured` into the open panes' cells, leaving their rows alone. */
+function patchPanes(measured: MeasuredPlaylist): void {
+  Array.from(filesBody.rows).forEach((tr, position) => {
+    const clip = measured.clips.at(position);
+    const cell = tr.querySelector('[data-cell="clip-measured"]');
+    if (clip !== undefined && cell !== null) {
+      cell.textContent = sizeCell(clip.measuredBytes || null);
+    }
+  });
+  for (const tr of codecsBody.rows) {
+    const rate = measured.streams.find(
+      (row) => String(row.pid) === tr.dataset.pid && String(row.angleIndex) === tr.dataset.angle,
+    );
+    const cell = tr.querySelector('[data-cell="bitrate"]');
+    if (rate !== undefined && cell !== null) {
+      cell.textContent = bitrateCell(rate.bitrateBps);
+    }
+  }
 }
 
 // ── scan + report ────────────────────────────────────────────────────────────
@@ -830,12 +956,20 @@ async function runScan(): Promise<void> {
     streamDiagnostics: settings.reportStreamDiagnostics,
     quickSummary: settings.reportQuickSummary,
   };
+  // The live cells: guarded by the same stamp the completion is, so a snapshot
+  // from a scan the page has already moved on from writes nothing.
+  const onMeasured = (snapshot: MeasuredSnapshot) => {
+    if (gen === generation) {
+      applyMeasured(snapshot);
+    }
+  };
   try {
     const result = await scan(src.kind === "folder" ? src.files : src.file, onProgress, {
       selection,
       signal: controller.signal,
       shortPlaylistSeconds: threshold,
       keepPartial: settings.keepPartialScans,
+      onMeasured,
       ...sections,
     });
     if (gen !== generation) {
@@ -859,6 +993,12 @@ async function runScan(): Promise<void> {
     scanController = null;
     hide(progressCard);
     scanBtn.disabled = selectedNames().length === 0 || !scanOffered();
+    // The overlay dies with the scan that fed it. A finished scan cleared it
+    // already, adopting the measured disc; a cancelled or failed one clears it
+    // here, and the redraw puts back what the held disc knows — partial numbers
+    // beside a report that does not carry them would be the worse half-state.
+    live.clear();
+    renderRows();
   }
   // A report switch flipped while the scan ran was deferred (the disc it would
   // have rendered was about to be replaced); one cheap re-render catches up,

--- a/crates/bdinfo-rs-wasm/web/src/measured.ts
+++ b/crates/bdinfo-rs-wasm/web/src/measured.ts
@@ -1,0 +1,51 @@
+// The rate gate on the live measured tallies, between the WebAssembly module
+// and the page.
+//
+// The module hands its measured observer one snapshot per demuxed read chunk —
+// a BYTE cadence (5 MiB on this target), deliberately untimed, because only the
+// consumer knows how often it can draw. Relaying every one of them would post a
+// whole disc worth of playlist, clip and stream numbers across the Worker
+// boundary at whatever rate the media happens to read at, which on a fast
+// source is far more often than a page can use. This gate turns that byte
+// cadence into a wall-clock one, at the rate classic BDInfo samples its own
+// live grids.
+//
+// It lives in its own module so both the Worker relay and the Node harness can
+// use it: the harness drives it with a mock clock, which is the only way to
+// assert the rate without waiting in real time.
+import type { MeasuredSnapshot } from "../pkg/bdinfo_rs_wasm.js";
+
+/**
+ * How often a live snapshot is relayed at most — 1 Hz, the rate classic BDInfo
+ * samples its live grids at, and the same interval the desktop app ticks its
+ * grids on.
+ */
+export const MEASURE_INTERVAL_MS = 1000;
+
+/**
+ * Wraps `relay` so it runs at most once per `intervalMs`, dropping the
+ * snapshots that arrive in between.
+ *
+ * The first snapshot always passes, so a display starts ticking as soon as the
+ * scan has measured anything. Dropping the rest loses nothing: the byte tallies
+ * only grow, so a dropped snapshot is a number a later one carries anyway, and
+ * the scan ends by handing back the finished disc, which replaces every cell —
+ * including whatever the last dropped snapshot would have raised.
+ *
+ * `now` is the clock, injectable so a test can run the gate without waiting.
+ */
+export function throttleMeasured(
+  relay: (snapshot: MeasuredSnapshot) => void,
+  intervalMs: number = MEASURE_INTERVAL_MS,
+  now: () => number = Date.now,
+): (snapshot: MeasuredSnapshot) => void {
+  let relayed: number | null = null;
+  return (snapshot) => {
+    const at = now();
+    if (relayed !== null && at - relayed < intervalMs) {
+      return;
+    }
+    relayed = at;
+    relay(snapshot);
+  };
+}

--- a/crates/bdinfo-rs-wasm/web/src/worker.ts
+++ b/crates/bdinfo-rs-wasm/web/src/worker.ts
@@ -13,6 +13,11 @@
 // forwarded to the main thread as it demuxes; the answer is posted back when
 // done.
 //
+// A measured scan also forwards the tallies it has so far, so the page can tick
+// its cells during the scan. Those messages carry a whole disc worth of numbers
+// where a progress message carries three, so they are the one reply this module
+// rate-limits (`throttleMeasured`) rather than relaying as they arrive.
+//
 // This module is internal: `dist/worker.js` is not an importable subpath of the
 // package, so the request and reply shapes below are free to change with the
 // `analyze.ts` that speaks them.
@@ -26,6 +31,7 @@ import init, {
   scan_files,
   scan_iso,
 } from "../pkg/bdinfo_rs_wasm.js";
+import { throttleMeasured } from "./measured.js";
 
 /**
  * The options object every request carries, built in `analyze.ts` and handed to
@@ -101,6 +107,11 @@ self.onmessage = async (event: MessageEvent<Request>) => {
     const onProgress = (file: string, done: number, total: number) => {
       self.postMessage({ type: "progress", file, done, total });
     };
+    // One gate per request: a scan starts ticking on its first snapshot, and
+    // the clock does not carry over from the previous scan.
+    const onMeasured = throttleMeasured((measured) => {
+      self.postMessage({ type: "measured", measured });
+    });
     switch (data.kind) {
       case "inspect":
         self.postMessage({
@@ -117,13 +128,20 @@ self.onmessage = async (event: MessageEvent<Request>) => {
       case "scan":
         self.postMessage({
           type: "result",
-          result: scan_files(data.paths, data.files, data.selection, onProgress, data.options),
+          result: scan_files(
+            data.paths,
+            data.files,
+            data.selection,
+            onProgress,
+            data.options,
+            onMeasured,
+          ),
         });
         break;
       case "scan-iso":
         self.postMessage({
           type: "result",
-          result: scan_iso(data.file, data.selection, onProgress, data.options),
+          result: scan_iso(data.file, data.selection, onProgress, data.options, onMeasured),
         });
         break;
       case "render":

--- a/crates/bdinfo-rs-wasm/web/test/measured.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/measured.node.mjs
@@ -1,0 +1,249 @@
+// Node live-measured harness — the tallies a scan reports WHILE it runs, and
+// the gate that rate-limits them.
+//
+// The golden harness next door proves what a finished scan renders; this one
+// drives the same production export (`scan_files`, with the measured callback
+// its sixth argument installs) over the synthetic `MultiPlaylist` disc and pins
+// what arrives mid-scan:
+//
+//   - snapshots arrive per demuxed read chunk, not only at the end;
+//   - each covers exactly the playlists that sequence the file it was taken over;
+//   - the byte tallies only grow, and the last ones land on the numbers the finished
+//     disc model carries — which is what lets a page tick cells and then take the summaries
+//     without the cells jumping;
+//   - a scan given no callback renders the identical report, so the observer is additive.
+//
+// It then drives `throttleMeasured` (dist/measured.js — what the Worker relays
+// through) on a MOCK CLOCK: the gate is what keeps the wide payload off the
+// Worker boundary at read speed, and a mock clock is the only way to assert its
+// rate without waiting in real time.
+//
+// The disc is the same three playlists over three clips faults.node.mjs
+// describes; 00011.M2TS is shared by 00000 and 00002, and is the one clip
+// bigger than a read chunk, so it alone yields two chunk snapshots.
+//
+// Prereq: `npm run build` (emits pkg/ and dist/). Run with `npm run test:node`.
+
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { installShims, ShimFile } from "./shims.mjs";
+
+installShims();
+
+const here = dirname(fileURLToPath(import.meta.url));
+const discRoot = resolve(here, "../../../bdinfo-rs/tests/fixtures/MultiPlaylist");
+const wasmPath = resolve(here, "../pkg/bdinfo_rs_wasm_bg.wasm");
+
+/** Bytes per transport packet — what turns a packet count into a byte tally. */
+const PACKET_BYTES = 192;
+
+/** Which playlists each stream file belongs to, by the disc's own topology. */
+const COVERAGE = {
+  "00011.M2TS": ["00000.MPLS", "00002.MPLS"],
+  "00022.M2TS": ["00001.MPLS"],
+  "00033.M2TS": ["00002.MPLS"],
+};
+
+/** Every file under `dir`, as absolute paths. */
+async function walk(dir) {
+  const found = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    found.push(...(entry.isDirectory() ? await walk(full) : [full]));
+  }
+  return found;
+}
+
+/** The measured bytes the finished model carries for `playlist`. */
+function modelBytes(playlist) {
+  return playlist.clips.reduce((bytes, clip) => bytes + clip.packetCount * PACKET_BYTES, 0);
+}
+
+async function main() {
+  const { initSync, scan_files } = await import("../pkg/bdinfo_rs_wasm.js");
+  initSync({ module: await readFile(wasmPath) });
+  const { MEASURE_INTERVAL_MS, throttleMeasured } = await import("../dist/measured.js");
+
+  // The disc as a folder pick, exactly as the demo hands one over.
+  const paths = [];
+  const files = [];
+  for (const full of await walk(discRoot)) {
+    const rel = relative(discRoot, full).split("\\").join("/");
+    paths.push(`MultiPlaylist/${rel}`);
+    files.push(
+      new ShimFile(new Uint8Array(await readFile(full)), rel.slice(rel.lastIndexOf("/") + 1)),
+    );
+  }
+
+  const failures = [];
+  const check = (ok, message) => {
+    if (!ok) {
+      failures.push(message);
+    }
+  };
+
+  // ── the observed scan ──────────────────────────────────────────────────────
+
+  const snapshots = [];
+  const watched = scan_files(paths, files, [], undefined, undefined, (snapshot) => {
+    snapshots.push(snapshot);
+  });
+
+  // The measurement pass demuxes four chunks over three clips and closes each
+  // file with one more snapshot, so a scan that only reported at the end could
+  // not produce this many.
+  check(snapshots.length >= 5, `expected several snapshots, got ${snapshots.length}`);
+
+  // Each snapshot names the file it was taken over and covers exactly the
+  // playlists that sequence it — the property a display leans on when it keeps
+  // its last known numbers for every other row.
+  for (const snapshot of snapshots) {
+    const covered = snapshot.playlists.map((playlist) => playlist.name);
+    const want = COVERAGE[snapshot.file];
+    check(
+      want !== undefined && JSON.stringify(covered) === JSON.stringify(want),
+      `snapshot over ${snapshot.file} covered ${JSON.stringify(covered)}, want ${JSON.stringify(want)}`,
+    );
+  }
+
+  // The byte tallies only grow, per playlist, across the whole scan — and they
+  // do move mid-file: 00011.M2TS spans two read chunks, so the playlists that
+  // play it are seen part-measured before they are seen whole.
+  const seen = new Map();
+  const first = new Map();
+  for (const snapshot of snapshots) {
+    for (const playlist of snapshot.playlists) {
+      const previous = seen.get(playlist.name) ?? 0;
+      check(
+        playlist.measuredBytes >= previous,
+        `${playlist.name} fell from ${previous} to ${playlist.measuredBytes}`,
+      );
+      seen.set(playlist.name, playlist.measuredBytes);
+      if (!first.has(playlist.name)) {
+        first.set(playlist.name, playlist.measuredBytes);
+      }
+    }
+  }
+  check(
+    first.get("00000.MPLS") < seen.get("00000.MPLS"),
+    `the shared clip must be seen part-measured first: ${first.get("00000.MPLS")} then ${seen.get("00000.MPLS")}`,
+  );
+
+  // Where the ticking ends is where the report begins: for every playlist, the
+  // last snapshot that covered it carries the finished model's numbers — the
+  // playlist total, each clip row, and each stream rate keyed by (pid, angle).
+  const last = new Map();
+  for (const snapshot of snapshots) {
+    for (const playlist of snapshot.playlists) {
+      last.set(playlist.name, playlist);
+    }
+  }
+  for (const playlist of watched.disc.playlists) {
+    const live = last.get(playlist.name);
+    if (live === undefined) {
+      check(false, `no snapshot ever covered ${playlist.name}`);
+      continue;
+    }
+    check(
+      live.measuredBytes === modelBytes(playlist) && live.measuredBytes > 0,
+      `${playlist.name} settled at ${live.measuredBytes}, model says ${modelBytes(playlist)}`,
+    );
+    check(
+      live.clips.length === playlist.clips.length &&
+        live.clips.every(
+          (clip, index) =>
+            clip.name === playlist.clips[index].name &&
+            clip.angleIndex === playlist.clips[index].angleIndex &&
+            clip.measuredBytes === playlist.clips[index].packetCount * PACKET_BYTES,
+        ),
+      `${playlist.name} clip rows diverged from the model`,
+    );
+    check(
+      live.streams.length === playlist.streams.length &&
+        playlist.streams.every((stream) => {
+          const rate = live.streams.find(
+            (row) => row.pid === stream.pid && row.angleIndex === stream.angleIndex,
+          );
+          return (
+            rate !== undefined &&
+            rate.bitrateBps === stream.bitrateBps &&
+            rate.activeBitrateBps === stream.activeBitrateBps
+          );
+        }),
+      `${playlist.name} stream rates diverged from the model`,
+    );
+  }
+
+  // The callback is additive: the same scan without one renders the identical
+  // report, so an existing five-argument caller sees no change at all.
+  const plain = scan_files(paths, files, []);
+  check(
+    plain.report === watched.report,
+    `an unobserved scan rendered ${plain.report.length} bytes against ${watched.report.length}`,
+  );
+
+  // ── the rate gate ──────────────────────────────────────────────────────────
+
+  // The gate under the scan's own cadence, on a mock clock: seven snapshots
+  // 100 ms apart is 600 ms of scanning, which the page must see as ONE update
+  // (the first) rather than seven.
+  let clock = 0;
+  const relayed = [];
+  const gate = throttleMeasured(
+    (snapshot) => relayed.push(snapshot),
+    MEASURE_INTERVAL_MS,
+    () => clock,
+  );
+  for (const snapshot of snapshots) {
+    gate(snapshot);
+    clock += 100;
+  }
+  check(
+    relayed.length === 1 && relayed[0] === snapshots[0],
+    `a fast scan must relay its first snapshot and no more, got ${relayed.length}`,
+  );
+
+  // And over a longer run at the same speed: one relay per interval, never two,
+  // with the first one immediate. 1,000 events 5 ms apart span 4,995 ms, so the
+  // gate passes those at 0, 1000, 2000, 3000 and 4000 ms.
+  clock = 0;
+  const burst = [];
+  const fast = throttleMeasured(
+    (snapshot) => burst.push(snapshot),
+    MEASURE_INTERVAL_MS,
+    () => clock,
+  );
+  const at = [];
+  for (let i = 0; i < 1000; i++) {
+    clock = i * 5;
+    fast({ file: `${i}`, playlists: [] });
+    if (burst.length > at.length) {
+      at.push(clock);
+    }
+  }
+  check(
+    burst.length === 5 && JSON.stringify(at) === JSON.stringify([0, 1000, 2000, 3000, 4000]),
+    `the gate relayed ${burst.length} of 1,000 events, at ${JSON.stringify(at)}`,
+  );
+
+  if (failures.length === 0) {
+    console.log(
+      `PASS — ${snapshots.length} live snapshots over ${Object.keys(COVERAGE).length} stream files: ` +
+        "per-file coverage, monotone tallies, mid-file movement, they settle on the model, " +
+        "an unobserved scan is unchanged, and the gate holds 1,000 events to 5 relays.",
+    );
+    process.exit(0);
+  }
+
+  console.error(`FAIL — ${failures.length} live-measured assertion(s):`);
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -327,6 +327,7 @@ async function main() {
           names: texts("#playlist-body td.name"),
           positions: texts("#playlist-body tr td:nth-child(2)"),
           sizes: texts("#playlist-body tr td:nth-child(6)"),
+          measured: texts('#playlist-body td[data-cell="measured"]'),
           active: document.querySelector("#playlist-body tr.active")?.dataset.name ?? null,
           panesVisible: !document.getElementById("detail-panes").hidden,
           paneLabel: document.getElementById("pane-playlist").textContent,
@@ -725,6 +726,15 @@ async function main() {
   demoOk &= demoEq("scan keeps the active row", demo.scanned.active, "00000.MPLS");
   demoOk &= demoEq("measured size fills after the scan", demo.scanned.files, [
     ["00000.M2TS", "1", "00:00:30", "10.63 MB", "10.55 MB"],
+  ]);
+  // The table's own measured column: empty before any scan, and filled for both
+  // rows afterwards — they play the same clip, so they measure the same bytes.
+  // Mid-scan the same cells tick from the scan's snapshots; the page reads them
+  // here after it finished, where the numbers are the report's.
+  demoOk &= demoEq("measured column starts empty", demo.initial.measured, ["—", "—"]);
+  demoOk &= demoEq("measured column fills after the scan", demo.scanned.measured, [
+    "10.55 MB",
+    "10.55 MB",
   ]);
   // 973, not the report's 974: the pane integer-divides bits/s to kbps like the
   // desktop pane, where the report's codec table rounds.


### PR DESCRIPTION
Refs #325.

The scanning exports (`scan_files`, `scan_iso`) take an optional measured callback as a trailing argument and hand it one `MeasuredSnapshot` per demuxed read chunk — the mirror of the core snapshot type — so a page can tick its measured cells during a scan instead of waiting for the report. Existing five-argument callers are unaffected: with no callback the scan installs no observer and builds no snapshot at all.

**Throttle.** The Worker relays the snapshots through a 1 Hz gate (`web/src/measured.ts`, clock injectable) rather than as they arrive, so the wide payload crosses the Worker boundary at a wall-clock rate and not at read speed. The per-read progress path is untouched.

**TypeScript surface** (additive): the `MeasuredSnapshot` / `MeasuredPlaylist` / `MeasuredClip` / `MeasuredStream` types, `MeasuredFn`, `ScanOptions.onMeasured`, and a `measured` reply in the worker union. `dist/measured.js` joins the published files.

**Demo.** The playlist table gains a measured-size column; its cells and the two detail panes are patched in place as the scan runs — cells only, no reorder, no report re-render — and the overlay is dropped when the scan ends or is cancelled.

**Tests.** `web/test/measured.node.mjs` drives the export over the `MultiPlaylist` fixture and pins the 7 live snapshots: per-file playlist coverage, monotone byte tallies, mid-file movement on the two-chunk clip, that they settle on the finished model (playlist totals, clip rows, stream rates keyed by pid and angle), that an unobserved scan renders identical bytes, and that the gate holds 1,000 events to 5 relays on a mock clock. Two native tests cover the mirror conversion; the Chrome demo harness pins the new column empty before a scan and filled after.

Optimized wasm 536,014 → 540,482 B (+4,468 B, 51.5% of the 1 MiB budget) — the four serialized mirror types; recorded in `wasm-size-budget.txt`.

Verified: `pwsh scripts/compliance.ps1 -All` PASS (root, wasm — Tier-A coverage 100,00% lines 1919/1919 / regions / functions, mt 10 mutants → 4 caught + 6 unviable, 0 missed — and gui).
