### PR TITLE
ci: demote arm/macos legs and routine msrv to the sweep, gate gui drive on gui changes

### DIFF
--- a/.github/scripts/classify-diff.ps1
+++ b/.github/scripts/classify-diff.ps1
@@ -19,10 +19,11 @@
     Areas and the jobs they gate:
 
       core       build + test, lint, coverage, mutants, install + scan, musl scan
-      gui        the gui reusable workflow and its mutation job
+      gui        the gui workflow's build + test and checks jobs, and its mutation job
+      gui-full   the gui workflow's drive, packaging and mosaic jobs
       wasm       the wasm reusable workflow and its mutation job
       fuzz       corpus replay
-      deps       cargo deny, cargo vet
+      deps       cargo deny, cargo vet, and all three workspaces' msrv jobs
       yaml       action-validator + ryl
       workflows  zizmor
       canary     build + test on one leg per shell family
@@ -31,6 +32,13 @@
       toml       taplo
       links      lychee
       typos      typos
+
+    gui-full always rides with gui: it marks the diffs whose verdict the gui
+    workflow's expensive real-window and packaging legs could change — a
+    gui-path or toolchain change — while a bdinfo-rs-core edit reaching gui
+    through the path-dependency edge fires gui alone, running only the gui
+    build + test and checks jobs on the pull-request path. The daily sweep
+    fires every area, so the legs gui alone skips still run there daily.
 
     A rule with an empty Areas list is a deliberate declaration that no job on
     the pull-request path reads the file. -SelfTest requires every tracked path
@@ -71,7 +79,7 @@ begin {
     # Every area this script can emit. The workflow reads each as a job output,
     # so adding one here without adding the matching `if:` gates nothing.
     $script:AllAreas = @(
-        'core', 'gui', 'wasm', 'fuzz', 'deps', 'yaml', 'workflows',
+        'core', 'gui', 'gui-full', 'wasm', 'fuzz', 'deps', 'yaml', 'workflows',
         'canary', 'dist', 'pkg', 'toml', 'links', 'typos'
     )
 
@@ -151,9 +159,9 @@ begin {
         },
         @{
             Name       = 'gui crate'
-            Areas      = @('gui')
+            Areas      = @('gui', 'gui-full')
             Structural = $true
-            Why        = 'Sources, the generated icon set the packaging step consumes, and the crate manifest all feed the gui workflow.'
+            Why        = 'Sources, the generated icon set the packaging step consumes, and the crate manifest all feed the gui workflow — including the drive, packaging and mosaic jobs that gui-full gates.'
             Match      = { param($f) (Test-Match $f @('crates/bdinfo-rs-gui/*')) -and -not (Test-Prose $f) }
         },
         @{
@@ -186,23 +194,23 @@ begin {
         },
         @{
             Name       = 'toolchain and formatting configuration'
-            Areas      = $script:CoreDependents + @('toml')
+            Areas      = $script:CoreDependents + @('gui-full', 'toml')
             Structural = $true
-            Why        = 'rust-toolchain.toml pins the compiler for every workspace in the tree; rustfmt reads the nearest rustfmt.toml walking up from each file, so the root file governs the sibling crates too.'
+            Why        = 'rust-toolchain.toml pins the compiler for every workspace in the tree; rustfmt reads the nearest rustfmt.toml walking up from each file, so the root file governs the sibling crates too. gui-full because a toolchain change changes the binary the gui drive and packaging jobs build.'
             Match      = { param($f) Test-Match $f @('rust-toolchain.toml', 'rustfmt.toml') }
         },
         @{
             Name       = 'root clippy configuration'
-            Areas      = $script:CoreDependents + @('toml')
+            Areas      = $script:CoreDependents + @('gui-full', 'toml')
             Structural = $true
-            Why        = 'crates/bdinfo-rs-gui carries its own clippy.toml but crates/bdinfo-rs-wasm does not; rather than depend on clippy resolving a configuration across workspace roots, this fires every lint that could read it.'
+            Why        = 'crates/bdinfo-rs-gui carries its own clippy.toml but crates/bdinfo-rs-wasm does not; rather than depend on clippy resolving a configuration across workspace roots, this fires every lint that could read it. gui-full for the same conservative reach: a toolchain-rule file fires the whole gui stack.'
             Match      = { param($f) $f -eq 'clippy.toml' }
         },
         @{
             Name       = 'cargo configuration'
-            Areas      = $script:CoreDependents + @('toml')
+            Areas      = $script:CoreDependents + @('gui-full', 'toml')
             Structural = $true
-            Why        = 'Cargo merges configuration from every ancestor directory of the invocation, so the root aliases and build settings apply inside the sibling workspaces as well.'
+            Why        = 'Cargo merges configuration from every ancestor directory of the invocation, so the root aliases and build settings apply inside the sibling workspaces as well — including the builds the gui drive and packaging jobs run, hence gui-full.'
             Match      = { param($f) $f -eq '.cargo/config.toml' }
         },
         @{
@@ -263,9 +271,9 @@ begin {
         },
         @{
             Name       = 'gui reusable workflow'
-            Areas      = @('yaml', 'workflows', 'gui')
+            Areas      = @('yaml', 'workflows', 'gui', 'gui-full')
             Structural = $true
-            Why        = 'The file is the gui gate: an edit to it, including a pinned action digest, changes what those jobs do.'
+            Why        = 'The file is the gui gate: an edit to it, including a pinned action digest, changes what those jobs do — the drive, packaging and mosaic jobs gui-full gates included.'
             Match      = { param($f) $f -eq '.github/workflows/gui.yml' }
         },
         @{
@@ -361,9 +369,9 @@ begin {
         },
         @{
             Name       = 'gui packaging composite action'
-            Areas      = @('gui', 'yaml', 'workflows')
+            Areas      = @('gui', 'gui-full', 'yaml', 'workflows')
             Structural = $true
-            Why        = 'The gui-package composite is the body of gui.yml''s packaging smoke, the only pull-request job that runs it; the gui-release.yml lane shares it but runs on a tag or a dispatch. action-validator and zizmor read the action definitions under .github/actions as well as the workflows.'
+            Why        = 'The gui-package composite is the body of gui.yml''s packaging smoke — a gui-full job, so the area that runs it must fire — and the only pull-request job that runs it; the gui-release.yml lane shares it but runs on a tag or a dispatch. action-validator and zizmor read the action definitions under .github/actions as well as the workflows.'
             Match      = { param($f) Test-Match $f @('.github/actions/gui-package/*') }
         },
         @{
@@ -375,9 +383,9 @@ begin {
         },
         @{
             Name       = 'gui gate scripts'
-            Areas      = @('gui')
+            Areas      = @('gui', 'gui-full')
             Structural = $true
-            Why        = 'The gui workflow runs these directly, and _gui-walk.ps1 is the click-target table its three injected drive legs dot-source. The publishing helpers are named publish-gui-* so that this pattern cannot reach them.'
+            Why        = 'The gui workflow runs these directly, and _gui-walk.ps1 is the click-target table its injected drive legs dot-source; the drive and mosaic scripts belong to the jobs gui-full gates. The publishing helpers are named publish-gui-* so that this pattern cannot reach them.'
             Match      = { param($f) (Test-Match $f @('.github/scripts/gui-*.ps1', '.github/scripts/_gui-walk.ps1')) }
         },
         @{
@@ -558,9 +566,11 @@ end {
             @{ Path = 'crates/bdinfo-rs/tests/fixtures/golden/folder.txt'; Areas = 'core' }
             @{ Path = 'crates/bdinfo-rs/src/main.rs'; Areas = 'core links typos' }
             @{ Path = 'crates/bdinfo-rs-core/src/bdrom/m2ts.rs'; Areas = 'core fuzz gui links typos wasm' }
-            @{ Path = 'crates/bdinfo-rs-gui/packaging/icons/hicolor/32x32/apps/bdinfo-rs-gui.png'; Areas = 'gui' }
-            @{ Path = 'crates/bdinfo-rs-gui/src/main.rs'; Areas = 'gui links typos' }
-            @{ Path = '.cargo/config.toml'; Areas = 'core fuzz gui links toml typos wasm' }
+            @{ Path = 'crates/bdinfo-rs-gui/packaging/icons/hicolor/32x32/apps/bdinfo-rs-gui.png'; Areas = 'gui gui-full' }
+            @{ Path = 'crates/bdinfo-rs-gui/src/main.rs'; Areas = 'gui gui-full links typos' }
+            @{ Path = '.cargo/config.toml'; Areas = 'core fuzz gui gui-full links toml typos wasm' }
+            @{ Path = 'rust-toolchain.toml'; Areas = 'core fuzz gui gui-full links toml typos wasm' }
+            @{ Path = 'clippy.toml'; Areas = 'core fuzz gui gui-full links toml typos wasm' }
             @{ Path = '.cargo/mutants.toml'; Areas = 'core links toml typos' }
             @{ Path = '.config/nextest.toml'; Areas = 'core links toml typos' }
             @{ Path = 'Cargo.lock'; Areas = 'core deps pkg' }
@@ -572,7 +582,7 @@ end {
             @{ Path = '.github/workflows/ci.yml'; Areas = 'canary links typos workflows yaml' }
             @{ Path = '.github/workflows/core.yml'; Areas = 'core deps dist fuzz links pkg typos workflows yaml' }
             @{ Path = '.github/workflows/repo.yml'; Areas = 'links toml typos workflows yaml' }
-            @{ Path = '.github/workflows/gui.yml'; Areas = 'gui links typos workflows yaml' }
+            @{ Path = '.github/workflows/gui.yml'; Areas = 'gui gui-full links typos workflows yaml' }
             @{ Path = '.github/workflows/sweep-mutants.yml'; Areas = 'links typos workflows yaml' }
             @{ Path = '.github/workflows/docker.yml'; Areas = 'links typos workflows yaml' }
             @{ Path = '.github/actions/mutate-crate/action.yml'; Areas = 'core gui links typos wasm workflows yaml' }
@@ -582,9 +592,9 @@ end {
             @{ Path = '.github/actions/msrv-check/action.yml'; Areas = 'core gui links typos wasm workflows yaml' }
             @{ Path = '.github/actions/fuzz-toolchain/action.yml'; Areas = 'fuzz links typos workflows yaml' }
             @{ Path = '.github/actions/lint-crate/action.yml'; Areas = 'gui links typos wasm workflows yaml' }
-            @{ Path = '.github/actions/gui-package/action.yml'; Areas = 'gui links typos workflows yaml' }
-            @{ Path = '.github/scripts/gui-package-windows.ps1'; Areas = 'gui links typos' }
-            @{ Path = '.github/scripts/_gui-walk.ps1'; Areas = 'gui links typos' }
+            @{ Path = '.github/actions/gui-package/action.yml'; Areas = 'gui gui-full links typos workflows yaml' }
+            @{ Path = '.github/scripts/gui-package-windows.ps1'; Areas = 'gui gui-full links typos' }
+            @{ Path = '.github/scripts/_gui-walk.ps1'; Areas = 'gui gui-full links typos' }
             @{ Path = '.github/scripts/wasm-rules.ps1'; Areas = 'links typos wasm' }
             @{ Path = '.github/scripts/cov-floor.ps1'; Areas = 'gui links typos wasm' }
             @{ Path = '.github/scripts/publish-gui-aur.ps1'; Areas = 'links typos' }
@@ -646,12 +656,20 @@ end {
 
     # build + test runs one leg per released target when the root workspace is
     # in play, and one leg per shell family when only the orchestrator changed.
+    # test-os-pr is the pull-request variant of the same matrix: the caller
+    # (ci.yml) passes it instead of test-os on pull_request events, dropping
+    # the two aarch64 Linux/Windows legs — those run on master pushes and the
+    # daily sweep, while the x64 legs of all three OS families plus
+    # Apple-silicon macOS hold the pull-request verdict.
     $testOs = '[]'
+    $testOsPr = '[]'
     if ($fired.Contains('core')) {
         $testOs = '["ubuntu-latest","ubuntu-24.04-arm","windows-2025","windows-11-arm","macos-15-intel","macos-15"]'
+        $testOsPr = '["ubuntu-latest","windows-2025","macos-15-intel","macos-15"]'
     }
     elseif ($fired.Contains('canary')) {
         $testOs = '["ubuntu-latest","windows-2025"]'
+        $testOsPr = $testOs
     }
 
     foreach ($a in $script:AllAreas) {
@@ -659,4 +677,5 @@ end {
     }
     "test=$(($testOs -ne '[]').ToString().ToLowerInvariant())"
     "test-os=$testOs"
+    "test-os-pr=$testOsPr"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
       should_run: ${{ steps.skip.outputs.should_run || 'true' }}
       core: ${{ steps.classify.outputs.core }}
       gui: ${{ steps.classify.outputs.gui }}
+      gui-full: ${{ steps.classify.outputs.gui-full }}
       wasm: ${{ steps.classify.outputs.wasm }}
       fuzz: ${{ steps.classify.outputs.fuzz }}
       deps: ${{ steps.classify.outputs.deps }}
@@ -132,6 +133,7 @@ jobs:
       typos: ${{ steps.classify.outputs.typos }}
       test: ${{ steps.classify.outputs.test }}
       test-os: ${{ steps.classify.outputs.test-os }}
+      test-os-pr: ${{ steps.classify.outputs.test-os-pr }}
     steps:
       # Depth 1, .github only: the diff comes from the API, so the checkout
       # exists for the classifier and its self-test — whose `git ls-files`
@@ -421,7 +423,12 @@ jobs:
       fuzz: ${{ needs.plan.outputs.fuzz }}
       pkg: ${{ needs.plan.outputs.pkg }}
       test: ${{ needs.plan.outputs.test }}
-      test-os: ${{ needs.plan.outputs.test-os }}
+      # Pull requests take the classifier's shrunk matrix — no aarch64
+      # Linux/Windows legs; those run on master pushes and the daily sweep,
+      # which pass the full list here. A matrix shrunk by expression still
+      # reports each remaining leg normally; nothing here is a required
+      # context, so the absent legs hang no PR.
+      test-os: ${{ github.event_name == 'pull_request' && needs.plan.outputs.test-os-pr || needs.plan.outputs.test-os }}
 
   # The whole-tree scanners: YAML, TOML, workflow security, spelling, links.
   # Same caller shape as `core` above.
@@ -447,21 +454,40 @@ jobs:
   # content stays with their crates while the plan gates them here. Their
   # check-runs render prefixed (`gui / gui build + test (…)`,
   # `wasm / wasm gate (…)`); a red anywhere inside reddens the caller job and
-  # therefore ci-ok. When the area is skipped, the single caller job reports
-  # `skipped` — the inner jobs never appear, which is fine because only the
-  # caller jobs feed ci-ok and no inner name is a required context. One area
-  # each, so these two need no input plumbing.
+  # therefore ci-ok. When every consumed area is skipped, the single caller
+  # job reports `skipped` — the inner jobs never appear, which is fine because
+  # only the caller jobs feed ci-ok and no inner name is a required context.
+  # Same caller shape as `core` above: the `if:` is the UNION of the areas the
+  # inner jobs consume, each passed through as an input. `gui` alone (a
+  # bdinfo-rs-core edit reaching the crate through the path-dependency edge)
+  # runs the gui build + test and checks jobs; `gui-full` (a gui-path or
+  # toolchain change) adds the drive, packaging and mosaic jobs; `deps` runs
+  # both crates' msrv jobs.
   gui:
     name: gui
     needs: plan
-    if: needs.plan.outputs.should_run != 'false' && needs.plan.outputs.gui == 'true'
+    if: >-
+      needs.plan.outputs.should_run != 'false' &&
+      (needs.plan.outputs.gui == 'true' ||
+      needs.plan.outputs.gui-full == 'true' ||
+      needs.plan.outputs.deps == 'true')
     uses: ./.github/workflows/gui.yml
+    with:
+      gui: ${{ needs.plan.outputs.gui }}
+      full: ${{ needs.plan.outputs.gui-full }}
+      deps: ${{ needs.plan.outputs.deps }}
 
   wasm:
     name: wasm
     needs: plan
-    if: needs.plan.outputs.should_run != 'false' && needs.plan.outputs.wasm == 'true'
+    if: >-
+      needs.plan.outputs.should_run != 'false' &&
+      (needs.plan.outputs.wasm == 'true' ||
+      needs.plan.outputs.deps == 'true')
     uses: ./.github/workflows/wasm.yml
+    with:
+      wasm: ${{ needs.plan.outputs.wasm }}
+      deps: ${{ needs.plan.outputs.deps }}
 
   # The fan-in: the ONE result branch protection requires (plus the three
   # standalone checks outside this workflow). Green = every gate job either

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -62,7 +62,12 @@ on:
         required: true
         type: string
       test-os:
-        description: The build + test matrix as a JSON array — six legs for `core`, two for `canary`.
+        description: >-
+          The build + test matrix as a JSON array. The classifier emits six
+          legs for `core` and two for `canary`; on pull requests the caller
+          passes the classifier's shrunk variant instead, which drops the two
+          aarch64 Linux/Windows legs (those run on master pushes and the
+          daily sweep).
         required: true
         type: string
 
@@ -85,10 +90,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     # One native runner per RELEASED binary — x86_64 AND aarch64 across Linux,
     # Windows and macOS — so `cargo test` (including the real-disc end-to-end scan
-    # in tests/cli.rs) runs on every architecture we ship: no shipped arch goes
-    # unscanned. arm64 Linux/Windows and Intel macOS are standard GitHub-hosted
-    # runners, free for public repos. The OS list arrives as an input — the full
-    # six for `core`, one leg per shell family for `canary`; keep the list in
+    # in tests/cli.rs) runs on every architecture we ship. arm64 Linux/Windows
+    # and Intel macOS are standard GitHub-hosted runners, free for public
+    # repos. The OS list arrives as an input — the full six for `core`, one
+    # leg per shell family for `canary`, and on pull requests the caller's
+    # shrunk `core` variant without the two aarch64 Linux/Windows legs, whose
+    # verdicts come from master pushes and the daily sweep instead (the
+    # windows-11-arm legs were the whole run's pacing jobs); keep the lists in
     # classify-diff.ps1 in lockstep with the six dist-workspace.toml targets.
     strategy:
       fail-fast: false
@@ -339,9 +347,17 @@ jobs:
   # and the build-only posture live in .github/actions/msrv-check.
   # `gui msrv` in gui.yml holds the same bar for the GUI crate and `wasm msrv`
   # in wasm.yml for the wasm crate.
+  #
+  # Keyed on `deps`, not `core`: a manifest or lockfile change can raise the
+  # resolved tree's effective floor invisibly, so dependency changes prove
+  # the floor on the pull-request path. A source edit that uses an API newer
+  # than the floor builds green on the pinned stable and is caught by the
+  # daily sweep instead, which fires every area — at most a day of staleness,
+  # traded for removing one of the two ~10 min jobs that paced whole
+  # pull-request runs.
   msrv:
     name: msrv
-    if: inputs.core == 'true'
+    if: inputs.deps == 'true'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -366,6 +382,15 @@ jobs:
   # parallel costs nothing but wall-clock. (Running the binary in TOTAL
   # isolation — FROM scratch, zero runtime deps — is the separate `isolation`
   # job below; docker.yml ships that same scratch image on release.)
+  #
+  # The matrix is keyed on the event, mirroring the build + test shrink: pull
+  # requests skip the two aarch64 Linux/Windows legs (the windows-11-arm legs
+  # were the whole run's pacing jobs), whose verdicts come from master pushes
+  # and the daily sweep; a called workflow sees the caller's original event,
+  # so the sweep's schedule/dispatch runs and master pushes keep all six.
+  # Shrinking by expression rather than a job-level `if:` keeps each
+  # remaining leg reporting normally — a skipped matrix job would report
+  # once, unexpanded.
   e2e:
     name: real-world install + scan (${{ matrix.os }})
     if: inputs.core == 'true'
@@ -373,13 +398,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - {os: ubuntu-latest, target: x86_64-unknown-linux-musl}
-          - {os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl}
-          - {os: windows-2025, target: ""}
-          - {os: windows-11-arm, target: ""}
-          - {os: macos-15-intel, target: ""}
-          - {os: macos-15, target: ""}
+        include: >-
+          ${{ fromJson(github.event_name == 'pull_request'
+          && '[{"os":"ubuntu-latest","target":"x86_64-unknown-linux-musl"},
+               {"os":"windows-2025","target":""},
+               {"os":"macos-15-intel","target":""},
+               {"os":"macos-15","target":""}]'
+          || '[{"os":"ubuntu-latest","target":"x86_64-unknown-linux-musl"},
+               {"os":"ubuntu-24.04-arm","target":"aarch64-unknown-linux-musl"},
+               {"os":"windows-2025","target":""},
+               {"os":"windows-11-arm","target":""},
+               {"os":"macos-15-intel","target":""},
+               {"os":"macos-15","target":""}]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -2,14 +2,20 @@ name: gui
 
 # The PROPORTIONATE Posture-C gate for the native desktop GUI
 # (crates/bdinfo-rs-gui), mirrored 1:1 by the local scripts/gui-compliance.ps1.
-# A workflow_call REUSABLE: ci.yml invokes it when its plan job fires the `gui`
-# area (a crate-dir change, a core change via the encoded path-dep edge —
-# root-Cargo.lock-only bumps excluded — or an edit to this file / the
-# .github/scripts/gui-*.ps1 helpers, since a gate's implementation files
-# re-fire the gate), and the daily sweep re-runs it ungated through the same
-# orchestrator. This file carries no triggers or concurrency
-# of its own — both are the caller's — so it can never fire on its own and
-# never needs a paths filter.
+# A workflow_call REUSABLE: ci.yml invokes it when its plan job fires any of
+# the three areas passed through as inputs, and each job below keys on its
+# own input. `gui` (a crate-dir change, a core change via the encoded
+# path-dep edge — root-Cargo.lock-only bumps excluded — or an edit to this
+# file / the .github/scripts/gui-*.ps1 helpers, since a gate's implementation
+# files re-fire the gate) runs build + test and the checks job. `full` (the
+# classifier's gui-full area: a gui-path or toolchain change, never the core
+# edge alone) adds the drive, packaging and mosaic jobs — the expensive
+# real-window legs a core-only edit cannot redden beyond what build + test
+# already proves. `deps` runs the msrv job. The daily sweep re-runs
+# everything ungated through the same orchestrator (its plan fires every
+# area), so the jobs a pull request skips still run daily. This file carries
+# no triggers or concurrency of its own — both are the caller's — so it can
+# never fire on its own and never needs a paths filter.
 #
 # Tier A — the crate's LIBRARY (flow / model / selection / panes / progress /
 # paths / clipboard / columns / settings / theme / icon / winres / scan) — is held to the
@@ -41,6 +47,21 @@ name: gui
 
 on:
   workflow_call:
+    inputs:
+      gui:
+        description: The gui crate, its gate files, or bdinfo-rs-core (a path dependency) changed.
+        required: true
+        type: string
+      full:
+        description: >-
+          The classifier's gui-full area — a gui-path or toolchain change, so
+          the drive, packaging and mosaic jobs run too.
+        required: true
+        type: string
+      deps:
+        description: The dependency graph or the audit policy changed.
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -70,6 +91,7 @@ jobs:
   # a hung window would burn the 6-hour default.
   test:
     name: gui build + test (${{ matrix.os }})
+    if: inputs.gui == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -285,6 +307,7 @@ jobs:
   # moved to sweep.yml + the release-tag leg; see the header.)
   checks:
     name: gui checks (lint + coverage + deny)
+    if: inputs.gui == 'true'
     # One Linux runner, arch-invariant verdict — arm64 (rationale in core.yml).
     # The snapshot ties this job's coverage step runs are pinned per OS FAMILY
     # and hold across arches within one, which is what `gui build + test`
@@ -373,8 +396,11 @@ jobs:
   # The GUI crate's leg of the MSRV gate — the shared body, the rationale and
   # the build-only posture live in .github/actions/msrv-check. Build-only costs
   # nothing here in particular: iced_test may float its own MSRV.
+  # Keyed on `deps` like `msrv` in core.yml, which carries the rationale; the
+  # daily sweep fires every area and so still runs this daily.
   msrv:
     name: gui msrv
+    if: inputs.deps == 'true'
     # One Linux runner, arch-invariant verdict — arm64 (rationale in core.yml).
     runs-on: ubuntu-24.04-arm
     steps:
@@ -402,6 +428,7 @@ jobs:
   # arm64 MSI's platform tag there).
   package:
     name: gui packaging smoke (${{ matrix.os }})
+    if: inputs.full == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -475,21 +502,24 @@ jobs:
   #             (calibrated to the 880-wide layout): a deliberate layout
   #             change must update it in the same PR, snapshot-test semantics.
   #
-  # Blocking on ALL FIVE legs — Linux/Windows x86 AND arm plus macos-15, hard
-  # like the launch smoke in build + test: macOS is a crucial supported
-  # platform, and a gate that ignores its own signal is not a gate. Known
-  # macos-15 failure modes (residual risks, not reasons to soften): the
-  # paravirtual Metal path has no software fallback, and the injected walk
-  # carries the Sequoia screen-capture re-approval residual. If a leg ever
-  # flakes for environment reasons, fix the harness (the scripts already handle
-  # window polling and capture pre-authorization) or deliberately re-soften —
-  # never a silent retry loop. macos-15-intel is absent because its hosted VMs
-  # expose no Metal at all. The x86 legs ride the proven display recipes (xvfb
-  # + lavapipe, DX12 WARP); every leg runs at a 1920x1080 desktop with shots
+  # A hard gate on every leg that runs, like the launch smoke in build + test:
+  # if a leg ever flakes for environment reasons, fix the harness (the
+  # scripts already handle window polling and capture pre-authorization) or
+  # deliberately re-soften — never a silent retry loop. The matrix is keyed
+  # on the event: pull requests drive the two x64 legs (ubuntu-latest +
+  # windows-2025, the proven display recipes — xvfb + lavapipe, DX12 WARP),
+  # while the arm legs and macos-15 run on master pushes and the daily sweep,
+  # which re-runs this workflow ungated and files the rolling issue on a
+  # scheduled red — the ~9.5 min windows-11-arm leg paced every pull-request
+  # run before the shrink. Shrinking by expression rather than a job-level
+  # `if:` keeps each remaining leg reporting normally (a skipped matrix job
+  # reports once, unexpanded). Known macos-15 failure modes (residual risks,
+  # not reasons to soften): the paravirtual Metal path has no software
+  # fallback, and the injected walk carries the Sequoia screen-capture
+  # re-approval residual. macos-15-intel is absent because its hosted VMs
+  # expose no Metal at all. Every leg runs at a 1920x1080 desktop with shots
   # cropped to the 880x960 window, so the galleries are comparable across
-  # OSes. Scheduled coverage comes from the daily sweep, which re-runs this
-  # whole workflow ungated and files the rolling issue on a scheduled red; a
-  # red leg here reddens the `gui` caller job and therefore ci-ok.
+  # OSes; a red leg here reddens the `gui` caller job and therefore ci-ok.
   #
   # Both walks share one job per arch because they need the byte-identical
   # debug binary: building it once and walking it twice removes a second
@@ -498,6 +528,7 @@ jobs:
   # hides it, and each walk keeps its own gallery directory and artifact.
   drive:
     name: gui drive (${{ matrix.os }})
+    if: inputs.full == 'true'
     runs-on: ${{ matrix.os }}
     # Two walks plus the build, against per-arch p90s (2026-08-02, 20 runs per
     # leg): the slowest arch, windows-2025, spends ~200 s assisted + ~175 s
@@ -508,12 +539,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-2025
-          - ubuntu-24.04-arm
-          - windows-11-arm
-          - macos-15
+        os: >-
+          ${{ fromJson(github.event_name == 'pull_request'
+          && '["ubuntu-latest","windows-2025"]'
+          || '["ubuntu-latest","windows-2025","ubuntu-24.04-arm","windows-11-arm","macos-15"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -639,16 +668,19 @@ jobs:
 
   # The run's showcase artifact: every drive leg's `00-listed` shot at NATIVE
   # resolution in one labelled 2x5 image (assisted top row, inject bottom,
-  # matrix column order) — all ten rendered windows at a glance without
-  # opening ten gallery artifacts. Fan-in over the leg uploads; `!cancelled()`
-  # so a red leg still yields the partial evidence (a missing shot renders as
-  # a labelled dark tile; only zero shots fails, by which point the legs have
-  # already reddened the gate). A WINDOWS runner because the composer is
-  # System.Drawing (GDI+) with the true Segoe UI / Consolas faces.
+  # matrix column order) — the rendered windows at a glance without opening
+  # each gallery artifact. Fan-in over the leg uploads; `!cancelled()` so a
+  # red leg still yields the partial evidence (a missing shot renders as a
+  # labelled dark tile — on pull requests the three demoted legs' tiles are
+  # dark by design; only zero shots fails, by which point the legs have
+  # already reddened the gate). Gated with `drive` on the same input: with no
+  # drive legs there is nothing to compose, and zero shots would fail. A
+  # WINDOWS runner because the composer is System.Drawing (GDI+) with the
+  # true Segoe UI / Consolas faces.
   drive-mosaic:
     name: gui drive mosaic
     needs: [drive]
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && inputs.full == 'true' }}
     runs-on: windows-2025
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -10,10 +10,12 @@ name: wasm
 # native CLI e2e test scans) — proven in Node and in real headless browsers
 # (Chrome + Firefox via wasm-bindgen-test).
 #
-# A workflow_call REUSABLE: ci.yml invokes it when its plan job fires the
-# `wasm` area (a crate-dir change, or a core change via the encoded path-dep
-# edge — root-Cargo.lock-only bumps excluded), and the daily sweep re-runs it
-# ungated through the same orchestrator. Trigger/concurrency policy is the
+# A workflow_call REUSABLE: ci.yml invokes it when its plan job fires either
+# of the two areas passed through as inputs, and each job below keys on its
+# own input: `wasm` (a crate-dir change, or a core change via the encoded
+# path-dep edge — root-Cargo.lock-only bumps excluded) runs the gate job, and
+# `deps` runs the msrv job. The daily sweep re-runs everything ungated
+# through the same orchestrator (its plan fires every area). Trigger/concurrency policy is the
 # caller's; the gate still deliberately NEVER runs on tags, so its build
 # caches are never a publishing-time cache-poisoning vector (the tag-driven
 # npm publish lives beside publish-crates.yml in publish-npm.yml). The
@@ -27,6 +29,15 @@ name: wasm
 
 on:
   workflow_call:
+    inputs:
+      wasm:
+        description: The wasm crate, its gate files, or bdinfo-rs-core (a path dependency) changed.
+        required: true
+        type: string
+      deps:
+        description: The dependency graph or the audit policy changed.
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -42,6 +53,7 @@ env:
 jobs:
   gate:
     name: wasm gate (build + size + parity)
+    if: inputs.wasm == 'true'
     # x64: two steps below need Google Chrome and chromedriver, and the arm64
     # Ubuntu runner image ships neither (its browser set is Firefox +
     # geckodriver; CHROMEWEBDRIVER is empty there). `msrv` below stays beside
@@ -245,8 +257,11 @@ jobs:
   # target-specific MSRV breakage in js-sys/web-sys/wasm-bindgen would otherwise
   # pass unnoticed. `msrv` in core.yml and `gui msrv` in gui.yml hold the same
   # bar for the other two shipping surfaces.
+  # Keyed on `deps` like `msrv` in core.yml, which carries the rationale; the
+  # daily sweep fires every area and so still runs this daily.
   msrv:
     name: wasm msrv
+    if: inputs.deps == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
The pull-request path ran every leg the daily sweep also runs; the pacing jobs were gui drive on windows-11-arm (about 9.5 min) and msrv (about 10.6 min). Every leg removed from the PR path below still runs in the daily sweep and on any master push that executes, so coverage is unchanged.

- build + test and real-world install + scan: pull requests drop the ubuntu-24.04-arm and windows-11-arm legs; the x64 legs of all three OS families and Apple-silicon macOS stay.
- gui drive: pull requests run ubuntu-latest and windows-2025 only; the arm legs and macos-15 move to the sweep. The mosaic renders absent legs as dark tiles.
- msrv (core, gui, wasm): runs on the PR path only when the deps area fired; the sweep fires every area and keeps all three daily.
- New classifier area gui-full, set by gui-path and toolchain rules, gates the gui drive, packaging and mosaic jobs; a bdinfo-rs-core edit reaching the gui crate through the path-dependency edge fires gui alone and runs gui build + test and checks only.
- gui.yml gains gui/full/deps inputs and wasm.yml gains wasm/deps inputs; ci.yml plumbs them and passes the classifier's shrunk build + test matrix on pull_request events.

Matrices shrink by event-keyed expressions, never job-level conditions, so every remaining leg reports normally; no demoted job name is a required status context.