### PR TITLE
fix(fuzz): count an empty promotion set as zero units

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -723,7 +723,11 @@ jobs:
           # a promotion pull request would add EXACTLY, rather than summing
           # per-leg counts that double every unit both widths found.
           $promoteDir = "fuzz/promote/$($env:TARGET)"
-          $promoteNames = @(if (Test-Path $promoteDir) { (Get-ChildItem -File $promoteDir).Name })
+          # ENUMERATED, never `@((Get-ChildItem -File $dir).Name)`: over an EMPTY
+          # directory that expression is an array of one $null, which reports one
+          # unit to promote where there are none — and an empty delta is the
+          # normal state of a saturated target, not an edge case.
+          $promoteNames = @(if (Test-Path $promoteDir) { Get-ChildItem -File $promoteDir | ForEach-Object Name })
           $stats = [ordered]@{
             target = $env:TARGET
             arch = $env:ARCH
@@ -949,7 +953,9 @@ jobs:
           # A leg whose delta merge could not run promotes its whole accumulated
           # set, so its artifact holds units that add no coverage; the issue says
           # so rather than letting the headline imply a filtering that did not
-          # happen.
+          # happen. The count guard is load-bearing: a leg whose accumulated set
+          # is empty skips the merge for want of anything to filter and reports
+          # the same flag, with nothing to promote and nothing to warn about.
           $unfiltered = @($stats | Where-Object { -not $_.merged -and $_.promote -gt 0 })
           # [int] on purpose: Measure-Object sums an empty set to $null, and
           # $null is not 0, so an artifact-less run would otherwise file a


### PR DESCRIPTION
A leg whose coverage delta is empty reported one unit to promote instead of
zero, with a null entry in its sha1 list.

Get-ChildItem over an empty directory returns nothing, so the property access
evaluates to $null and @($null) is a one-element array. Verified on the first
dispatched pass (run 31855371983): the four legs with an empty delta -
discovery and read_be at both widths - each recorded promote=1 and
promote_sha1=[null], which put a phantom row in the rolling corpus issue and
listed them under "the delta merge did not run". Enumerating the names fixes
both.

Not affected, and checked rather than assumed: the headline count, because the
union that produces it skips null entries (6,653 was correct), and the artifact
upload, which keys on the shell step's own count and correctly uploaded nothing
for those legs.
