### PR TITLE
test(core): pin the damaged-disc report from the core and browser paths

### DIFF
--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -5737,6 +5737,131 @@ Total Bitrate:  0.00 Mbps
         assert_eq!(second.max_frame_size.to_bits(), 0.0_f64.to_bits());
     }
 
+    // ── the cross-surface damaged-disc golden ───────────────────────────────
+
+    /// The first unreadable byte of `00011.M2TS` in the damaged-disc pin.
+    ///
+    /// 5 MiB is the browser build's read-chunk size
+    /// ([`m2ts::DATA_SIZE`](crate::bdrom::m2ts::DATA_SIZE) under
+    /// `target_arch = "wasm32"`) and exactly 20 native chunks of its 256 KiB, so
+    /// it is a chunk boundary on BOTH builds: each keeps the bytes below it and
+    /// loses every byte above, whatever its chunk size. Any other offset splits
+    /// the two — the browser voids its whole 5 MiB chunk while the native scan
+    /// keeps another 256 KiB chunk of it — and the two sides would then render
+    /// different numbers from the same damage for a reason that is not a defect.
+    /// The offset also sits inside `00011.M2TS`'s second chunk (the clip is
+    /// 6,297,600 bytes), which is what makes the failure a truncation rather
+    /// than a voided file: the codec pass finishes well below it and only the
+    /// measured pass dies, so the file is named ONCE in the `WARNING:` block.
+    const DAMAGED_FAULT_AT: usize = 5_242_880;
+
+    /// The committed damaged-disc golden — the report both surfaces pin.
+    ///
+    /// Beside the healthy goldens, one crate over, so the browser harness
+    /// (`crates/bdinfo-rs-wasm/web/test/faults.node.mjs`) reads the very same
+    /// committed file this test does. The golden directory's `*.txt -text`
+    /// entry in `.gitattributes` keeps its CRLF bytes through a checkout.
+    fn damaged_disc_golden() -> String {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../bdinfo-rs/tests/fixtures/golden/damaged-multiplaylist.txt");
+        std::fs::read_to_string(path).expect("read the damaged-disc golden")
+    }
+
+    /// The report with every `WARNING:` line's reason replaced by `<reason>`.
+    ///
+    /// The block renders `{file}⇥{reason}`, and the reason is each surface's
+    /// own error text — [`BdError`]'s `io error: {0}` for a native read, the
+    /// value the browser's `FileReaderSync` threw for a web one — so it is the
+    /// one field two surfaces cannot be expected to share for the same fault.
+    /// The file list beside it is what they must agree on. Tabs appear nowhere
+    /// else in the report, which is what makes the per-line rule safe over the
+    /// whole text.
+    fn normalize_warning_reasons(report: &str) -> String {
+        report
+            .split("\r\n")
+            .map(|line| {
+                line.split_once('\t')
+                    .map_or_else(|| line.to_owned(), |(file, _)| format!("{file}\t<reason>"))
+            })
+            .collect::<Vec<String>>()
+            .join("\r\n")
+    }
+
+    /// The committed fixture disc `name` as a mock tree whose stream files can
+    /// fail: `faults` names a file (case-insensitively) and the byte count its
+    /// reader serves before erroring, as [`MockFile::fail_read_at`].
+    ///
+    /// The bytes are the real fixture's, read from disk; only the reader is
+    /// synthetic, so no damaged copy of a disc is committed.
+    fn fixture_tree(name: &str, faults: &[(&str, usize)]) -> MockDir {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../bdinfo-rs/tests/fixtures")
+            .join(name);
+        load_fixture_dir(&root, name, faults)
+    }
+
+    /// One directory of a [`fixture_tree`], recursing into its subdirectories.
+    ///
+    /// Entries are sorted by name: `read_dir` order is filesystem-defined, and
+    /// listing order reaches the report (the disc's playlist and clip order).
+    fn load_fixture_dir(path: &std::path::Path, name: &str, faults: &[(&str, usize)]) -> MockDir {
+        let trip = Trip::new(usize::MAX);
+        let mut entries: Vec<PathBuf> = std::fs::read_dir(path)
+            .expect("list the fixture directory")
+            .map(|entry| entry.expect("read the directory entry").path())
+            .collect();
+        entries.sort();
+        let mut dirs = Vec::new();
+        let mut files = Vec::new();
+        for entry in entries {
+            let entry_name = entry
+                .file_name()
+                .expect("a fixture entry has a name")
+                .to_string_lossy()
+                .into_owned();
+            if entry.is_dir() {
+                dirs.push(load_fixture_dir(&entry, &entry_name, faults));
+            } else {
+                files.push(MockFile {
+                    extension: extension_of_name(&entry_name),
+                    bytes: std::fs::read(&entry).expect("read the fixture file"),
+                    trip: trip.clone(),
+                    fail_read_at: faults
+                        .iter()
+                        .find(|(file, _)| file.eq_ignore_ascii_case(&entry_name))
+                        .map(|&(_, serve)| serve),
+                    name: entry_name,
+                });
+            }
+        }
+        MockDir { name: name.to_owned(), dirs, files, trip }
+    }
+
+    #[test]
+    fn the_damaged_disc_report_matches_the_golden_the_browser_pins_too() {
+        // The core half of the cross-surface pin. The browser half scans the
+        // SAME committed disc, damaged at the SAME byte of the same stream
+        // file, and compares the SAME committed golden — so a change that moves
+        // damaged-disc output on either side reddens that side's own gate,
+        // whichever gate the diff selected. (The browser harness runs only in
+        // the wasm gate, which a core-only diff never selects.)
+        //
+        // Characterization, not judgement: the golden is what current master
+        // renders, including anything a later ruling may decide is wrong.
+        let disc = fixture_tree("MultiPlaylist", &[("00011.m2ts", DAMAGED_FAULT_AT)]);
+        let report =
+            BdRom::open_resilient(&disc, ScanMode::Full).expect("resilient scan continues");
+        let rendered = crate::report::text::render(&report.bdrom, &report.errors);
+
+        // The damage is one truncation, so exactly one failure is recorded —
+        // the shape the golden's single WARNING line carries.
+        assert_eq!(report.errors.len(), 1);
+        let recorded = report.errors.first().expect("the recorded failure");
+        assert_eq!((recorded.stage, recorded.file.as_str()), (ScanStage::StreamFile, "00011.m2ts"));
+
+        assert_eq!(normalize_warning_reasons(&rendered), damaged_disc_golden());
+    }
+
     // ── scan progress + selection ───────────────────────────────────────────
 
     #[test]

--- a/crates/bdinfo-rs-wasm/web/test/faults.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/faults.node.mjs
@@ -12,6 +12,11 @@
 // does today, not what it ought to do — a row that looks wrong is a pinned
 // observation, and changing it is a deliberate decision, not a test fix.
 //
+// The run at the end is the cross-surface one: the same disc damaged at the
+// same byte, compared against a golden the library renders from the native
+// build too. The rows above characterize the browser alone and would not
+// notice a core-side change that moved damaged-disc output on both sides.
+//
 // The disc is three playlists over three clips, one of them shared:
 //
 //   00000.MPLS  1640 s  00011.M2TS                marks at 0, 600, 1200, 1500
@@ -39,6 +44,16 @@ installShims();
 const here = dirname(fileURLToPath(import.meta.url));
 const discRoot = resolve(here, "../../../bdinfo-rs/tests/fixtures/MultiPlaylist");
 const wasmPath = resolve(here, "../pkg/bdinfo_rs_wasm_bg.wasm");
+// The damaged-disc golden, committed beside the healthy ones and pinned from
+// BOTH sides: the library test
+// `the_damaged_disc_report_matches_the_golden_the_browser_pins_too` renders it
+// from the native build inside the root gate, this harness renders it from the
+// built wasm inside the wasm gate. The file is the coupling point — neither
+// side can move damaged-disc output without reddening the other's gate too.
+const goldenPath = resolve(
+  here,
+  "../../../bdinfo-rs/tests/fixtures/golden/damaged-multiplaylist.txt",
+);
 
 /** The clip byte lengths, so a fault offset can be placed inside or past one. */
 const CLIP_BYTES = { "00011.m2ts": 6_297_600, "00022.m2ts": 96_000, "00033.m2ts": 76_800 };
@@ -227,6 +242,24 @@ function warningFiles(report) {
 }
 
 /**
+ * The report with every `WARNING:` line's reason replaced by `<reason>` — the
+ * library's `normalize_warning_reasons` in JavaScript.
+ *
+ * The block renders `{file}\t{reason}`, and the reason is each surface's own
+ * error text (`io error: …` natively, the thrown JavaScript value here), so it
+ * is the one field the two sides cannot share. Tabs appear nowhere else in the
+ * report, which is what makes the per-line rule safe over the whole text.
+ */
+const normalizeWarningReasons = (report) =>
+  report
+    .split("\r\n")
+    .map((line) => {
+      const tab = line.indexOf("\t");
+      return tab === -1 ? line : `${line.slice(0, tab)}\t<reason>`;
+    })
+    .join("\r\n");
+
+/**
  * Whether a logged read is one whole chunk of the cadence: it starts on a chunk
  * boundary and ends one chunk later, or at the end of its file.
  */
@@ -410,6 +443,31 @@ async function main() {
     }
   }
 
+  // The cross-surface pin. The same disc, damaged at the same byte of the same
+  // stream file, scanned whole and compared against the committed golden the
+  // library test renders from the native build.
+  //
+  // The fault sits exactly on a chunk boundary of BOTH builds — 5 MiB is one
+  // browser chunk and twenty native 256 KiB ones — so each keeps the bytes
+  // below it and loses every byte above, and the two reports are comparable
+  // byte for byte. A fault anywhere else splits them: this side would void its
+  // whole 5 MiB chunk while the native scan kept another 256 KiB of it.
+  //
+  // The scan is the whole-disc path (an empty selection), which renders in the
+  // disc's own filtered presentation order rather than a caller's order — the
+  // only shape a library render can produce, so the only one both sides share.
+  setFaults({ files: { "00011.m2ts": WASM_CHUNK } });
+  const pinned = normalizeWarningReasons(scan_files(paths, files, []).report);
+  const golden = await readFile(goldenPath, "utf8");
+  if (pinned !== golden) {
+    const at = [...golden].findIndex((char, i) => pinned[i] !== char);
+    const context = (text) => JSON.stringify(text.slice(Math.max(0, at - 40), at + 40));
+    failures.push(
+      `the damaged-disc golden moved (${pinned.length} chars against ${golden.length}), ` +
+        `first difference at ${at}:\n     golden ${context(golden)}\n     got    ${context(pinned)}`,
+    );
+  }
+
   if (failures.length > 0) {
     console.error(`FAIL — ${failures.length} read-failure characterization(s) moved:`);
     for (const failure of failures) {
@@ -420,7 +478,8 @@ async function main() {
 
   console.log(
     `PASS — ${reports.size} read-failure runs (${Object.keys(MODES).length} fault modes ` +
-      `× ${Object.keys(SELECTIONS).length} selections) match their pinned shapes.`,
+      `× ${Object.keys(SELECTIONS).length} selections) match their pinned shapes, ` +
+      `and the damaged-disc scan matches the shared golden (${golden.length} chars).`,
   );
 }
 

--- a/crates/bdinfo-rs/tests/fixtures/golden/damaged-multiplaylist.txt
+++ b/crates/bdinfo-rs/tests/fixtures/golden/damaged-multiplaylist.txt
@@ -1,0 +1,252 @@
+Disc Label:     MultiPlaylist
+Disc Size:      6,472,420 bytes
+Protection:     AACS
+BDInfo:         0.8.0.1
+
+Notes:          
+
+BDINFO HOME:
+  Cinema Squid (old)
+    http://www.cinemasquid.com/blu-ray/tools/bdinfo
+  UniqProject GitHub (new)
+    https://github.com/UniqProject/BDInfo
+
+INCLUDES FORUMS REPORT FOR:
+  AVS Forum Blu-ray Audio and Video Specifications Thread
+    http://www.avsforum.com/avs-vb/showthread.php?t=1155731
+
+WARNING: File errors were encountered during scan:
+
+00011.m2ts	<reason>
+
+********************
+PLAYLIST: 00002.MPLS
+********************
+
+<--- BEGIN FORUMS PASTE --->
+[code]
+                                                                                                                      Total        Video                                                                           
+Title                                                           Codec   Length    Movie Size        Disc Size         Bitrate      Bitrate      Main Audio Track                          Secondary Audio Track    
+-----                                                           ------  -------   --------------    ----------------  -----------  -----------  ------------------                        ---------------------    
+00002.MPLS                                                      AVC     00:27:40  5,318,976         6,472,420         0.03 Mbps    0.02 Mbps    DD AC3 5.1 640 kbps                                                
+[/code]
+
+[code]
+DISC INFO:
+Disc Label:     MultiPlaylist
+Disc Size:      6,472,420 bytes
+Protection:     AACS
+BDInfo:         0.8.0.1b
+
+PLAYLIST REPORT:
+
+Name:           00002.MPLS
+Length:         00:27:40.000 (h:m:s.ms)
+Size:           5,318,976 bytes
+Total Bitrate:  0.03 Mbps
+
+VIDEO:
+
+Codec                   Bitrate             Description     
+---------------         -------------       -----------     
+MPEG-4 AVC Video        19 kbps             1080p / 24 fps / 16:9 / High Profile 4.1
+
+AUDIO:
+
+Codec                           Language        Bitrate         Description     
+---------------                 -------------   -------------   -----------     
+Dolby Digital Audio             English           640 kbps      5.1 / 48 kHz /   640 kbps / DN -31dB
+
+FILES:
+
+Name            Time In         Length          Size            Total Bitrate   
+--------------- -------------   -------------   -------------   -------------   
+00033.M2TS      0:00:00.000     0:00:20.000     76,800              31 kbps     
+00011.M2TS      0:00:20.000     0:27:20.000     5,242,176           31 kbps     
+
+CHAPTERS:
+
+Number          Time In         Length          Avg Video Rate  Max 1-Sec Rate  Max 1-Sec Time  Max 5-Sec Rate  Max 5-Sec Time  Max 10Sec Rate  Max 10Sec Time  Avg Frame Size  Max Frame Size  Max Frame Time  
+------          -------------   -------------   --------------  --------------  --------------  --------------  --------------  --------------  --------------  --------------  --------------  --------------  
+1               0:00:00.000     0:00:10.000         19 kbps         24 kbps     00:00:00.000        20 kbps     00:00:00.000         0 kbps     00:00:00.000        239 bytes       901 bytes   00:00:00.100    
+2               0:00:10.000     0:00:10.000         20 kbps         24 kbps     00:00:10.000        20 kbps     00:00:10.000         0 kbps     00:00:00.000        246 bytes       901 bytes   00:00:10.100    
+3               0:00:20.000     0:10:00.000         19 kbps         24 kbps     00:00:21.000        20 kbps     00:00:21.000        20 kbps     00:00:21.000        238 bytes       901 bytes   00:00:21.100    
+4               0:10:20.000     0:10:00.000         19 kbps         24 kbps     00:10:20.000        20 kbps     00:10:20.000        20 kbps     00:10:20.000        239 bytes       901 bytes   00:10:20.100    
+5               0:20:20.000     0:05:00.000         10 kbps         24 kbps     00:20:20.000        20 kbps     00:20:20.000        20 kbps     00:20:20.000        239 bytes       901 bytes   00:20:20.100    
+6               0:25:20.000     0:02:20.000          0 kbps          0 kbps     00:00:00.000         0 kbps     00:00:00.000         0 kbps     00:00:00.000          0 bytes         0 bytes   00:00:00.000    
+
+STREAM DIAGNOSTICS:
+
+File            PID             Type            Codec           Language                Seconds                     Bitrate                  Bytes        Packets       
+----------      -------------   -----           ----------      -------------           --------------          ---------------         --------------  -----------     
+00033.M2TS      4113 (0x1011)   0x1B            AVC                                     19.800                       19 kbps                    47,555          280     
+00033.M2TS      4352 (0x1100)   0x81            AC3             eng (English)           19.800                        5 kbps                    13,600           80     
+00011.M2TS      4113 (0x1011)   0x1B            AVC                                     1364.900                     19 kbps                 3,256,890       19,111     
+00011.M2TS      4352 (0x1100)   0x81            AC3             eng (English)           1364.900                      5 kbps                   928,200        5,460     
+
+[/code]
+<---- END FORUMS PASTE ---->
+
+QUICK SUMMARY:
+
+Disc Label:     MultiPlaylist
+Disc Size:      6,472,420 bytes
+Protection:     AACS
+Playlist:       00002.MPLS
+Size:           5,318,976 bytes
+Length:         00:27:40.000
+Total Bitrate:  0.03 Mbps
+Video:          MPEG-4 AVC Video / 19 kbps / 1080p / 24 fps / 16:9 / High Profile 4.1
+Audio:          English / Dolby Digital Audio / 5.1 / 48 kHz /   640 kbps / DN -31dB
+
+
+********************
+PLAYLIST: 00000.MPLS
+********************
+
+<--- BEGIN FORUMS PASTE --->
+[code]
+                                                                                                                      Total        Video                                                                           
+Title                                                           Codec   Length    Movie Size        Disc Size         Bitrate      Bitrate      Main Audio Track                          Secondary Audio Track    
+-----                                                           ------  -------   --------------    ----------------  -----------  -----------  ------------------                        ---------------------    
+00000.MPLS                                                      AVC     00:27:20  5,242,176         6,472,420         0.03 Mbps    0.02 Mbps    DD AC3 5.1 640 kbps                                                
+[/code]
+
+[code]
+DISC INFO:
+Disc Label:     MultiPlaylist
+Disc Size:      6,472,420 bytes
+Protection:     AACS
+BDInfo:         0.8.0.1b
+
+PLAYLIST REPORT:
+
+Name:           00000.MPLS
+Length:         00:27:20.000 (h:m:s.ms)
+Size:           5,242,176 bytes
+Total Bitrate:  0.03 Mbps
+
+VIDEO:
+
+Codec                   Bitrate             Description     
+---------------         -------------       -----------     
+MPEG-4 AVC Video        19 kbps             1080p / 24 fps / 16:9 / High Profile 4.1
+
+AUDIO:
+
+Codec                           Language        Bitrate         Description     
+---------------                 -------------   -------------   -----------     
+Dolby Digital Audio             English           640 kbps      5.1 / 48 kHz /   640 kbps / DN -31dB
+
+FILES:
+
+Name            Time In         Length          Size            Total Bitrate   
+--------------- -------------   -------------   -------------   -------------   
+00011.M2TS      0:00:00.000     0:27:20.000     5,242,176           31 kbps     
+
+CHAPTERS:
+
+Number          Time In         Length          Avg Video Rate  Max 1-Sec Rate  Max 1-Sec Time  Max 5-Sec Rate  Max 5-Sec Time  Max 10Sec Rate  Max 10Sec Time  Avg Frame Size  Max Frame Size  Max Frame Time  
+------          -------------   -------------   --------------  --------------  --------------  --------------  --------------  --------------  --------------  --------------  --------------  --------------  
+1               0:00:00.000     0:10:00.000         19 kbps         24 kbps     00:00:00.000        20 kbps     00:00:00.000        20 kbps     00:00:00.000        239 bytes       901 bytes   00:00:00.100    
+2               0:10:00.000     0:10:00.000         19 kbps         24 kbps     00:10:00.000        20 kbps     00:10:00.000        20 kbps     00:10:00.000        239 bytes       901 bytes   00:10:00.100    
+3               0:20:00.000     0:05:00.000         10 kbps         24 kbps     00:20:00.000        20 kbps     00:20:00.000        20 kbps     00:20:00.000        239 bytes       901 bytes   00:20:00.100    
+4               0:25:00.000     0:02:20.000          0 kbps          0 kbps     00:00:00.000         0 kbps     00:00:00.000         0 kbps     00:00:00.000          0 bytes         0 bytes   00:00:00.000    
+
+STREAM DIAGNOSTICS:
+
+File            PID             Type            Codec           Language                Seconds                     Bitrate                  Bytes        Packets       
+----------      -------------   -----           ----------      -------------           --------------          ---------------         --------------  -----------     
+00011.M2TS      4113 (0x1011)   0x1B            AVC                                     1364.900                     19 kbps                 3,256,890       19,111     
+00011.M2TS      4352 (0x1100)   0x81            AC3             eng (English)           1364.900                      5 kbps                   928,200        5,460     
+
+[/code]
+<---- END FORUMS PASTE ---->
+
+QUICK SUMMARY:
+
+Disc Label:     MultiPlaylist
+Disc Size:      6,472,420 bytes
+Protection:     AACS
+Playlist:       00000.MPLS
+Size:           5,242,176 bytes
+Length:         00:27:20.000
+Total Bitrate:  0.03 Mbps
+Video:          MPEG-4 AVC Video / 19 kbps / 1080p / 24 fps / 16:9 / High Profile 4.1
+Audio:          English / Dolby Digital Audio / 5.1 / 48 kHz /   640 kbps / DN -31dB
+
+
+********************
+PLAYLIST: 00001.MPLS
+********************
+
+<--- BEGIN FORUMS PASTE --->
+[code]
+                                                                                                                      Total        Video                                                                           
+Title                                                           Codec   Length    Movie Size        Disc Size         Bitrate      Bitrate      Main Audio Track                          Secondary Audio Track    
+-----                                                           ------  -------   --------------    ----------------  -----------  -----------  ------------------                        ---------------------    
+00001.MPLS                                                      AVC     00:00:25  96,000            6,472,420         0.03 Mbps    0.02 Mbps    DD AC3 5.1 640 kbps                                                
+[/code]
+
+[code]
+DISC INFO:
+Disc Label:     MultiPlaylist
+Disc Size:      6,472,420 bytes
+Protection:     AACS
+BDInfo:         0.8.0.1b
+
+PLAYLIST REPORT:
+
+Name:           00001.MPLS
+Length:         00:00:25.000 (h:m:s.ms)
+Size:           96,000 bytes
+Total Bitrate:  0.03 Mbps
+
+VIDEO:
+
+Codec                   Bitrate             Description     
+---------------         -------------       -----------     
+MPEG-4 AVC Video        19 kbps             1080p / 24 fps / 16:9 / High Profile 4.1
+
+AUDIO:
+
+Codec                           Language        Bitrate         Description     
+---------------                 -------------   -------------   -----------     
+Dolby Digital Audio             English           640 kbps      5.1 / 48 kHz /   640 kbps / DN -31dB
+
+FILES:
+
+Name            Time In         Length          Size            Total Bitrate   
+--------------- -------------   -------------   -------------   -------------   
+00022.M2TS      0:00:00.000     0:00:25.000     96,000              31 kbps     
+
+CHAPTERS:
+
+Number          Time In         Length          Avg Video Rate  Max 1-Sec Rate  Max 1-Sec Time  Max 5-Sec Rate  Max 5-Sec Time  Max 10Sec Rate  Max 10Sec Time  Avg Frame Size  Max Frame Size  Max Frame Time  
+------          -------------   -------------   --------------  --------------  --------------  --------------  --------------  --------------  --------------  --------------  --------------  --------------  
+1               0:00:00.000     0:00:08.000         19 kbps         24 kbps     00:00:00.000        20 kbps     00:00:00.000         0 kbps     00:00:00.000        239 bytes       901 bytes   00:00:00.100    
+2               0:00:08.000     0:00:08.000         19 kbps         24 kbps     00:00:08.000        20 kbps     00:00:08.000         0 kbps     00:00:00.000        239 bytes       901 bytes   00:00:08.100    
+3               0:00:16.000     0:00:09.000         19 kbps         24 kbps     00:00:16.000        20 kbps     00:00:16.000         0 kbps     00:00:00.000        239 bytes       901 bytes   00:00:16.100    
+
+STREAM DIAGNOSTICS:
+
+File            PID             Type            Codec           Language                Seconds                     Bitrate                  Bytes        Packets       
+----------      -------------   -----           ----------      -------------           --------------          ---------------         --------------  -----------     
+00022.M2TS      4113 (0x1011)   0x1B            AVC                                     24.800                       19 kbps                    59,485          350     
+00022.M2TS      4352 (0x1100)   0x81            AC3             eng (English)           24.800                        5 kbps                    17,000          100     
+
+[/code]
+<---- END FORUMS PASTE ---->
+
+QUICK SUMMARY:
+
+Disc Label:     MultiPlaylist
+Disc Size:      6,472,420 bytes
+Protection:     AACS
+Playlist:       00001.MPLS
+Size:           96,000 bytes
+Length:         00:00:25.000
+Total Bitrate:  0.03 Mbps
+Video:          MPEG-4 AVC Video / 19 kbps / 1080p / 24 fps / 16:9 / High Profile 4.1
+Audio:          English / Dolby Digital Audio / 5.1 / 48 kHz /   640 kbps / DN -31dB
+


### PR DESCRIPTION
One committed golden holds the damaged-disc report both surfaces render, so
neither can move it alone.

- A library test scans the committed multi-playlist fixture through a reader
  that dies at byte 5,242,880 of 00011.M2TS, renders the report, and compares
  the golden. It rides the root gate.
- The browser fault harness scans the same disc through a read that throws at
  the same byte and compares the same golden. It rides the wasm gate.

The offset is a read-chunk boundary on both builds (one 5 MiB browser chunk,
twenty native 256 KiB ones), so both keep the same bytes and the reports
compare byte for byte. The WARNING block reason field is each surface own
error text, so it is normalized before the compare; the ordered file list is
not.

The golden characterizes current behavior as-is. Test-only: no behavior
change, no public API change, no new binary fixture.