### PR TITLE
fix(ci): grant the sweep orchestrator the plan job's read scopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,10 @@ jobs:
     # The default token carries contents: read only; the tree-identity skip
     # lists workflow runs (actions) and the classifier reads the PR's files
     # (pull-requests).
+    #
+    # COUPLED to sweep.yml's `orchestrator` job, which calls this workflow: a
+    # called job may only request permissions its caller holds, so widening
+    # this set without widening that one fails the whole sweep run at startup.
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -74,6 +74,24 @@ jobs:
   orchestrator:
     name: orchestrator
     if: github.event_name != 'push'
+    # The token a called workflow's jobs run under is the CALLING job's, and a
+    # called job may only request permissions the caller already holds — ask
+    # for more and GitHub rejects the entire run before it creates a single
+    # job (conclusion `startup_failure`, zero jobs, zero check runs, so the
+    # `report` job below never runs and files nothing). This block must
+    # therefore stay a superset of every permission any job inside ci.yml and
+    # the workflows it calls declares; today that is ci.yml's `plan` job
+    # alone. Job-level, not workflow-level: the mutants legs below keep the
+    # narrow default.
+    #
+    # A workflow_call invocation uses neither elevated scope — `plan` reads
+    # workflow runs only on `push` and pull-request files only on
+    # `pull_request` — but permissions are static, evaluated before any event
+    # condition, so the grant is required all the same.
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/ci.yml
 
   # Full mutation over the ROOT workspace (bdinfo-rs-core + the CLI), 0


### PR DESCRIPTION
The daily sweep has failed at startup since the plan job gained job-level permissions: run 31868080891, conclusion startup_failure, zero jobs, zero check runs.

A called workflow runs under the calling job token and may only request permissions that token already holds. sweep.yml calls ci.yml from its orchestrator job, which had no permissions block and so inherited the workflow-level contents: read. ci.yml plan asks for actions: read and pull-requests: read, which exceeds that, and GitHub rejects the whole run before creating any job.

Only the sweep path is affected. On push and pull_request, ci.yml is the top-level workflow and sets its own token.

The failure is silent by construction: the rolling-issue job lives inside the rejected run, so nothing was filed. A follow-up adds a permission-compatibility check across local reusable-workflow edges and a watchdog that catches a sweep that never started.

Verified by dispatching the sweep after merge.