### PR TITLE
ci: bump cloudsmith-cli to 1.23.0 and the biome schema to 2.5.8

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -94,4 +94,4 @@ WRANGLER=4.123.0
 KOMAC=2.16.0
 
 # cloudsmith-cli, installed with pipx by the package push legs.
-CLOUDSMITH_CLI=1.22.0
+CLOUDSMITH_CLI=1.23.0

--- a/crates/bdinfo-rs-wasm/web/biome.json
+++ b/crates/bdinfo-rs-wasm/web/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
Bumps the cloudsmith-cli pin in .github/pins.env from 1.22.0 to 1.23.0, and the biome.json schema URL from 2.5.7 to 2.5.8 to match the version the lockfile installs.

Closes #357