### PR TITLE
fix(core): scan the base view when the interleaved file fails to open

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -34,6 +34,7 @@ actually see on a normal disc.
 | [AACS-encrypted discs are refused](#aacs-encrypted-discs-are-refused) | **Yes** — no report at all | Discs whose stream content is still encrypted |
 | [Damaged-media read granularity](#damaged-media-read-granularity) | Only on damaged media — partial scans retain more | Discs with unreadable spans |
 | [Read errors: folder input vs `.iso` input](#read-errors-folder-input-vs-iso-input) | Only on damaged media — the same disc measures differently through the two inputs | Damaged discs and damaged disc images |
+| [An unreadable `.ssif` falls back to the base view](#an-unreadable-ssif-falls-back-to-the-base-view) | Only on damaged media — the clip is measured in 2D instead of lost | 3D discs whose `STREAM/SSIF` file will not open |
 
 ---
 
@@ -252,9 +253,53 @@ stream file, which is why the `.iso` path keeps it. Every surface that takes an 
 drains those recordings — the command line, the desktop app and the browser package alike
 — so an unreadable image is never reported as a clean scan.
 
+The split reaches the report text: the `WARNING:` block names a different thing for each
+input, because a different thing failed.
+
+```diff
+  WARNING: File errors were encountered during scan:
+
+- 00011.M2TS	<the read failure>
++ 00011.M2TS @ byte 5242880	<the read failure>
+```
+
+The `-` line is folder input, the `+` line the same disc as an `.iso`. Folder input names
+the stream file that a failed read aborted. `.iso` input names the open file handle and
+the byte offset it first found unreadable; the reader then serves that handle zeros and
+reads on, so further bad sectors under the same handle add no further lines. Both shapes
+are per attempt, not per disc: a damaged span that both measurement passes read as far as
+prints a line for each of them.
+
+Neither shape is BDInfo's — it reads folders only, and prompts per failing file instead of
+collecting the failures into the report.
+
 <sub>Source: `crates/bdinfo-rs-core/src/vfs/udf/source.rs` (`UdfSource::open_resilient`,
 `take_errors`), `crates/bdinfo-rs-core/src/scan.rs` (`open_iso`),
 `crates/bdinfo-rs-wasm/src/lib.rs` (`scan_iso`, `run_iso_report`).</sub>
+
+### An unreadable `.ssif` falls back to the base view
+
+A 3D clip stores its base and dependent views interleaved in
+`BDMV/STREAM/SSIF/<clip>.ssif`, and both tools demux that file in preference to the plain
+`BDMV/STREAM/<clip>.m2ts` — it is the superset, and it is the only place the dependent
+(MVC) view exists. It is not, however, the only readable source of the base view.
+
+When the `.ssif` cannot be opened, BDInfo abandons the clip: no streams, no bitrates, no
+chapter rows. bdinfo-rs opens the `.m2ts` instead and measures the base view from it, so a
+3D disc with an unreadable interleaved file still reports everything a 2D scan of it would
+— minus the dependent-view row, which genuinely could not be read. The failure is not
+swallowed: it is recorded against the `.ssif` and printed in the report `WARNING:` block,
+and the clip is named by the `.m2ts` it was actually read from wherever the report names
+its source file. The on-disk sizes still count the `.ssif` — the file is on the disc
+either way, and an unreadable one is no smaller. A strict (fail-fast) scan still aborts;
+degrading is the resilient scan's job.
+
+This applies to the failed *open* only. An `.ssif` that opens and then fails partway is an
+ordinary damaged stream file, handled as
+[above](#read-errors-folder-input-vs-iso-input): what was demuxed before the failure is
+kept, and the base view is not re-read from the `.m2ts`.
+
+<sub>Source: `crates/bdinfo-rs-core/src/bdrom/disc.rs` (`scan_one_stream_file`).</sub>
 
 ---
 

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -2394,7 +2394,9 @@ fn stream_summary(stream: &TsStream) -> StreamSummary {
 /// pass), keyed by upper-cased name. Each file is scanned once, with the
 /// playlists handed in so the demux can attribute packets to their clips. A
 /// file with an interleaved 3D counterpart (`SSIF/<stem>.SSIF` under
-/// `ssif_dir`) is demuxed through it, so the dependent-view streams register.
+/// `ssif_dir`) is demuxed through it, so the dependent-view streams register —
+/// unless that file will not open, which in resilient mode falls back to the
+/// plain `*.m2ts` (see [`scan_one_stream_file`]).
 /// `is_full_scan` selects the pass: the quick pass stops once every stream's
 /// codec detail is initialised; the full pass demuxes every packet to EOF —
 /// the measurement pass. Used only at the `streams` level; the
@@ -2487,6 +2489,7 @@ fn scan_stream_files(
             is_full_scan,
             backfill_detail,
             progress,
+            sink,
         );
         // Cancellation aborts the whole open, in strict and resilient modes
         // alike — the sink collects disc damage, not the caller's abort, so
@@ -2548,6 +2551,11 @@ enum StreamScan {
 /// `Err` is reserved for the two no-demux-state cases — the source would not
 /// open, or the caller cancelled ([`BdError::ScanCancelled`], whose partial
 /// state is deliberately never offered: cancellation is an abort, not damage).
+///
+/// An interleaved source that will not open is recovered from rather than
+/// failed on, in resilient mode: the clip is scanned from its plain `*.m2ts`
+/// instead and the `*.ssif` failure recorded through `sink` — see
+/// `DIFFERENCES.md`.
 fn scan_one_stream_file(
     file: &dyn BdFile,
     interleaved: Option<Box<dyn BdFile>>,
@@ -2555,17 +2563,43 @@ fn scan_one_stream_file(
     is_full_scan: bool,
     backfill_detail: bool,
     progress: &mut Progress<'_>,
+    sink: &mut Sink<'_>,
 ) -> Result<StreamScan, BdError> {
     let mut stream_file = TsStreamFile::new(file.name());
     stream_file.backfill_detail = backfill_detail;
+    // The `*.ssif` handle's name as the disc spells it, read before the handle
+    // is wrapped (which upper-cases it), so the failure below is recorded in
+    // the same casing as every other name this scan records.
+    let interleaved_name = interleaved.as_ref().map_or_else(String::new, |s| s.name().to_owned());
     stream_file.interleaved_file = interleaved.map(TsInterleavedFile::new);
     // The interleaved 3D `*.ssif` is the demux source in preference to the plain
     // `*.m2ts` whenever the clip has one: its base/dependent extents are just more
     // source packets, and without reading it the dependent-view (MVC) streams
     // never register. The selected reader is wrapped so each read advances the
     // progress.
-    let inner = match &stream_file.interleaved_file {
-        Some(interleaved) => interleaved.open_read().map_err(BdError::Io)?,
+    let inner = match stream_file.interleaved_file.take() {
+        Some(interleaved) => match interleaved.open_read() {
+            Ok(reader) => {
+                stream_file.interleaved_file = Some(interleaved);
+                reader
+            }
+            // The `*.ssif` is the superset source, not the only one: the base
+            // view is also in the plain `*.m2ts`, so a clip whose interleaved
+            // file will not open is measured in 2D rather than lost — only the
+            // dependent view is unreachable. `interleaved_file` stays taken,
+            // so the clip reports the source it was read from. Strict mode has
+            // no such policy: `absorb` propagates the failure there, exactly as
+            // an unopenable `*.m2ts` does.
+            Err(reason) => {
+                sink.absorb(
+                    ScanStage::StreamFile,
+                    &interleaved_name,
+                    (),
+                    Err(BdError::Io(reason)),
+                )?;
+                file.open_read()?
+            }
+        },
         None => file.open_read()?,
     };
     // The shared reference and the measured observer are moved out before the
@@ -4822,6 +4856,136 @@ mod tests {
         )
     }
 
+    /// The same one-clip 3D disc as a mock tree, so either source can be made
+    /// unopenable: the base view alone in `00000.m2ts` (opening under `m2ts`),
+    /// base plus dependent view in `00000.ssif` (opening under `ssif`). Every
+    /// other file is intact.
+    fn interleaved_mock_disc(ssif: &Trip, m2ts: &Trip) -> MockDir {
+        let trip = Trip::new(usize::MAX);
+        let file = |name: &str, bytes: Vec<u8>, trip: &Trip| MockFile {
+            name: name.to_owned(),
+            extension: extension_of_name(name),
+            bytes,
+            trip: trip.clone(),
+            fail_read_at: None,
+            reads: None,
+        };
+        let dir = |name: &str, dirs: Vec<MockDir>, files: Vec<MockFile>| MockDir {
+            name: name.to_owned(),
+            dirs,
+            files,
+            trip: trip.clone(),
+        };
+        dir(
+            "disc",
+            vec![dir(
+                "BDMV",
+                vec![
+                    dir(
+                        "CLIPINF",
+                        vec![],
+                        vec![file(
+                            "00000.clpi",
+                            clpi(&[(0x1011, 0x1B, [0x62, 0x30, 0, 0])]),
+                            &trip,
+                        )],
+                    ),
+                    dir(
+                        "PLAYLIST",
+                        vec![],
+                        vec![file("00000.mpls", mpls("00000", 0, 4_500_000, &[]), &trip)],
+                    ),
+                    dir(
+                        "STREAM",
+                        vec![dir(
+                            "SSIF",
+                            vec![],
+                            vec![file("00000.ssif", interleaved_ssif(true), ssif)],
+                        )],
+                        vec![file("00000.m2ts", interleaved_ssif(false), m2ts)],
+                    ),
+                ],
+                vec![],
+            )],
+            vec![],
+        )
+    }
+
+    #[test]
+    fn an_unopenable_interleaved_source_falls_back_to_the_base_view() {
+        // Control: with the `.ssif` openable this really is a 3D scan, so the
+        // 2D result below is the failed open's doing, not the fixture's.
+        let intact = Trip::new(usize::MAX);
+        let healthy =
+            BdRom::open_resilient(&interleaved_mock_disc(&intact, &intact), ScanMode::Full)
+                .expect("healthy 3D scan");
+        assert!(healthy.errors.is_empty());
+        let control = healthy.bdrom.playlists.first().unwrap();
+        assert!(control.streams.iter().any(|s| s.pid == Pid::new(0x1012)), "the dependent view");
+        assert_eq!(control.clips.first().unwrap().display_name, "00000.SSIF");
+
+        let report =
+            BdRom::open_resilient(&interleaved_mock_disc(&Trip::always(), &intact), ScanMode::Full)
+                .expect("the resilient scan degrades to the base view");
+        // Both measurement passes open the source, so both record the failure
+        // — the per-attempt shape every unopenable file already has.
+        // The file that failed is the file named — the `.ssif`, not the
+        // `.m2ts` the clip is keyed by.
+        let recorded: Vec<(ScanStage, &str)> =
+            report.errors.iter().map(|e| (e.stage, e.file.as_str())).collect();
+        assert_eq!(recorded, vec![(ScanStage::StreamFile, "00000.ssif"); 2]);
+
+        // The clip is measured from its `*.m2ts` — base view present with its
+        // rate, dependent view absent, and named by the source it was read
+        // from.
+        let pl = report.bdrom.playlists.first().unwrap();
+        let base = pl.streams.iter().find(|s| s.pid == Pid::new(0x1011)).expect("the base view");
+        assert!(base.bitrate > 0, "the base view carries its measured rate");
+        assert!(pl.streams.iter().all(|s| s.pid != Pid::new(0x1012)), "no dependent-view row");
+        let clip = pl.clips.first().unwrap();
+        assert_eq!(clip.display_name, "00000.M2TS");
+        assert!(clip.streams.iter().any(|t| t.pid == Pid::new(0x1011)));
+        assert!(clip.file_seconds > 0.0, "the base view was demuxed");
+    }
+
+    #[test]
+    fn a_strict_scan_still_fails_on_an_unopenable_interleaved_source() {
+        // The fallback is the resilient scan's keep-what-you-can policy; strict
+        // mode is the fail-fast path and has no policy to apply.
+        let failed = BdRom::open(
+            &interleaved_mock_disc(&Trip::always(), &Trip::new(usize::MAX)),
+            ScanMode::Full,
+        )
+        .expect_err("strict mode propagates the failed interleaved open");
+        assert_eq!(failed.to_string(), "io error: injected io failure");
+    }
+
+    #[test]
+    fn a_clip_with_neither_source_openable_keeps_the_scan_going() {
+        // The fallback is an attempt, not a guarantee: with the `*.m2ts`
+        // unopenable too there is nothing left to read, so the clip is dropped
+        // and both failures are recorded — one per source, per pass.
+        let dead = Trip::always();
+        let report = BdRom::open_resilient(&interleaved_mock_disc(&dead, &dead), ScanMode::Full)
+            .expect("the resilient scan continues past a clip it cannot read");
+        let recorded: Vec<(ScanStage, &str)> =
+            report.errors.iter().map(|e| (e.stage, e.file.as_str())).collect();
+        assert_eq!(
+            recorded,
+            vec![
+                (ScanStage::StreamFile, "00000.ssif"),
+                (ScanStage::StreamFile, "00000.m2ts"),
+                (ScanStage::StreamFile, "00000.ssif"),
+                (ScanStage::StreamFile, "00000.m2ts"),
+            ]
+        );
+        // The playlist still reports, on clip-info detail alone.
+        let pl = report.bdrom.playlists.first().unwrap();
+        let base = pl.streams.iter().find(|s| s.pid == Pid::new(0x1011)).expect("the base view");
+        assert_eq!(base.bitrate, 0, "nothing was measured");
+        assert!(pl.clips.first().unwrap().streams.is_empty());
+    }
+
     #[test]
     fn a_full_scan_without_the_quick_pass_presents_the_two_pass_result() {
         // The hardest resolution case: the dependent view exists only in the
@@ -5407,15 +5571,24 @@ mod tests {
     struct Trip {
         count: Arc<AtomicUsize>,
         fail_at: usize,
+        /// Whether *every* operation fails, `fail_at` notwithstanding — an
+        /// object that never opens, which a scan opening it once per
+        /// measurement pass needs (a one-shot trip would let the second pass
+        /// through).
+        always: bool,
     }
 
     impl Trip {
         fn new(fail_at: usize) -> Self {
-            Self { count: Arc::new(AtomicUsize::new(0)), fail_at }
+            Self { count: Arc::new(AtomicUsize::new(0)), fail_at, always: false }
+        }
+
+        fn always() -> Self {
+            Self { count: Arc::new(AtomicUsize::new(0)), fail_at: usize::MAX, always: true }
         }
 
         fn tick(&self) -> io::Result<()> {
-            if self.count.fetch_add(1, Ordering::Relaxed) == self.fail_at {
+            if self.count.fetch_add(1, Ordering::Relaxed) == self.fail_at || self.always {
                 Err(io::Error::other("injected io failure"))
             } else {
                 Ok(())

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -578,10 +578,12 @@ pub struct TsStreamFile {
     pub size: u64,
     /// Presentation length in seconds.
     pub length: f64,
-    /// The interleaved 3D source (`*.ssif`), when this clip has one. When
-    /// present, the per-file scan in [`super::disc`] opens it and streams it
-    /// through [`scan`](Self::scan) instead of the plain `*.m2ts` (see
-    /// [`super::interleaved`]).
+    /// The interleaved 3D source (`*.ssif`) this clip was read through, when it
+    /// has one. When present, the per-file scan in [`super::disc`] opened it and
+    /// streamed it through [`scan`](Self::scan) instead of the plain `*.m2ts`
+    /// (see [`super::interleaved`]). It records the source actually read, not
+    /// the one on the disc: a clip whose `*.ssif` would not open is scanned
+    /// from its `*.m2ts` and leaves this `None`.
     pub interleaved_file: Option<TsInterleavedFile>,
     /// The elementary streams keyed by PID, registered from the PMT.
     pub streams: BTreeMap<u16, TsStream>,


### PR DESCRIPTION
A 3D clip whose `BDMV/STREAM/SSIF/<clip>.ssif` would not open lost everything, including the base view its plain `*.m2ts` still holds, and the failure was recorded against that `*.m2ts` rather than against the `*.ssif` that actually failed.

A resilient scan now opens the `*.m2ts` instead, measures the base view from it, and records the open failure against the `*.ssif`. `TsStreamFile::interleaved_file` is left unset on that path, so the clip is named by the source it was read from. A strict scan still propagates the failure, and an `*.ssif` that opens and then fails partway is unaffected — that stays an ordinary damaged stream file.

Also documents in DIFFERENCES.md the report `WARNING:` line-shape split between folder and `.iso` input: one names the stream file, the other the open handle plus the byte offset it first found unreadable.

Committed fixtures are 2D, so every golden is byte-identical.