### PR TITLE
fix(core): correct pts intervals, audio codec-name fallbacks, and playlist attribute selection

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -26,8 +26,11 @@ actually see on a normal disc.
 | [MaxCLL unit label (`cd / m2` → `cd/m2`)](#maxcll-unit-label) | **Yes** — unit spelling | **Common** — every HDR title with a content-light-level SEI |
 | [AVC High 4:4:4 (profile 244)](#avc-high-444-profile-244) | **Yes** — profile token | Rare — Blu-ray video is almost always 4:2:0 |
 | [PGS forced-caption counts](#pgs-forced-caption-counts) | **Yes** — caption tally | Discs with multi-object subtitle compositions |
+| [Playlist attribute selection on short clips](#playlist-attribute-selection-on-short-clips) | **Yes** — which clip's streams are presented | Rare — multi-clip playlists whose early clips are short |
 | [E-AC-3 reduced data-rate](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on non-BD input | Reduced-rate E-AC-3 (24 / 22.05 / 16 kHz) isn't used on Blu-ray |
 | [AC-3 low-sample-rate shift](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on non-BD input | Legacy `bsid` 9/10; conforming Blu-ray AC-3 is always `bsid` 8 |
+| [Audio bitrate under a backwards PTS](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on non-monotone audio PTS | Damaged or non-conforming streams whose audio PTS steps backwards |
+| [Undecoded MPEG-1/2 and AAC audio names](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only when the stream was never decoded | Damaged discs whose MPA/AAC frames the scan could not read |
 | [HEVC `profile_idc` recovery](#correctness-fixes-with-no-effect-on-a-normal-disc) | Edge case only | Malformed headers with `general_profile_idc == 0` |
 | [VC-1 interlaced-field picture type](#correctness-fixes-with-no-effect-on-a-normal-disc) | **No** — internal only | Never — the picture tag is counted, never printed |
 | [PAT `table_id` validation](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on malformed input | Never — no conforming disc carries a wrong PAT table id |
@@ -141,6 +144,29 @@ bdinfo-rs parses the spec layout and reports the true normal/forced split.
 BDInfo's existing forms. Source: `crates/bdinfo-rs-core/src/codec/pgs.rs` (PCS
 composition-object parse).</sub>
 
+### Playlist attribute selection on short clips
+
+BDInfo 0.8 guards its per-playlist stream table against negligibly short clips: when two
+play items declare the same PID, the later item's declared attributes win only if that
+clip's `RelativeLength` exceeds 1% of the playlist, and the same guard gates whether a
+clip with more streams becomes the reference clip whose streams the report presents. The
+intent is sound — a 3-second logo clip must not decide a feature's stream layout — but
+0.8 computes `RelativeLength` against the playlist length accumulated *before* the clip
+is appended (`TSPlaylistFile.LoadPlaylist`): the first clip divides by zero into
+`+Infinity`, the second is measured against the opener alone, and every clip against a
+partial total — so early clips pass the guard however short they are. bdinfo-rs computes
+each clip's true fraction of the finished playlist. (BDInfo 0.7.5.6 has no guard at all:
+the last duplicate always wins.)
+
+The outcome differs only when a playlist's clips disagree about the declared attributes
+or stream counts — mainly playlists that open with short logo or warning clips whose
+stream layout differs from the feature's. On such a playlist the reference clip, and with
+it the presented stream rows, can change; on a playlist whose clips agree, the report is
+byte-identical.
+
+<sub>Source: `crates/bdinfo-rs-core/src/bdrom/mpls.rs` (the post-parse resolution),
+`crates/bdinfo-rs-core/src/bdrom/disc.rs` (`select_reference`).</sub>
+
 ---
 
 ## Correctness fixes with no effect on a normal disc
@@ -169,6 +195,21 @@ value is never rendered.
   a PMT whose `table_id` is not 0x02. BDInfo assembles the mislabeled section and adopts
   whatever PMT PID it announces. No conforming disc carries a wrong PAT table id, so the
   report is unchanged for every real disc.
+- **Audio bitrate under a backwards PTS.** BDInfo 0.8 measures an audio access unit's
+  transfer interval whenever the PTS merely *changes* (`TSStreamFile`'s PES parse compares
+  `PTS != PTSLast`): a backwards step measures a negative interval — discarding that
+  unit's bitrate sample — and drags the interval base backwards, so the next forward
+  unit's interval is overstated and its rate understated. bdinfo-rs measures only forward
+  steps against the running maximum, as BDInfo 0.7.5.6 did (`PTS > PTSLast`) and as the
+  PTS+DTS path of both tools already does. Audio PTS within a conforming stream file is
+  monotone, so a healthy disc measures identically.
+- **Undecoded MPEG-1/2 and AAC audio names.** BDInfo derives these four codec names from
+  the decoded frame header alone and renders an empty name when no frame was ever decoded
+  (the unset `ExtendedData` cast to a null string). bdinfo-rs falls back to the
+  type-derived constants BDInfo itself emits — `MP1 Audio` / `MP2 Audio` (0.7.5.6's fixed
+  codec names) and `MPEG-2 AAC` / `MPEG-4 AAC` (the short-name constants) — so an audio
+  row whose stream the scan could not read never renders a hole. A decoded stream prints
+  the same header-derived name as BDInfo.
 
 ---
 

--- a/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/m2ts.rs
@@ -1365,7 +1365,16 @@ impl TsStreamFile {
                                             (state.parse & 0xFE).wrapping_shr(1),
                                         ));
                                         state.pts = i128::from(state.pts_temp);
-                                        if state.pts != state.pts_last {
+                                        // Only a forward PTS measures an interval and
+                                        // advances `pts_last` — a backwards step (a
+                                        // discontinuity, damage) must neither produce
+                                        // a negative interval (`pts_transfer > 0`
+                                        // discards the access unit's bitrate sample)
+                                        // nor drag the interval base back so the next
+                                        // forward unit's rate is understated. Mirrors
+                                        // the PTS+DTS arm's running max below; see
+                                        // DIFFERENCES.md.
+                                        if state.pts > state.pts_last {
                                             if state.pts_last > 0 {
                                                 state.pts_transfer =
                                                     state.pts.wrapping_sub(state.pts_last);
@@ -2564,6 +2573,30 @@ mod tests {
         let st = file.stream_states.get(&0x1100).unwrap();
         assert_eq!(st.peak_transfer_rate, 400);
         assert!(st.transfer_count >= 2);
+    }
+
+    #[test]
+    fn backwards_pts_keeps_the_interval_base_and_the_bitrate_sample() {
+        // Audio PES at PTS 1s, 2s, a backwards 1.5s, then 3s twice. A backwards
+        // or repeated PTS must neither measure an interval nor move `pts_last`:
+        // the backwards access unit keeps the prior 1s interval (its 100-byte
+        // payload ⇒ peak 800 bits/s, the sample a negative interval would
+        // discard), and the next forward unit measures 3s − 2s = 1s from the
+        // running max — not 3s − 1.5s from the regressed value. The final
+        // repeated PTS pins that an equal PTS leaves the interval untouched
+        // (a `>=` would zero it).
+        let mut bytes = packet(0, true, &pat_payload(0x0100));
+        bytes.extend(packet(0x0100, true, &pmt_payload(&[(0x81, 0x1100)])));
+        bytes.extend(packet(0x1100, true, &pes_pts(0xC0, 90_000, &[0; 50])));
+        bytes.extend(packet(0x1100, true, &pes_pts(0xC0, 180_000, &[0; 50])));
+        bytes.extend(packet(0x1100, true, &pes_pts(0xC0, 135_000, &[0; 100]))); // backwards
+        bytes.extend(packet(0x1100, true, &pes_pts(0xC0, 270_000, &[0; 50])));
+        bytes.extend(packet(0x1100, true, &pes_pts(0xC0, 270_000, &[0; 50]))); // repeated
+        let file = scan("00000.m2ts", &bytes, &mut [empty_playlist()], true);
+        let st = file.stream_states.get(&0x1100).unwrap();
+        assert_eq!(st.peak_transfer_rate, 800);
+        assert_eq!(st.pts_last, 270_000);
+        assert_eq!(st.pts_transfer, 90_000);
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/bdrom/mpls.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/mpls.rs
@@ -94,7 +94,10 @@ impl TsPlaylistFile {
 
         let mut stream_clips: Vec<TsStreamClip> = Vec::new();
         let mut chapter_clips: Vec<usize> = Vec::new();
-        let mut playlist_streams: BTreeMap<u16, TsStream> = BTreeMap::new();
+        // Stream-Number-table entries, each with its play item's length, queued
+        // for the duplicate-PID resolution after the loop — the rule needs the
+        // finished playlist length, unknowable mid-parse.
+        let mut pending_streams: Vec<(f64, TsStream)> = Vec::new();
         let mut angle_count: i32 = 0;
 
         for _ in 0..item_count {
@@ -110,11 +113,12 @@ impl TsPlaylistFile {
             let time_in = read_time(data, item_start.saturating_add(14))?;
             let time_out = read_time(data, item_start.saturating_add(18))?;
 
-            // Build the main clip; relative_time_in is the playlist length so far.
+            // Build the main clip; relative_time_in is the playlist length so
+            // far, while relative_length waits for the finished total after
+            // the loop.
             let relative_time_in = total_length(&stream_clips);
             let length = time_out - time_in;
             let relative_time_out = relative_time_in + length;
-            let relative_length = length / relative_time_in;
             let clip = TsStreamClip {
                 name: format!("{item_name}{}", clip_extension(&codec_id)),
                 time_in,
@@ -122,7 +126,6 @@ impl TsPlaylistFile {
                 length,
                 relative_time_in,
                 relative_time_out,
-                relative_length,
                 ..TsStreamClip::default()
             };
             let main_index = stream_clips.len();
@@ -177,13 +180,13 @@ impl TsPlaylistFile {
             pos = pos_item.saturating_add(16);
 
             for _ in 0..count_video {
-                pos = add_playlist_stream(data, pos, &mut playlist_streams, relative_length)?;
+                pos = add_playlist_stream(data, pos, &mut pending_streams, length)?;
             }
             for _ in 0..count_audio {
-                pos = add_playlist_stream(data, pos, &mut playlist_streams, relative_length)?;
+                pos = add_playlist_stream(data, pos, &mut pending_streams, length)?;
             }
             for _ in 0..count_presentation {
-                pos = add_playlist_stream(data, pos, &mut playlist_streams, relative_length)?;
+                pos = add_playlist_stream(data, pos, &mut pending_streams, length)?;
             }
             // PiP-PG entries sit in-line in the PG section, before the IG
             // entries; they are consumed to keep the walk aligned but not
@@ -193,15 +196,15 @@ impl TsPlaylistFile {
                 pos = next;
             }
             for _ in 0..count_interactive {
-                pos = add_playlist_stream(data, pos, &mut playlist_streams, relative_length)?;
+                pos = add_playlist_stream(data, pos, &mut pending_streams, length)?;
             }
             for _ in 0..count_secondary_audio {
-                pos = add_playlist_stream(data, pos, &mut playlist_streams, relative_length)?;
+                pos = add_playlist_stream(data, pos, &mut pending_streams, length)?;
                 // One comb-info block: the primary-audio refs.
                 pos = skip_comb_info(data, pos)?;
             }
             for _ in 0..count_secondary_video {
-                pos = add_playlist_stream(data, pos, &mut playlist_streams, relative_length)?;
+                pos = add_playlist_stream(data, pos, &mut pending_streams, length)?;
                 // Two comb-info blocks: the secondary-audio refs, then the
                 // PiP-PG refs.
                 pos = skip_comb_info(data, pos)?;
@@ -212,12 +215,35 @@ impl TsPlaylistFile {
             pos = item_start.saturating_add(item_length).saturating_add(2);
         }
 
+        // relative_length is each clip's share of the finished playlist, so it
+        // and the duplicate-PID rule it gates resolve only now that every play
+        // item's length is summed. Classic BDInfo divides by the running total
+        // before the clip is appended (`TSPlaylistFile.LoadPlaylist`), so its
+        // first clip divides by zero into `+Infinity` and always overwrites —
+        // see DIFFERENCES.md. Angle clips keep the default `0.0`, as in
+        // classic. An unseen PID is always inserted; a duplicate overwrites
+        // only when its clip's share exceeds `0.01`.
+        let final_total = total_length(&stream_clips);
+        for clip in &mut stream_clips {
+            if clip.angle_index == 0 {
+                clip.relative_length = clip.length / final_total;
+            }
+        }
+        let mut playlist_streams: BTreeMap<u16, TsStream> = BTreeMap::new();
+        for (length, stream) in pending_streams {
+            // The map is keyed by the raw wire PID; read the stream's typed
+            // PID back out.
+            let pid = stream.base().pid.get();
+            if !playlist_streams.contains_key(&pid) || length / final_total > 0.01 {
+                playlist_streams.insert(pid, stream);
+            }
+        }
+
         // PlayListMark: 4-byte length, then a u16 count, then 14-byte entries.
         let mut chapters: Vec<f64> = Vec::new();
         let mut chap_pos = chapters_offset.saturating_add(4);
         let chapter_count = u16_be(data, chap_pos)?;
         chap_pos = chap_pos.saturating_add(2);
-        let final_total = total_length(&stream_clips);
         for _ in 0..chapter_count {
             let chapter_type = byte(data, chap_pos.saturating_add(1))?;
             if chapter_type == 1 {
@@ -258,12 +284,13 @@ impl TsPlaylistFile {
 }
 
 /// Sum of the main clips' (`angle_index == 0`) lengths — the playlist length
-/// accumulated over the clips collected so far.
+/// over the clips collected so far, and the finished total once every play
+/// item is parsed.
 ///
 /// Written as an explicit `length = 0.0; for …` accumulation rather than
-/// `Iterator::sum`, whose `f64` identity is `-0.0` — that would make the first
-/// clip's `length / total` evaluate to `-inf` instead of the defined `+inf`
-/// (`40.0 / +0.0`), flipping the sign on the empty-prefix case.
+/// `Iterator::sum`, whose `f64` identity is `-0.0` — that would flip the
+/// first clip's `relative_time_in` (the empty-prefix call) to `-0.0`, a
+/// different bit pattern on a public field than the `0.0` it holds today.
 fn total_length(clips: &[TsStreamClip]) -> f64 {
     let mut length = 0.0;
     for clip in clips {
@@ -303,22 +330,18 @@ fn skip_comb_info(data: &[u8], pos: usize) -> Result<usize, BdError> {
 }
 
 /// Parses one Stream-Number-table entry at `pos` and, if it yields a stream,
-/// records it in `playlist_streams`: an unseen PID is always inserted, and a
-/// duplicate only overwrites when the clip's `relative_length` exceeds `0.01`.
+/// queues it with its play item's `length` for the duplicate-PID resolution
+/// that runs once the whole playlist is parsed (see [`TsPlaylistFile::scan`]).
 /// Returns the position after the entry.
 fn add_playlist_stream(
     data: &[u8],
     pos: usize,
-    playlist_streams: &mut BTreeMap<u16, TsStream>,
-    relative_length: f64,
+    pending: &mut Vec<(f64, TsStream)>,
+    length: f64,
 ) -> Result<usize, BdError> {
     let (stream, new_pos) = create_playlist_stream(data, pos)?;
     if let Some(stream) = stream {
-        // The map is keyed by the raw wire PID; read the stream's typed PID back out.
-        let pid = stream.base().pid.get();
-        if !playlist_streams.contains_key(&pid) || relative_length > 0.01 {
-            playlist_streams.insert(pid, stream);
-        }
+        pending.push((length, stream));
     }
     Ok(new_pos)
 }
@@ -594,13 +617,13 @@ mod tests {
         assert_eq!(clip0.length.to_bits(), 40.0_f64.to_bits());
         assert_eq!(clip0.relative_time_in.to_bits(), 0.0_f64.to_bits());
         assert_eq!(clip0.relative_time_out.to_bits(), 40.0_f64.to_bits()); // rel_in + length
-        assert!(clip0.relative_length.is_infinite()); // length / 0 for the first clip
+        assert_eq!(clip0.relative_length.to_bits(), (40.0_f64 / 60.0).to_bits()); // of 60s total
         assert_eq!(clip0.chapters, vec![60.0]); // one chapter landed in this clip
         let clip1 = file.stream_clips.get(1).unwrap();
         assert_eq!(clip1.name, "00017.M2TS");
         assert_eq!(clip1.relative_time_in.to_bits(), 40.0_f64.to_bits());
         assert_eq!(clip1.relative_time_out.to_bits(), 60.0_f64.to_bits());
-        assert_eq!(clip1.relative_length.to_bits(), 0.5_f64.to_bits()); // 20 / 40
+        assert_eq!(clip1.relative_length.to_bits(), (20.0_f64 / 60.0).to_bits()); // of 60s total
 
         // Playlist streams keyed by PID (MVC produced nothing).
         let pids: Vec<u16> = file.playlist_streams.keys().copied().collect();
@@ -624,7 +647,7 @@ mod tests {
         audio.base.stream_type = TsStreamType::DtsHdMasterAudio;
         assert_eq!(file.playlist_streams.get(&0x1100), Some(&TsStream::Audio(audio)));
 
-        // PID 0x1011 was overwritten by item 1's clip (relative_length 0.5 > 0.01):
+        // PID 0x1011 was overwritten by item 1's clip (20s of 60s > 0.01):
         // it now carries item 1's coding (576i / 29.97), not item 0's.
         let mut video = TsVideoStream::default();
         video.set_video_format(TsVideoFormat::Videoformat576i);
@@ -692,6 +715,13 @@ mod tests {
         assert_eq!(angle.length.to_bits(), 20.0_f64.to_bits());
         assert_eq!(angle.relative_time_in.to_bits(), 40.0_f64.to_bits());
         assert_eq!(angle.relative_time_out.to_bits(), 60.0_f64.to_bits());
+        // Main clips carry their share of the 60s total; angle clips keep the
+        // default 0.0 (only `angle_index == 0` lengths count and are filled).
+        assert_eq!(
+            file.stream_clips.first().unwrap().relative_length.to_bits(),
+            (40.0_f64 / 60.0).to_bits()
+        );
+        assert_eq!(angle.relative_length.to_bits(), 0.0_f64.to_bits());
         assert!(!file.mvc_base_view_r); // misc flags 0
     }
 
@@ -721,17 +751,18 @@ mod tests {
     #[test]
     fn duplicate_pid_at_the_relative_length_threshold_is_not_overwritten() {
         // Item 0 is a long clip (PID 0x1011, 1080p); item 1 reuses PID 0x1011 with
-        // different coding but its relative_length is exactly 0.01 (1s / 100s). The
-        // rule is `> 0.01`, so it does NOT overwrite — item 0's stream is kept.
+        // different coding but its share of the playlist is exactly 0.01
+        // (1s of a 99s + 1s = 100s total). The rule is `> 0.01`, so it does NOT
+        // overwrite — item 0's stream is kept.
         // (This pins the `>` boundary: a `>=` would wrongly overwrite.)
         let v0 = pl_stream(1, 0x1011, 0x1B, [0x62, 0x30, 0, 0]); // 1080p / 24 / 16:9
-        let item0 = build_item("00000", 0, 4_500_000, None, [1, 0, 0, 0, 0, 0, 0], &v0); // 100s
+        let item0 = build_item("00000", 0, 4_455_000, None, [1, 0, 0, 0, 0, 0, 0], &v0); // 99s
         let v1 = pl_stream(1, 0x1011, 0x1B, [0x24, 0x20, 0, 0]); // 576i / 29.97 / 4:3
         let item1 = build_item("00017", 0, 45_000, None, [1, 0, 0, 0, 0, 0, 0], &v1); // 1s
         let buf = build_mpls(0, &[item0, item1], &[]);
         let file = TsPlaylistFile::scan("p.mpls", &buf).unwrap();
 
-        // relative_length of item 1 is 1.0 / 100.0 == 0.01 (not > 0.01) → kept.
+        // Item 1's share is 1.0 / 100.0 == 0.01 (not > 0.01) → kept.
         let mut video = TsVideoStream::default();
         video.set_video_format(TsVideoFormat::Videoformat1080p);
         video.set_frame_rate(TsFrameRate::Framerate24);

--- a/crates/bdinfo-rs-core/src/stream.rs
+++ b/crates/bdinfo-rs-core/src/stream.rs
@@ -837,11 +837,13 @@ impl TsAudioStream {
     pub fn codec_name(&self) -> &str {
         match self.base.stream_type {
             // MPEG-1/2 audio and AAC report their codec-supplied `ext_data`
-            // string (an unset value → empty).
-            TsStreamType::Mpeg1Audio
-            | TsStreamType::Mpeg2Audio
-            | TsStreamType::Mpeg2AacAudio
-            | TsStreamType::Mpeg4AacAudio => self.ext_data.as_deref().unwrap_or(""),
+            // string; when the packet scan never decoded the stream (unset),
+            // the type-derived constant stands in rather than an empty name
+            // (see DIFFERENCES.md).
+            TsStreamType::Mpeg1Audio => self.ext_data.as_deref().unwrap_or("MP1 Audio"),
+            TsStreamType::Mpeg2Audio => self.ext_data.as_deref().unwrap_or("MP2 Audio"),
+            TsStreamType::Mpeg2AacAudio => self.ext_data.as_deref().unwrap_or("MPEG-2 AAC"),
+            TsStreamType::Mpeg4AacAudio => self.ext_data.as_deref().unwrap_or("MPEG-4 AAC"),
             TsStreamType::LpcmAudio => "LPCM Audio",
             TsStreamType::Ac3Audio => {
                 if self.audio_mode == TsAudioMode::Extended {
@@ -2046,17 +2048,17 @@ mod tests {
         assert_eq!(ma.codec_name(), "DTS-HD Master Audio");
         ma.has_extensions = true;
         assert_eq!(ma.codec_name(), "DTS:X Master Audio");
-        // LPCM is a fixed label; MPEG-1/2 audio and AAC echo their ext_data
-        // (empty when unset).
+        // LPCM is a fixed label; MPEG-1/2 audio and AAC echo their ext_data,
+        // with the type-derived constant standing in when it was never set.
         assert_eq!(audio(TsStreamType::LpcmAudio, 6, 1, 48_000, 0).codec_name(), "LPCM Audio");
-        for ty in [
-            TsStreamType::Mpeg1Audio,
-            TsStreamType::Mpeg2Audio,
-            TsStreamType::Mpeg2AacAudio,
-            TsStreamType::Mpeg4AacAudio,
+        for (ty, fallback) in [
+            (TsStreamType::Mpeg1Audio, "MP1 Audio"),
+            (TsStreamType::Mpeg2Audio, "MP2 Audio"),
+            (TsStreamType::Mpeg2AacAudio, "MPEG-2 AAC"),
+            (TsStreamType::Mpeg4AacAudio, "MPEG-4 AAC"),
         ] {
             let mut s = audio(ty, 2, 0, 48_000, 0);
-            assert_eq!(s.codec_name(), "", "{ty:?} with no ExtendedData");
+            assert_eq!(s.codec_name(), fallback, "{ty:?} with no ExtendedData");
             s.ext_data = Some("MPEG-4 AAC LC".to_owned());
             assert_eq!(s.codec_name(), "MPEG-4 AAC LC", "{ty:?} echoes ExtendedData");
         }


### PR DESCRIPTION
Three defects inherited from the BDInfo 0.8 lineage, each recorded in DIFFERENCES.md:

- The demux measured an audio transfer interval on any PTS change, so a backwards PTS discarded that access unit's bitrate sample (negative interval) and dragged the interval base back, understating the next unit's rate. Only a forward PTS now measures an interval and advances the base, matching the PTS+DTS arm's existing running max. Pinned by a synthetic demux test covering backwards, repeated and forward PTS in one sequence.
- MPEG-1/2 and AAC audio rendered an empty long codec name when the packet scan never decoded a frame. The type-derived constants now stand in: MP1 Audio, MP2 Audio, MPEG-2 AAC, MPEG-4 AAC.
- The relative_length > 0.01 guard on duplicate-PID overwrites and reference-clip selection divided by the playlist total accumulated before the clip was appended: the first clip divided by zero into +Infinity and early clips passed the guard however short they were. Each clip's fraction is now its share of the finished playlist, resolved after the parse; the threshold boundary test pins 1s of a 100s total as exactly 0.01.

Every committed golden is byte-identical, including the damaged-disc and real-disc fixtures.