### PR TITLE
fix(gui): keep partial results on cancel and follow the selection during a scan

### DIFF
--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -669,7 +669,7 @@ impl Flow {
     /// values, and the scan's completion ([`Flow::finished`]) replaces every
     /// cell with the measured summaries.
     ///
-    /// The cells live on the [`Listing`], not on the scan, so a cancel keeps
+    /// The cells live on the listing rather than on the scan, so a cancel keeps
     /// what the partial scan gathered on the grids.
     pub fn measured(&mut self, generation: u64, playlists: Vec<(String, LivePlaylist)>) {
         if let Inner::Scanning { generation: active, listing, .. } = &mut self.inner
@@ -701,9 +701,9 @@ impl Flow {
     /// `since_progress` (since the last progress event) drives the stall flag
     /// (its fixed threshold lives in [`crate::progress`], beside the model's
     /// other display constants). The re-stamp re-derives the remaining estimate
-    /// from the same clock ([`ProgressModel::set_elapsed`]), so it climbs
-    /// through a stall instead of holding a value the stuck read has already
-    /// invalidated.
+    /// from the same clock and the last event's byte counts
+    /// ([`ProgressModel`]), so it climbs through a stall instead of holding a
+    /// value the stuck read has already invalidated.
     ///
     /// Both in-flight stages take it, on identical terms: the measured scan
     /// ([`Stage::Scanning`]) and the structural listing ([`Stage::Listing`]),

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -96,6 +96,21 @@ struct Listing {
     /// A failed measured scan returns here with its message — a banner over the
     /// still-usable table, so the user can re-select and retry.
     error: Option<String>,
+    /// The measured cells the last scan reported, by playlist name — what the
+    /// table's `Measured Bytes` column and the two panes show over the
+    /// summaries ([`crate::live`]). Filled by [`Flow::measured`] while a scan
+    /// runs and **kept** when that scan ends without summaries (a cancel, a
+    /// failure), so the values a partial scan gathered stay on the grids, as
+    /// classic `BDInfo`'s do. Cleared when a scan starts (a fresh pass restarts
+    /// the tallies) and when a finished scan's summaries take over
+    /// ([`apply_measured`](Self::apply_measured)). Empty until the first
+    /// snapshot, so an unreported playlist keeps showing the summaries' zeros.
+    ///
+    /// **Cells only.** Nothing here reaches the rows, their order or the
+    /// rendered report: a cancelled scan leaves the retained structural
+    /// (zero-bitrate) report exactly as it was, which is what the report path
+    /// then saves.
+    live: BTreeMap<String, LivePlaylist>,
     /// The rendered structural (zero-bitrate) report over the playlists a scan
     /// would cover now — `BDInfo`'s pre-scan "View Report", stored so the view
     /// borrows it per rebuild instead of re-rendering per frame. Kept fresh by
@@ -124,6 +139,7 @@ impl Listing {
             show_hidden,
             warnings: structural.warnings,
             error: None,
+            live: BTreeMap::new(),
             structural_report: String::new(),
         };
         listing.refresh_report();
@@ -264,6 +280,10 @@ impl Listing {
     /// re-attached by playlist NAME, so they survive any reordering. The
     /// disc-level facts are unchanged by measurement, so only `bdrom.playlists`
     /// is swapped.
+    ///
+    /// The live cells are a display of these same numbers on their way here, so
+    /// they are dropped: the summaries are the finished truth for every row,
+    /// including the ones the last snapshot never covered.
     fn apply_measured(&mut self, playlists: Vec<PlaylistSummary>) {
         let checked: BTreeSet<String> = self.selected_names().into_iter().collect();
         let active_name = self.rows.get(self.active).map(|row| row.name.clone());
@@ -278,6 +298,7 @@ impl Listing {
         self.show_hidden = model::any_hidden(&rows);
         self.bdrom.playlists = playlists;
         self.rows = rows;
+        self.live.clear();
         // The retained structural render must follow the measured disc — it
         // is what a LATER scan serves while in flight.
         self.refresh_report();
@@ -408,14 +429,6 @@ enum Inner {
         /// every applied progress event. The status line then reads "still
         /// reading" instead of implying normal progress.
         stalled: bool,
-        /// The measured cells the scan has reported so far, by playlist name —
-        /// what the table's `Measured Bytes` column and the two panes show
-        /// while the scan runs ([`crate::live`]). Merged per playlist by
-        /// [`Flow::measured`] and read only here: the rows, their order and the
-        /// retained report never see it, and the finished scan's summaries
-        /// replace it rather than adding to it. Empty until the first snapshot,
-        /// so an unreported playlist keeps showing the summaries' zeros.
-        live: BTreeMap<String, LivePlaylist>,
     },
     Reported {
         listing: Listing,
@@ -544,8 +557,14 @@ impl Flow {
     /// Sets the active (highlighted) row — the playlist whose clips and streams
     /// the master-detail panes show. A row click drives this; it is independent
     /// of the scan-selection checkboxes. An out-of-range index is ignored.
+    ///
+    /// Live **during a scan** too ([`Stage::Scanning`], unlike every selection
+    /// edit): classic `BDInfo` never disables its playlist list, and the panes
+    /// re-target to the clicked row's live cells on the next repaint. Only the
+    /// highlight moves — the row set, the order and the checked set stay frozen
+    /// under the running scan, so the scan set cannot change under it.
     pub const fn set_active(&mut self, index: usize) {
-        if let Some(listing) = self.editable_listing_mut()
+        if let Some(listing) = self.any_listing_mut()
             && index < listing.rows.len()
         {
             listing.active = index;
@@ -587,6 +606,10 @@ impl Flow {
     /// state that has at least one listed playlist (the same gate as
     /// [`Flow::scan_request`]); the selection may be empty (scan-all). No-op
     /// otherwise.
+    ///
+    /// A new pass restarts the tallies from zero, so any live cells an earlier
+    /// cancelled or failed scan left on the grids are cleared here rather than
+    /// left to be overwritten playlist by playlist.
     #[must_use]
     pub fn start_scanning(self, generation: u64) -> Self {
         match self.inner {
@@ -594,6 +617,7 @@ impl Flow {
                 if !listing.rows.is_empty() =>
             {
                 listing.error = None;
+                listing.live.clear();
                 let scanned = listing.scan_names();
                 Self {
                     inner: Inner::Scanning {
@@ -602,7 +626,6 @@ impl Flow {
                         progress: None,
                         scanned,
                         stalled: false,
-                        live: BTreeMap::new(),
                     },
                 }
             }
@@ -645,11 +668,14 @@ impl Flow {
     /// playlist no snapshot has covered yet keeps showing the (zero) summary
     /// values, and the scan's completion ([`Flow::finished`]) replaces every
     /// cell with the measured summaries.
+    ///
+    /// The cells live on the [`Listing`], not on the scan, so a cancel keeps
+    /// what the partial scan gathered on the grids.
     pub fn measured(&mut self, generation: u64, playlists: Vec<(String, LivePlaylist)>) {
-        if let Inner::Scanning { generation: active, live, .. } = &mut self.inner
+        if let Inner::Scanning { generation: active, listing, .. } = &mut self.inner
             && *active == generation
         {
-            live.extend(playlists);
+            listing.live.extend(playlists);
         }
     }
 
@@ -674,8 +700,10 @@ impl Flow {
     /// event arrives (a read stuck in drive-firmware retries emits none), and
     /// `since_progress` (since the last progress event) drives the stall flag
     /// (its fixed threshold lives in [`crate::progress`], beside the model's
-    /// other display constants). The remaining estimate is untouched —
-    /// it is meaningful only against real progress.
+    /// other display constants). The re-stamp re-derives the remaining estimate
+    /// from the same clock ([`ProgressModel::set_elapsed`]), so it climbs
+    /// through a stall instead of holding a value the stuck read has already
+    /// invalidated.
     ///
     /// Both in-flight stages take it, on identical terms: the measured scan
     /// ([`Stage::Scanning`]) and the structural listing ([`Stage::Listing`]),
@@ -723,6 +751,8 @@ impl Flow {
     /// The measured scan failed — applied only when `generation` matches; returns
     /// to [`Stage::Listed`] with the message as a banner over the still-usable
     /// table, so the user can retry (mirroring the CLI's resilient posture).
+    /// The cells it managed to measure stay on the grids, like a cancel's
+    /// ([`Flow::cancel`]).
     #[must_use]
     pub fn scan_failed(self, generation: u64, message: String) -> Self {
         match self.inner {
@@ -746,6 +776,12 @@ impl Flow {
     /// `listed` (and any straggling progress) drop it. Starting a new scan
     /// immediately is safe: it gets a fresh generation and its own cancel
     /// flag, and the old worker only ever reads the disc.
+    ///
+    /// The measured cells the partial scan gathered stay on the grids, as
+    /// classic `BDInfo`'s do — they live on the listing, so returning it is
+    /// enough. The report is untouched by them: what "View Report" and Save
+    /// serve after a cancel is the same structural (zero-bitrate) render as
+    /// before the scan, which classic likewise leaves unmarked as partial.
     #[must_use]
     pub fn cancel(self) -> Self {
         match self.inner {
@@ -851,8 +887,9 @@ impl Flow {
     /// The "Stream Files" pane rows for the active playlist (empty when none),
     /// their size cells rendered under the human-readable toggle.
     ///
-    /// While a scan is reporting that playlist, the measured column carries its
-    /// sizes as of the last snapshot.
+    /// Once a scan has reported that playlist, the measured column carries its
+    /// sizes as of the last snapshot — ticking while the scan runs, and holding
+    /// there if it is cancelled.
     #[must_use]
     pub fn stream_file_rows(&self) -> Vec<StreamFileRow> {
         self.any_listing()
@@ -902,9 +939,10 @@ impl Flow {
 
     /// The selectable table rows (empty unless a disc is loaded).
     ///
-    /// A row whose playlist a scan in flight has reported shows that scan's
-    /// running `Measured Bytes` count in place of the summary's; every other
-    /// cell, and the row order, is the same one a settled table renders.
+    /// A row whose playlist the last scan reported shows that scan's
+    /// `Measured Bytes` count in place of the summary's — while it runs, and
+    /// afterwards if it was cancelled; every other cell, and the row order, is
+    /// the same one a settled table renders.
     #[must_use]
     pub fn table(&self) -> Vec<SelectableRow> {
         let Some(listing) = self.any_listing() else { return Vec::new() };
@@ -950,8 +988,9 @@ impl Flow {
         self.any_listing().is_some_and(|listing| listing.reveal.is_some())
     }
 
-    /// Whether the table checkboxes + selection controls are live (the table is
-    /// frozen while a scan is in flight).
+    /// Whether the table checkboxes + selection controls are live (the scan set
+    /// is frozen while a scan is in flight). The active-row highlight is not
+    /// gated on this — it stays live mid-scan ([`Flow::set_active`]).
     #[must_use]
     pub const fn editable(&self) -> bool {
         matches!(self.inner, Inner::Listed(_) | Inner::Reported { .. })
@@ -1105,13 +1144,28 @@ impl Flow {
         }
     }
 
-    /// The named playlist's cells as the in-flight scan last reported them, or
-    /// `None` outside a scan and for a playlist no snapshot has covered yet.
-    /// Only [`Stage::Scanning`] answers: a settled table's numbers come from
-    /// the summaries themselves.
+    /// The named playlist's cells as the last scan reported them, or `None` for
+    /// a playlist no snapshot has covered.
+    ///
+    /// Looked up by playlist NAME, so a row that moved (a sort applied before
+    /// the scan, a re-derived row set) still reads its own numbers and an
+    /// unmatched name reads none — the same identity guard the panes' per-clip
+    /// and per-stream lookups use ([`crate::live`]). Answers in every
+    /// disc-loaded stage: a scan in flight fills the map, a cancelled or failed
+    /// scan leaves its partial cells there, and a finished one empties it so
+    /// the measured summaries show through.
     fn live_playlist(&self, name: &str) -> Option<&LivePlaylist> {
-        match &self.inner {
-            Inner::Scanning { live, .. } => live.get(name),
+        self.any_listing().and_then(|listing| listing.live.get(name))
+    }
+
+    /// The mutable listing behind any disc-loaded state (Listed / Scanning /
+    /// Reported) — the write side of [`any_listing`](Self::any_listing), for
+    /// the one mutation a running scan allows ([`set_active`](Self::set_active)).
+    const fn any_listing_mut(&mut self) -> Option<&mut Listing> {
+        match &mut self.inner {
+            Inner::Listed(listing)
+            | Inner::Scanning { listing, .. }
+            | Inner::Reported { listing, .. } => Some(listing),
             _ => None,
         }
     }
@@ -1519,10 +1573,12 @@ mod tests {
         flow.tick(Duration::from_secs(65), Duration::from_secs(2));
         let after = flow.progress_view().expect("the model survives the tick");
         assert_eq!(after.elapsed_hms(), "00:01:05");
-        // …and only elapsed follows: the percent, the remaining estimate and
-        // the file hold, and 2 s of quiet is not yet a stall.
+        // …and the estimate follows it: half the bytes in 65 s projects 65 s
+        // more, so the readout climbs instead of holding the 4 s the last
+        // event computed. The percent and the file cannot move without a
+        // progress event, and 2 s of quiet is not yet a stall.
         assert_eq!(after.percent, 50);
-        assert_eq!(after.remaining_hms(), "00:00:04");
+        assert_eq!(after.remaining_hms(), "00:01:05");
         assert_eq!(after.file(), "A.M2TS");
         assert!(!flow.scan_stalled());
     }
@@ -1924,6 +1980,65 @@ mod tests {
     }
 
     #[test]
+    fn the_highlight_moves_during_a_scan_and_the_panes_follow_it() {
+        // Both playlists present a stream, so each has a live rate of its own
+        // for the panes to show.
+        let mut structural = structural();
+        for (index, playlist) in structural.bdrom.playlists.iter_mut().enumerate() {
+            playlist.streams = vec![stream_summary(Pid::new(0x1011), 0)];
+            playlist.clips = fixtures::clips(&[if index == 0 { "A.M2TS" } else { "B.M2TS" }], 50.0);
+        }
+        let flow =
+            Flow::start_listing(input()).listed(&input(), Ok(structural), ViewSettings::default());
+        let mut flow = flow.start_scanning(1);
+        flow.measured(
+            1,
+            vec![
+                live_cells("00000.MPLS", 960, &[960], 19_000),
+                live_cells("00001.MPLS", 480, &[480], 7_000),
+            ],
+        );
+        assert_eq!(flow.active_index(), Some(0));
+        assert_eq!(pane_sizes(&flow), ["960"]);
+        assert_eq!(pane_rates(&flow), ["19 kbps"]);
+
+        // The click lands mid-scan: the highlight moves and both panes
+        // re-target to the newly active playlist's own live cells.
+        flow.set_active(1);
+        assert_eq!(flow.stage(), Stage::Scanning, "the scan runs on");
+        assert_eq!(flow.active_index(), Some(1));
+        assert_eq!(flow.active_playlist_name(), Some("00001.MPLS".to_owned()));
+        assert_eq!(pane_sizes(&flow), ["480"]);
+        assert_eq!(pane_rates(&flow), ["7 kbps"]);
+        // A later snapshot ticks the row the user moved to, not the one the
+        // scan started on.
+        flow.measured(1, vec![live_cells("00001.MPLS", 960, &[960], 9_000)]);
+        assert_eq!(pane_sizes(&flow), ["960"]);
+        assert_eq!(pane_rates(&flow), ["9 kbps"]);
+        // An out-of-range index is still ignored, mid-scan as anywhere.
+        flow.set_active(9);
+        assert_eq!(flow.active_index(), Some(1));
+    }
+
+    #[test]
+    fn the_scan_set_stays_frozen_while_the_highlight_moves() {
+        // Only the highlight is live mid-scan: every edit that could change
+        // WHAT is scanned, or which row is which, is still refused.
+        let mut flow = listed3();
+        flow.toggle(0);
+        let mut flow = flow.start_scanning(1);
+        assert!(!flow.editable());
+        flow.set_active(2);
+        assert_eq!(flow.active_index(), Some(2), "the highlight moves");
+        flow.toggle(1);
+        flow.select_all();
+        assert_eq!(flow.selected_count(), 1, "the checked set is frozen");
+        flow.sort_by(SortColumn::Length);
+        assert_eq!(flow.sort(), None, "the row order is frozen");
+        assert_eq!(row_names(&flow), ["00000.MPLS", "00001.MPLS", "00002.MPLS"]);
+    }
+
+    #[test]
     fn measured_cells_reach_only_the_scan_they_belong_to() {
         // A snapshot from a superseded scan is dropped, like a stale progress
         // event…
@@ -1961,10 +2076,57 @@ mod tests {
             .packet_count = 1000; // 1000 * 192 = 192,000 bytes
         let done = flow.clone().finished(1, "R".to_owned(), Arc::new(Vec::new()), measured);
         assert_eq!(measured_cells(&done), ["192,000", "0"]);
-        // Cancelling ends the scan without measured summaries to show, so the
-        // table returns to the pre-scan zeros rather than keeping the numbers
-        // of a scan that never completed.
-        assert_eq!(measured_cells(&flow.cancel()), ["0", "0"]);
+        // Cancelling has no summaries to swap in, so the partial cells stay
+        // exactly where the last snapshot left them — what the scan gathered
+        // is what the user keeps.
+        assert_eq!(measured_cells(&flow.cancel()), ["960", "0"]);
+    }
+
+    #[test]
+    fn a_cancelled_scan_keeps_its_partial_values_on_the_grids() {
+        // Two clips and one presented stream on the active playlist, so the
+        // table cell and both panes have a partial value to keep.
+        let mut structural = structural();
+        let feature = structural.bdrom.playlists.first_mut().expect("the feature playlist");
+        feature.clips = fixtures::clips(&["A.M2TS", "B.M2TS"], 50.0);
+        feature.streams = vec![stream_summary(Pid::new(0x1011), 0)];
+        let flow =
+            Flow::start_listing(input()).listed(&input(), Ok(structural), ViewSettings::default());
+        let mut flow = flow.start_scanning(1);
+        flow.measured(1, vec![live_cells("00000.MPLS", 960, &[768, 192], 19_000)]);
+
+        let report = flow.report().expect("the pre-scan report").to_owned();
+        let flow = flow.cancel();
+
+        assert_eq!(flow.stage(), Stage::Listed);
+        assert_eq!(measured_cells(&flow), ["960", "0"], "the table keeps the partial count");
+        assert_eq!(pane_sizes(&flow), ["768", "192"], "the Stream Files pane keeps its sizes");
+        assert_eq!(pane_rates(&flow), ["19 kbps"], "the Streams pane keeps its rates");
+        // The report is untouched by the partial cells: a cancel still serves
+        // the structural (zero-bitrate) render, unmarked as partial.
+        assert_eq!(flow.report(), Some(report.as_str()));
+        assert!(flow.editable(), "the table is usable again");
+    }
+
+    #[test]
+    fn a_new_scan_clears_the_partial_cells_of_the_cancelled_one() {
+        // A fresh pass restarts the tallies, so last attempt's numbers go
+        // rather than lingering on rows the new pass has not reached.
+        let mut flow = listed().start_scanning(1);
+        flow.measured(1, vec![live_cells("00000.MPLS", 960, &[960], 19_000)]);
+        let flow = flow.cancel().start_scanning(2);
+        assert_eq!(measured_cells(&flow), ["0", "0"]);
+    }
+
+    #[test]
+    fn a_failed_scan_keeps_its_partial_values_too() {
+        // The banner road ends the scan without summaries as well; what it
+        // measured before the failure stays visible for the retry.
+        let mut flow = listed().start_scanning(1);
+        flow.measured(1, vec![live_cells("00000.MPLS", 960, &[960], 19_000)]);
+        let flow = flow.scan_failed(1, "disc vanished".to_owned());
+        assert_eq!(measured_cells(&flow), ["960", "0"]);
+        assert_eq!(flow.error_message(), Some("disc vanished"));
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/live.rs
+++ b/crates/bdinfo-rs-gui/src/live.rs
@@ -5,10 +5,10 @@
 //! and is handed an owned [`MeasuredSnapshot`] as each demuxed chunk lands. The
 //! worker thread turns each one into the per-playlist [`updates`] below and
 //! sends them to the shell, which merges them into the state the playlist table
-//! and the two panes read while `Stage::Scanning`
-//! ([`crate::flow`]). Only the cells: nothing here changes which rows exist,
-//! their order, or the rendered report — the finished scan's summaries replace
-//! these values wholesale.
+//! and the two panes read ([`crate::flow`]). Only the cells: nothing here
+//! changes which rows exist, their order, or the rendered report — the finished
+//! scan's summaries replace these values wholesale, and a scan that ends
+//! without summaries (a cancel, a failure) leaves them showing.
 //!
 //! A snapshot covers only the playlists that play the stream file it was taken
 //! over, so the merge is per playlist and every other playlist keeps its last

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -3092,6 +3092,9 @@ fn resizable_header<'a>(
 /// [`ui::row_surface`] container wrapped in a `mouse_area`, so hover lifts the
 /// **entire** row as a single band (no checkbox-vs-cells seam) and the **active**
 /// row carries the amber wash. `hovered` is whether the cursor is over this row.
+///
+/// `editable` gates the checkbox alone — the cells stay clickable while a scan
+/// runs, so the master-detail panes can follow a different playlist mid-scan.
 fn table_row<'a>(
     p: Palette,
     row_data: &SelectableRow,
@@ -3148,7 +3151,10 @@ fn table_row<'a>(
             .height(Length::Fill)
             .padding(0.0)
             .style(ui::flat_button(p))
-            .on_press_maybe(editable.then_some(Message::RowActivated(index)));
+            // Not gated on `editable`: the highlight follows the click during a
+            // scan too, so the panes can be re-targeted while it runs
+            // ([`Flow::set_active`]). Only the checkbox above freezes.
+            .on_press(Message::RowActivated(index));
 
     let row = Row::new()
         .width(Length::Fill)
@@ -4306,6 +4312,110 @@ mod interaction {
         // The toggle re-labels; clicking it clears the selection.
         click(&mut app, "Unselect All");
         assert_eq!(app.flow.selected_count(), 0);
+    }
+
+    #[test]
+    fn a_row_click_during_a_scan_moves_the_highlight_and_the_panes() {
+        use bdinfo_rs_gui::live::LivePlaylist;
+
+        let mut app = listed_app();
+        click(&mut app, "Scan Bitrates"); // nothing checked — scan-all
+        assert_eq!(app.flow.stage(), Stage::Scanning);
+        let cells = |name: &str, bytes: u64| {
+            (
+                name.to_owned(),
+                LivePlaylist { measured_bytes: bytes, clips: vec![bytes], streams: Vec::new() },
+            )
+        };
+        let _ = app.update(Message::Measured {
+            generation: app.generation,
+            playlists: vec![cells("00000.MPLS", 111_000), cells("00001.MPLS", 222_000)],
+        });
+        assert_eq!(app.flow.active_index(), Some(0));
+
+        // The cells button is live mid-scan, so the click dispatches — and the
+        // panes re-target to the newly active playlist's live count.
+        let messages = click(&mut app, "00001.MPLS");
+        assert!(
+            messages.iter().any(|m| matches!(m, Message::RowActivated(1))),
+            "the row stays clickable while the scan runs: {messages:?}"
+        );
+        assert_eq!(app.flow.stage(), Stage::Scanning, "the scan runs on");
+        assert_eq!(app.flow.active_index(), Some(1));
+        assert_eq!(
+            app.flow.stream_file_rows().first().map(|row| row.measured.clone()),
+            Some("222,000".to_owned())
+        );
+        // The checkbox beside it is still frozen: nothing the scan set is
+        // derived from can move under the running scan.
+        assert_eq!(app.flow.selected_count(), 0);
+        let _ = app.update(Message::RowToggled(1));
+        assert_eq!(app.flow.selected_count(), 0, "the checkbox stays locked");
+    }
+
+    #[test]
+    fn cancelling_a_scan_keeps_the_values_it_measured() {
+        use bdinfo_rs_gui::live::LivePlaylist;
+
+        let mut app = listed_app();
+        click(&mut app, "Scan Bitrates");
+        let _ = app.update(Message::Measured {
+            generation: app.generation,
+            playlists: vec![(
+                "00000.MPLS".to_owned(),
+                LivePlaylist {
+                    measured_bytes: 1_234_560,
+                    clips: vec![1_234_560],
+                    ..LivePlaylist::default()
+                },
+            )],
+        });
+        assert!(sees(&app, "1,234,560"));
+
+        click(&mut app, "Cancel");
+        assert_eq!(app.flow.stage(), Stage::Listed);
+        // What the partial scan gathered is still on screen and in the pane.
+        assert!(sees(&app, "1,234,560"), "the cancelled scan's count stays on the table");
+        assert_eq!(
+            app.flow.stream_file_rows().first().map(|row| row.measured.clone()),
+            Some("1,234,560".to_owned())
+        );
+        // Starting the next scan clears them — that pass counts from zero.
+        click(&mut app, "Scan Bitrates");
+        assert!(!sees(&app, "1,234,560"));
+    }
+
+    #[test]
+    fn a_stalled_scans_remaining_estimate_climbs_with_the_clock() {
+        let mut app = listed_app();
+        click(&mut app, "Scan Bitrates");
+        let _ = app.update(Message::Progress {
+            generation: app.generation,
+            file: "A.M2TS".to_owned(),
+            done: 1,
+            total: 2,
+        });
+        let remaining = |app: &App| {
+            app.flow.progress_view().map(bdinfo_rs_gui::progress::ProgressModel::remaining_hms)
+        };
+        // Ticks arrive with no progress event in between (a read stuck in
+        // drive-firmware retries emits none): each one re-derives a longer
+        // estimate from the cumulative average, never the frozen last value.
+        let mut previous = String::new();
+        for seconds in [30_u64, 60, 120] {
+            app.scan_start = Instant::now().checked_sub(Duration::from_secs(seconds));
+            app.last_progress = Instant::now().checked_sub(Duration::from_secs(seconds));
+            let _ = app.update(Message::Tick);
+            let now = remaining(&app).expect("the model survives the tick");
+            assert!(
+                now > previous,
+                "the estimate must climb at {seconds} s: {now} after {previous}"
+            );
+            previous = now;
+        }
+        // Half the bytes read in 120 s projects 120 s more.
+        assert_eq!(previous, "00:02:00");
+        assert!(app.flow.scan_stalled(), "and the quiet is flagged as a stall");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/progress.rs
+++ b/crates/bdinfo-rs-gui/src/progress.rs
@@ -94,6 +94,13 @@ pub fn measure_due(since_last: Option<Duration>) -> bool {
 pub struct ProgressModel {
     /// The stream file currently being demuxed (the CLI line's middle field).
     pub(crate) file: String,
+    /// The bytes read as of the last progress event — retained so a
+    /// wall-clock tick can re-derive the estimate
+    /// ([`set_elapsed`](Self::set_elapsed)).
+    done: u64,
+    /// The bytes the pass will read, as of the last progress event — the other
+    /// half of that re-derivation.
+    total: u64,
     /// Completion percent (0–100; 100 when there is nothing to read).
     pub(crate) percent: u64,
     /// Whole seconds elapsed since the scan started.
@@ -107,16 +114,22 @@ impl ProgressModel {
     /// and the wall time elapsed since the scan started.
     pub(crate) fn compute(file: String, done: u64, total: u64, elapsed: Duration) -> Self {
         let (percent, elapsed_seconds, remaining_seconds) = progress_stats(done, total, elapsed);
-        Self { file, percent, elapsed_seconds, remaining_seconds }
+        Self { file, done, total, percent, elapsed_seconds, remaining_seconds }
     }
 
-    /// Re-stamps the elapsed wall time from the clock, leaving `file`,
-    /// `percent` and `remaining_seconds` at their last computed values — the
-    /// remaining estimate is meaningful only against real progress, so a
-    /// wall-clock tick may never touch it. Whole seconds, truncated, like
-    /// every displayed time.
-    pub(crate) const fn set_elapsed(&mut self, elapsed: Duration) {
-        self.elapsed_seconds = elapsed.as_secs();
+    /// Re-stamps the wall clock, re-deriving the estimate from the retained
+    /// byte counts at the new elapsed time — the same cumulative-average math
+    /// [`compute`](Self::compute) ran, so a tick during a stall makes the
+    /// estimate CLIMB (more time, no more bytes) instead of holding the value a
+    /// now-stale event left. Classic `BDInfo` recomputes its remaining time on
+    /// every 1 Hz tick the same way. `file` and `percent` cannot move without a
+    /// progress event and do not. Whole seconds, truncated, like every
+    /// displayed time.
+    pub(crate) fn set_elapsed(&mut self, elapsed: Duration) {
+        let (_, elapsed_seconds, remaining_seconds) =
+            progress_stats(self.done, self.total, elapsed);
+        self.elapsed_seconds = elapsed_seconds;
+        self.remaining_seconds = remaining_seconds;
     }
 
     /// The bar fill, a fraction in `0.0..=1.0` (the progress bar's value over a
@@ -189,16 +202,49 @@ mod tests {
     }
 
     #[test]
-    fn set_elapsed_restamps_only_the_wall_clock() {
+    fn set_elapsed_restamps_the_clock_and_re_derives_the_estimate() {
         let mut model =
             ProgressModel::compute("00000.M2TS".to_owned(), 50, 200, Duration::from_secs(4));
-        // 65.999 s truncates to 00:01:05; percent, remaining and the file
-        // hold their last computed values.
+        // 65.999 s truncates to 00:01:05, and the estimate re-derives from the
+        // retained counts at that time: 65.999 s for a quarter of the bytes
+        // projects 3 * 65.999 s = 00:03:17 still to read. The file and the
+        // percent cannot move without a progress event.
         model.set_elapsed(Duration::from_millis(65_999));
         assert_eq!(model.elapsed_hms(), "00:01:05");
         assert_eq!(model.percent, 25);
-        assert_eq!(model.remaining_hms(), "00:00:12");
+        assert_eq!(model.remaining_hms(), "00:03:17");
         assert_eq!(model.file(), "00000.M2TS");
+    }
+
+    #[test]
+    fn the_estimate_climbs_while_a_read_is_stuck() {
+        // No progress event arrives, so `done` stands still while the clock
+        // runs: every tick projects a longer remaining time, never the frozen
+        // value the last event computed.
+        let mut model =
+            ProgressModel::compute("00000.M2TS".to_owned(), 50, 200, Duration::from_secs(4));
+        let mut previous = model.remaining_seconds;
+        assert_eq!(previous, 12);
+        for seconds in 5..=10 {
+            model.set_elapsed(Duration::from_secs(seconds));
+            assert!(
+                model.remaining_seconds > previous,
+                "the estimate must climb at {seconds} s: {} is not past {previous}",
+                model.remaining_seconds
+            );
+            previous = model.remaining_seconds;
+        }
+    }
+
+    #[test]
+    fn a_tick_before_any_bytes_estimates_nothing() {
+        // `done == 0` gives the cumulative average nothing to extrapolate from,
+        // so the readout stays at zero however long the clock runs — the same
+        // blind window `progress_stats` defines for the first event.
+        let mut model = ProgressModel::compute("00000.M2TS".to_owned(), 0, 200, Duration::ZERO);
+        model.set_elapsed(Duration::from_secs(30));
+        assert_eq!(model.elapsed_hms(), "00:00:30");
+        assert_eq!(model.remaining_hms(), "00:00:00");
     }
 
     #[test]


### PR DESCRIPTION
Three live-scan behaviors in the desktop app diverged from classic BDInfo.

**Cancel keeps partials.** The measured cells a scan reports now live on the
listing rather than on the scan state, so a scan that ends without summaries (a
cancel, a failure) leaves the table's Measured Bytes cell and both master-detail
panes showing what the pass gathered, instead of reverting to the pre-scan
zeros. A new scan clears them (a fresh pass counts from zero); a finished one
replaces them with its summaries. The report path is unchanged: a cancel still
serves the structural (zero-bitrate) render, unmarked as partial.

**Live selection.** The active-row highlight is no longer gated on the editable
state, so clicking a playlist row during a scan re-targets the panes at the next
repaint. Checkbox edits, sorting and the row set stay frozen, so the scan set
cannot change under the running scan. Live cells are looked up by playlist name,
and by PID and camera angle within a playlist, so a row that moved reads its own
numbers and an unmatched one reads none.

**Remaining climbs.** The progress model retains the last event's byte counts
and re-derives the estimate on every wall-clock tick from the cumulative
average, so a read stuck in drive-firmware retries projects a longer remaining
time each second instead of holding a value that read has already invalidated.
The window before the first progress event stays blank.

GUI only: no core, report or CLI change. `gui-compliance.ps1` green - 305 tests,
100% lines/regions/functions, diff-scoped mutants 9 caught / 3 unviable, all six
snapshot hashes unchanged.
