### PR TITLE
fix(gui): surface listing-phase read errors and harden the log

### DIFF
--- a/crates/bdinfo-rs-gui/src/diagnostics.rs
+++ b/crates/bdinfo-rs-gui/src/diagnostics.rs
@@ -4,12 +4,19 @@
 //! The release binary hides the console on Windows (`windows_subsystem`), so
 //! stderr does not exist — without a file, a failed boot, a panic, or a
 //! settings write that didn't stick would all be invisible. This module
-//! writes one plain-text log (`gui.log`, next to `gui.conf`), truncated at
-//! each launch (per-launch truncation bounds its size — no rotation), fed
-//! through the `log` facade so the dependencies that already speak it land
-//! in the same file: `iced_wgpu` logs the selected adapter (the renderer
-//! identity every graphics bug report needs first) and `rfd` logs the Linux
-//! portal errors it otherwise swallows.
+//! writes one plain-text log (`gui.log`, next to `gui.conf`), fed through the
+//! `log` facade so the dependencies that already speak it land in the same
+//! file: `iced_wgpu` logs the selected adapter (the renderer identity every
+//! graphics bug report needs first) and `rfd` logs the Linux portal errors it
+//! otherwise swallows.
+//!
+//! Each launch starts a fresh file and keeps exactly one previous generation
+//! beside it as `gui.log.1` ([`init`]) — two generations bound the size, and
+//! the second one exists because the first thing a user does when something
+//! goes wrong is run the app again, which would otherwise destroy the record
+//! of the launch that showed it. Every line is stamped with seconds since
+//! launch; the one wall-clock line [`init`] writes is what places them all in
+//! absolute time.
 //!
 //! Everything here is best-effort by contract: logging never panics, never
 //! meaningfully blocks (one short line write under a mutex), and a failure
@@ -27,12 +34,36 @@ use std::time::Instant;
 /// The log file's name — a sibling of `gui.conf`.
 const FILE_NAME: &str = "gui.log";
 
-/// Where the log lives: `gui.log` beside the config file. `None` when no
-/// config path resolved — the app then runs without a log, exactly as it
-/// runs without persistence.
+/// The log's name when it lands in the shared temp directory instead, where
+/// `gui.log` would be an unattributable stray.
+const FALLBACK_NAME: &str = "bdinfo-rs-gui.log";
+
+/// The suffix the previous launch's log is renamed to.
+const PREVIOUS_SUFFIX: &str = ".1";
+
+/// Where the log lives: `gui.log` beside the config file, or
+/// `bdinfo-rs-gui.log` in the OS temp directory when no config location
+/// resolved.
+///
+/// The app runs without persistence in that case, but not without a log: a
+/// desktop that resolves no config directory is exactly the environment whose
+/// failures need a witness most, and a temp file is one every OS gives.
 #[must_use]
-pub fn log_path_from(config: Option<&Path>) -> Option<PathBuf> {
-    Some(config?.parent()?.join(FILE_NAME))
+pub fn log_path_from(config: Option<&Path>) -> PathBuf {
+    config
+        .and_then(Path::parent)
+        .map_or_else(|| std::env::temp_dir().join(FALLBACK_NAME), |dir| dir.join(FILE_NAME))
+}
+
+/// Where the previous launch's log is kept: the same path with
+/// [`PREVIOUS_SUFFIX`] appended (`gui.log` → `gui.log.1`).
+///
+/// Appended to the whole file name rather than swapped into the extension, so
+/// the pair sorts together and neither name can collide with a config file.
+fn previous_log_path(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_owned();
+    name.push(PREVIOUS_SUFFIX);
+    PathBuf::from(name)
 }
 
 /// The process-wide sink behind the `log` facade. All state is interior,
@@ -94,33 +125,83 @@ fn line_allowed(level: log::Level, target: &str) -> bool {
     }
 }
 
-/// Opens (truncating) the log file at `path` and installs the global logger.
+/// Rotates the previous log out of the way, opens a fresh file at `path`,
+/// installs the global logger, and writes the launch's wall-clock anchor.
 ///
-/// Called once, first thing in `main`. Best-effort at every step: a `None`
-/// path, an uncreatable directory, or a failed open all leave a sink that
-/// swallows writes — the app never notices the difference.
-pub fn init(path: Option<&Path>) {
+/// Called once, first thing in `main`. Best-effort at every step: an
+/// uncreatable directory, a rename that finds nothing to rename, or a failed
+/// open all leave a sink that swallows writes — the app never notices the
+/// difference.
+pub fn init(path: &Path) {
     let _ = SINK.start.set(Instant::now());
-    if let Some(path) = path {
-        if let Some(dir) = path.parent() {
-            let _ = std::fs::create_dir_all(dir);
-        }
-        if let Ok(file) = File::create(path) {
-            *SINK.file() = Some(file);
-        }
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    // The previous launch's file becomes `gui.log.1` before this one truncates
+    // it away; the rename fails harmlessly on the first launch, when there is
+    // nothing there yet.
+    let _ = std::fs::rename(path, previous_log_path(path));
+    if let Ok(file) = File::create(path) {
+        *SINK.file() = Some(file);
     }
     // Err means a logger is already installed (a test re-initializing) — the
     // installed one keeps working; the level cap applies either way.
     let _ = log::set_logger(&SINK);
     log::set_max_level(log::LevelFilter::Info);
+    log::info!("launched {} UTC", utc_stamp(epoch_secs()));
 }
 
-/// Installs a panic hook that writes the payload and location to the log
-/// before the default hook runs.
+/// Seconds since the Unix epoch, now. A clock set before the epoch reads as
+/// the epoch itself rather than failing the launch line.
+fn epoch_secs() -> u64 {
+    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+/// `secs` (seconds since the Unix epoch) as a UTC `YYYY-MM-DD HH:MM:SS` stamp
+/// — the launch line every relative timestamp in the file is measured from.
+///
+/// UTC rather than local time: safe `std` reads no timezone offset, and an
+/// unambiguous instant is what a log arriving from another timezone needs
+/// anyway.
+///
+/// The date is Howard Hinnant's `civil_from_days`
+/// (`howardhinnant.github.io/date_algorithms.html`), whose 400-year era
+/// begins on 1 March so that leap days fall at the end of a year and need no
+/// special case. `wrapping_*` is exact here, never a tolerated overflow:
+/// every intermediate is bounded by the input, and even `u64::MAX` seconds —
+/// about 2.1e14 days — leaves the largest product below (`era * 146_097`)
+/// four orders of magnitude short of `u64::MAX`.
+fn utc_stamp(secs: u64) -> String {
+    let days = secs / 86_400;
+    let time = secs % 86_400;
+    let (hour, minute, second) = (time / 3_600, time % 3_600 / 60, time % 60);
+    // 719_468 is the day count from the era's 0000-03-01 origin to the epoch.
+    let z = days.wrapping_add(719_468);
+    let era = z / 146_097;
+    let doe = z.wrapping_sub(era.wrapping_mul(146_097));
+    let yoe =
+        doe.wrapping_sub(doe / 1_460).wrapping_add(doe / 36_524).wrapping_sub(doe / 146_096) / 365;
+    let doy = doe.wrapping_sub(yoe.wrapping_mul(365).wrapping_add(yoe / 4).wrapping_sub(yoe / 100));
+    let mp = doy.wrapping_mul(5).wrapping_add(2) / 153;
+    let day = doy.wrapping_sub(mp.wrapping_mul(153).wrapping_add(2) / 5).wrapping_add(1);
+    // The era's months run March (0) to February (11), so 10 and 11 are the
+    // January and February that belong to the NEXT calendar year.
+    let month = if mp < 10 { mp.wrapping_add(3) } else { mp.wrapping_sub(9) };
+    let year = era.wrapping_mul(400).wrapping_add(yoe).wrapping_add(u64::from(month <= 2));
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}")
+}
+
+/// Installs a panic hook that writes the payload, location and a backtrace to
+/// the log before the default hook runs.
 ///
 /// Release builds keep it too — a hidden Windows console leaves the log as
 /// the only witness. The scan worker's `PanicAlarm` still reports the death
 /// to the UI; this records **why**.
+///
+/// The backtrace is forced rather than left to `RUST_BACKTRACE`, which nobody
+/// running a desktop app has set. The shipped binary is built with
+/// `strip = true`, so its frames may resolve to addresses and module offsets
+/// only — still the difference between a locatable crash and a bare message.
 pub fn install_panic_hook() {
     let previous = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -131,7 +212,8 @@ pub fn install_panic_hook() {
             .copied()
             .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
             .unwrap_or("(non-string panic payload)");
-        log::error!(target: "panic", "panicked at {location}: {message}");
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        log::error!(target: "panic", "panicked at {location}: {message}\n{backtrace}");
         previous(info);
     }));
 }
@@ -166,19 +248,45 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::{Mutex, OnceLock};
 
-    use super::{LogErr, Sink, format_line, line_allowed, log_path_from};
+    use super::{
+        LogErr, Sink, format_line, line_allowed, log_path_from, previous_log_path, utc_stamp,
+    };
 
     #[test]
-    fn the_log_lives_next_to_the_config() {
+    fn the_log_lives_next_to_the_config_or_in_the_temp_dir() {
         // Built by joins, not path literals: a Windows-separator literal is one
         // opaque component on Unix, where `parent()` would strip nothing.
         let dir = PathBuf::from("config-home").join("bdinfo-rs");
         let config = dir.join("gui.conf");
-        assert_eq!(log_path_from(Some(&config)), Some(dir.join("gui.log")));
-        // No config location → no log location (run without either).
-        assert_eq!(log_path_from(None), None);
-        // A parentless config path can't have a sibling.
-        assert_eq!(log_path_from(Some(Path::new("/"))), None);
+        assert_eq!(log_path_from(Some(&config)), dir.join("gui.log"));
+        // No config location, and a parentless config path that can have no
+        // sibling, both fall back to a named file in the temp directory.
+        let fallback = std::env::temp_dir().join("bdinfo-rs-gui.log");
+        assert_eq!(log_path_from(None), fallback);
+        assert_eq!(log_path_from(Some(Path::new("/"))), fallback);
+    }
+
+    #[test]
+    fn the_previous_generation_keeps_the_whole_name() {
+        // `.1` after the extension, not instead of it: `gui.log.1` sorts beside
+        // `gui.log` and can never be mistaken for another kind of file.
+        assert_eq!(previous_log_path(Path::new("dir/gui.log")), PathBuf::from("dir/gui.log.1"));
+    }
+
+    #[test]
+    fn the_wall_clock_stamp_renders_utc_civil_time() {
+        // The epoch itself, and the last second of that day.
+        assert_eq!(utc_stamp(0), "1970-01-01 00:00:00");
+        assert_eq!(utc_stamp(86_399), "1970-01-01 23:59:59");
+        // 1970-03-01: the day the era's month numbering starts from, so this
+        // is the arm that renders a month without the year correction.
+        assert_eq!(utc_stamp(5_097_600), "1970-03-01 00:00:00");
+        // A leap day: February belongs to the previous era-year, so its date
+        // renders only if the year correction applies to month 2 as well as 1.
+        assert_eq!(utc_stamp(1_709_164_800), "2024-02-29 00:00:00");
+        // Two arbitrary instants with every field non-zero.
+        assert_eq!(utc_stamp(1_000_000_000), "2001-09-09 01:46:40");
+        assert_eq!(utc_stamp(1_700_000_000), "2023-11-14 22:13:20");
     }
 
     #[test]
@@ -255,14 +363,27 @@ mod tests {
     /// the panic hook): everything global runs INSIDE this single function,
     /// sequentially, so no other test races it.
     #[test]
-    fn the_global_logger_truncates_hooks_panics_and_tags_tolerated_errors() {
+    fn the_global_logger_rotates_hooks_panics_and_tags_tolerated_errors() {
         let path = scratch("global/gui.log");
+        let previous = super::previous_log_path(&path);
         let _ = std::fs::create_dir_all(path.parent().expect("a parent"));
+        let _ = std::fs::remove_file(&previous);
         std::fs::write(&path, "stale content from a previous launch\n").expect("scratch write");
 
-        super::init(Some(&path));
+        super::init(&path);
         let after_init = std::fs::read_to_string(&path).expect("scratch read");
-        assert_eq!(after_init, "", "init truncates the previous launch's log");
+        assert_eq!(
+            std::fs::read_to_string(&previous).expect("the previous generation reads"),
+            "stale content from a previous launch\n",
+            "the launch before this one is kept, not destroyed"
+        );
+
+        // The launch line anchors every relative timestamp in the file. Its
+        // date is read from the clock, so it can only be this century.
+        let anchor = after_init.lines().next().expect("init writes the launch line");
+        assert!(anchor.contains("launched 20"), "the anchor carries a real date: {anchor}");
+        assert!(anchor.ends_with(" UTC"), "the anchor names its timezone: {anchor}");
+        assert_eq!(after_init.lines().count(), 1, "and nothing else survived the launch");
 
         // The facade now reaches the file, at the Info cap.
         log::info!("MARKER_HEADER");
@@ -283,9 +404,9 @@ mod tests {
         assert!(text.contains("MARKER_BOOM"));
         assert!(!text.contains("MARKER_FINE"));
 
-        // The panic hook writes payload + location before the previous hook
-        // runs. A no-op previous hook keeps the test output clean; each
-        // payload shape (&str, String, non-string) lands.
+        // The panic hook writes payload + location + backtrace before the
+        // previous hook runs. A no-op previous hook keeps the test output
+        // clean; each payload shape (&str, String, non-string) lands.
         std::panic::set_hook(Box::new(|_| {}));
         super::install_panic_hook();
         assert!(std::panic::catch_unwind(|| std::panic::panic_any("MARKER_STR")).is_err());
@@ -300,11 +421,13 @@ mod tests {
         assert!(text.contains("MARKER_STR"));
         assert!(text.contains("MARKER_STRING"));
         assert!(text.contains("(non-string panic payload)"));
+        // The forced backtrace follows the message: frames are rendered
+        // `   0: symbol`, one per line, by `Backtrace`'s own Display.
+        assert!(text.contains("\n   0: "), "the panic record carries a backtrace");
 
-        // Re-initialization is tolerated: a pathless init keeps the open
-        // file, an unopenable path keeps it too, and the facade still lands.
-        super::init(None);
-        super::init(Some(Path::new("/")));
+        // Re-initialization is tolerated: an unopenable path leaves the open
+        // file in place, and the facade still lands.
+        super::init(Path::new("/"));
         log::info!("MARKER_STILL_ALIVE");
         let text = std::fs::read_to_string(&path).expect("scratch read");
         assert!(text.contains("MARKER_STILL_ALIVE"));

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -836,6 +836,28 @@ impl Flow {
         self.any_listing().map_or(&[], |listing| listing.features.as_slice())
     }
 
+    /// The loaded disc named for a diagnostic log: volume label, byte size,
+    /// detected features, and the two content-protection flags the feature
+    /// list leaves out (`BdRom::extra_features` carries neither). `None`
+    /// before any disc is listed.
+    ///
+    /// Which disc a log came from is otherwise unrecoverable from it — the
+    /// path a log records is the user's, and says nothing about the media.
+    #[must_use]
+    pub fn disc_identity(&self) -> Option<String> {
+        let listing = self.any_listing()?;
+        let mut flags: Vec<&str> = listing.features.iter().map(String::as_str).collect();
+        if listing.bdrom.is_aacs_encrypted {
+            flags.push("AACS");
+        }
+        if listing.bdrom.is_bd_plus {
+            flags.push("BD+");
+        }
+        let flags =
+            if flags.is_empty() { String::new() } else { format!(", {}", flags.join(", ")) };
+        Some(format!("{} ({} bytes{flags})", listing.bdrom.volume_label, listing.bdrom.size))
+    }
+
     /// The active (highlighted) row index, when a disc is loaded.
     #[must_use]
     pub fn active_index(&self) -> Option<usize> {
@@ -1427,6 +1449,27 @@ mod tests {
         assert_eq!(Flow::idle().disc_size(), None);
         assert!(Flow::idle().disc_features().is_empty());
         assert_eq!(Flow::idle().input_display(), None);
+    }
+
+    #[test]
+    fn the_disc_identity_names_the_media_for_a_log() {
+        // Label, size and features, on one line.
+        assert_eq!(listed().disc_identity().as_deref(), Some("DISC (78000000000 bytes, Ultra HD)"));
+        // A disc with no detected feature carries no trailing list.
+        assert_eq!(listed3().disc_identity().as_deref(), Some("DISC (78000000000 bytes)"));
+        // The two protection flags are appended after the features, because
+        // the core's feature list carries neither.
+        let mut structural = structural();
+        structural.bdrom.is_aacs_encrypted = true;
+        structural.bdrom.is_bd_plus = true;
+        let flow =
+            Flow::start_listing(input()).listed(&input(), Ok(structural), ViewSettings::default());
+        assert_eq!(
+            flow.disc_identity().as_deref(),
+            Some("DISC (78000000000 bytes, Ultra HD, AACS, BD+)")
+        );
+        // No disc, no identity.
+        assert_eq!(Flow::idle().disc_identity(), None);
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -116,13 +116,14 @@ fn run_window(open: Option<PathBuf>) -> ExitCode {
     // `boot`. The path travels into the app so every later save writes the
     // same file (and a test-built `App` — path `None` — never writes at all).
     let config = config_path();
-    // Diagnostics come up before anything can fail: the per-launch log next
-    // to the config file, the panic hook (release too — a hidden Windows
-    // console leaves the log as the only witness), and a launch header. The
+    // Diagnostics come up before anything can fail: the per-launch log beside
+    // the config file (or in the temp directory when no config location
+    // resolved), the panic hook (release too — a hidden Windows console
+    // leaves the log as the only witness), and a launch header. The
     // renderer identity lands by itself: iced_wgpu logs its adapter selection
     // through the same facade once the compositor initializes.
     let log_path = diagnostics::log_path_from(config.as_deref());
-    diagnostics::init(log_path.as_deref());
+    diagnostics::init(&log_path);
     diagnostics::install_panic_hook();
     log::info!(
         "bdinfo-rs-gui {} ({}, {})",
@@ -178,7 +179,7 @@ fn run_window(open: Option<PathBuf>) -> ExitCode {
             // own stderr report, so the error is printed here — before the
             // dialog, which blocks on a human.
             let _ = writeln!(std::io::stderr(), "Error: {error}").is_ok();
-            surface_boot_failure(&error, log_path.as_deref());
+            surface_boot_failure(&error, &log_path);
             ExitCode::FAILURE
         }
     }
@@ -200,17 +201,16 @@ fn run_window(open: Option<PathBuf>) -> ExitCode {
 /// strictly worse than the non-zero exit and stderr line it decorates, and
 /// exactly what a packaging validation sandbox with a desktop but no human
 /// would hit.
-fn surface_boot_failure(error: &iced::Error, log_path: Option<&std::path::Path>) {
+fn surface_boot_failure(error: &iced::Error, log_path: &std::path::Path) {
     log::error!("boot failed: {error}");
     if !attended_session() {
         log::info!("unattended session: boot-failure dialog suppressed");
         return;
     }
-    let mut description = format!("The window could not be started.\n\n{error}");
-    if let Some(path) = log_path {
-        use std::fmt::Write as _;
-        let _ = write!(description, "\n\nDiagnostic log: {}", path.display());
-    }
+    let description = format!(
+        "The window could not be started.\n\n{error}\n\nDiagnostic log: {}",
+        log_path.display()
+    );
     let show = move || {
         rfd::MessageDialog::new()
             .set_level(rfd::MessageLevel::Error)
@@ -1696,8 +1696,23 @@ impl App {
         // The listing outcome, next to begin_listing's start line. A stale
         // worker's outcome is logged too, then dropped: after a cancel it is
         // the record that the blocked thread finally returned.
+        //
+        // The per-failure lines are the listing's half of what `on_finished`
+        // records for the measured scan. A structural open records a stream
+        // file it could not read, and that read is the one a damaged disc can
+        // hold for a minute at a time — without these lines the listing looks,
+        // in the log, like it simply took a while.
         match &result {
-            Ok(_) => log::info!("listed {}", input.display()),
+            Ok(structural) => {
+                log::info!(
+                    "listed {}: {} error(s) recorded",
+                    input.display(),
+                    structural.warnings.len()
+                );
+                for warning in &structural.warnings {
+                    log::info!("listing error: {warning}");
+                }
+            }
             Err(error) => log::info!("listing failed: {error}"),
         }
         if generation != self.generation {
@@ -1764,7 +1779,18 @@ impl App {
         self.pulse = progress::pulse_advance(self.pulse);
         let elapsed = self.scan_start.map_or(Duration::ZERO, |start| start.elapsed());
         let since_progress = self.last_progress.map_or(Duration::ZERO, |at| at.elapsed());
+        let stalled = self.flow.scan_stalled();
         self.flow.tick(elapsed, since_progress);
+        // The two transitions are logged, never the state (the tick runs at
+        // 1 Hz). A log that records neither cannot tell a read stuck in drive
+        // firmware from a process that stopped: both simply go quiet.
+        if let Some(line) = progress::stall_line(
+            stalled,
+            self.flow.scan_stalled(),
+            self.flow.progress_view().map(ProgressModel::file),
+        ) {
+            log::info!("{line}");
+        }
     }
 
     /// Cancels the in-flight scan for real — the measured scan back to the
@@ -1800,7 +1826,14 @@ impl App {
         let was_scanning = self.flow.stage() == Stage::Scanning;
         self.flow = std::mem::take(&mut self.flow).finished(generation, report, errors, playlists);
         if was_scanning && self.flow.stage() == Stage::Reported {
-            log::info!("scan finished: {} error(s) recorded", self.flow.report_errors().len());
+            // The duration is what a field report's "it took forever" becomes
+            // a number: the elapsed readout is gone from the screen by the
+            // time anyone writes the report up.
+            log::info!(
+                "scan finished in {:.1}s: {} error(s) recorded",
+                self.scan_start.map_or(Duration::ZERO, |start| start.elapsed()).as_secs_f64(),
+                self.flow.report_errors().len()
+            );
             for error in self.flow.report_errors() {
                 log::info!("scan error: {error}");
             }
@@ -1866,6 +1899,11 @@ impl App {
         match Input::classify(path) {
             Ok(input) => self.begin_listing(input),
             Err(message) => {
+                // The one open road that ends before `begin_listing` — and so
+                // before the "listing …" line — leaving a log in which a drop
+                // or a command-line path the user swears they gave simply
+                // never appears.
+                log::info!("open failed: {message}");
                 self.status = None;
                 self.showing_report = false;
                 self.notice = None;
@@ -1972,14 +2010,21 @@ impl App {
         self.scan_start = Some(Instant::now());
         self.last_progress = self.scan_start;
         // The scan's opening log line: with the per-file lines and the
-        // terminal line below, gui.log can now place a field report's hang
-        // inside the scan (and name the file) rather than only before it.
+        // terminal line below, gui.log can place a field report's hang inside
+        // the scan (and name the file) rather than only before it. The disc
+        // identity rides this line rather than the listing's, because a scan
+        // is what a report is usually about, and the counts say how much of
+        // the disc it covers: an unchecked table scans every listed playlist.
         log::info!(
-            "scan started: {} playlist(s), {} stream file(s), input {}",
+            "scan started: {} of {} playlist(s), {} stream file(s), input {}",
             selection.len(),
+            self.flow.row_count(),
             scan_files.len(),
             input.display()
         );
+        if let Some(identity) = self.flow.disc_identity() {
+            log::info!("disc: {identity}");
+        }
         self.status = None;
         self.showing_report = false;
         self.notice = None;
@@ -4137,6 +4182,39 @@ mod interaction {
         });
         assert!(!app.flow.scan_stalled());
         assert!(sees(&app, "Reading A.M2TS…"));
+    }
+
+    #[test]
+    fn a_listing_that_recorded_a_failure_banners_it_and_logs_it() {
+        // A stream file the listing could not read is recorded by the
+        // structural open, and this is where it becomes visible: a banner over
+        // the usable table, and a line per failure in the diagnostics log —
+        // the two surfaces a report from the field is written from.
+        //
+        // The global logger is process-wide, and each test here runs in its
+        // own process, so installing it inside one test races nothing.
+        let log = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/listing-log/gui.log");
+        bdinfo_rs_gui::diagnostics::init(&log);
+
+        let failure = "stream 00011.M2TS: io error: incorrect function";
+        let mut app = App::default();
+        let _ = app.update(Message::FolderPicked(Some(PathBuf::from("disc"))));
+        let mut structural = structural();
+        structural.warnings = vec![failure.to_owned()];
+        let _ = app.update(Message::Listed {
+            generation: app.generation,
+            input: bdinfo_rs_gui::scan::Input::Folder("disc".into()),
+            result: Ok(structural),
+        });
+
+        assert_eq!(app.flow.stage(), Stage::Listed, "the disc still lists");
+        assert!(sees(&app, failure), "the banner carries the recorded failure");
+        let text = std::fs::read_to_string(&log).expect("the diagnostics log reads");
+        assert!(
+            text.contains("listed disc: 1 error(s) recorded"),
+            "the listing outcome counts them: {text}"
+        );
+        assert!(text.contains(&format!("listing error: {failure}")), "and names each: {text}");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/progress.rs
+++ b/crates/bdinfo-rs-gui/src/progress.rs
@@ -56,6 +56,26 @@ pub(crate) fn stalled(since_progress: Duration) -> bool {
     since_progress >= STALL_AFTER
 }
 
+/// The log line a change in the stall flag deserves — `None` while it holds
+/// steady, in either position.
+///
+/// The flag is recomputed on every display tick, so only the two transitions
+/// are worth recording: without them a log shows a scan going quiet and a log
+/// shows a process that died mid-read as the same thing — nothing, then
+/// nothing. `file` is the stream file the last progress event named, absent
+/// when a read stalls before the first event of a pass.
+#[must_use]
+pub fn stall_line(previous: bool, current: bool, file: Option<&str>) -> Option<String> {
+    match (previous, current) {
+        (false, true) => Some(file.map_or_else(
+            || "read stalled before the first progress event".to_owned(),
+            |file| format!("read stalled on {file}"),
+        )),
+        (true, false) => Some("read resumed".to_owned()),
+        _ => None,
+    }
+}
+
 /// Whether a scan-progress event should become a UI message.
 ///
 /// The scan fires its callback before and after every read — hundreds of
@@ -252,6 +272,27 @@ mod tests {
         assert!(!super::stalled(Duration::from_millis(4_999)));
         assert!(super::stalled(Duration::from_secs(5)));
         assert!(super::stalled(Duration::from_secs(6)));
+    }
+
+    #[test]
+    fn only_a_change_of_stall_state_is_worth_a_line() {
+        // Raised and cleared each say so once; a flag that holds — down through
+        // an ordinary scan, up through a minutes-long stuck read — says nothing,
+        // so a 1 Hz tick cannot fill the log with its own repetitions.
+        assert_eq!(
+            super::stall_line(false, true, Some("00011.M2TS")).as_deref(),
+            Some("read stalled on 00011.M2TS")
+        );
+        assert_eq!(
+            super::stall_line(false, true, None).as_deref(),
+            Some("read stalled before the first progress event")
+        );
+        assert_eq!(
+            super::stall_line(true, false, Some("00011.M2TS")).as_deref(),
+            Some("read resumed")
+        );
+        assert_eq!(super::stall_line(false, false, Some("00011.M2TS")), None);
+        assert_eq!(super::stall_line(true, true, Some("00011.M2TS")), None);
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -101,7 +101,9 @@ pub struct Structural {
     /// fixed order — the info box's `Detected Features` line.
     pub features: Vec<String>,
     /// Any failures recorded while reading the structure (a corrupt playlist,
-    /// an unreadable directory) — shown as a non-blocking warning banner.
+    /// an unreadable directory, a stream head that never returned) — shown as
+    /// a non-blocking warning banner. Merged across both structural opens
+    /// ([`listing_scan`]), so a failure the AACS probe hit is here too.
     pub warnings: Vec<String>,
 }
 
@@ -222,17 +224,43 @@ pub fn scan_structural(
 /// open's verdict ([`ScanOptions::aacs_encrypted`]), so one listing probes
 /// the disc once.
 ///
+/// The disc is the second open's, and the recorded failures are **both**
+/// opens' ([`merge_errors`]): the metadata open is where the AACS probe reads
+/// each stream file's head, so on damaged media it is the open that records
+/// the failed head read — keeping only the codec pass's list would drop it,
+/// and the listing would show a playlist whose codec detail is silently
+/// absent.
+///
 /// # Errors
 /// Whatever `open` reports, from either call.
 fn listing_scan(mut open: impl FnMut(ScanMode, ScanOptions) -> Opened) -> Opened {
-    let cheap = open(ScanMode::Metadata, ScanOptions::default())?;
-    if cheap.0.is_aacs_encrypted {
-        Ok(cheap)
-    } else {
-        let mut options = ScanOptions::default();
-        options.aacs_encrypted = Some(cheap.0.is_aacs_encrypted);
-        open(ScanMode::Codecs, options)
+    let (bdrom, errors) = open(ScanMode::Metadata, ScanOptions::default())?;
+    if bdrom.is_aacs_encrypted {
+        return Ok((bdrom, errors));
     }
+    let mut options = ScanOptions::default();
+    options.aacs_encrypted = Some(bdrom.is_aacs_encrypted);
+    let (bdrom, deep_errors) = open(ScanMode::Codecs, options)?;
+    Ok((bdrom, merge_errors(errors, deep_errors)))
+}
+
+/// Both structural opens' recorded failures as one list — the first open's in
+/// order, then whatever the second added — with a repeated rendering dropped.
+///
+/// The two opens read the same disc, so a fault the first hit is usually
+/// recorded again by the second, and each recorded failure becomes one banner:
+/// without the fold the user would see the same disc fault twice. The rendered
+/// string is the whole identity, because that is exactly what the banner and
+/// the log line show.
+fn merge_errors(first: Vec<ScanError>, second: Vec<ScanError>) -> Vec<ScanError> {
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut merged: Vec<ScanError> = Vec::new();
+    for error in first.into_iter().chain(second) {
+        if seen.insert(error.to_string()) {
+            merged.push(error);
+        }
+    }
+    merged
 }
 
 /// Runs the **measured** scan over `input`, narrowed to the selected clips.
@@ -623,6 +651,53 @@ mod tests {
             "both opens, in that order; only the first probes"
         );
         assert_eq!(bdrom.volume_label, "DEEP", "the codec pass is what the listing keeps");
+    }
+
+    /// A recorded stream-read failure naming `file` — the shape a head read
+    /// that never returned leaves behind.
+    fn read_error(file: &str) -> super::ScanError {
+        super::ScanError {
+            file: file.to_owned(),
+            stage: bdinfo_rs_core::error::ScanStage::StreamFile,
+            reason: super::BdError::UnexpectedEof,
+        }
+    }
+
+    #[test]
+    fn the_listing_seam_keeps_the_failures_of_both_opens() {
+        // The metadata open is where the AACS probe reads the stream heads, so
+        // a failed head read is recorded THERE — keeping only the codec pass's
+        // list leaves the listing with no record of it at all. A fault both
+        // opens hit is one entry, not two, so it becomes one banner.
+        let (result, modes) = opened_modes(|mode| {
+            let bdrom = cheap_open(false).0;
+            let errors = match mode {
+                ScanMode::Metadata => vec![read_error("00011.M2TS"), read_error("00012.M2TS")],
+                _ => vec![read_error("00011.M2TS"), read_error("00013.M2TS")],
+            };
+            Ok((bdrom, errors))
+        });
+        let (_, errors) = result.expect("the codec pass answers");
+        assert_eq!(
+            super::error_lines(&errors),
+            [
+                "stream 00011.M2TS: unexpected end of input",
+                "stream 00012.M2TS: unexpected end of input",
+                "stream 00013.M2TS: unexpected end of input"
+            ],
+            "the metadata open's failures first, then what the codec pass added"
+        );
+        assert_eq!(modes.len(), 2, "both opens ran");
+    }
+
+    #[test]
+    fn an_encrypted_listing_keeps_its_one_opens_failures() {
+        // The road that stops at the metadata open carries that open's list
+        // through untouched — there is no second list to merge it with.
+        let (result, _) =
+            opened_modes(|_| Ok((cheap_open(true).0, vec![read_error("00011.M2TS")])));
+        let (_, errors) = result.expect("the metadata open stands in");
+        assert_eq!(super::error_lines(&errors), ["stream 00011.M2TS: unexpected end of input"]);
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -102,8 +102,8 @@ pub struct Structural {
     pub features: Vec<String>,
     /// Any failures recorded while reading the structure (a corrupt playlist,
     /// an unreadable directory, a stream head that never returned) — shown as
-    /// a non-blocking warning banner. Merged across both structural opens
-    /// ([`listing_scan`]), so a failure the AACS probe hit is here too.
+    /// a non-blocking warning banner. Merged across both opens
+    /// [`scan_structural`] makes, so a failure the AACS probe hit is here too.
     pub warnings: Vec<String>,
 }
 


### PR DESCRIPTION
The structural listing opens the disc twice on an unencrypted disc, and the AACS probe that reads each stream file head runs in the first of the two. Only the second open's recorded failures reached the UI, so a failed head read left no banner, no log line, and a playlist whose codec detail was silently absent. Both opens' lists are now merged, deduped by their rendered form so one disc fault is one banner, and the listing outcome logs a count plus a line per failure, as the measured scan already did.

The log gains what remote diagnosis needs:

- the previous launch is kept as `gui.log.1` instead of being truncated away;
- a wall-clock line anchors the relative per-line timestamps;
- stall raise and clear transitions are recorded, so a stuck read and a dead process no longer read alike;
- the disc identity and the selected-of-listed counts open a scan, and its duration closes it;
- a path rejected before the listing starts is recorded;
- the panic hook captures a backtrace;
- a desktop that resolves no config directory logs to the temp directory instead of not at all.

Fixes #344