### PR TITLE
fix(wasm): surface scan errors on the page and name downloads from the disc label

### DIFF
--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -774,7 +774,9 @@ impl std::fmt::Display for SelectionError {
 /// pass.
 ///
 /// # Errors
-/// [`SelectionError::Open`] if the structure is too damaged to scan, or
+/// [`SelectionError::Open`] if the structure is too damaged to scan — from
+/// either open, so a tree that stops resolving between them is reported instead
+/// of rendering as an unmeasured disc — or
 /// [`SelectionError::NoMatch`] if `selection` names no playlist on the disc
 /// (mirroring the CLI's `--mpls`, which exits with "No matching playlists found
 /// on BD" rather than rendering a header-only report).
@@ -791,14 +793,15 @@ fn scan_selection(
         return Err(SelectionError::NoMatch);
     }
     let files = selection_stream_files(&structural.bdrom.playlists, &names);
-    // The measured scan re-opens the same tree, narrowed to the selected clips.
-    // It locates the same `BDMV`/`CLIPINF`/`PLAYLIST` the structural open just
-    // found, so it cannot hit the only hard error (`StructureNotFound`); on that
-    // unreachable failure it degrades to the structural disc (zero measured
-    // tallies) rather than erroring.
+    // The measured scan re-opens the same tree, narrowed to the selected clips,
+    // and its failure is reported rather than swallowed. Serving the structural
+    // disc instead would render a complete report whose every measured tally is
+    // zero, carrying no error and no `WARNING:` block — indistinguishable from a
+    // healthy scan of a disc holding no data. Only a structure the second open
+    // cannot walk gets this far: a per-file read failure is recorded by the
+    // resilient sink and never returned.
     let measured =
-        BdRom::open_resilient_observed(root, ScanMode::Full, options, Some(&files), observers)
-            .unwrap_or(structural);
+        BdRom::open_resilient_observed(root, ScanMode::Full, options, Some(&files), observers)?;
     let order = selection_order(&measured.bdrom.playlists, &names);
     Ok(Scan { report: measured, order })
 }
@@ -2016,8 +2019,12 @@ mod tests {
     /// CLI-parity selection helpers: the classification threshold and the
     /// by-name measured scan, native-tested.
     mod selection {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
         use bdinfo_rs_core::bdrom::disc::{PlaylistSummary, fixtures};
         use bdinfo_rs_core::bdrom::order::PlaylistFilter;
+        use bdinfo_rs_core::vfs::mem::MemDir;
+        use bdinfo_rs_core::vfs::{BdDir, BdFile, SearchOption};
 
         use crate::classification_filter;
 
@@ -2225,6 +2232,122 @@ mod tests {
             )
             .expect_err("an all-unknown selection must error");
             assert_eq!(no_match.to_string(), "No matching playlists found on BD");
+        }
+
+        /// The committed fixture's disc tree, listing its directories through a
+        /// counter — and refusing to list them from the `fail_from`-th call on.
+        ///
+        /// The counter runs across the whole life of one value, so a scan that
+        /// opens the same tree twice can be made to fail on the SECOND open
+        /// alone: point `fail_from` past the listings the first open makes.
+        /// Only the root counts; the sub-directories it hands out are the
+        /// fixture's own and always answer.
+        struct FlakyRoot {
+            inner: MemDir,
+            listings: AtomicUsize,
+            fail_from: usize,
+        }
+
+        impl FlakyRoot {
+            fn new(inner: MemDir, fail_from: usize) -> Self {
+                Self { inner, listings: AtomicUsize::new(0), fail_from }
+            }
+
+            /// How many times the root has been listed so far.
+            fn listings(&self) -> usize {
+                self.listings.load(Ordering::Relaxed)
+            }
+        }
+
+        impl BdDir for FlakyRoot {
+            fn name(&self) -> &str {
+                self.inner.name()
+            }
+
+            fn full_name(&self) -> &str {
+                self.inner.full_name()
+            }
+
+            fn parent(&self) -> Option<Box<dyn BdDir>> {
+                self.inner.parent()
+            }
+
+            fn get_files_pattern_option(
+                &self,
+                pattern: &str,
+                option: SearchOption,
+            ) -> std::io::Result<Vec<Box<dyn BdFile>>> {
+                self.inner.get_files_pattern_option(pattern, option)
+            }
+
+            fn get_directories(&self) -> std::io::Result<Vec<Box<dyn BdDir>>> {
+                let seen = self.listings.fetch_add(1, Ordering::Relaxed);
+                if seen >= self.fail_from {
+                    return Err(std::io::Error::other("the disc stopped listing"));
+                }
+                self.inner.get_directories()
+            }
+        }
+
+        #[test]
+        fn a_by_name_scan_reports_a_failure_of_its_measured_open() {
+            use bdinfo_rs_core::bdrom::disc::ScanProgress;
+            use bdinfo_rs_core::report::text::RenderOptions;
+
+            use super::fixture_blob;
+            use crate::{
+                BdRom, CoreScanOptions, ScanMode, ScanObservers, framed_tree, never_cancelled,
+                scan_selection,
+            };
+
+            let blob = fixture_blob();
+            let mut sink: for<'a> fn(ScanProgress<'a>) = |_| {};
+            let selection = ["00000.MPLS".to_owned()];
+            let mut scan = |root: &FlakyRoot| {
+                scan_selection(
+                    root,
+                    &selection,
+                    CoreScanOptions::default(),
+                    ScanObservers::new(&mut sink, &never_cancelled()),
+                )
+            };
+
+            // How many root listings ONE structural open makes — the same open
+            // `scan_selection` starts with, so the next listing after them is
+            // the measured open's first.
+            let counted = FlakyRoot::new(framed_tree(&blob), usize::MAX);
+            BdRom::open_resilient(&counted, ScanMode::Metadata).expect("the fixture disc opens");
+            let structural_listings = counted.listings();
+            assert!(structural_listings > 0, "a structural open lists the root at least once");
+            // The delegating accessors, which the scan reads for the disc label
+            // and the walk-up to the disc root.
+            assert_eq!(counted.name(), "WASMDISC");
+            assert_eq!(counted.full_name(), "WASMDISC");
+            assert!(counted.parent().is_none(), "the fixture root is the top of its tree");
+
+            // Healthy, the same tree renders the selected playlist measured.
+            let healthy = scan(&FlakyRoot::new(framed_tree(&blob), usize::MAX))
+                .expect("an unfaulted by-name scan")
+                .render(RenderOptions::default());
+            assert!(
+                healthy.contains("PLAYLIST: 00000.MPLS"),
+                "the control scan renders:\n{healthy}"
+            );
+
+            // Faulted from the measured open's first listing on, the failure is
+            // reported — where degrading to the structural disc would have
+            // rendered that same block with every measured value zero and no
+            // WARNING line to say so.
+            let flaky = FlakyRoot::new(framed_tree(&blob), structural_listings);
+            let err = scan(&flaky).expect_err("the measured open's failure must be reported");
+            assert_eq!(
+                err.to_string(),
+                "no readable Blu-ray structure (io error: the disc stopped listing)"
+            );
+            assert!(
+                flaky.listings() > structural_listings,
+                "the structural open must have completed before the fault"
+            );
         }
     }
 

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -666,6 +666,16 @@
         padding: 0;
         list-style: none;
       }
+      .warning p {
+        margin: 0 0 0.3rem;
+      }
+      /* The recorded failures read as data, not prose — one line per file, in
+         the report's own wording. */
+      #scan-errors-list {
+        font-family: var(--mono);
+        font-size: 0.82rem;
+        overflow-wrap: anywhere;
+      }
 
       /* ── footer ──────────────────────────────────────────────── */
       .footer {
@@ -852,6 +862,22 @@
             the measured scan is unavailable. Everything above is read from the
             disc's own metadata and is correct.
           </p>
+          <!-- Files the scan could not read or parse and continued past. It
+               sits in this card rather than beside the report because a
+               structural listing records them too, and that listing renders no
+               report at all — the case where a damaged disc would otherwise
+               show as a clean table. -->
+          <div id="scan-errors" class="warning" hidden>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+              <line x1="12" x2="12" y1="9" y2="13" />
+              <line x1="12" x2="12.01" y1="17" y2="17" />
+            </svg>
+            <div>
+              <p id="scan-errors-count"></p>
+              <ul id="scan-errors-list"></ul>
+            </div>
+          </div>
           <p class="hint" id="hidden-hint" hidden></p>
           <div class="card-foot">
             <span class="muted" id="sel-count">0 selected</span>

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -26,10 +26,11 @@ import {
   type Playlist,
   renderReport,
   reportFileName,
+  type ScanError,
   type Stream,
   scan,
 } from "./analyze.js";
-import { sizeCell as formatSize } from "./format.js";
+import { errorLine, sizeCell as formatSize, reportLabel } from "./format.js";
 
 /**
  * One selection-table row — the CLI columns this page draws, distilled from a
@@ -132,6 +133,9 @@ const errorBox = el("error");
 const errorText = el("error-text");
 const shortStreams = el("short-streams");
 const shortStreamsList = el("short-streams-list");
+const scanErrors = el("scan-errors");
+const scanErrorsCount = el("scan-errors-count");
+const scanErrorsList = el("scan-errors-list");
 const mainEl = el("main");
 const listingBox = el("listing");
 const settingsBtn = el<HTMLButtonElement>("settings-btn");
@@ -458,7 +462,29 @@ function adoptDisc(next: Disc, threshold: number): void {
     }),
   );
   shortStreams.hidden = notices.length === 0;
+  renderScanErrors(next.errors);
   renderRows();
+}
+
+/**
+ * Fills the failure strip from the held disc: one line per file the scan could
+ * not read or parse, in the wording the report's `WARNING:` block and the
+ * command line use.
+ *
+ * A structural listing records these as a measured scan does, and it renders no
+ * report — so this strip, not the report, is what tells a browser user their
+ * disc is damaged. A disc that recorded none hides it.
+ */
+function renderScanErrors(errors: ScanError[]): void {
+  scanErrorsCount.textContent = `Recorded ${errors.length} error(s) — the readable rest is shown.`;
+  scanErrorsList.replaceChildren(
+    ...errors.map((error) => {
+      const item = document.createElement("li");
+      item.textContent = errorLine(error);
+      return item;
+    }),
+  );
+  scanErrors.hidden = errors.length === 0;
 }
 
 /**
@@ -1023,9 +1049,12 @@ async function copyReport(): Promise<void> {
 async function downloadReport(): Promise<void> {
   // The module's sanitizer names the file: the disc controls its own label
   // bytes, and this is the one place the demo turns that label into a path.
+  // The label comes off the scanned disc, so an `.iso` saves under the volume
+  // label recorded in its filesystem — the name every other surface writes —
+  // rather than under whatever the image file is called here.
   let name: string;
   try {
-    name = await reportFileName(discName);
+    name = await reportFileName(reportLabel(disc?.volumeLabel, discName));
   } catch (error) {
     showError(errMessage(error));
     return;

--- a/crates/bdinfo-rs-wasm/web/src/format.ts
+++ b/crates/bdinfo-rs-wasm/web/src/format.ts
@@ -1,13 +1,15 @@
-// The demo's byte-size cell formatter, in a module of its own so a test can
-// reach it: `demo.ts` reads the page's DOM at import time and cannot be loaded
-// outside a browser. Nothing in the published package imports this — the demo
-// is the site, not the API.
+// The demo's pure formatters, in a module of its own so a test can reach them:
+// `demo.ts` reads the page's DOM at import time and cannot be loaded outside a
+// browser. Nothing in the published package imports this — the demo is the
+// site, not the API.
 //
 // The desktop app formats the same cell in Rust (`model::byte_cell`), which no
 // amount of arranging can share with TypeScript. What holds the two together is
 // the vector table `crates/bdinfo-rs-gui/tests/size-vectors.tsv`: both sides
 // assert every row of it, so a change here that is not mirrored there fails a
 // test on both.
+
+import type { ScanError, ScanErrorReason } from "./analyze.js";
 
 /**
  * A size cell under the size-format setting: `83.62 GB` / `335.37 MB`
@@ -29,4 +31,56 @@ export function sizeCell(bytes: number | null, humanReadable: boolean): string {
     unit += 1;
   }
   return `${value.toFixed(unit === 0 ? 0 : 2)} ${units[unit]}`;
+}
+
+/**
+ * One recorded scan failure as one line — `{stage} {file}: {reason}`, the
+ * sentence the `bdinfo-rs` command line prints on stderr and the desktop app
+ * banners.
+ *
+ * The wording is the library's `ScanError`/`BdError` display, which crosses to
+ * the browser as structured data rather than as text, so the mapping below is
+ * the second copy of it. `faults.node.mjs` renders the errors of a real damaged
+ * scan through this function, so a reason whose wording moves in the library
+ * fails that harness rather than drifting quietly.
+ */
+export function errorLine(error: ScanError): string {
+  return `${error.stage} ${error.file}: ${errorReason(error.reason)}`;
+}
+
+/** The reason half of {@link errorLine}. */
+export function errorReason(reason: ScanErrorReason): string {
+  switch (reason.kind) {
+    case "unknownFileType":
+      return `unknown file type: ${reason.magic}`;
+    case "unexpectedEof":
+      return "unexpected end of input";
+    case "structureNotFound":
+      return "unable to locate BD structure";
+    case "missingClipFile":
+      return `referenced missing clip file: ${reason.file}`;
+    case "io":
+      return `io error: ${reason.message}`;
+    case "metadataTooLarge":
+      return `metadata file too large: ${reason.file} exceeds ${reason.limitBytes} bytes`;
+    // The open kinds — a cancelled scan today, anything the library adds
+    // tomorrow — carry their own message and nothing to prefix it with.
+    case "other":
+      return reason.message;
+  }
+}
+
+/**
+ * The disc label a saved report is named after: the disc's own volume label,
+ * falling back to `picked` — the name of the folder or file the user chose —
+ * when no disc is held or its label is empty.
+ *
+ * The two differ on an `.iso`, whose volume label is the one recorded in the
+ * UDF filesystem while the file name is only what the image happens to be
+ * called on this machine. Every other surface names the report after the
+ * volume label, so the browser does too; the page still SHOWS the picked name,
+ * which is what the user recognizes.
+ */
+export function reportLabel(volumeLabel: string | undefined, picked: string): string {
+  return volumeLabel !== undefined && volumeLabel !== "" ? volumeLabel : picked;
 }

--- a/crates/bdinfo-rs-wasm/web/test/faults.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/faults.node.mjs
@@ -37,6 +37,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { errorLine } from "../dist/format.js";
 import { installShims, readLog, ShimFile, setFaults } from "./shims.mjs";
 
 installShims();
@@ -400,6 +401,42 @@ async function main() {
   }
   if (thrown.some((line) => line.includes("JavaScript exception"))) {
     failures.push(`a WARNING line fell back to the placeholder: ${JSON.stringify(thrown)}`);
+  }
+
+  // What a browser user is shown for that same damaged scan: the demo page
+  // renders `disc.errors` through its own formatter (src/format.ts), one line
+  // per recorded failure. Each line must be the report's own `WARNING:` line
+  // with the stage in front — the page and the report saying the same thing
+  // about the same failure, which is what makes the strip trustworthy on a
+  // listing that renders no report at all.
+  const damagedLines = subsetDisc.errors.map(errorLine);
+  const warningLines = reports
+    .get("twoClips/defectiveOnly")
+    .split("\r\n")
+    .filter((line) => line.includes("\tio error:"));
+  if (damagedLines.length !== 2) {
+    failures.push(`the damaged subset scan recorded ${damagedLines.length} error(s), not 2`);
+  }
+  const rendered = damagedLines.every(
+    (line, index) =>
+      line === `${subsetDisc.errors[index].stage} ${warningLines[index]?.replace("\t", ": ")}`,
+  );
+  if (!rendered) {
+    failures.push(
+      `the page's error lines are not the report's: ${JSON.stringify(damagedLines)} against ` +
+        `${JSON.stringify(warningLines)}`,
+    );
+  }
+  if (
+    !damagedLines.every(
+      (line) =>
+        // The stream stage, and the clip named as it is ON DISC (lower case
+        // here) — where the report's own tables print it upper-cased.
+        line.startsWith("stream 00011.m2ts: io error:") &&
+        line.includes("unreadable from byte 40000"),
+    )
+  ) {
+    failures.push(`the page's error lines lost the failure: ${JSON.stringify(damagedLines)}`);
   }
 
   // Damage deep inside a multi-chunk clip is named ONCE per file, not twice.

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -299,6 +299,8 @@ async function main() {
         ),
       );
       files.push(toFile("WASMDISC/BDMV/PLAYLIST/00002.mpls", withLength(decode(source.b64), 10)));
+      // Kept for the damaged re-pick at the end of the run.
+      window.__demoFiles = files;
       const transfer = new DataTransfer();
       for (const file of files) {
         transfer.items.add(file);
@@ -335,6 +337,9 @@ async function main() {
           codecs: grid("#codecs-body tr"),
           hintHidden: document.getElementById("hidden-hint").hidden,
           hintText: document.getElementById("hidden-hint").textContent,
+          errorsHidden: document.getElementById("scan-errors").hidden,
+          errorsCount: document.getElementById("scan-errors-count").textContent,
+          errorLines: texts("#scan-errors-list li"),
           reportHidden: document.getElementById("report-card").hidden,
           progressHidden: document.getElementById("progress-card").hidden,
           discardHidden: document.getElementById("discard-note").hidden,
@@ -459,6 +464,30 @@ async function main() {
       () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
     );
 
+    // A damaged disc through the page: the same folder plus a file in PLAYLIST
+    // that is not a playlist, which the structural listing records and reads
+    // past. A listing renders no report, so the failure strip is the only place
+    // this shows — the state a browser user reaches before scanning anything.
+    await demoPage.evaluate(() => {
+      const junk = new File([new TextEncoder().encode("NOPE0100garbage")], "00009.mpls");
+      Object.defineProperty(junk, "webkitRelativePath", {
+        value: "WASMDISC/BDMV/PLAYLIST/00009.mpls",
+      });
+      const transfer = new DataTransfer();
+      for (const file of [...window.__demoFiles, junk]) {
+        transfer.items.add(file);
+      }
+      const picker = document.getElementById("picker");
+      picker.files = transfer.files;
+      picker.dispatchEvent(new Event("change"));
+    });
+    await demoPage.waitForFunction(
+      () => !document.getElementById("scan-errors").hidden,
+      undefined,
+      { timeout: 30000 },
+    );
+    const damagedListing = await readDemo();
+
     // The settings survive a reload through `localStorage`; the dialog's
     // controls are initialized from what was stored.
     await demoPage.reload();
@@ -498,6 +527,7 @@ async function main() {
       retentionOff,
       zeroThreshold,
       pageScrolls,
+      damagedListing,
       persisted,
     };
   } finally {
@@ -835,6 +865,19 @@ async function main() {
   demoOk &= demoEq("a zero threshold shows no short hint", demo.zeroThreshold.hintHidden, true);
 
   demoOk &= demoEq("no sideways page scroll at phone width", demo.pageScrolls, false);
+
+  // The failure strip: absent for healthy media, and on a damaged listing it
+  // names the file and says what was wrong with it, in the report's wording.
+  demoOk &= demoEq("healthy media shows no failure strip", demo.initial.errorsHidden, true);
+  demoOk &= demoEq("a damaged listing shows the strip", demo.damagedListing.errorsHidden, false);
+  demoOk &= demoEq(
+    "the strip counts the failures",
+    demo.damagedListing.errorsCount,
+    "Recorded 1 error(s) — the readable rest is shown.",
+  );
+  demoOk &= demoEq("the strip names the failure", demo.damagedListing.errorLines, [
+    "playlist 00009.mpls: unknown file type: NOPE0100",
+  ]);
   // Retention was switched off above, so the reload proves the stored `false`
   // is read back rather than defaulted to on like an absent setting; the
   // stored 0 threshold likewise comes back as the committed 0, not the default.

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -227,7 +227,7 @@ async function main() {
   // The demo's size cells against the shared vector table, columns 4 and 5 (the
   // desktop app asserts columns 2 and 3 of the same rows). A row count is
   // asserted too: a badly parsed table would check nothing and still pass.
-  const { sizeCell } = await import("../dist/format.js");
+  const { reportLabel, sizeCell } = await import("../dist/format.js");
   const vectors = (await readFile(sizeVectorsPath, "utf8"))
     .split(/\r?\n/)
     .filter((line) => line.length > 0 && !line.startsWith("#"))
@@ -359,6 +359,21 @@ async function main() {
   if (!isoInspectOk) {
     console.error(`FAIL — inspect_iso disc unexpected: ${JSON.stringify(isoInspected)}`);
   }
+  // The name a saved report takes for this image. The demo picks the label the
+  // way `reportLabel` does — off the scanned disc — so an `.iso` downloads under
+  // the volume label in its filesystem (`Blu-Ray`), the same file name the
+  // command line writes, and not under the image's own file name. Without a
+  // disc, or with a label-less one, the picked name is the fallback.
+  const isoDownloadName = report_file_name(
+    reportLabel(isoInspected.volumeLabel, "BigBuckBunny.iso"),
+  );
+  const downloadNameOk =
+    isoDownloadName === "BDINFO.Blu-Ray.txt" &&
+    reportLabel(undefined, "BigBuckBunny.iso") === "BigBuckBunny.iso" &&
+    reportLabel("", "BigBuckBunny.iso") === "BigBuckBunny.iso";
+  if (!downloadNameOk) {
+    console.error(`FAIL — the .iso report download name was ${isoDownloadName}.`);
+  }
   // The both-outputs scan over the image, round-tripped the same way.
   const isoFullOk =
     isoOk &&
@@ -408,10 +423,11 @@ async function main() {
     isoOk &&
     isoSelOk &&
     isoInspectOk &&
-    isoFullOk
+    isoFullOk &&
+    downloadNameOk
   ) {
     console.log(
-      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + rejection + codecs + size vectors + file name + selection + round trip + retention + short-stream notices + .iso OK.`,
+      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + rejection + codecs + size vectors + file name + download name + selection + round trip + retention + short-stream notices + .iso OK.`,
     );
     process.exit(0);
   }


### PR DESCRIPTION
Three fixes on the browser surface.

A by-name scan opens the disc twice, and a failure of the second open was
swallowed: the report rendered in full with every measured tally zero, no
error and no WARNING block. The measured open's failure is now reported.
A native test drives a disc tree that stops listing after the structural
open and pins the surfaced error.

The demo renders the disc model's recorded failures in a strip of its own,
one line per file in the wording the command line prints. It is drawn for a
structural listing as well as for a finished scan, because a listing renders
no report at all, so a browser user listing a damaged disc saw a clean table.
The Node fault harness renders a real damaged scan's failures through the
same formatter and requires each line to be the report's own WARNING line
with the stage in front; the Chrome harness drives a damaged folder pick
through the page and reads the strip back.

The report download takes its name from the scanned disc volume label, so an
image saves under the label recorded in its filesystem instead of the picked
file name. The page still displays the picked name.