### PR TITLE
feat(core)!: take scan observers in the open entry points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "bdinfo-rs-core",
  "clap",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "proptest",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["crates/bdinfo-rs-core", "crates/bdinfo-rs"]
 exclude = ["fuzz", "crates/bdinfo-rs-wasm", "crates/bdinfo-rs-gui"]
 
 [workspace.package]
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.96"
 # LGPL (unlike GPL) permits use from other applications.
@@ -123,7 +123,7 @@ private_intra_doc_links = "allow"
 
 [workspace.dependencies]
 # Internal (version + path so bdinfo-rs is publishable to crates.io).
-bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "3.0.0" }
+bdinfo-rs-core = { path = "crates/bdinfo-rs-core", version = "4.0.0" }
 # External (pinned to latest stable minor; deny.toml forbids wildcards).
 clap = { version = "4.6", features = ["derive"] }
 proptest = "1.11"

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -529,7 +529,7 @@ pub struct ScanReport {
 }
 
 /// One live-progress observation of the packet scan, handed to the callback
-/// of [`BdRom::open_with`] as the demux pulls bytes.
+/// of the [`ScanObservers`] an open carries, as the demux pulls bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScanProgress<'a> {
     /// The stream file currently being demuxed (its upper-cased name; the
@@ -556,29 +556,44 @@ pub struct ScanProgress<'a> {
 /// progress goes, what watches the measured tallies build up, and the flag
 /// that stops it.
 ///
-/// The bundle [`BdRom::open_observed`] and
-/// [`BdRom::open_resilient_observed`] take in place of a widening argument
-/// list. Its contents are set only through [`new`](Self::new) and the builder
-/// methods — `ScanObservers::new(&mut progress, &cancel)`, then
-/// `.with_measured(&mut watch)` for a caller that wants the live tallies too —
-/// so a scan facility added later is another builder method rather than a
-/// break at every call site.
+/// The bundle every open takes ([`BdRom::open`], [`BdRom::open_resilient`],
+/// [`crate::scan::open_folder`], [`crate::scan::open_iso`]) in place of a
+/// widening argument list. Its contents are set only through
+/// [`none`](Self::none) or [`new`](Self::new) and the builder methods —
+/// `ScanObservers::none()` for a caller that watches nothing,
+/// `ScanObservers::new(&mut progress, &cancel)` then
+/// `.with_measured(&mut watch)` for one that wants the live tallies too — so a
+/// scan facility added later is another builder method rather than a break at
+/// every call site.
 pub struct ScanObservers<'a> {
-    /// Where each [`ScanProgress`] observation goes.
-    progress: &'a mut dyn FnMut(ScanProgress<'_>),
+    /// Where each [`ScanProgress`] observation goes; `None` discards them.
+    progress: Option<&'a mut dyn FnMut(ScanProgress<'_>)>,
     /// The measured-tally observer, when the caller installed one.
     measured: Option<&'a mut dyn FnMut(MeasuredSnapshot)>,
-    /// The cooperative cancel flag the packet scan polls.
-    cancel: &'a AtomicBool,
+    /// The cooperative cancel flag the packet scan polls; `None` is a scan
+    /// that cannot be cancelled.
+    cancel: Option<&'a AtomicBool>,
 }
 
 impl<'a> ScanObservers<'a> {
+    /// The observers of a scan nobody watches: progress is discarded, no
+    /// measured tallies are snapshotted, and the scan runs to completion —
+    /// nothing can set a flag it does not carry, so [`BdError::ScanCancelled`]
+    /// is unreachable through this bundle.
+    ///
+    /// No [`MeasuredSnapshot`] is built at all (the observer's absence is what
+    /// makes an unobserved scan cost nothing there); the progress reports are
+    /// still made, into a callback that discards them.
+    #[must_use]
+    pub const fn none() -> Self {
+        Self { progress: None, measured: None, cancel: None }
+    }
+
     /// The observers of a scan that reports to `progress` and stops when
-    /// `cancel` is set, watching no measured tallies — what
-    /// [`BdRom::open_with`] passes.
+    /// `cancel` is set, watching no measured tallies.
     #[must_use]
     pub fn new(progress: &'a mut dyn FnMut(ScanProgress<'_>), cancel: &'a AtomicBool) -> Self {
-        Self { progress, measured: None, cancel }
+        Self { progress: Some(progress), measured: None, cancel: Some(cancel) }
     }
 
     /// The same observers with `measured` watching the tallies build up: it is
@@ -606,13 +621,15 @@ impl<'a> ScanObservers<'a> {
 }
 
 // A closure has no `Debug`, so the observers print what a reader can act on:
-// whether a measured observer is installed, and whether the scan has been told
-// to stop.
+// which observers are installed, and whether the scan has been told to stop.
+// A bundle carrying no cancel flag prints `cancelled: false` — it is a scan
+// nothing can stop, which is what that reads as.
 impl fmt::Debug for ScanObservers<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ScanObservers")
+            .field("progress", &self.progress.is_some())
             .field("measured", &self.measured.is_some())
-            .field("cancelled", &self.cancel.load(Ordering::Relaxed))
+            .field("cancelled", &self.cancel.is_some_and(|flag| flag.load(Ordering::Relaxed)))
             .finish_non_exhaustive()
     }
 }
@@ -930,77 +947,39 @@ impl BdRom {
     /// bitrate pass. The disc and `playlists` diff levels pass `Metadata`; no field
     /// they emit depends on the packet scan.
     ///
-    /// # Errors
-    /// - [`BdError::StructureNotFound`] if `root` has no `BDMV`, or `BDMV` lacks
-    ///   `CLIPINF`/`PLAYLIST` ("unable to locate BD structure").
-    /// - [`BdError::MissingClipFile`] if a playlist references an absent `*.clpi`.
-    /// - [`BdError::UnknownFileType`]/[`BdError::UnexpectedEof`] for malformed metadata, or
-    ///   [`BdError::Io`] for a filesystem error.
-    pub fn open(root: &dyn BdDir, mode: ScanMode) -> Result<Self, BdError> {
-        Self::open_with(
-            root,
-            mode,
-            ScanOptions::default(),
-            None,
-            &mut |_| {},
-            &AtomicBool::new(false),
-        )
-    }
-
-    /// Opens and scans the disc like [`open`](Self::open), with the scan's
-    /// behavior switches set by `options`, the packet scan narrowed to
-    /// `scan_files`, observed by `progress`, and abortable through `cancel`.
-    ///
     /// `options` — the [`ScanOptions`] behavior switches.
-    /// [`keep_partial`](ScanOptions::keep_partial) matters only to the
-    /// resilient opens; this strict open aborts on the first failure
-    /// regardless.
+    /// [`keep_partial`](ScanOptions::keep_partial) matters only to
+    /// [`open_resilient`](Self::open_resilient); this strict open aborts on the
+    /// first failure regardless.
     ///
     /// `scan_files` — when `Some`, only the stream files whose upper-cased
     /// names (`00000.M2TS`) it contains are packet-scanned; the rest keep
     /// their metadata-only summaries (zero measured rates). `None` scans
     /// every stream file.
     ///
-    /// `progress` is called before each stream file's source is opened (so a
-    /// blocking open on damaged media is already attributed to the file being
-    /// opened), before and after every demux read of the reported pass, and
-    /// at every file boundary with the running [`ScanProgress`], whose
-    /// [`total`](ScanProgress::total) documents which pass each mode reports;
-    /// it never fires without the packet scan.
-    ///
-    /// `cancel` — a cooperative stop flag: set it from any thread (a UI cancel
-    /// button, a Ctrl+C handler, the progress callback itself) and the packet
-    /// scan aborts at its next read chunk with [`BdError::ScanCancelled`],
-    /// yielding no partial result. The flag is polled with one relaxed load
-    /// per chunk, so the demux hot path is unaffected; a scan that reads no
-    /// packets ([`ScanMode::Metadata`]) never observes it.
-    ///
-    /// To watch the measured tallies as well as the byte count, pass the same
-    /// two through a [`ScanObservers`] bundle to
-    /// [`open_observed`](Self::open_observed).
+    /// `observers` — where the scan reports and what stops it
+    /// ([`ScanObservers`]); [`ScanObservers::none`] for a caller watching
+    /// nothing. Its progress callback is called before each stream file's
+    /// source is opened (so a blocking open on damaged media is already
+    /// attributed to the file being opened), before and after every demux read
+    /// of the reported pass, and at every file boundary with the running
+    /// [`ScanProgress`], whose [`total`](ScanProgress::total) documents which
+    /// pass each mode reports; it never fires without the packet scan. Its
+    /// cancel flag is cooperative: set it from any thread (a UI cancel button,
+    /// a Ctrl+C handler, the progress callback itself) and the packet scan
+    /// aborts at its next read chunk with [`BdError::ScanCancelled`], yielding
+    /// no partial result. The flag is polled with one relaxed load per chunk,
+    /// so the demux hot path is unaffected; a scan that reads no packets
+    /// ([`ScanMode::Metadata`]) never observes it.
     ///
     /// # Errors
-    /// As [`open`](Self::open), plus [`BdError::ScanCancelled`] when `cancel`
-    /// was set mid-scan.
-    pub fn open_with(
-        root: &dyn BdDir,
-        mode: ScanMode,
-        options: ScanOptions,
-        scan_files: Option<&BTreeSet<String>>,
-        progress: &mut dyn FnMut(ScanProgress<'_>),
-        cancel: &AtomicBool,
-    ) -> Result<Self, BdError> {
-        Self::open_observed(root, mode, options, scan_files, ScanObservers::new(progress, cancel))
-    }
-
-    /// Opens and scans the disc like [`open_with`](Self::open_with), taking its
-    /// progress callback and cancel flag as a [`ScanObservers`] bundle — the
-    /// form that can carry a measured observer too
-    /// ([`ScanObservers::with_measured`]).
-    ///
-    /// # Errors
-    /// As [`open_with`](Self::open_with).
-    pub fn open_observed(
+    /// - [`BdError::StructureNotFound`] if `root` has no `BDMV`, or `BDMV` lacks
+    ///   `CLIPINF`/`PLAYLIST` ("unable to locate BD structure").
+    /// - [`BdError::MissingClipFile`] if a playlist references an absent `*.clpi`.
+    /// - [`BdError::UnknownFileType`]/[`BdError::UnexpectedEof`] for malformed metadata, or
+    ///   [`BdError::Io`] for a filesystem error.
+    /// - [`BdError::ScanCancelled`] when the observers' cancel flag was set mid-scan.
+    pub fn open(
         root: &dyn BdDir,
         mode: ScanMode,
         options: ScanOptions,
@@ -1019,61 +998,22 @@ impl BdRom {
     /// scan continues over the readable rest; the affected playlist (or flag) is
     /// simply absent (or its default) in the returned [`BdRom`] — except a stream
     /// file whose packet scan failed partway, which keeps its partial demux state
-    /// by default ([`ScanOptions::keep_partial`]). On healthy media the result is
-    /// identical to [`open`](Self::open) with an empty error list.
+    /// by default ([`ScanOptions::keep_partial`], which takes effect here and
+    /// nowhere else). On healthy media the result is identical to
+    /// [`open`](Self::open) with an empty error list.
+    ///
+    /// `root`, `mode`, `scan_files` and `observers` are [`open`](Self::open)'s,
+    /// passed through unchanged.
     ///
     /// # Errors
     /// Only the failures with no readable rest to degrade to: locating
     /// `BDMV`/`CLIPINF`/`PLAYLIST` failed ([`BdError::StructureNotFound`], or
-    /// [`BdError::Io`] if those lookups cannot enumerate).
-    pub fn open_resilient(root: &dyn BdDir, mode: ScanMode) -> Result<ScanReport, BdError> {
-        Self::open_resilient_with(
-            root,
-            mode,
-            ScanOptions::default(),
-            None,
-            &mut |_| {},
-            &AtomicBool::new(false),
-        )
-    }
-
-    /// Opens and scans the disc like [`open_resilient`](Self::open_resilient),
-    /// with the scan's behavior switches set by `options` and the packet scan
-    /// narrowed to `scan_files`, observed by `progress`, and abortable through
-    /// `cancel` (the [`open_with`](Self::open_with) extras). This resilient
-    /// open is where [`ScanOptions::keep_partial`] takes effect.
-    ///
-    /// # Errors
-    /// As [`open_resilient`](Self::open_resilient), plus
-    /// [`BdError::ScanCancelled`] when `cancel` was set mid-scan — resilience
-    /// collects disc damage, not the caller's abort, so a cancelled scan
-    /// returns this error (never a partial [`ScanReport`], and never a
-    /// recorded per-file failure).
-    pub fn open_resilient_with(
-        root: &dyn BdDir,
-        mode: ScanMode,
-        options: ScanOptions,
-        scan_files: Option<&BTreeSet<String>>,
-        progress: &mut dyn FnMut(ScanProgress<'_>),
-        cancel: &AtomicBool,
-    ) -> Result<ScanReport, BdError> {
-        Self::open_resilient_observed(
-            root,
-            mode,
-            options,
-            scan_files,
-            ScanObservers::new(progress, cancel),
-        )
-    }
-
-    /// Opens and scans the disc like
-    /// [`open_resilient_with`](Self::open_resilient_with), taking its progress
-    /// callback and cancel flag as a [`ScanObservers`] bundle — the form that
-    /// can carry a measured observer too ([`ScanObservers::with_measured`]).
-    ///
-    /// # Errors
-    /// As [`open_resilient_with`](Self::open_resilient_with).
-    pub fn open_resilient_observed(
+    /// [`BdError::Io`] if those lookups cannot enumerate) — plus
+    /// [`BdError::ScanCancelled`] when the observers' cancel flag was set
+    /// mid-scan, since resilience collects disc damage, not the caller's abort:
+    /// a cancelled scan returns that error, never a partial [`ScanReport`] and
+    /// never a recorded per-file failure.
+    pub fn open_resilient(
         root: &dyn BdDir,
         mode: ScanMode,
         options: ScanOptions,
@@ -1761,7 +1701,29 @@ fn run_measurement_scan(
     // The measured observer belongs to the measurement pass alone (see
     // `ScanObservers::with_measured`): the quick pass is built without one, so
     // its file boundaries have nothing to snapshot to.
-    let ScanObservers { progress: callback, measured, cancel } = observers;
+    //
+    // The two passes below carry a callback and a flag, not options: keeping
+    // the `None`s out of `Progress` keeps the per-chunk cancel poll and the
+    // per-read report free of a branch that an unobserved scan would take on
+    // every packet. A bundle carrying no flag scans under one that is never
+    // set, and one carrying no callback reports into `discarded` — declared
+    // ahead of the bundle it stands in for, so it outlives the `Progress`
+    // that borrows it.
+    static NEVER_CANCELLED: AtomicBool = AtomicBool::new(false);
+    let mut discarded = |_: ScanProgress<'_>| {};
+    let ScanObservers { progress, measured, cancel } = observers;
+    let callback: &mut dyn FnMut(ScanProgress<'_>) = match progress {
+        Some(callback) => callback,
+        None => &mut discarded,
+    };
+    // `Progress` holds both observers under one lifetime, so the installed one
+    // is reborrowed down to `callback`'s rather than pulling it back up to the
+    // bundle's (which `discarded`, a local, cannot reach).
+    let measured: Option<&mut dyn FnMut(MeasuredSnapshot)> = match measured {
+        Some(measured) => Some(&mut *measured),
+        None => None,
+    };
+    let cancel = cancel.unwrap_or(&NEVER_CANCELLED);
     let total = scan_total(stream_files, interleaved_files, scan_files);
     // `skip_quick_pass` only ever skips a pass that would be followed by the
     // measurement pass — in `Codecs` mode the quick pass is the whole scan,
@@ -2821,6 +2783,17 @@ mod tests {
     use crate::vfs::fs::{FsDir, FsFile};
     use crate::vfs::{BdDir, BdFile, ReadSeek, SearchOption, extension_of_name};
 
+    /// [`BdRom::open`] over the whole disc, with no observers and the default
+    /// options — the shape most tests here want, spelled once.
+    fn open(root: &dyn BdDir, mode: ScanMode) -> Result<BdRom, BdError> {
+        BdRom::open(root, mode, ScanOptions::default(), None, ScanObservers::none())
+    }
+
+    /// [`open`]'s resilient twin.
+    fn open_resilient(root: &dyn BdDir, mode: ScanMode) -> Result<ScanReport, BdError> {
+        BdRom::open_resilient(root, mode, ScanOptions::default(), None, ScanObservers::none())
+    }
+
     // ── synthetic metadata builders (minimal valid `*.clpi` / `*.mpls`) ──────
     //
     // Convenience wrappers only: the on-disc byte layouts live once, in the
@@ -2959,15 +2932,15 @@ mod tests {
         }
 
         fn open(&self) -> Result<BdRom, BdError> {
-            BdRom::open(&FsDir::new(self.root.clone()), ScanMode::Metadata)
+            open(&FsDir::new(self.root.clone()), ScanMode::Metadata)
         }
 
         fn open_scanned(&self) -> Result<BdRom, BdError> {
-            BdRom::open(&FsDir::new(self.root.clone()), ScanMode::Full)
+            open(&FsDir::new(self.root.clone()), ScanMode::Full)
         }
 
         fn open_codecs(&self) -> Result<BdRom, BdError> {
-            BdRom::open(&FsDir::new(self.root.clone()), ScanMode::Codecs)
+            open(&FsDir::new(self.root.clone()), ScanMode::Codecs)
         }
     }
 
@@ -3759,7 +3732,7 @@ mod tests {
         );
         assert!(disc.open().expect("scan encrypted disc").is_aacs_encrypted);
         // State only: the resilient sink records nothing for the verdict.
-        let report = BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
+        let report = open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
             .expect("resilient scan");
         assert!(report.bdrom.is_aacs_encrypted);
         assert!(report.errors.is_empty());
@@ -4703,13 +4676,12 @@ mod tests {
         let unselected = {
             let mut progress = |_: ScanProgress<'_>| reported = reported.saturating_add(1);
             progress(ScanProgress { file: "00000.M2TS", done: 0, total: 0 });
-            BdRom::open_with(
+            BdRom::open(
                 &FsDir::new(short.root.clone()),
                 ScanMode::Full,
                 ScanOptions::default(),
                 Some(&BTreeSet::new()),
-                &mut progress,
-                &AtomicBool::new(false),
+                ScanObservers::new(&mut progress, &AtomicBool::new(false)),
             )
             .expect("selective scan")
         };
@@ -4809,18 +4781,23 @@ mod tests {
     /// with [`ScanOptions::skip_quick_pass`] — returning `(two_pass,
     /// skipped)` for the equality assertions the skipping scan is held to.
     fn scan_both_ways(root: &dyn BdDir, mode: ScanMode) -> (BdRom, BdRom) {
-        let two_pass = BdRom::open_with(
+        let two_pass = BdRom::open(
             root,
             mode,
             ScanOptions::default(),
             None,
-            &mut |_| {},
-            &never_cancel(),
+            ScanObservers::new(&mut |_| {}, &never_cancel()),
         )
         .expect("the two-pass scan opens");
         let options = ScanOptions { skip_quick_pass: true, ..ScanOptions::default() };
-        let skipped = BdRom::open_with(root, mode, options, None, &mut |_| {}, &never_cancel())
-            .expect("the quick-pass-skipping scan opens");
+        let skipped = BdRom::open(
+            root,
+            mode,
+            options,
+            None,
+            ScanObservers::new(&mut |_| {}, &never_cancel()),
+        )
+        .expect("the quick-pass-skipping scan opens");
         (two_pass, skipped)
     }
 
@@ -4916,16 +4893,15 @@ mod tests {
         // Control: with the `.ssif` openable this really is a 3D scan, so the
         // 2D result below is the failed open's doing, not the fixture's.
         let intact = Trip::new(usize::MAX);
-        let healthy =
-            BdRom::open_resilient(&interleaved_mock_disc(&intact, &intact), ScanMode::Full)
-                .expect("healthy 3D scan");
+        let healthy = open_resilient(&interleaved_mock_disc(&intact, &intact), ScanMode::Full)
+            .expect("healthy 3D scan");
         assert!(healthy.errors.is_empty());
         let control = healthy.bdrom.playlists.first().unwrap();
         assert!(control.streams.iter().any(|s| s.pid == Pid::new(0x1012)), "the dependent view");
         assert_eq!(control.clips.first().unwrap().display_name, "00000.SSIF");
 
         let report =
-            BdRom::open_resilient(&interleaved_mock_disc(&Trip::always(), &intact), ScanMode::Full)
+            open_resilient(&interleaved_mock_disc(&Trip::always(), &intact), ScanMode::Full)
                 .expect("the resilient scan degrades to the base view");
         // Both measurement passes open the source, so both record the failure
         // — the per-attempt shape every unopenable file already has.
@@ -4952,11 +4928,9 @@ mod tests {
     fn a_strict_scan_still_fails_on_an_unopenable_interleaved_source() {
         // The fallback is the resilient scan's keep-what-you-can policy; strict
         // mode is the fail-fast path and has no policy to apply.
-        let failed = BdRom::open(
-            &interleaved_mock_disc(&Trip::always(), &Trip::new(usize::MAX)),
-            ScanMode::Full,
-        )
-        .expect_err("strict mode propagates the failed interleaved open");
+        let failed =
+            open(&interleaved_mock_disc(&Trip::always(), &Trip::new(usize::MAX)), ScanMode::Full)
+                .expect_err("strict mode propagates the failed interleaved open");
         assert_eq!(failed.to_string(), "io error: injected io failure");
     }
 
@@ -4966,7 +4940,7 @@ mod tests {
         // unopenable too there is nothing left to read, so the clip is dropped
         // and both failures are recorded — one per source, per pass.
         let dead = Trip::always();
-        let report = BdRom::open_resilient(&interleaved_mock_disc(&dead, &dead), ScanMode::Full)
+        let report = open_resilient(&interleaved_mock_disc(&dead, &dead), ScanMode::Full)
             .expect("the resilient scan continues past a clip it cannot read");
         let recorded: Vec<(ScanStage, &str)> =
             report.errors.iter().map(|e| (e.stage, e.file.as_str())).collect();
@@ -5047,13 +5021,12 @@ mod tests {
         let m2ts = two_chunk_m2ts(&[(0x1B, 0x1011)], &[1, 2, 3], &[46, 47, 48]);
         let scan = |options: ScanOptions| {
             let disc = tripping_disc(m2ts.clone(), Some(DATA_SIZE));
-            BdRom::open_resilient_with(
+            BdRom::open_resilient(
                 &disc,
                 ScanMode::Full,
                 options,
                 None,
-                &mut |_| {},
-                &never_cancel(),
+                ScanObservers::new(&mut |_| {}, &never_cancel()),
             )
             .expect("the resilient scan continues")
         };
@@ -5118,13 +5091,12 @@ mod tests {
         let scan = |options: ScanOptions| {
             log.lock().unwrap().clear();
             drop(
-                BdRom::open_with(
+                BdRom::open(
                     &disc,
                     ScanMode::Full,
                     options,
                     None,
-                    &mut |_| {},
-                    &never_cancel(),
+                    ScanObservers::new(&mut |_| {}, &never_cancel()),
                 )
                 .expect("the mock disc scans"),
             );
@@ -5150,8 +5122,14 @@ mod tests {
         let open = |mode: ScanMode, options: ScanOptions| {
             log.lock().unwrap().clear();
             let mut observe = |_: ScanProgress<'_>| progressed.store(true, Ordering::Relaxed);
-            BdRom::open_with(&disc, mode, options, None, &mut observe, &never_cancel())
-                .expect("the mock disc opens")
+            BdRom::open(
+                &disc,
+                mode,
+                options,
+                None,
+                ScanObservers::new(&mut observe, &never_cancel()),
+            )
+            .expect("the mock disc opens")
         };
         // Probing (the default): the key file is present, so the probe reads
         // the stream head — a `Metadata` open's only stream read — and the
@@ -5207,13 +5185,12 @@ mod tests {
         let mut events: Vec<(String, u64)> = Vec::new();
         let mut collect = |p: ScanProgress<'_>| events.push((p.file.to_owned(), p.done));
         drop(
-            BdRom::open_resilient_with(
+            BdRom::open_resilient(
                 &disc,
                 ScanMode::Full,
                 ScanOptions::default(),
                 None,
-                &mut collect,
-                &never_cancel(),
+                ScanObservers::new(&mut collect, &never_cancel()),
             )
             .expect("the resilient scan continues over the failed read"),
         );
@@ -5383,7 +5360,7 @@ mod tests {
     /// Opens the disc with the scan rooted at `rel` under the fixture root —
     /// exercising [`walked_disc_root`] over the real filesystem backend.
     fn open_at(disc: &TempDisc, rel: &str) -> Result<BdRom, BdError> {
-        BdRom::open(&FsDir::new(disc.root.join(rel)), ScanMode::Metadata)
+        open(&FsDir::new(disc.root.join(rel)), ScanMode::Metadata)
     }
 
     #[test]
@@ -5491,7 +5468,7 @@ mod tests {
         let dir = WalkDir { name: "BDMV", cyclic: true, fail_listing: false };
         assert!(walked_disc_root(&dir).is_none());
         assert_eq!(
-            BdRom::open(&dir, ScanMode::Metadata).unwrap_err().to_string(),
+            open(&dir, ScanMode::Metadata).unwrap_err().to_string(),
             "unable to locate BD structure"
         );
     }
@@ -5878,7 +5855,7 @@ mod tests {
         // A clean scan establishes the IO-operation count. The packet scan is on, so
         // the count also covers the per-stream-file open in `scan_stream_files`.
         let probe = Trip::new(usize::MAX);
-        let bd = BdRom::open(&mock_disc(&probe), ScanMode::Full).expect("mock disc scans clean");
+        let bd = open(&mock_disc(&probe), ScanMode::Full).expect("mock disc scans clean");
         assert_eq!(bd.playlists.len(), 2); // exercises the playlist sort comparator
         assert!(bd.is_uhd && bd.is_3d && bd.is_bd_plus && bd.is_bd_java && bd.is_psp);
         let total = probe.used();
@@ -5893,7 +5870,7 @@ mod tests {
             let trip = Trip::new(fail_at);
             // Each injected io failure surfaces as an error (never a panic); the io
             // path only ever yields `BdError::Io`.
-            if let Ok(scanned) = BdRom::open(&mock_disc(&trip), ScanMode::Full) {
+            if let Ok(scanned) = open(&mock_disc(&trip), ScanMode::Full) {
                 assert_eq!(scanned, bd, "io failure at op {fail_at} altered the scan");
                 fail_open = fail_open.saturating_add(1);
             }
@@ -6093,7 +6070,7 @@ mod tests {
         // Healthy control: the same tree scans clean and both chapters carry
         // measured rates — so the damaged scan's zero second row below is the
         // trip's doing, not the fixture's.
-        let healthy = BdRom::open_resilient(&tripping_disc(m2ts.clone(), None), ScanMode::Full)
+        let healthy = open_resilient(&tripping_disc(m2ts.clone(), None), ScanMode::Full)
             .expect("healthy scan");
         assert!(healthy.errors.is_empty());
         let control = healthy.bdrom.playlists.first().unwrap();
@@ -6101,7 +6078,7 @@ mod tests {
         assert!(control.chapters.get(1).unwrap().avg_rate > 0.0);
 
         // Tripped at the chunk boundary: the head frames demuxed, the rest died.
-        let report = BdRom::open_resilient(&tripping_disc(m2ts, Some(DATA_SIZE)), ScanMode::Full)
+        let report = open_resilient(&tripping_disc(m2ts, Some(DATA_SIZE)), ScanMode::Full)
             .expect("resilient scan continues");
         // The full pass trips; the quick pass stops inside the served first
         // chunk once the lone video stream's codec detail initialises, so it
@@ -6137,16 +6114,14 @@ mod tests {
     fn keep_partial_off_drops_the_partial_scan_wholesale() {
         use crate::bdrom::m2ts::DATA_SIZE;
         let m2ts = two_chunk_m2ts(&[(0x1B, 0x1011)], &[1, 2, 3], &[46, 47, 48]);
-        let kept =
-            BdRom::open_resilient(&tripping_disc(m2ts.clone(), Some(DATA_SIZE)), ScanMode::Full)
-                .expect("resilient scan continues");
-        let off = BdRom::open_resilient_with(
+        let kept = open_resilient(&tripping_disc(m2ts.clone(), Some(DATA_SIZE)), ScanMode::Full)
+            .expect("resilient scan continues");
+        let off = BdRom::open_resilient(
             &tripping_disc(m2ts, Some(DATA_SIZE)),
             ScanMode::Full,
             ScanOptions { keep_partial: false, ..ScanOptions::default() },
             None,
-            &mut |_| {},
-            &AtomicBool::new(false),
+            ScanObservers::new(&mut |_| {}, &AtomicBool::new(false)),
         )
         .expect("resilient scan continues");
 
@@ -6182,9 +6157,8 @@ mod tests {
         // A read failure leaves the same measured shortfall a truncated file
         // does, so the file is reported short as well as recorded — the two
         // lists deliberately overlap, and the caller pairs them by name.
-        let kept =
-            BdRom::open_resilient(&tripping_disc(m2ts.clone(), Some(DATA_SIZE)), ScanMode::Full)
-                .expect("resilient scan continues");
+        let kept = open_resilient(&tripping_disc(m2ts.clone(), Some(DATA_SIZE)), ScanMode::Full)
+            .expect("resilient scan continues");
         let short = kept.bdrom.short_stream_files();
         assert_eq!(short.len(), 1);
         assert_eq!(short.first().unwrap().file(), "00000.M2TS");
@@ -6197,13 +6171,12 @@ mod tests {
         // Retention off drops the dead file's demux state, so it carries no
         // measured tallies at all — indistinguishable from a file the scan
         // never opened, and named by the recorded failure alone.
-        let off = BdRom::open_resilient_with(
+        let off = BdRom::open_resilient(
             &tripping_disc(m2ts, Some(DATA_SIZE)),
             ScanMode::Full,
             ScanOptions { keep_partial: false, ..ScanOptions::default() },
             None,
-            &mut |_| {},
-            &AtomicBool::new(false),
+            ScanObservers::new(&mut |_| {}, &AtomicBool::new(false)),
         )
         .expect("resilient scan continues");
         assert_eq!(off.errors.len(), 1);
@@ -6321,7 +6294,7 @@ Total Bitrate:  0.00 Mbps
         let clip =
             clpi(&[(0x1011, 0x1B, [0x62, 0x30, 0, 0]), (0x1100, 0x81, [0x61, b'e', b'n', b'g'])]);
         let m2ts = two_chunk_m2ts(&[(0x1B, 0x1011), (0x81, 0x1100)], &[1, 2, 3], &[46, 47, 48]);
-        let report = BdRom::open_resilient(
+        let report = open_resilient(
             &tripping_disc_with(clip.clone(), m2ts.clone(), Some(DATA_SIZE)),
             ScanMode::Full,
         )
@@ -6334,13 +6307,12 @@ Total Bitrate:  0.00 Mbps
         // Switched off, the same damage loses the quick pass's codec detail
         // with everything else: the presented video keeps only its clip-info
         // description.
-        let off = BdRom::open_resilient_with(
+        let off = BdRom::open_resilient(
             &tripping_disc_with(clip, m2ts, Some(DATA_SIZE)),
             ScanMode::Full,
             ScanOptions { keep_partial: false, ..ScanOptions::default() },
             None,
-            &mut |_| {},
-            &AtomicBool::new(false),
+            ScanObservers::new(&mut |_| {}, &AtomicBool::new(false)),
         )
         .expect("resilient scan continues");
         assert_eq!(off.errors.len(), 2);
@@ -6354,9 +6326,8 @@ Total Bitrate:  0.00 Mbps
         // pass each open the file and each trip, so ONE failure is recorded
         // per pass — two `WARNING` lines for the same file, deliberately
         // undeduplicated.
-        let report =
-            BdRom::open_resilient(&tripping_disc(vec![0_u8; 400], Some(0)), ScanMode::Full)
-                .expect("resilient scan continues");
+        let report = open_resilient(&tripping_disc(vec![0_u8; 400], Some(0)), ScanMode::Full)
+            .expect("resilient scan continues");
         assert_eq!(report.errors.len(), 2);
         for recorded in &report.errors {
             assert_eq!(
@@ -6376,7 +6347,7 @@ Total Bitrate:  0.00 Mbps
     fn open_strict_aborts_wholesale_on_a_stream_read_error() {
         // The strict open propagates the first read failure — no partial
         // state, no report — whatever `keep_partial` would have said.
-        assert!(BdRom::open(&tripping_disc(vec![0_u8; 400], Some(0)), ScanMode::Full).is_err());
+        assert!(open(&tripping_disc(vec![0_u8; 400], Some(0)), ScanMode::Full).is_err());
     }
 
     proptest! {
@@ -6395,7 +6366,7 @@ Total Bitrate:  0.00 Mbps
         ) {
             let m2ts = two_chunk_m2ts(&[(0x1B, 0x1011)], &[1, 2, 3], &[46, 47]);
             let report =
-                BdRom::open_resilient(&tripping_disc(m2ts, Some(serve)), ScanMode::Full)
+                open_resilient(&tripping_disc(m2ts, Some(serve)), ScanMode::Full)
                     .expect("the resilient scan is total");
             let pl = report.bdrom.playlists.first().unwrap();
             prop_assert_eq!(pl.chapters.len(), 2);
@@ -6431,13 +6402,12 @@ Total Bitrate:  0.00 Mbps
             &[("00000", &["00000"]), ("00001", &["00001"]), ("00002", &["00002"])],
         );
         let scan = |selection: Option<&BTreeSet<String>>| {
-            BdRom::open_resilient_with(
+            BdRom::open_resilient(
                 &disc,
                 ScanMode::Full,
                 ScanOptions::default(),
                 selection,
-                &mut |_| {},
-                &never_cancel(),
+                ScanObservers::new(&mut |_| {}, &never_cancel()),
             )
             .expect("resilient scan continues")
         };
@@ -6517,7 +6487,7 @@ Total Bitrate:  0.00 Mbps
                 ],
                 &[("00000", &["00000", "00001"])],
             );
-            BdRom::open_resilient(&disc, ScanMode::Full)
+            open_resilient(&disc, ScanMode::Full)
                 .expect("resilient scan continues")
                 .bdrom
                 .playlists
@@ -6670,8 +6640,7 @@ Total Bitrate:  0.00 Mbps
         // Characterization, not judgement: the golden is what current master
         // renders, including anything a later ruling may decide is wrong.
         let disc = fixture_tree("MultiPlaylist", &[("00011.m2ts", DAMAGED_FAULT_AT)]);
-        let report =
-            BdRom::open_resilient(&disc, ScanMode::Full).expect("resilient scan continues");
+        let report = open_resilient(&disc, ScanMode::Full).expect("resilient scan continues");
         let rendered = crate::report::text::render(&report.bdrom, &report.errors);
 
         // The damage is one truncation, so exactly one failure is recorded —
@@ -6797,7 +6766,7 @@ Total Bitrate:  0.00 Mbps
     }
 
     #[test]
-    fn open_with_reports_progress_and_narrows_the_scan_to_selected_files() {
+    fn an_observed_open_reports_progress_and_narrows_the_scan_to_selected_files() {
         let disc = TempDisc::build(
             &[],
             &[
@@ -6816,13 +6785,12 @@ Total Bitrate:  0.00 Mbps
         // reported).
         let mut events: Vec<(String, u64, u64)> = Vec::new();
         let mut collect = |p: ScanProgress<'_>| events.push((p.file.to_owned(), p.done, p.total));
-        let bd = BdRom::open_with(
+        let bd = BdRom::open(
             &root,
             ScanMode::Full,
             ScanOptions::default(),
             None,
-            &mut collect,
-            &never_cancel(),
+            ScanObservers::new(&mut collect, &never_cancel()),
         )
         .expect("scan with progress");
         assert_eq!(bd.playlists.len(), 2);
@@ -6843,13 +6811,12 @@ Total Bitrate:  0.00 Mbps
         let selected = BTreeSet::from(["00000.M2TS".to_owned()]);
         let mut events: Vec<(String, u64, u64)> = Vec::new();
         let mut collect = |p: ScanProgress<'_>| events.push((p.file.to_owned(), p.done, p.total));
-        let bd = BdRom::open_with(
+        let bd = BdRom::open(
             &root,
             ScanMode::Full,
             ScanOptions::default(),
             Some(&selected),
-            &mut collect,
-            &never_cancel(),
+            ScanObservers::new(&mut collect, &never_cancel()),
         )
         .expect("scan the selection");
         assert_eq!(bd.playlists.len(), 2);
@@ -6860,13 +6827,12 @@ Total Bitrate:  0.00 Mbps
         // healthy media.
         let mut last_total = 0;
         let mut observe = |p: ScanProgress<'_>| last_total = p.total;
-        let report = BdRom::open_resilient_with(
+        let report = BdRom::open_resilient(
             &root,
             ScanMode::Full,
             ScanOptions::default(),
             Some(&selected),
-            &mut observe,
-            &never_cancel(),
+            ScanObservers::new(&mut observe, &never_cancel()),
         )
         .expect("resilient scan with progress");
         assert!(report.errors.is_empty());
@@ -6877,13 +6843,12 @@ Total Bitrate:  0.00 Mbps
         let mut fired = false;
         let mut observe = |_: ScanProgress<'_>| fired = true;
         drop(
-            BdRom::open_with(
+            BdRom::open(
                 &root,
                 ScanMode::Metadata,
                 ScanOptions::default(),
                 None,
-                &mut observe,
-                &never_cancel(),
+                ScanObservers::new(&mut observe, &never_cancel()),
             )
             .expect("metadata-only scan"),
         );
@@ -6906,13 +6871,12 @@ Total Bitrate:  0.00 Mbps
             let mut collect =
                 |p: ScanProgress<'_>| events.push((p.file.to_owned(), p.done, p.total));
             drop(
-                BdRom::open_with(
+                BdRom::open(
                     &disc,
                     mode,
                     ScanOptions::default(),
                     None,
-                    &mut collect,
-                    &never_cancel(),
+                    ScanObservers::new(&mut collect, &never_cancel()),
                 )
                 .expect("the healthy mock disc scans"),
             );
@@ -6993,7 +6957,7 @@ Total Bitrate:  0.00 Mbps
         let bd = {
             let mut watch = |snapshot: MeasuredSnapshot| snapshots.push(snapshot);
             let mut collect = |_: ScanProgress<'_>| {};
-            BdRom::open_observed(
+            BdRom::open(
                 disc,
                 mode,
                 ScanOptions::default(),
@@ -7092,7 +7056,7 @@ Total Bitrate:  0.00 Mbps
         // Installing an observer changes nothing about what the scan produces.
         let (observed, snapshots) = observed_scan(&disc, ScanMode::Full);
         assert_eq!(snapshots.len(), 6);
-        let plain = BdRom::open(&disc, ScanMode::Full).expect("the healthy mock disc scans");
+        let plain = open(&disc, ScanMode::Full).expect("the healthy mock disc scans");
         assert_eq!(observed, plain);
     }
 
@@ -7112,11 +7076,17 @@ Total Bitrate:  0.00 Mbps
         // closures with nothing to print.
         assert_eq!(
             format!("{:?}", ScanObservers::new(&mut collect, &cancel)),
-            "ScanObservers { measured: false, cancelled: false, .. }"
+            "ScanObservers { progress: true, measured: false, cancelled: false, .. }"
+        );
+        // The watch-nothing bundle: no observers, and no flag to read, which
+        // prints as the scan nothing can stop.
+        assert_eq!(
+            format!("{:?}", ScanObservers::none()),
+            "ScanObservers { progress: false, measured: false, cancelled: false, .. }"
         );
         // Both callbacks reach the scan through the bundle.
         drop(
-            BdRom::open_observed(
+            BdRom::open(
                 &disc,
                 ScanMode::Full,
                 ScanOptions::default(),
@@ -7135,7 +7105,7 @@ Total Bitrate:  0.00 Mbps
         cancel.store(true, Ordering::Relaxed);
         assert_eq!(
             format!("{:?}", ScanObservers::new(&mut collect, &cancel).with_measured(&mut watch)),
-            "ScanObservers { measured: true, cancelled: true, .. }"
+            "ScanObservers { progress: true, measured: true, cancelled: true, .. }"
         );
     }
 
@@ -7152,7 +7122,7 @@ Total Bitrate:  0.00 Mbps
         // fixture that never reported.
         let mut quiet = |_: ScanProgress<'_>| {};
         drop(
-            BdRom::open_observed(
+            BdRom::open(
                 &disc,
                 ScanMode::Full,
                 ScanOptions::default(),
@@ -7173,7 +7143,7 @@ Total Bitrate:  0.00 Mbps
                 cancel.store(true, Ordering::Relaxed);
             }
         };
-        let err = BdRom::open_observed(
+        let err = BdRom::open(
             &disc,
             ScanMode::Full,
             ScanOptions::default(),
@@ -7239,13 +7209,12 @@ Total Bitrate:  0.00 Mbps
         let mut baseline: Vec<u64> = Vec::new();
         let mut collect = |p: ScanProgress<'_>| baseline.push(p.done);
         drop(
-            BdRom::open_with(
+            BdRom::open(
                 &root,
                 ScanMode::Full,
                 ScanOptions::default(),
                 None,
-                &mut collect,
-                &never_cancel(),
+                ScanObservers::new(&mut collect, &never_cancel()),
             )
             .expect("the uncancelled scan"),
         );
@@ -7259,13 +7228,12 @@ Total Bitrate:  0.00 Mbps
             events.push(p.done);
             cancel.store(true, Ordering::Relaxed);
         };
-        let err = BdRom::open_with(
+        let err = BdRom::open(
             &root,
             ScanMode::Full,
             ScanOptions::default(),
             None,
-            &mut trip,
-            &cancel,
+            ScanObservers::new(&mut trip, &cancel),
         )
         .expect_err("the cancelled scan errors");
         assert_eq!(err.to_string(), "scan cancelled");
@@ -7279,13 +7247,12 @@ Total Bitrate:  0.00 Mbps
         // abort, not disc damage to collect, so no partial report escapes.
         let cancel = AtomicBool::new(false);
         let mut trip = |_: ScanProgress<'_>| cancel.store(true, Ordering::Relaxed);
-        let err = BdRom::open_resilient_with(
+        let err = BdRom::open_resilient(
             &root,
             ScanMode::Full,
             ScanOptions::default(),
             None,
-            &mut trip,
-            &cancel,
+            ScanObservers::new(&mut trip, &cancel),
         )
         .expect_err("the cancelled resilient scan errors");
         assert_eq!(err.to_string(), "scan cancelled");
@@ -7301,21 +7268,25 @@ Total Bitrate:  0.00 Mbps
         for mode in [ScanMode::Codecs, ScanMode::Full] {
             let mut fired = false;
             let mut observe = |_: ScanProgress<'_>| fired = true;
-            let err =
-                BdRom::open_with(&root, mode, ScanOptions::default(), None, &mut observe, &cancel)
-                    .expect_err("the pre-cancelled scan errors");
+            let err = BdRom::open(
+                &root,
+                mode,
+                ScanOptions::default(),
+                None,
+                ScanObservers::new(&mut observe, &cancel),
+            )
+            .expect_err("the pre-cancelled scan errors");
             assert_eq!(err.to_string(), "scan cancelled");
             assert!(!fired, "no progress escapes a pre-cancelled scan");
         }
         let mut resilient_fired = false;
         let mut observe = |_: ScanProgress<'_>| resilient_fired = true;
-        let err = BdRom::open_resilient_with(
+        let err = BdRom::open_resilient(
             &root,
             ScanMode::Full,
             ScanOptions::default(),
             None,
-            &mut observe,
-            &cancel,
+            ScanObservers::new(&mut observe, &cancel),
         )
         .expect_err("the pre-cancelled resilient scan errors");
         assert_eq!(err.to_string(), "scan cancelled");
@@ -7324,13 +7295,12 @@ Total Bitrate:  0.00 Mbps
         // bounded structural scan completes as if no flag existed.
         let mut metadata_fired = false;
         let mut observe = |_: ScanProgress<'_>| metadata_fired = true;
-        let bd = BdRom::open_with(
+        let bd = BdRom::open(
             &root,
             ScanMode::Metadata,
             ScanOptions::default(),
             None,
-            &mut observe,
-            &cancel,
+            ScanObservers::new(&mut observe, &cancel),
         )
         .expect("the metadata scan never polls the flag");
         assert!(!metadata_fired, "a metadata scan reads no packets");
@@ -7393,7 +7363,7 @@ Total Bitrate:  0.00 Mbps
             &[("BDMV/PLAYLIST/00000.mpls", play), ("BDMV/CLIPINF/00000.clpi", clip)],
         );
         let strict = disc.open().expect("strict scan");
-        let report = BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
+        let report = open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
             .expect("resilient scan");
         assert!(report.errors.is_empty());
         assert_eq!(report.bdrom, strict);
@@ -7417,7 +7387,7 @@ Total Bitrate:  0.00 Mbps
         );
         assert!(disc.open().is_err(), "the strict scan aborts on the corrupt clip");
 
-        let report = BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
+        let report = open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
             .expect("resilient scan continues");
         let names: Vec<&str> = report.bdrom.playlists.iter().map(|p| p.name.as_str()).collect();
         assert_eq!(names, vec!["00000.MPLS"]); // the readable rest is emitted
@@ -7445,7 +7415,7 @@ Total Bitrate:  0.00 Mbps
         );
         assert!(disc.open().is_err(), "the strict scan aborts on the corrupt playlist");
 
-        let report = BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
+        let report = open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
             .expect("resilient scan continues");
         let names: Vec<&str> = report.bdrom.playlists.iter().map(|p| p.name.as_str()).collect();
         assert_eq!(names, vec!["00000.MPLS"]);
@@ -7487,8 +7457,7 @@ Total Bitrate:  0.00 Mbps
             )],
             vec![],
         );
-        let report =
-            BdRom::open_resilient(&root, ScanMode::Metadata).expect("resilient scan continues");
+        let report = open_resilient(&root, ScanMode::Metadata).expect("resilient scan continues");
         assert!(!report.bdrom.is_uhd);
         assert_eq!(report.bdrom.disc_title, None);
         assert_eq!(report.errors.len(), 2);
@@ -7498,7 +7467,7 @@ Total Bitrate:  0.00 Mbps
         assert_eq!((title.stage, title.file.as_str()), (ScanStage::Discovery, "META"));
 
         // The strict scan aborts on the first of the same failures.
-        assert!(BdRom::open(&root, ScanMode::Metadata).is_err());
+        assert!(open(&root, ScanMode::Metadata).is_err());
     }
 
     #[test]
@@ -7508,8 +7477,7 @@ Total Bitrate:  0.00 Mbps
         // block) or completes with that failure recorded — never panics, never
         // silently swallows.
         let probe = Trip::new(usize::MAX);
-        let clean =
-            BdRom::open_resilient(&mock_disc(&probe), ScanMode::Full).expect("mock disc scans");
+        let clean = open_resilient(&mock_disc(&probe), ScanMode::Full).expect("mock disc scans");
         assert!(clean.errors.is_empty());
         let total = probe.used();
 
@@ -7520,7 +7488,7 @@ Total Bitrate:  0.00 Mbps
             // An `Err` is the fatal BDMV/CLIPINF/PLAYLIST block; a completed scan
             // must either record the failure or — only in the fail-open AACS
             // probe — absorb it with the scan left identical to the clean one.
-            if let Ok(report) = BdRom::open_resilient(&mock_disc(&trip), ScanMode::Full) {
+            if let Ok(report) = open_resilient(&mock_disc(&trip), ScanMode::Full) {
                 if report.errors.is_empty() {
                     assert_eq!(
                         report.bdrom, clean.bdrom,
@@ -7747,8 +7715,8 @@ Total Bitrate:  0.00 Mbps
         );
         assert!(disc.open().is_err(), "strict open ignores BACKUP");
 
-        let report = BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
-            .expect("recovers");
+        let report =
+            open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata).expect("recovers");
         let names: Vec<&str> = report.bdrom.playlists.iter().map(|p| p.name.as_str()).collect();
         assert_eq!(names, vec!["00000.MPLS"]); // recovered from BACKUP
         assert_eq!(report.errors.len(), 1);
@@ -7771,8 +7739,8 @@ Total Bitrate:  0.00 Mbps
                 ("BDMV/BACKUP/CLIPINF/00000.clpi", good_clip),
             ],
         );
-        let report = BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
-            .expect("recovers");
+        let report =
+            open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata).expect("recovers");
         let names: Vec<&str> = report.bdrom.playlists.iter().map(|p| p.name.as_str()).collect();
         assert_eq!(names, vec!["00000.MPLS"]); // the clip recovered → playlist scans
         assert_eq!(report.errors.len(), 1);
@@ -7815,7 +7783,7 @@ Total Bitrate:  0.00 Mbps
             )],
             vec![],
         );
-        let report = BdRom::open_resilient(&root, ScanMode::Metadata).expect("scans");
+        let report = open_resilient(&root, ScanMode::Metadata).expect("scans");
         assert!(report.bdrom.is_uhd, "UHD flag recovered from BACKUP");
         assert_eq!(report.errors.len(), 1);
         let err = report.errors.first().expect("index note");
@@ -7835,8 +7803,8 @@ Total Bitrate:  0.00 Mbps
                 ("BDMV/CLIPINF/00000.clpi", clip),
             ],
         );
-        let report = BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
-            .expect("scans");
+        let report =
+            open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata).expect("scans");
         assert!(report.bdrom.playlists.is_empty());
         assert_eq!(report.errors.len(), 1);
         assert_eq!(
@@ -7858,8 +7826,8 @@ Total Bitrate:  0.00 Mbps
                 ("BDMV/CLIPINF/00000.clpi", clip),
             ],
         );
-        let report = BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
-            .expect("scans");
+        let report =
+            open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata).expect("scans");
         assert!(report.bdrom.playlists.is_empty());
         assert_eq!(report.errors.len(), 1);
     }
@@ -7964,8 +7932,8 @@ Total Bitrate:  0.00 Mbps
 
         // A long (>= 8 byte) garbage index: warned, version magic reported.
         let disc = make(b"XXXXjunk");
-        let report = BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
-            .expect("scans");
+        let report =
+            open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata).expect("scans");
         assert!(!report.bdrom.is_uhd);
         assert_eq!(report.errors.len(), 1);
         let err = report.errors.first().expect("index warning");
@@ -7976,8 +7944,8 @@ Total Bitrate:  0.00 Mbps
 
         // A short (< 8 byte) garbage index: still warned, magic empty.
         let short = make(b"XX");
-        let report = BdRom::open_resilient(&FsDir::new(short.root.clone()), ScanMode::Metadata)
-            .expect("scans");
+        let report =
+            open_resilient(&FsDir::new(short.root.clone()), ScanMode::Metadata).expect("scans");
         assert!(!report.bdrom.is_uhd);
         assert_eq!(
             report.errors.first().expect("short index warning").reason.to_string(),
@@ -8006,8 +7974,7 @@ Total Bitrate:  0.00 Mbps
             TempDisc::build(&[], &files)
         };
         let scan = |disc: &TempDisc| {
-            BdRom::open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata)
-                .expect("scans")
+            open_resilient(&FsDir::new(disc.root.clone()), ScanMode::Metadata).expect("scans")
         };
 
         // A tagged BACKUP copy recovers the UHD verdict…
@@ -8069,7 +8036,7 @@ Total Bitrate:  0.00 Mbps
             )],
             vec![],
         );
-        let report = BdRom::open_resilient(&root, ScanMode::Metadata).expect("scans");
+        let report = open_resilient(&root, ScanMode::Metadata).expect("scans");
         assert!(!report.bdrom.is_uhd);
         assert_eq!(report.errors.len(), 2, "the unreadable primary, then its untagged stand-in");
         for err in &report.errors {

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -1719,6 +1719,10 @@ fn run_measurement_scan(
     // `Progress` holds both observers under one lifetime, so the installed one
     // is reborrowed down to `callback`'s rather than pulling it back up to the
     // bundle's (which `discarded`, a local, cannot reach).
+    #[expect(
+        clippy::option_if_let_else,
+        reason = "the `map_or`/`map` rewrite infers the closure's return at the bundle's lifetime, so the reborrow does not shorten and `discarded`, a local, cannot meet it"
+    )]
     let measured: Option<&mut dyn FnMut(MeasuredSnapshot)> = match measured {
         Some(measured) => Some(&mut *measured),
         None => None,

--- a/crates/bdinfo-rs-core/src/error.rs
+++ b/crates/bdinfo-rs-core/src/error.rs
@@ -63,8 +63,8 @@ pub enum BdError {
         limit: u64,
     },
     /// The packet scan was cancelled through the caller's cooperative cancel
-    /// flag (the `cancel` parameter of `BdRom::open_with` /
-    /// `BdRom::open_resilient_with`) — the caller's abort, not a disc failure.
+    /// flag (the one an open's `ScanObservers` carries) — the caller's abort,
+    /// not a disc failure.
     /// The whole open aborts with this error in strict **and** resilient modes
     /// alike: a cancelled scan yields no partial result and is never recorded
     /// as a per-file [`ScanError`].

--- a/crates/bdinfo-rs-core/src/scan.rs
+++ b/crates/bdinfo-rs-core/src/scan.rs
@@ -1,23 +1,21 @@
 //! Opening a disc from a path — the one place folder and `.iso` input diverge.
 //!
-//! [`BdRom::open_resilient_with`] reads through the [`crate::vfs`] seam and
-//! knows nothing about paths. A caller holding one must pick the backend, open
-//! it, and merge that backend's own recorded failures into the scan's — and for
-//! a folder repair the label the scan derived. These functions are that
-//! composition, so every path-driven surface shares one implementation of it —
-//! one pair per backend: the plain form and an `_observed` one for a caller that
-//! also watches the measured tallies build up.
+//! [`BdRom::open_resilient`] reads through the [`crate::vfs`] seam and knows
+//! nothing about paths. A caller holding one must pick the backend, open it,
+//! and merge that backend's own recorded failures into the scan's — and for a
+//! folder repair the label the scan derived. These functions are that
+//! composition, one per backend, so every path-driven surface shares one
+//! implementation of it.
 //! A browser caller has no paths and builds its [`BdDir`](crate::vfs::BdDir)
-//! itself, so it uses none of them.
+//! itself, so it uses neither.
 //!
 //! How deep to read stays the caller's choice: `mode` is passed through
 //! untouched.
 
 use std::collections::BTreeSet;
 use std::path::Path;
-use std::sync::atomic::AtomicBool;
 
-use crate::bdrom::disc::{BdRom, ScanMode, ScanObservers, ScanOptions, ScanProgress, ScanReport};
+use crate::bdrom::disc::{BdRom, ScanMode, ScanObservers, ScanOptions, ScanReport};
 use crate::error::BdError;
 use crate::vfs::fs::FsDir;
 use crate::vfs::udf::source::{PathIso, UdfSource};
@@ -38,33 +36,13 @@ use crate::vfs::volume;
 /// raw read could stall — so the label degrades to the bare drive letter
 /// there.
 ///
-/// `mode`, `options`, `scan_files`, `progress` and `cancel` are
-/// [`BdRom::open_resilient_with`]'s, passed through unchanged.
+/// `mode`, `options`, `scan_files` and `observers` are
+/// [`BdRom::open_resilient`]'s, passed through unchanged.
 ///
 /// # Errors
-/// As [`BdRom::open_resilient_with`]: only the failures with no readable rest
-/// to degrade to.
+/// As [`BdRom::open_resilient`]: only the failures with no readable rest to
+/// degrade to.
 pub fn open_folder(
-    path: &Path,
-    mode: ScanMode,
-    options: ScanOptions,
-    scan_files: Option<&BTreeSet<String>>,
-    progress: &mut dyn FnMut(ScanProgress<'_>),
-    cancel: &AtomicBool,
-) -> Result<ScanReport, BdError> {
-    open_folder_observed(path, mode, options, scan_files, ScanObservers::new(progress, cancel))
-}
-
-/// Opens the Blu-ray folder at `path` like [`open_folder`], observed.
-///
-/// Takes the progress callback and cancel flag as a [`ScanObservers`] bundle —
-/// the form that can carry a measured observer too
-/// ([`ScanObservers::with_measured`]), so a path-driven surface can watch the
-/// tallies build up during the scan.
-///
-/// # Errors
-/// As [`open_folder`].
-pub fn open_folder_observed(
     path: &Path,
     mode: ScanMode,
     options: ScanOptions,
@@ -72,7 +50,7 @@ pub fn open_folder_observed(
     observers: ScanObservers<'_>,
 ) -> Result<ScanReport, BdError> {
     let root = FsDir::new(path);
-    let mut report = BdRom::open_resilient_observed(&root, mode, options, scan_files, observers)?;
+    let mut report = BdRom::open_resilient(&root, mode, options, scan_files, observers)?;
     report.errors.extend(root.take_errors());
     report.bdrom.volume_label =
         volume::resolve_folder_label_after_scan(&report.bdrom.volume_label, &report.errors);
@@ -88,31 +66,13 @@ pub fn open_folder_observed(
 /// scan's own recorded failures **plus** the reader's bad-sector recordings
 /// ([`UdfSource::take_errors`]).
 ///
-/// `mode`, `options`, `scan_files`, `progress` and `cancel` are
-/// [`BdRom::open_resilient_with`]'s, passed through unchanged.
+/// `mode`, `options`, `scan_files` and `observers` are
+/// [`BdRom::open_resilient`]'s, passed through unchanged.
 ///
 /// # Errors
 /// [`BdError::StructureNotFound`] or [`BdError::Io`] when `path` holds no
-/// readable UDF volume, else as [`BdRom::open_resilient_with`].
+/// readable UDF volume, else as [`BdRom::open_resilient`].
 pub fn open_iso(
-    path: &Path,
-    mode: ScanMode,
-    options: ScanOptions,
-    scan_files: Option<&BTreeSet<String>>,
-    progress: &mut dyn FnMut(ScanProgress<'_>),
-    cancel: &AtomicBool,
-) -> Result<ScanReport, BdError> {
-    open_iso_observed(path, mode, options, scan_files, ScanObservers::new(progress, cancel))
-}
-
-/// Opens the Blu-ray `.iso` image at `path` like [`open_iso`], observed.
-///
-/// Takes the progress callback and cancel flag as a [`ScanObservers`] bundle —
-/// the `.iso` twin of [`open_folder_observed`].
-///
-/// # Errors
-/// As [`open_iso`].
-pub fn open_iso_observed(
     path: &Path,
     mode: ScanMode,
     options: ScanOptions,
@@ -120,8 +80,7 @@ pub fn open_iso_observed(
     observers: ScanObservers<'_>,
 ) -> Result<ScanReport, BdError> {
     let source = UdfSource::open_resilient(Box::new(PathIso::new(path)))?;
-    let mut report =
-        BdRom::open_resilient_observed(&source.root(), mode, options, scan_files, observers)?;
+    let mut report = BdRom::open_resilient(&source.root(), mode, options, scan_files, observers)?;
     report.errors.extend(source.take_errors());
     Ok(report)
 }
@@ -131,10 +90,8 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
-    use super::{
-        BdError, ScanMode, ScanObservers, ScanOptions, ScanProgress, ScanReport, open_folder,
-        open_folder_observed, open_iso, open_iso_observed,
-    };
+    use super::{BdError, ScanMode, ScanObservers, ScanOptions, ScanReport, open_folder, open_iso};
+    use crate::bdrom::disc::ScanProgress;
     use crate::bdrom::measured::MeasuredSnapshot;
 
     /// The committed real-disc fixtures, one crate over: `BigBuckBunny` (a BDMV
@@ -173,14 +130,17 @@ mod tests {
     /// and [`ScanMode::Metadata`] reads no packets to report.
     fn folder(path: &Path, mode: ScanMode) -> Result<ScanReport, BdError> {
         let mut reported = 0_usize;
-        let report = open_folder(
-            path,
-            mode,
-            ScanOptions::default(),
-            None,
-            &mut |_| reported = reported.saturating_add(1),
-            &AtomicBool::new(false),
-        );
+        let cancel = AtomicBool::new(false);
+        let report = {
+            let mut count = |_: ScanProgress<'_>| reported = reported.saturating_add(1);
+            open_folder(
+                path,
+                mode,
+                ScanOptions::default(),
+                None,
+                ScanObservers::new(&mut count, &cancel),
+            )
+        };
         assert_eq!(reported != 0, report.is_ok() && mode != ScanMode::Metadata);
         report
     }
@@ -188,14 +148,17 @@ mod tests {
     /// [`folder`]'s `.iso` twin.
     fn iso(path: &Path, mode: ScanMode) -> Result<ScanReport, BdError> {
         let mut reported = 0_usize;
-        let report = open_iso(
-            path,
-            mode,
-            ScanOptions::default(),
-            None,
-            &mut |_| reported = reported.saturating_add(1),
-            &AtomicBool::new(false),
-        );
+        let cancel = AtomicBool::new(false);
+        let report = {
+            let mut count = |_: ScanProgress<'_>| reported = reported.saturating_add(1);
+            open_iso(
+                path,
+                mode,
+                ScanOptions::default(),
+                None,
+                ScanObservers::new(&mut count, &cancel),
+            )
+        };
         assert_eq!(reported != 0, report.is_ok() && mode != ScanMode::Metadata);
         report
     }
@@ -218,14 +181,14 @@ mod tests {
 
     #[test]
     fn an_observed_folder_open_streams_the_measured_tallies() {
-        // The bundle form is what a live display opens through — the same scan
-        // as `open_folder`, plus the snapshots.
+        // A measured observer is what a live display opens through — the same
+        // scan the other folder tests run, plus the snapshots.
         let mut snapshots: Vec<MeasuredSnapshot> = Vec::new();
         let cancel = AtomicBool::new(false);
         let mut quiet = |_: ScanProgress<'_>| {};
         let report = {
             let mut watch = |snapshot| snapshots.push(snapshot);
-            open_folder_observed(
+            open_folder(
                 &fixture("BigBuckBunny"),
                 ScanMode::Full,
                 ScanOptions::default(),
@@ -245,7 +208,7 @@ mod tests {
         let mut quiet = |_: ScanProgress<'_>| {};
         let report = {
             let mut watch = |snapshot| snapshots.push(snapshot);
-            open_iso_observed(
+            open_iso(
                 &fixture("BigBuckBunny.iso"),
                 ScanMode::Full,
                 ScanOptions::default(),

--- a/crates/bdinfo-rs-core/src/vfs/udf/source.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/source.rs
@@ -2169,15 +2169,24 @@ mod tests {
 
     #[test]
     fn a_bd_iso_reports_aacs_encryption_through_the_udf_backend() {
-        use crate::bdrom::disc::{BdRom, ScanMode};
+        use crate::bdrom::disc::{BdRom, ScanMode, ScanObservers, ScanOptions};
+        let scan = |root: &dyn BdDir| {
+            BdRom::open(
+                root,
+                ScanMode::Metadata,
+                ScanOptions::default(),
+                None,
+                ScanObservers::none(),
+            )
+        };
         // Encrypted stream heads → the flag is set on the `.iso` backend, with
         // the marker file and the stream both found through the UDF tree.
         let encrypted = UdfSource::open(MemIso::boxed(bd_iso(false))).expect("open encrypted iso");
-        let bd = BdRom::open(&encrypted.root(), ScanMode::Metadata).expect("scan encrypted iso");
+        let bd = scan(&encrypted.root()).expect("scan encrypted iso");
         assert!(bd.is_aacs_encrypted);
         // The same image with clear streams is a decrypted rip: not encrypted.
         let ripped = UdfSource::open(MemIso::boxed(bd_iso(true))).expect("open ripped iso");
-        let bd = BdRom::open(&ripped.root(), ScanMode::Metadata).expect("scan ripped iso");
+        let bd = scan(&ripped.root()).expect("scan ripped iso");
         assert!(!bd.is_aacs_encrypted);
     }
 

--- a/crates/bdinfo-rs-core/src/vfs/volume.rs
+++ b/crates/bdinfo-rs-core/src/vfs/volume.rs
@@ -366,14 +366,13 @@ mod tests {
         let read = |letter: char| Some(format!("VOL{letter}"));
         // An io failure degrades a drive root straight to the letter, whatever
         // stage recorded it — a stream read is what a damaged disc trips first,
-        // but a metadata-only scan never reaches that stage at all.
-        for stage in [
-            ScanStage::Discovery,
-            ScanStage::ClipInfo,
-            ScanStage::Playlist,
-            ScanStage::StreamFile,
-            ScanStage::SectorRead,
-        ] {
+        // but a metadata-only scan never reaches that stage at all. These are
+        // the four a folder scan can record; `ScanStage::SectorRead` comes
+        // from the UDF `.iso` reader, and an `.iso` carries a genuine volume
+        // label that never reaches this repair.
+        for stage in
+            [ScanStage::Discovery, ScanStage::ClipInfo, ScanStage::Playlist, ScanStage::StreamFile]
+        {
             assert_eq!(resolve_after_scan_with(r"J:\", &[io_error_at(stage)], read), "J");
         }
         // A parse failure is no evidence against the device, so it leaves the

--- a/crates/bdinfo-rs-gui/Cargo.lock
+++ b/crates/bdinfo-rs-gui/Cargo.lock
@@ -270,7 +270,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "roxmltree 0.21.1",
  "thiserror 2.0.20",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-gui"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "bdinfo-rs-core",
  "iced",

--- a/crates/bdinfo-rs-gui/Cargo.toml
+++ b/crates/bdinfo-rs-gui/Cargo.toml
@@ -3,7 +3,7 @@ name = "bdinfo-rs-gui"
 # Lock-stepped with the root workspace's version by hand (this independent
 # workspace cannot inherit [workspace.package]); the gui-release.yml tag guard
 # and the gui-publish.yml crates leg both refuse a gui-v* tag that disagrees.
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.96"
 license = "LGPL-2.1-or-later"
@@ -53,7 +53,7 @@ path = "src/main.rs"
 # path + version, the same shape as the root [workspace.dependencies] pin, so
 # the crate is publishable: cargo strips the path on publish and resolves the
 # registry copy from the version alone. Keep lock-stepped with `version` above.
-bdinfo-rs-core = { path = "../bdinfo-rs-core", version = "3.0.0" }
+bdinfo-rs-core = { path = "../bdinfo-rs-core", version = "4.0.0" }
 # Pure-Rust GUI: wgpu (+ tiny-skia CPU fallback) / cosmic-text / winit. No C.
 # `tokio` makes iced's executor a Tokio runtime — the ambient context zbus's
 # tokio backend (forced tree-wide by rfd below; cargo features are additive)

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -139,12 +139,8 @@ fn open(
     observers: ScanObservers<'_>,
 ) -> Result<(BdRom, Vec<ScanError>), BdError> {
     let report = match input {
-        Input::Folder(path) => {
-            core_scan::open_folder_observed(path, mode, options, scan_files, observers)
-        }
-        Input::Iso(path) => {
-            core_scan::open_iso_observed(path, mode, options, scan_files, observers)
-        }
+        Input::Folder(path) => core_scan::open_folder(path, mode, options, scan_files, observers),
+        Input::Iso(path) => core_scan::open_iso(path, mode, options, scan_files, observers),
     }?;
     Ok((report.bdrom, report.errors))
 }
@@ -385,7 +381,14 @@ mod tests {
 
     use bdinfo_rs_core::vfs::fs::FsDir;
 
-    use super::{BdRom, Input, ScanMode, ScanOptions, Structural};
+    use super::{BdRom, Input, ScanMode, ScanObservers, ScanOptions, Structural};
+
+    /// A whole-disc metadata/codec open with no observers — the structural
+    /// scan a test performs for itself, without the seam under test.
+    fn open(root: &Path, mode: ScanMode) -> BdRom {
+        BdRom::open(&FsDir::new(root), mode, ScanOptions::default(), None, ScanObservers::none())
+            .expect("the disc opens")
+    }
 
     /// [`super::scan_structural`] with the silent sink and a never-set cancel
     /// flag — every test that only cares about the scan's result goes through
@@ -594,19 +597,16 @@ mod tests {
         // if the untouched fixture it is built from does NOT read as encrypted
         // — the key file alone must never be the verdict.
         let root = encrypted_fixture("aacs-probe");
-        let encrypted =
-            BdRom::open(&FsDir::new(&root), ScanMode::Metadata).expect("the crafted disc opens");
+        let encrypted = open(&root, ScanMode::Metadata);
         assert!(encrypted.is_aacs_encrypted, "the crafted stream shows the fingerprint");
 
-        let plain = BdRom::open(&FsDir::new(fixture("BigBuckBunny")), ScanMode::Metadata)
-            .expect("the fixture disc opens");
+        let plain = open(&fixture("BigBuckBunny"), ScanMode::Metadata);
         assert!(!plain.is_aacs_encrypted, "an ordinary disc is not encrypted");
     }
 
     /// The metadata open the listing seam decides from, flagged or not.
     fn cheap_open(is_aacs_encrypted: bool) -> (BdRom, Vec<super::ScanError>) {
-        let bdrom = BdRom::open(&FsDir::new(fixture("BigBuckBunny")), ScanMode::Metadata)
-            .expect("the fixture disc opens");
+        let bdrom = open(&fixture("BigBuckBunny"), ScanMode::Metadata);
         (BdRom { is_aacs_encrypted, ..bdrom }, Vec::new())
     }
 
@@ -730,15 +730,13 @@ mod tests {
         assert!(listed.bdrom.is_aacs_encrypted);
         assert!(!listed.bdrom.playlists.is_empty(), "the structure still lists");
 
-        let metadata =
-            BdRom::open(&FsDir::new(&root), ScanMode::Metadata).expect("the metadata pass opens");
+        let metadata = open(&root, ScanMode::Metadata);
         assert_eq!(listed.bdrom.playlists, metadata.playlists, "the listing ran the codec pass");
 
         // The proof that the assertion above discriminates: over this very
         // disc the codec pass produces different streams, so a listing that ran
         // it could not have matched the metadata pass.
-        let codecs =
-            BdRom::open(&FsDir::new(&root), ScanMode::Codecs).expect("the codec pass opens");
+        let codecs = open(&root, ScanMode::Codecs);
         assert_ne!(
             codecs.playlists, metadata.playlists,
             "the fixture cannot tell the two passes apart, so the assertion above proves nothing"
@@ -753,8 +751,7 @@ mod tests {
         let root = fixture("BigBuckBunny");
         let listed = scan_structural(&Input::Folder(root.clone())).expect("the fixture lists");
         assert!(!listed.bdrom.is_aacs_encrypted);
-        let codecs =
-            BdRom::open(&FsDir::new(&root), ScanMode::Codecs).expect("the codec pass opens");
+        let codecs = open(&root, ScanMode::Codecs);
         assert_eq!(listed.bdrom.playlists, codecs.playlists, "the listing skipped the codec pass");
     }
 

--- a/crates/bdinfo-rs-wasm/Cargo.lock
+++ b/crates/bdinfo-rs-wasm/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "roxmltree",
  "thiserror",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-wasm"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "bdinfo-rs-core",
  "js-sys",

--- a/crates/bdinfo-rs-wasm/Cargo.toml
+++ b/crates/bdinfo-rs-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdinfo-rs-wasm"
-version = "3.0.0"
+version = "4.0.0"
 publish = false
 edition = "2024"
 rust-version = "1.96"

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -4,8 +4,8 @@
 //! browser. Several entry points feed the very same render path:
 //!
 //! - [`scan_report`] — the in-memory export: BDMV bytes are framed into a synthetic disc tree (six
-//!   `u32`-BE sections), opened with [`BdRom::open_resilient_with`] (packet scan **on**), and
-//!   rendered to the classic report. Used by the native ⇄ in-browser byte-parity test.
+//!   `u32`-BE sections), opened with [`BdRom::open_resilient`] (packet scan **on**), and rendered
+//!   to the classic report. Used by the native ⇄ in-browser byte-parity test.
 //! - [`scan_files`] — the streaming export: a `webkitdirectory`-selected BDMV folder arrives as a
 //!   flat list of `(relativePath, File)` pairs. The files stay on disk; their bytes are read
 //!   **synchronously** at byte offsets through [`web_sys::FileReaderSync`] (no JSPI, no Asyncify),
@@ -725,7 +725,8 @@ fn inspect_disc(
     mode: ScanMode,
     filter: &PlaylistFilter,
 ) -> Result<Disc, BdError> {
-    let report = BdRom::open_resilient(root, mode)?;
+    let report =
+        BdRom::open_resilient(root, mode, CoreScanOptions::default(), None, ScanObservers::none())?;
     // No report was rendered, so the mirror carries no report order and a later
     // render of it falls back to the whole-disc presentation order.
     Ok(Disc::from_scan(&report.bdrom, &report.errors, false, filter, None))
@@ -787,7 +788,13 @@ fn scan_selection(
     options: CoreScanOptions,
     observers: ScanObservers<'_>,
 ) -> Result<Scan, SelectionError> {
-    let structural = BdRom::open_resilient(root, ScanMode::Metadata)?;
+    let structural = BdRom::open_resilient(
+        root,
+        ScanMode::Metadata,
+        CoreScanOptions::default(),
+        None,
+        ScanObservers::none(),
+    )?;
     let names = named_selection(&structural.bdrom.playlists, selection);
     if names.is_empty() {
         return Err(SelectionError::NoMatch);
@@ -800,8 +807,7 @@ fn scan_selection(
     // healthy scan of a disc holding no data. Only a structure the second open
     // cannot walk gets this far: a per-file read failure is recorded by the
     // resilient sink and never returned.
-    let measured =
-        BdRom::open_resilient_observed(root, ScanMode::Full, options, Some(&files), observers)?;
+    let measured = BdRom::open_resilient(root, ScanMode::Full, options, Some(&files), observers)?;
     let order = selection_order(&measured.bdrom.playlists, &names);
     Ok(Scan { report: measured, order })
 }
@@ -871,21 +877,21 @@ impl Scan {
 /// order.
 ///
 /// This is the byte-for-byte core shared by every export and the native parity
-/// test: [`BdRom::open_resilient_observed`] with the packet scan **on** and the
-/// scan's behaviour switches set by `options`, ordered by the standard filtered
-/// set ([`PlaylistFilter::default`], which drops playlists shorter than 20 s and
+/// test: [`BdRom::open_resilient`] with the packet scan **on** and the scan's
+/// behaviour switches set by `options`, ordered by the standard filtered set
+/// ([`PlaylistFilter::default`], which drops playlists shorter than 20 s and
 /// looping ones). `observers` watches the demux.
 ///
 /// # Errors
-/// Returns the [`BdError`] from [`BdRom::open_resilient_observed`] when the
-/// structure is too damaged to open at all (no `BDMV`/`CLIPINF`/`PLAYLIST`) —
-/// the caller decides whether that is an empty disc or an error to report.
+/// Returns the [`BdError`] from [`BdRom::open_resilient`] when the structure is
+/// too damaged to open at all (no `BDMV`/`CLIPINF`/`PLAYLIST`) — the caller
+/// decides whether that is an empty disc or an error to report.
 fn scan_whole(
     root: &dyn BdDir,
     options: CoreScanOptions,
     observers: ScanObservers<'_>,
 ) -> Result<Scan, BdError> {
-    let report = BdRom::open_resilient_observed(root, ScanMode::Full, options, None, observers)?;
+    let report = BdRom::open_resilient(root, ScanMode::Full, options, None, observers)?;
     let order = report.bdrom.presentation_order(&PlaylistFilter::default());
     Ok(Scan { report, order })
 }
@@ -2316,7 +2322,14 @@ mod tests {
             // `scan_selection` starts with, so the next listing after them is
             // the measured open's first.
             let counted = FlakyRoot::new(framed_tree(&blob), usize::MAX);
-            BdRom::open_resilient(&counted, ScanMode::Metadata).expect("the fixture disc opens");
+            BdRom::open_resilient(
+                &counted,
+                ScanMode::Metadata,
+                CoreScanOptions::default(),
+                None,
+                ScanObservers::none(),
+            )
+            .expect("the fixture disc opens");
             let structural_listings = counted.listings();
             assert!(structural_listings > 0, "a structural open lists the root at least once");
             // The delegating accessors, which the scan reads for the disc label

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -1874,7 +1874,16 @@ mod tests {
     /// standard 20 s classification.
     fn a_fixture_disc(mode: ScanMode) -> Disc {
         let tree = crate::framed_tree(&crate::tests::fixture_blob());
-        let report = BdRom::open_resilient(&tree, mode).expect("the fixture disc opens");
+        // The core's `ScanOptions`, not this module's mirrored one.
+        use bdinfo_rs_core::bdrom::disc::{ScanObservers, ScanOptions as CoreScanOptions};
+        let report = BdRom::open_resilient(
+            &tree,
+            mode,
+            CoreScanOptions::default(),
+            None,
+            ScanObservers::none(),
+        )
+        .expect("the fixture disc opens");
         Disc::from_scan(
             &report.bdrom,
             &report.errors,
@@ -1902,7 +1911,7 @@ mod tests {
             taken.push(MeasuredSnapshot::from(&snapshot));
         };
         let cancel = AtomicBool::new(false);
-        let report = BdRom::open_resilient_observed(
+        let report = BdRom::open_resilient(
             &tree,
             ScanMode::Full,
             ScanOptions::default(),

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -1873,9 +1873,10 @@ mod tests {
     /// The fixture disc scanned through the in-memory tree, mirrored under the
     /// standard 20 s classification.
     fn a_fixture_disc(mode: ScanMode) -> Disc {
-        let tree = crate::framed_tree(&crate::tests::fixture_blob());
         // The core's `ScanOptions`, not this module's mirrored one.
         use bdinfo_rs_core::bdrom::disc::{ScanObservers, ScanOptions as CoreScanOptions};
+
+        let tree = crate::framed_tree(&crate::tests::fixture_blob());
         let report = BdRom::open_resilient(
             &tree,
             mode,

--- a/crates/bdinfo-rs-wasm/web/package-lock.json
+++ b/crates/bdinfo-rs-wasm/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bdinfo-rs/wasm",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bdinfo-rs/wasm",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "license": "LGPL-2.1-or-later",
       "devDependencies": {
         "@biomejs/biome": "^2",

--- a/crates/bdinfo-rs-wasm/web/package.json
+++ b/crates/bdinfo-rs-wasm/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bdinfo-rs/wasm",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "type": "module",
   "sideEffects": [
     "./dist/worker.js",

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -87,7 +87,7 @@ use std::time::{Duration, Instant};
 
 use bdinfo_rs_core::bdrom::chapters::seconds_to_ticks;
 use bdinfo_rs_core::bdrom::disc::{
-    BdRom, HIDDEN_STREAMS_NOTE, PlaylistSummary, ScanMode, ScanOptions, ScanProgress,
+    BdRom, HIDDEN_STREAMS_NOTE, PlaylistSummary, ScanMode, ScanObservers, ScanOptions, ScanProgress,
 };
 use bdinfo_rs_core::bdrom::order::{
     HiddenRule, PlaylistFilter, hidden_by, named_selection, selection_order,
@@ -201,8 +201,8 @@ fn scan_options(cli: &Cli) -> ScanOptions {
 
 /// Dispatches `path` to the `.iso` or folder scan. `options` carries the
 /// behavior switches ([`scan_options`]), `scan_files` narrows the packet scan,
-/// `progress` observes it, and `cancel` aborts it (the library's `open_with`
-/// extras).
+/// `progress` observes it, and `cancel` aborts it (the pair the library takes
+/// as a `ScanObservers` bundle).
 fn scan_disc(
     path: &str,
     run_packet_scan: bool,
@@ -213,10 +213,11 @@ fn scan_disc(
 ) -> Result<ScanOutcome, BdError> {
     let location = Path::new(path);
     let mode = scan_mode(run_packet_scan);
+    let observers = ScanObservers::new(progress, cancel);
     let report = if is_iso(location) {
-        scan::open_iso(location, mode, options, scan_files, progress, cancel)
+        scan::open_iso(location, mode, options, scan_files, observers)
     } else {
-        scan::open_folder(location, mode, options, scan_files, progress, cancel)
+        scan::open_folder(location, mode, options, scan_files, observers)
     }?;
     Ok((report.bdrom, report.errors))
 }
@@ -2405,7 +2406,7 @@ Options:
         // The injectable seam plays the core's part: the observer runs like a
         // real scan tick (a test process has no console, so no press is ever
         // seen and the flag stays clear), then the scan aborts the way a
-        // signalled cancel flag makes `open_resilient_with` abort.
+        // signalled cancel flag makes `BdRom::open_resilient` abort.
         let dest = TempDest::new();
         let code = super::scan_and_report(
             &mut |progress, cancel| {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -270,7 +270,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bdinfo-rs-core"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "roxmltree 0.21.1",
  "thiserror 2.0.20",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-gui"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "bdinfo-rs-core",
  "iced",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "bdinfo-rs-wasm"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "bdinfo-rs-core",
  "js-sys",

--- a/fuzz/fuzz_targets/parse_report.rs
+++ b/fuzz/fuzz_targets/parse_report.rs
@@ -21,7 +21,7 @@
 //! behind it were unreachable from this harness. The directory is absent when
 //! the seed supplies no seventh section, so the 2D shape is unchanged.
 
-use bdinfo_rs_core::bdrom::disc::{BdRom, ScanMode};
+use bdinfo_rs_core::bdrom::disc::{BdRom, ScanMode, ScanObservers, ScanOptions};
 use bdinfo_rs_core::report::text;
 use bdinfo_rs_core::vfs::mem::{self, MemDir};
 use libfuzzer_sys::fuzz_target;
@@ -41,7 +41,14 @@ fn build_tree(data: &[u8]) -> MemDir {
 
 fuzz_target!(|data: &[u8]| {
     let root = build_tree(data);
-    if let Ok(report) = BdRom::open_resilient(&root, ScanMode::Full) {
+    let opened = BdRom::open_resilient(
+        &root,
+        ScanMode::Full,
+        ScanOptions::default(),
+        None,
+        ScanObservers::none(),
+    );
+    if let Ok(report) = opened {
         let _ = text::render(&report.bdrom, &report.errors);
     }
 });


### PR DESCRIPTION
Collapse the four public opens per layer into two. `BdRom::open` and
`BdRom::open_resilient` now take `ScanOptions`, `scan_files` and a
`ScanObservers<>` bundle, and `scan::open_folder` / `scan::open_iso` take the
same; the `_with` and `_observed` twins are gone. Every twin was a one-line
delegation into its `_observed` form, so a caller wanting to observe a scan had
to know the other name existed.

`ScanObservers` gains `none()` for a caller that watches nothing: its progress
and cancel fields are now `Option`, and `run_measurement_scan` substitutes a
discarding callback and a never-set flag, so the demux keeps its unconditional
per-chunk cancel poll and per-read progress report.

Ride-along: `ScanStage::SectorRead` leaves the folder-label gate stage sweep.
Only the UDF `.iso` reader records that stage, and an `.iso` carries a genuine
volume label the folder repair never touches.

The workspace declares 4.0.0 across the four lock-stepped surfaces (root
workspace, gui and wasm manifests, the wasm npm package), which is what the
semver gate needs for a breaking core diff.

Signature and plumbing only: no scan behavior changes, every golden byte-
identical.

Breaking: `BdRom::open_with`, `BdRom::open_observed`,
`BdRom::open_resilient_with`, `BdRom::open_resilient_observed`,
`scan::open_folder_observed` and `scan::open_iso_observed` are removed, and the
four surviving entry points changed signature. A two-argument
`BdRom::open(root, mode)` becomes
`BdRom::open(root, mode, ScanOptions::default(), None, ScanObservers::none())`;
an `_observed` call keeps its arguments under the plain name.

Verified: `scripts/compliance.ps1 -All` green. Root gate 19 steps, 1101 tests,
coverage 100% lines/regions/functions and 97.69% branches, diff-scoped mutants
6 tested (2 caught, 4 unviable, 0 missed), semver-checks clean against the
declared 4.0.0. Wasm gate 69 tests at 100% coverage plus the Node and Chrome
parity harnesses; gui gate 312 tests at 100% coverage with all six snapshot
hashes unchanged.
