### PR TITLE
fix(core)!: report stream files that demux to zero streams as short

### DIFF
--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -260,6 +260,18 @@ pub struct ClipSummary {
     pub relative_time_in: f64,
     /// Clip duration in seconds.
     pub length: f64,
+    /// Whether the measurement pass demuxed this clip's stream file.
+    ///
+    /// The one thing that separates "measured as empty" from "never looked
+    /// at", both of which leave every measured field below at zero: a
+    /// [`ScanMode::Metadata`] or [`ScanMode::Codecs`] open, a file a
+    /// `scan_files` selection left out, a file that failed to open, and a file
+    /// whose partial demux was dropped ([`ScanOptions::keep_partial`] off) all
+    /// come back `false`, while a 0-byte or header-destroyed file that opens,
+    /// reads to a clean end of file and registers no stream at all comes back
+    /// `true` with nothing measured — which is what lets
+    /// [`BdRom::short_stream_files`] name it.
+    pub measured: bool,
     /// Payload bytes the demux attributed to this clip.
     pub payload_bytes: u64,
     /// Transport packets the demux attributed to this clip.
@@ -311,7 +323,7 @@ impl ClipSummary {
 
 /// Test constructors for [`PlaylistSummary`] and [`ClipSummary`].
 ///
-/// Both are wide plain-data structs — 11 and 12 public fields — while a test
+/// Both are wide plain-data structs — 11 and 13 public fields — while a test
 /// usually cares about two or three. Each function takes those few and zeroes
 /// the rest, so a test spells only its own intent and a field added to either
 /// struct changes one body here instead of every construction site.
@@ -334,6 +346,7 @@ pub mod fixtures {
             angle_index: 0,
             relative_time_in: 0.0,
             length,
+            measured: false,
             payload_bytes: 0,
             packet_count: 0,
             packet_seconds: 0.0,
@@ -1216,15 +1229,19 @@ impl BdRom {
     /// each entry carries).
     ///
     /// Derived from the per-clip summaries on every call, over whatever this
-    /// [`BdRom`] holds: empty after an open that measured nothing
+    /// [`BdRom`] holds, and read through [`ClipSummary::measured`]: empty after
+    /// an open that measured nothing
     /// ([`ScanMode::Metadata`]/[`ScanMode::Codecs`]), and silent about the
-    /// files a `scan_files` selection left out.
+    /// files a `scan_files` selection left out. A 0-byte or header-destroyed
+    /// file that registers no stream at all IS named — it was measured, and
+    /// what it measured is nothing.
     ///
     /// A stream file whose read FAILED partway is named here too when its
     /// partial state was kept ([`ScanOptions::keep_partial`]) — its measured
     /// span is genuinely short. That file is also a [`ScanError`] of the
     /// resilient scan, and this type carries no error list, so a surface
-    /// showing both pairs them by file name.
+    /// showing both pairs them by file name. With the partial state dropped the
+    /// file is silent here and the [`ScanError`] is its only record.
     #[must_use]
     pub fn short_stream_files(&self) -> Vec<ShortStreamFile> {
         shortfall::short_stream_files(&self.playlists)
@@ -1992,6 +2009,11 @@ fn build_clip_summaries(
             angle_index: clip.angle_index,
             relative_time_in: clip.relative_time_in,
             length: clip.length,
+            // Presence in the full-pass map IS "the measurement pass demuxed
+            // this file": a file that never ran, failed to open, or had its
+            // partial state dropped is not in it, and one that opened and read
+            // to a clean end of file is — however little it carried.
+            measured: file.is_some(),
             payload_bytes: clip.payload_bytes,
             packet_count: clip.packet_count,
             packet_seconds: clip.packet_seconds,
@@ -4694,6 +4716,45 @@ mod tests {
     }
 
     #[test]
+    fn a_stream_file_that_demuxes_to_nothing_at_all_is_reported_short() {
+        // Total destruction leaves every number a never-scanned file leaves:
+        // no per-stream tally, no demuxed second, no error (both files open and
+        // read to a clean end of file). `ClipSummary::measured` is the only
+        // thing that tells the two apart, so this is the case that would go
+        // silent if the check read the tally list instead.
+        let clip = clpi(&[(0x1011, 0x1B, [0x62, 0x30, 0, 0])]);
+        // A 0-byte stub, as a rip that died before writing a byte leaves, and a
+        // non-empty file whose header is gone — no PAT, no PMT, so no stream
+        // ever registers.
+        for stub in [Vec::new(), vec![0xFF; 4096]] {
+            let bytes = stub.len();
+            let disc = TempDisc::build(
+                &[],
+                &[
+                    ("BDMV/PLAYLIST/00000.mpls", mpls("00000", 0, 4_500_000, &[])), // 100 s
+                    ("BDMV/CLIPINF/00000.clpi", clip.clone()),
+                    ("BDMV/STREAM/00000.m2ts", stub),
+                ],
+            );
+            let scanned = disc.open_scanned().expect("measured scan");
+            let summary = scanned
+                .playlists
+                .first()
+                .and_then(|pl| pl.clips.first())
+                .expect("the destroyed file's clip row");
+            assert!(summary.measured, "{bytes} bytes: the file was demuxed");
+            assert!(summary.streams.is_empty(), "{bytes} bytes: nothing registered");
+            let reported = scanned.short_stream_files();
+            assert_eq!(reported.len(), 1, "{bytes} bytes: {reported:?}");
+            assert_eq!(
+                reported.first().expect("the short file").notice(),
+                "00000.M2TS is shorter than declared: \
+                 measured 0.0 s of 100.0 s (100.0 s missing)"
+            );
+        }
+    }
+
+    #[test]
     fn clip_summaries_skip_a_registration_order_entry_without_a_stream() {
         // The two registration fields are public: a caller can desync them, so
         // an order entry whose stream is gone is skipped, not trusted.
@@ -6137,6 +6198,7 @@ mod tests {
         assert_eq!(pl.chapters.len(), 2);
         assert_eq!(pl.chapters.first().unwrap().avg_rate.to_bits(), 0.0_f64.to_bits());
         let clip = pl.clips.first().unwrap();
+        assert!(!clip.measured, "a dropped file is not in the full-pass map");
         assert!(clip.streams.is_empty());
         assert_eq!(clip.file_seconds.to_bits(), 0.0_f64.to_bits());
         // …while the in-place playlist tallies the demux flushed before dying
@@ -6172,9 +6234,9 @@ mod tests {
             short.first().unwrap().file()
         );
 
-        // Retention off drops the dead file's demux state, so it carries no
-        // measured tallies at all — indistinguishable from a file the scan
-        // never opened, and named by the recorded failure alone.
+        // Retention off drops the dead file from the full-pass map, so its clip
+        // comes back unmeasured — the same marker a file the scan never opened
+        // carries — and the recorded failure alone names it.
         let off = BdRom::open_resilient(
             &tripping_disc(m2ts, Some(DATA_SIZE)),
             ScanMode::Full,
@@ -6184,6 +6246,13 @@ mod tests {
         )
         .expect("resilient scan continues");
         assert_eq!(off.errors.len(), 1);
+        let dropped = off
+            .bdrom
+            .playlists
+            .first()
+            .and_then(|pl| pl.clips.first())
+            .expect("the dropped file's clip row");
+        assert!(!dropped.measured);
         assert!(off.bdrom.short_stream_files().is_empty());
     }
 

--- a/crates/bdinfo-rs-core/src/bdrom/shortfall.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/shortfall.rs
@@ -118,8 +118,8 @@ impl ShortStreamFile {
 ///
 /// Silent by construction for everything that was never measured — a
 /// metadata-only or codec-only open, and every file a `scan_files` selection
-/// left out (see [`is_measured`]) — so the result is evidence of a short file,
-/// not of an unscanned one.
+/// left out (see [`ClipSummary::measured`]) — so the result is evidence of a
+/// short file, not of an unscanned one.
 pub(crate) fn short_stream_files(playlists: &[PlaylistSummary]) -> Vec<ShortStreamFile> {
     let mut worst: BTreeMap<String, ShortStreamFile> = BTreeMap::new();
     for playlist in playlists {
@@ -147,11 +147,16 @@ pub(crate) fn short_stream_files(playlists: &[PlaylistSummary]) -> Vec<ShortStre
 /// file or a part of it: a play item that ends before the damage measures its
 /// full window and stays quiet, while one that reaches past it comes up short.
 ///
+/// [`ClipSummary::measured`] is what says the file was demuxed at all — not
+/// the presence of per-stream tallies, which a 0-byte or header-destroyed file
+/// leaves as empty as an unscanned one does, so that total destruction would
+/// go unreported where partial truncation notices.
+///
 /// Comparisons on the difference, not on a ratio, so a `length` of zero — or
 /// any non-finite value a caller-assembled summary could hold — falls out as
 /// "not short" instead of dividing.
 fn clip_shortfall(clip: &ClipSummary) -> Option<ShortStreamFile> {
-    if !is_measured(clip) {
+    if !clip.measured {
         return None;
     }
     let missing = clip.length - clip.packet_seconds;
@@ -162,21 +167,6 @@ fn clip_shortfall(clip: &ClipSummary) -> Option<ShortStreamFile> {
     })
 }
 
-/// Whether `clip`'s stream file was measured at all.
-///
-/// A clip carries whole-file per-stream tallies exactly when the full
-/// measurement pass demuxed its file, so an empty tally list means "not
-/// measured" rather than "measured as empty" — which is what keeps an open that
-/// measures nothing, and every file left out of a selective scan, out of the
-/// result.
-///
-/// The blind spot it buys: a file too short for a single stream to register
-/// leaves the same empty list as a file the scan never opened, so it goes
-/// unreported.
-const fn is_measured(clip: &ClipSummary) -> bool {
-    !clip.streams.is_empty()
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::disc::{ClipStreamTally, ClipSummary, PlaylistSummary, fixtures};
@@ -185,11 +175,10 @@ mod tests {
     use crate::stream::TsStreamType;
 
     /// A measured clip of `name`: `declared` seconds of play item, `measured`
-    /// seconds demuxed, and the one per-stream tally that marks the file as
-    /// scanned.
+    /// seconds demuxed, and the one per-stream tally a file the demux got
+    /// anywhere into carries.
     fn measured_clip(name: &str, declared: f64, measured: f64) -> ClipSummary {
         ClipSummary {
-            packet_seconds: measured,
             streams: vec![ClipStreamTally {
                 pid: Pid::new(0x1011),
                 stream_type: TsStreamType::AvcVideo,
@@ -197,8 +186,15 @@ mod tests {
                 payload_bytes: 1024,
                 packet_count: 8,
             }],
-            ..fixtures::clip(name, declared)
+            ..empty_clip(name, declared, measured)
         }
+    }
+
+    /// A measured clip that registered no stream at all — the shape a 0-byte
+    /// or header-destroyed stream file leaves: opened, read to a clean end of
+    /// file, nothing demuxed.
+    fn empty_clip(name: &str, declared: f64, measured: f64) -> ClipSummary {
+        ClipSummary { measured: true, packet_seconds: measured, ..fixtures::clip(name, declared) }
     }
 
     /// One playlist named `00000.MPLS` presenting `clips`.
@@ -246,13 +242,27 @@ mod tests {
     }
 
     #[test]
-    fn a_clip_without_measured_tallies_is_never_reported() {
+    fn an_unmeasured_clip_is_never_reported() {
         // The shape every clip has after an open that measured nothing, and
         // every file a selective scan skipped: a declared length, no demuxed
-        // seconds, and no per-stream tallies.
+        // seconds, and the flag down.
         let unmeasured = fixtures::clip("00000.M2TS", 1640.0);
-        assert!(unmeasured.streams.is_empty());
+        assert!(!unmeasured.measured);
         assert!(reported(&disc_of(vec![unmeasured])).is_empty());
+    }
+
+    #[test]
+    fn a_file_that_demuxed_to_nothing_is_reported_as_the_whole_span_missing() {
+        // The flag, not the tally list, is what separates this from the case
+        // above: a 0-byte or header-destroyed file opens, ends at once and
+        // registers no stream, so every number it leaves matches a file the
+        // scan never touched. Only the marker tells them apart.
+        let destroyed = empty_clip("00000.M2TS", 1640.0, 0.0);
+        assert!(destroyed.streams.is_empty());
+        assert_eq!(
+            reported(&disc_of(vec![destroyed])),
+            vec![("00000.M2TS".to_owned(), 1640.0, 0.0)]
+        );
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -2313,11 +2313,11 @@ mod tests {
         assert!(flow.short_stream_notices().is_empty(), "unmeasured clips raise no notice");
 
         // The measured result comes back with the first clip demuxed to 500 of
-        // its declared 1640 seconds, carrying the per-stream tally that marks
-        // the file as measured.
+        // its declared 1640 seconds.
         let mut measured = structural().bdrom.playlists;
         let clip = measured.first_mut().and_then(|p| p.clips.first_mut()).expect("the first clip");
         clip.length = 1640.0;
+        clip.measured = true;
         clip.packet_seconds = 500.0;
         clip.streams = vec![ClipStreamTally {
             pid: Pid::new(0x1011),

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -366,6 +366,13 @@ pub struct Clip {
     pub relative_time_in_seconds: f64,
     /// How long the clip runs, in seconds.
     pub length_seconds: f64,
+    /// Whether the measurement pass demuxed this clip's stream file. False for
+    /// a file the scan never opened, one a selection left out and one whose
+    /// failed read was discarded; true for a 0-byte or header-destroyed file
+    /// that opened and yielded nothing, which is what tells "measured as
+    /// empty" from "never looked at" when every field below is zero. The disc's
+    /// own `measured` says whether the scan ran a measurement pass at all.
+    pub measured: bool,
     /// Payload bytes the packet scan attributed to this clip.
     pub payload_bytes: u64,
     /// Transport packets the packet scan attributed to this clip. The
@@ -836,6 +843,7 @@ impl From<&ClipSummary> for Clip {
             angle_index: clip.angle_index,
             relative_time_in_seconds: clip.relative_time_in,
             length_seconds: clip.length,
+            measured: clip.measured,
             payload_bytes: clip.payload_bytes,
             packet_count: clip.packet_count,
             packet_seconds: clip.packet_seconds,
@@ -1121,6 +1129,7 @@ impl From<Clip> for ClipSummary {
             angle_index: clip.angle_index,
             relative_time_in: clip.relative_time_in_seconds,
             length: clip.length_seconds,
+            measured: clip.measured,
             payload_bytes: clip.payload_bytes,
             packet_count: clip.packet_count,
             packet_seconds: clip.packet_seconds,
@@ -1344,6 +1353,7 @@ mod tests {
             angle_index: 14,
             relative_time_in_seconds: 15.5,
             length_seconds: 16.25,
+            measured: true,
             payload_bytes: 17,
             packet_count: 18,
             packet_seconds: 19.5,
@@ -1362,6 +1372,7 @@ mod tests {
             "angleIndex": 14,
             "relativeTimeInSeconds": 15.5,
             "lengthSeconds": 16.25,
+            "measured": true,
             "payloadBytes": 17,
             "packetCount": 18,
             "packetSeconds": 19.5,
@@ -1606,9 +1617,9 @@ mod tests {
 
     #[test]
     fn a_short_stream_file_crosses_as_cores_notice_sentence() {
-        // A clip demuxed to 500 of its declared 1640 seconds, carrying the
-        // per-stream tally that marks its file as measured.
+        // A clip demuxed to 500 of its declared 1640 seconds.
         let clip = ClipSummary {
+            measured: true,
             packet_seconds: 500.0,
             streams: vec![a_core_clip_stream()],
             ..fixtures::clip("00011.M2TS", 1640.0)
@@ -1774,6 +1785,7 @@ mod tests {
             interleaved_file_size: 13,
             angle_index: 14,
             relative_time_in: 15.5,
+            measured: true,
             payload_bytes: 17,
             packet_count: 18,
             packet_seconds: 19.5,

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -2327,10 +2327,10 @@ Options:
     }
 
     /// A scanned disc whose one stream file was demuxed to 500 of its declared
-    /// 1640 seconds — past both shortfall thresholds — with the per-stream
-    /// tally that marks the file as measured.
+    /// 1640 seconds — past both shortfall thresholds.
     fn short_disc() -> BdRom {
         let clip = bdinfo_rs_core::bdrom::disc::ClipSummary {
+            measured: true,
             packet_seconds: 500.0,
             streams: vec![ClipStreamTally {
                 pid: Pid::new(0x1011),


### PR DESCRIPTION
`ClipSummary` gains a `measured` marker, set from the clip's presence in the measurement pass's file map, and the short-stream check reads it instead of inferring measurement from a non-empty per-stream tally list.

A 0-byte or header-destroyed `*.m2ts` opens, reads to a clean end of file and registers no stream, so it left exactly the tallies of a file the scan never opened and went unreported where a partially truncated file is named. It now yields `measured 0.0 s of N s` through the existing thresholds, on all three surfaces, through the shared notice sentence.

A file whose partial demux was discarded (`keep_partial` off) is absent from the map, stays unmeasured, and remains recorded as a `ScanError` alone.

The browser mirror carries the marker as `Clip.measured`, so a mirror still rebuilds the disc it mirrors.

Report bytes are unchanged: notices are stderr, banner and mirror surfaces, never report lines. Every golden is byte-identical.
