### PR TITLE
fix: agree plural nouns with their counts in cli, gui and web messages

### DIFF
--- a/crates/bdinfo-rs-core/src/report.rs
+++ b/crates/bdinfo-rs-core/src/report.rs
@@ -5,9 +5,19 @@
 //! the classic human-readable disc report in [`text`].
 //!
 //! The file a caller saves it as is part of the same contract, so the name is
-//! composed here too: [`file_name`].
+//! composed here too: [`file_name`]. [`counted`] words the count-parametric
+//! messages the front ends print around the report; the report text itself
+//! never uses it.
 
 pub mod text;
+
+/// The count with its noun's number agreed — `"1 error"`, `"0 errors"`,
+/// `"3 stream files"`. The noun is the singular; the plural is `s`-appended,
+/// which every noun the front ends count inflects regularly.
+#[must_use]
+pub fn counted(n: usize, noun: &str) -> String {
+    if n == 1 { format!("1 {noun}") } else { format!("{n} {noun}s") }
+}
 
 /// Characters illegal in a Windows filename component, plus the separators that
 /// would re-root the report path. Replaced so [`file_name`] is always one
@@ -36,7 +46,14 @@ pub fn file_name(label: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::file_name;
+    use super::{counted, file_name};
+
+    #[test]
+    fn counted_agrees_the_noun_with_the_count() {
+        assert_eq!(counted(0, "error"), "0 errors");
+        assert_eq!(counted(1, "error"), "1 error");
+        assert_eq!(counted(2, "stream file"), "2 stream files");
+    }
 
     #[test]
     fn a_clean_label_passes_through() {

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -24,6 +24,7 @@ use bdinfo_rs_core::bdrom::disc::{BdRom, PlaylistSummary, ScanOptions};
 use bdinfo_rs_core::bdrom::order::{PlaylistFilter, selection_order, selection_stream_files};
 use bdinfo_rs_core::bdrom::shortfall::ShortStreamFile;
 use bdinfo_rs_core::error::ScanError;
+use bdinfo_rs_core::report::counted;
 use bdinfo_rs_core::report::text::{self, RenderOptions};
 
 use crate::live::LivePlaylist;
@@ -332,14 +333,6 @@ impl Listing {
         let order = selection_order(&self.bdrom.playlists, scanned);
         text::render_with(&self.bdrom, &order, errors, self.view.render_options())
     }
-}
-
-/// The count with its noun's number agreed — `"1 error"`, `"0 errors"`,
-/// `"3 stream files"`. The noun is the singular; the plural is `s`-appended,
-/// which every noun the GUI counts inflects regularly.
-#[must_use]
-pub fn counted(n: usize, noun: &str) -> String {
-    if n == 1 { format!("1 {noun}") } else { format!("{n} {noun}s") }
 }
 
 /// The scan-complete confirmation text for a scan that recorded `errors`
@@ -1398,13 +1391,6 @@ mod tests {
             super::scan_notice(2),
             "Scan completed with 2 errors.\nThe report below was still written."
         );
-    }
-
-    #[test]
-    fn counted_agrees_the_noun_with_the_count() {
-        assert_eq!(super::counted(0, "error"), "0 errors");
-        assert_eq!(super::counted(1, "error"), "1 error");
-        assert_eq!(super::counted(2, "stream file"), "2 stream files");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -334,6 +334,14 @@ impl Listing {
     }
 }
 
+/// The count with its noun's number agreed — `"1 error"`, `"0 errors"`,
+/// `"3 stream files"`. The noun is the singular; the plural is `s`-appended,
+/// which every noun the GUI counts inflects regularly.
+#[must_use]
+pub fn counted(n: usize, noun: &str) -> String {
+    if n == 1 { format!("1 {noun}") } else { format!("{n} {noun}s") }
+}
+
 /// The scan-complete confirmation text for a scan that recorded `errors`
 /// failures.
 ///
@@ -344,7 +352,10 @@ pub fn scan_notice(errors: usize) -> String {
     if errors == 0 {
         "Scan completed successfully.".to_owned()
     } else {
-        format!("Scan completed with {errors} error(s).\nThe report below was still written.")
+        format!(
+            "Scan completed with {}.\nThe report below was still written.",
+            counted(errors, "error")
+        )
     }
 }
 
@@ -1380,9 +1391,20 @@ mod tests {
     fn the_scan_notice_names_the_error_count() {
         assert_eq!(super::scan_notice(0), "Scan completed successfully.");
         assert_eq!(
-            super::scan_notice(2),
-            "Scan completed with 2 error(s).\nThe report below was still written."
+            super::scan_notice(1),
+            "Scan completed with 1 error.\nThe report below was still written."
         );
+        assert_eq!(
+            super::scan_notice(2),
+            "Scan completed with 2 errors.\nThe report below was still written."
+        );
+    }
+
+    #[test]
+    fn counted_agrees_the_noun_with_the_count() {
+        assert_eq!(super::counted(0, "error"), "0 errors");
+        assert_eq!(super::counted(1, "error"), "1 error");
+        assert_eq!(super::counted(2, "stream file"), "2 stream files");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -1705,9 +1705,9 @@ impl App {
         match &result {
             Ok(structural) => {
                 log::info!(
-                    "listed {}: {} error(s) recorded",
+                    "listed {}: {} recorded",
                     input.display(),
-                    structural.warnings.len()
+                    flow::counted(structural.warnings.len(), "error")
                 );
                 for warning in &structural.warnings {
                     log::info!("listing error: {warning}");
@@ -1830,9 +1830,9 @@ impl App {
             // a number: the elapsed readout is gone from the screen by the
             // time anyone writes the report up.
             log::info!(
-                "scan finished in {:.1}s: {} error(s) recorded",
+                "scan finished in {:.1}s: {} recorded",
                 self.scan_start.map_or(Duration::ZERO, |start| start.elapsed()).as_secs_f64(),
-                self.flow.report_errors().len()
+                flow::counted(self.flow.report_errors().len(), "error")
             );
             for error in self.flow.report_errors() {
                 log::info!("scan error: {error}");
@@ -2016,10 +2016,10 @@ impl App {
         // is what a report is usually about, and the counts say how much of
         // the disc it covers: an unchecked table scans every listed playlist.
         log::info!(
-            "scan started: {} of {} playlist(s), {} stream file(s), input {}",
+            "scan started: {} of {}, {}, input {}",
             selection.len(),
-            self.flow.row_count(),
-            scan_files.len(),
+            flow::counted(self.flow.row_count(), "playlist"),
+            flow::counted(scan_files.len(), "stream file"),
             input.display()
         );
         if let Some(identity) = self.flow.disc_identity() {
@@ -2711,8 +2711,8 @@ impl App {
                 p,
                 p.warning,
                 &format!(
-                    "Completed with {} error(s) — the report below was still written.",
-                    errors.len()
+                    "Completed with {} — the report below was still written.",
+                    flow::counted(errors.len(), "error")
                 ),
             ));
         }
@@ -4211,7 +4211,7 @@ mod interaction {
         assert!(sees(&app, failure), "the banner carries the recorded failure");
         let text = std::fs::read_to_string(&log).expect("the diagnostics log reads");
         assert!(
-            text.contains("listed disc: 1 error(s) recorded"),
+            text.contains("listed disc: 1 error recorded"),
             "the listing outcome counts them: {text}"
         );
         assert!(text.contains(&format!("listing error: {failure}")), "and names each: {text}");

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -1707,7 +1707,7 @@ impl App {
                 log::info!(
                     "listed {}: {} recorded",
                     input.display(),
-                    flow::counted(structural.warnings.len(), "error")
+                    report::counted(structural.warnings.len(), "error")
                 );
                 for warning in &structural.warnings {
                     log::info!("listing error: {warning}");
@@ -1832,7 +1832,7 @@ impl App {
             log::info!(
                 "scan finished in {:.1}s: {} recorded",
                 self.scan_start.map_or(Duration::ZERO, |start| start.elapsed()).as_secs_f64(),
-                flow::counted(self.flow.report_errors().len(), "error")
+                report::counted(self.flow.report_errors().len(), "error")
             );
             for error in self.flow.report_errors() {
                 log::info!("scan error: {error}");
@@ -2018,8 +2018,8 @@ impl App {
         log::info!(
             "scan started: {} of {}, {}, input {}",
             selection.len(),
-            flow::counted(self.flow.row_count(), "playlist"),
-            flow::counted(scan_files.len(), "stream file"),
+            report::counted(self.flow.row_count(), "playlist"),
+            report::counted(scan_files.len(), "stream file"),
             input.display()
         );
         if let Some(identity) = self.flow.disc_identity() {
@@ -2712,7 +2712,7 @@ impl App {
                 p.warning,
                 &format!(
                     "Completed with {} — the report below was still written.",
-                    flow::counted(errors.len(), "error")
+                    report::counted(errors.len(), "error")
                 ),
             ));
         }

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -30,7 +30,7 @@ import {
   type Stream,
   scan,
 } from "./analyze.js";
-import { errorLine, sizeCell as formatSize, reportLabel } from "./format.js";
+import { counted, errorLine, sizeCell as formatSize, reportLabel } from "./format.js";
 
 /**
  * One selection-table row — the CLI columns this page draws, distilled from a
@@ -389,7 +389,7 @@ async function loadSource(src: Source): Promise<void> {
   discName = src.label;
   pickedName.textContent = discName;
   pickedCount.textContent =
-    src.kind === "folder" ? `${src.files.length} files` : "disc image (.iso)";
+    src.kind === "folder" ? counted(src.files.length, "file") : "disc image (.iso)";
   mainEl.classList.remove("landing");
   show(pickedBox);
   hide(errorBox);
@@ -476,7 +476,7 @@ function adoptDisc(next: Disc, threshold: number): void {
  * disc is damaged. A disc that recorded none hides it.
  */
 function renderScanErrors(errors: ScanError[]): void {
-  scanErrorsCount.textContent = `Recorded ${errors.length} error(s) — the readable rest is shown.`;
+  scanErrorsCount.textContent = `Recorded ${counted(errors.length, "error")} — the readable rest is shown.`;
   scanErrorsList.replaceChildren(
     ...errors.map((error) => {
       const item = document.createElement("li");

--- a/crates/bdinfo-rs-wasm/web/src/format.ts
+++ b/crates/bdinfo-rs-wasm/web/src/format.ts
@@ -12,6 +12,15 @@
 import type { ScanError, ScanErrorReason } from "./analyze.js";
 
 /**
+ * The count with its noun's number agreed — `"1 error"`, `"0 errors"`,
+ * `"3 files"`. The noun is the singular; the plural is `s`-appended, which
+ * every noun the demo counts inflects regularly.
+ */
+export function counted(n: number, noun: string): string {
+  return n === 1 ? `1 ${noun}` : `${n} ${noun}s`;
+}
+
+/**
  * A size cell under the size-format setting: `83.62 GB` / `335.37 MB`
  * (1024-based, like BDInfo) when `humanReadable`, the thousands-grouped exact
  * byte count (`11,145,216`) when not, and `—` for a size nothing knows yet.

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -873,7 +873,7 @@ async function main() {
   demoOk &= demoEq(
     "the strip counts the failures",
     demo.damagedListing.errorsCount,
-    "Recorded 1 error(s) — the readable rest is shown.",
+    "Recorded 1 error — the readable rest is shown.",
   );
   demoOk &= demoEq("the strip names the failure", demo.damagedListing.errorLines, [
     "playlist 00009.mpls: unknown file type: NOPE0100",

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -225,17 +225,10 @@ fn scan_disc(
 /// Prints the "scan completed with errors" stderr summary — one line per recorded
 /// failure (the always-report discipline; stdout stays clean).
 fn report_errors(errors: &[ScanError]) {
-    eprintln!("warning: scan completed with {}:", counted(errors.len(), "error"));
+    eprintln!("warning: scan completed with {}:", report::counted(errors.len(), "error"));
     for err in errors {
         eprintln!("warning:   {err}");
     }
-}
-
-/// The count with its noun's number agreed — `"1 error"`, `"0 errors"`. The
-/// noun is the singular; the plural is `s`-appended, which every noun the CLI
-/// counts inflects regularly.
-fn counted(n: usize, noun: &str) -> String {
-    if n == 1 { format!("1 {noun}") } else { format!("{n} {noun}s") }
 }
 
 /// The stderr line for one stream file the demux measured shorter than the disc
@@ -1293,17 +1286,10 @@ mod tests {
 
     use super::{
         BAR_MAX_CELLS, Cli, ProgressDisplay, analyze_preamble, banner, compose_progress,
-        compose_styled_progress, counted, erase_sequence, finish_early, help_page, hidden_hint,
+        compose_styled_progress, erase_sequence, finish_early, help_page, hidden_hint,
         pick_playlists, redraw_sequence, report_parse_failure, row_names, run, scan_options,
         selection_table,
     };
-
-    #[test]
-    fn counted_agrees_the_noun_with_the_count() {
-        assert_eq!(counted(0, "error"), "0 errors");
-        assert_eq!(counted(1, "error"), "1 error");
-        assert_eq!(counted(2, "error"), "2 errors");
-    }
 
     /// A throwaway minimal BD folder (`BDMV/PLAYLIST` + `BDMV/CLIPINF`, both empty)
     /// under the system temp dir, removed on drop. Enough for `BDROM` to scan it

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -225,10 +225,17 @@ fn scan_disc(
 /// Prints the "scan completed with errors" stderr summary — one line per recorded
 /// failure (the always-report discipline; stdout stays clean).
 fn report_errors(errors: &[ScanError]) {
-    eprintln!("warning: scan completed with {} error(s):", errors.len());
+    eprintln!("warning: scan completed with {}:", counted(errors.len(), "error"));
     for err in errors {
         eprintln!("warning:   {err}");
     }
+}
+
+/// The count with its noun's number agreed — `"1 error"`, `"0 errors"`. The
+/// noun is the singular; the plural is `s`-appended, which every noun the CLI
+/// counts inflects regularly.
+fn counted(n: usize, noun: &str) -> String {
+    if n == 1 { format!("1 {noun}") } else { format!("{n} {noun}s") }
 }
 
 /// The stderr line for one stream file the demux measured shorter than the disc
@@ -1286,10 +1293,17 @@ mod tests {
 
     use super::{
         BAR_MAX_CELLS, Cli, ProgressDisplay, analyze_preamble, banner, compose_progress,
-        compose_styled_progress, erase_sequence, finish_early, help_page, hidden_hint,
+        compose_styled_progress, counted, erase_sequence, finish_early, help_page, hidden_hint,
         pick_playlists, redraw_sequence, report_parse_failure, row_names, run, scan_options,
         selection_table,
     };
+
+    #[test]
+    fn counted_agrees_the_noun_with_the_count() {
+        assert_eq!(counted(0, "error"), "0 errors");
+        assert_eq!(counted(1, "error"), "1 error");
+        assert_eq!(counted(2, "error"), "2 errors");
+    }
 
     /// A throwaway minimal BD folder (`BDMV/PLAYLIST` + `BDMV/CLIPINF`, both empty)
     /// under the system temp dir, removed on drop. Enough for `BDROM` to scan it

--- a/crates/bdinfo-rs/tests/cli.rs
+++ b/crates/bdinfo-rs/tests/cli.rs
@@ -615,7 +615,7 @@ fn scan_errors_use_the_classic_epilogue_and_exit_3() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Scan completed with errors (see report)."), "stdout: {stdout}");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("warning: scan completed with 1 error(s):"), "stderr: {stderr}");
+    assert!(stderr.contains("warning: scan completed with 1 error:"), "stderr: {stderr}");
     // The report itself carries the WARNING block.
     assert!(report.contains("WARNING: File errors"));
 }


### PR DESCRIPTION
Count-parametric messages printed a fixed `(s)` suffix, so a single failure read as `1 error(s)`.

- New `bdinfo_rs_core::report::counted(n, noun)` words the count with its noun's number agreed (`1 error`, `2 errors`); the CLI stderr epilogue, the GUI completion modal, the GUI report banner, and the gui.log listing/scan lines all use it.
- The web demo gets the same helper in `format.ts` (cross-language copy) for the failure strip and the picked-file count.
- The locked report format is untouched; test pins updated to the agreed wording.