### PR TITLE
docs: prepare the 4.0.0 release documents

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: bdinfo-rs version
       description: Output of `bdinfo-rs --version`.
-      placeholder: "3.0.0"
+      placeholder: "4.0.0"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/gui_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/gui_bug_report.yml
@@ -28,7 +28,7 @@ body:
     attributes:
       label: bdinfo-rs GUI version
       description: Output of `bdinfo-rs-gui --version`.
-      placeholder: "3.0.0"
+      placeholder: "4.0.0"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/output_difference.yml
+++ b/.github/ISSUE_TEMPLATE/output_difference.yml
@@ -121,7 +121,7 @@ body:
     attributes:
       label: bdinfo-rs version
       description: Output of `bdinfo-rs --version`.
-      placeholder: "3.0.0"
+      placeholder: "4.0.0"
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      heading shape used below, which cargo-dist parses for the GitHub Release notes. See
      CONTRIBUTING.md § "Cutting a release". -->
 
+## [v4.0.0](https://github.com/agentjp/bdinfo-rs/compare/v3.0.0...v4.0.0) (2026-08-16)
+
+### ⚠ BREAKING CHANGES
+
+* **core:** each layer has one scan entry point again, and it takes the observers. `BdRom::open`
+  and `BdRom::open_resilient` take `(root, mode, ScanOptions, scan_files, ScanObservers)`, and
+  `scan::open_folder` / `scan::open_iso` take the same; the `_with` and `_observed` twins
+  (`open_with`, `open_observed`, `open_resilient_with`, `open_resilient_observed`,
+  `open_folder_observed`, `open_iso_observed`) are removed. Migration: call the plain name and pass
+  the bundle — `ScanObservers::none()` where a caller has no progress callback, no cancel flag, and
+  no measured observer, `ScanObservers::new(&mut progress, &cancel)` otherwise, plus
+  `.with_measured(&mut observer)` for live snapshots. ([#372](https://github.com/agentjp/bdinfo-rs/issues/372))
+* **core:** `ClipSummary` gains a `measured: bool` field recording whether the measurement pass
+  demuxed that stream file, so a 0-byte or header-destroyed `*.m2ts` is reported as short rather
+  than read as unscanned. Struct-literal construction of a `ClipSummary` therefore has to name it;
+  building through `fixtures::clip(…)` does not. The browser package's `Clip` mirrors it as
+  `measured`, additively on the wire. ([#373](https://github.com/agentjp/bdinfo-rs/issues/373))
+
+### Added
+
+* **core:** a measured-snapshot observer on the scan API — the full pass emits per-stream byte
+  tallies and bitrates at chunk boundaries while it reads, so a front-end can fill measured cells
+  during the scan instead of waiting for the report. ([#347](https://github.com/agentjp/bdinfo-rs/issues/347), [#348](https://github.com/agentjp/bdinfo-rs/issues/348))
+* **gui:** the playlist, stream-file, and codec grids tick their measured sizes and bitrates while
+  the scan runs. ([#349](https://github.com/agentjp/bdinfo-rs/issues/349))
+* **wasm:** `onMeasured` streams those snapshots to the page, throttled to at most one a second.
+  ([#350](https://github.com/agentjp/bdinfo-rs/issues/350))
+* **core:** stream files whose bytes stop before the span the disc declares are detected and named.
+  Such a file reads to a clean end of file, so nothing is recorded as a read error and every value
+  measured from it is silently smaller than the disc says; the CLI raises one stderr notice per
+  short file, the desktop app a banner, and the browser package `disc.shortStreamNotices`. The
+  report bytes are unchanged. ([#345](https://github.com/agentjp/bdinfo-rs/issues/345), [#346](https://github.com/agentjp/bdinfo-rs/issues/346))
+
+### Performance
+
+* **core:** a caller whose earlier `Codecs` open already read the codec detail can skip the quick
+  codec pass (`ScanOptions::skip_quick_pass`), and can hand a prior open's AACS verdict to the next
+  one (`ScanOptions::aacs_encrypted`) instead of re-probing. The desktop app uses both, so its
+  measured scan no longer re-reads every stream file head — on damaged media each such read can
+  stall for minutes. ([#358](https://github.com/agentjp/bdinfo-rs/issues/358))
+* **core:** the demux reads 256 KiB per request in the full pass and 16 KiB in the quick pass, so a
+  stalled read blocks for less and a cancel takes effect sooner. ([#333](https://github.com/agentjp/bdinfo-rs/issues/333))
+
+### Fixes
+
+* **core:** a 3D clip whose `BDMV/STREAM/SSIF/<clip>.ssif` will not open is measured from the plain
+  `*.m2ts` instead of being abandoned — the base view is reported, the dependent (MVC) row is not,
+  and the failure is recorded against the `.ssif` in the `WARNING` block. ([#363](https://github.com/agentjp/bdinfo-rs/issues/363))
+* **core:** three classic-parity corrections — an audio access unit's transfer interval is measured
+  only on a forward PTS (a backwards step no longer drags the interval base back), undecoded
+  MPEG-1/2 and AAC audio rows fall back to the type-derived codec names instead of rendering an
+  empty one, and each clip's share of its playlist is computed against the finished playlist length
+  rather than the part accumulated so far. ([#364](https://github.com/agentjp/bdinfo-rs/issues/364))
+* **core:** the raw-device volume-label read on a Windows drive root is skipped once any io error
+  has been recorded, at any scan stage — one less sector-by-sector grind of a failing drive.
+  ([#341](https://github.com/agentjp/bdinfo-rs/issues/341))
+* **cli:** the progress line repaints about once a second through a stalled read, switching its
+  lead-in to `Still reading` after five seconds, so a hung drive no longer looks like a hung
+  program. ([#366](https://github.com/agentjp/bdinfo-rs/issues/366))
+* **gui:** cancelling a scan keeps the values it measured on the grids, the selection stays live
+  during a scan so the panes follow the highlighted row, and the remaining-time estimate climbs
+  through a stall instead of freezing. ([#365](https://github.com/agentjp/bdinfo-rs/issues/365))
+* **gui:** read errors from the listing pass reach the warning banner and the log — both structural
+  opens' failures are merged and deduplicated — and `gui.log` keeps the previous launch as
+  `gui.log.1`, stamps its launch time, and records stalls, disc identity, and scan durations.
+  ([#367](https://github.com/agentjp/bdinfo-rs/issues/367))
+* **gui:** the listing pass is cancellable and reports its progress, and the stall hint covers it.
+  ([#339](https://github.com/agentjp/bdinfo-rs/issues/339), [#342](https://github.com/agentjp/bdinfo-rs/issues/342))
+* **wasm:** a failed measured open is reported instead of rendering a report of zero tallies, scan
+  errors are shown on the page, and a downloaded report is named from the scanned disc's volume
+  label. ([#336](https://github.com/agentjp/bdinfo-rs/issues/336), [#369](https://github.com/agentjp/bdinfo-rs/issues/369))
+* Plural nouns agree with their counts in the command-line, desktop, and browser messages.
+  ([#374](https://github.com/agentjp/bdinfo-rs/issues/374))
+
 ## [v3.0.0](https://github.com/agentjp/bdinfo-rs/compare/v2.0.0...v3.0.0) (2026-08-08)
 
 ### ⚠ BREAKING CHANGES

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ abstract: >-
 authors:
   - name: bdinfo-rs contributors
     email: agent@fastmail.jp
-version: 3.0.0
-date-released: "2026-08-08"
+version: 4.0.0
+date-released: "2026-08-16"
 license: LGPL-2.1-or-later
 repository-code: https://github.com/agentjp/bdinfo-rs
 url: https://github.com/agentjp/bdinfo-rs

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -255,8 +255,9 @@ deliberately diverge from BDInfo 0.8:
 - cancellation, polled once per request, takes effect within 256 KiB of reading instead
   of 5 MiB;
 - one unreadable span stalls one small request inside the drive's retry storm rather
-  than a 5 MiB one — 16 KiB in the quick codec pass (which runs first in every
-  measurement scan and alone in a codec-only browse), 256 KiB in the full pass.
+  than a 5 MiB one — 16 KiB in the quick codec pass (which runs alone in a codec-only
+  browse, and ahead of the full pass in a measurement scan that did not already read
+  the codec detail — the desktop app's does, and skips it), 256 KiB in the full pass.
 
 A damaged scan of a bare Windows drive root also keeps a degraded disc label: once any
 io error is recorded — at any scan stage, so a metadata-only browse counts too — the
@@ -370,6 +371,16 @@ Deliberately different:
 - **An encrypted disc is never scanned.** The original measures the ciphertext; the app lists the
   disc and leaves the scan action disabled — see
   [AACS-encrypted discs are refused](#aacs-encrypted-discs-are-refused).
+- **A dropped stream file loses its codec detail.** The app browses a disc at codec depth before
+  you scan it, so its measured scan skips the quick codec pass rather than reading every stream
+  file's head a second time — on damaged media that second read can stall for minutes. The pass it
+  skips is also the fallback for a file the measured pass gives up on, so with *Keep partially
+  scanned stream files* turned **off** (it is on by default) a stream file that fails partway
+  through leaves its rows carrying only what the disc's clip info declares — codec name,
+  resolution, channel layout — without the profile, level, and HDR detail the stream itself would
+  have supplied. Nothing else changes: the file is still named in the warning banner and the
+  report's `WARNING` block, and with the setting left on, or on media that reads cleanly, the rows
+  are identical to the command line's.
 
 ## See also
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -194,11 +194,11 @@ Multi-arch images (`linux/amd64`, `linux/arm64`) on the GitHub Container Registr
 the static binary on `scratch` — no OS, no shell, no libc, about 1 MB.
 
 ```sh
-docker pull ghcr.io/agentjp/bdinfo-rs:latest      # or pin a release: :3.0.0
+docker pull ghcr.io/agentjp/bdinfo-rs:latest      # or pin a release: :4.0.0
 ```
 
-- **Updates** — `docker pull` a newer tag. Tags track the repo's versions (`3.0.0`, plus rolling
-  `3.0` and `3`).
+- **Updates** — `docker pull` a newer tag. Tags track the repo's versions (`4.0.0`, plus rolling
+  `4.0` and `4`).
 - **Uninstall** — `docker rmi ghcr.io/agentjp/bdinfo-rs`.
 
 Mount the disc and pass its in-container path. `-it` gives the interactive picker a terminal;

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ whole-file demux — and `scan` measures the streams, returning the report along
 model. `renderReport` re-renders that model with different report sections, and `reportFileName`
 gives the `BDINFO.{volume label}.txt` name to save it under. Every call takes either a folder pick
 or a single `.iso` `File`. Bundler, CSP, and browser-support notes:
-[`crates/bdinfo-rs-wasm`](crates/bdinfo-rs-wasm).
+[`crates/bdinfo-rs-wasm/web`](crates/bdinfo-rs-wasm/web).
 
 ## Differences from BDInfo
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,9 +20,9 @@ Security fixes land on the latest release of the current major line.
 
 | Version | Supported |
 |---|---|
-| 3.0.x | ✅ |
-| 2.x | ❌ |
-| < 2.0 | ❌ |
+| 4.0.x | ✅ |
+| 3.x | ❌ |
+| < 3.0 | ❌ |
 
 ## Reporting a vulnerability
 

--- a/crates/bdinfo-rs-gui/README.md
+++ b/crates/bdinfo-rs-gui/README.md
@@ -51,9 +51,12 @@ One per-user directory, created on first use:
 - **`gui.conf`** — settings and window geometry, saved as they change. **Deleting it is the full
   reset**: window size and position, theme, and every setting return to defaults. This is also the
   fix when the window restores off-screen, for example onto a monitor you have since unplugged.
-- **`gui.log`** — a plain-text diagnostic log, overwritten at each launch. It records which
-  renderer was selected, any panics, and dialog or portal errors. **Attach it when filing a bug** —
-  it answers the first questions a graphics issue raises.
+- **`gui.log`** — a plain-text diagnostic log, one file per launch. It opens with the launch time
+  and records which renderer was selected, the disc each scan opened, stalled reads, scan
+  durations, any panics, and dialog or portal errors. Each launch renames the previous log to
+  **`gui.log.1`** before starting a new one, so the run before the one you are in is still there.
+  **Attach it when filing a bug** — it answers the first questions a graphics issue raises, and
+  after a crash the interesting file is usually `gui.log.1`.
 
 ## Troubleshooting
 

--- a/crates/bdinfo-rs-gui/packaging/io.github.agentjp.bdinfo-rs.metainfo.xml
+++ b/crates/bdinfo-rs-gui/packaging/io.github.agentjp.bdinfo-rs.metainfo.xml
@@ -38,6 +38,7 @@
   <url type="bugtracker">https://github.com/agentjp/bdinfo-rs/issues</url>
   <developer_name>agentjp</developer_name>
   <releases>
+    <release version="4.0.0" date="2026-08-16"/>
     <release version="3.0.0" date="2026-08-08"/>
     <release version="2.0.0" date="2026-07-20"/>
   </releases>


### PR DESCRIPTION
The CHANGELOG section for 4.0.0 (the version bump itself landed with the entry-point collapse), and the number carried into every surface that holds it as prose: the supported-versions table, the Docker pin example and its rolling-tag sentence, the three issue-template placeholders, CITATION.cff, and the AppStream release list. Every manifest, lockfile and package.json was already at 4.0.0; nothing else in the tree still reads 3.0.0 outside the historical entries.

Breaking entries carry the migration shape: the plain entry-point names now take a ScanObservers bundle, with ScanObservers::none() for the no-observer case, and ClipSummary gains a measured field.

DIFFERENCES.md gains one Desktop-app entry: the app browses at codec depth before scanning, so its measured scan skips the quick codec pass — which is also the fallback for a stream file the measured pass drops, so with partial-scan retention turned off a failing file keeps clip-info codec detail only. The read-granularity section is corrected alongside it; it still said the quick pass runs first in every measurement scan.

Two further documentation corrections found while checking the user-facing docs against the code: gui.log keeps the previous launch as gui.log.1 rather than being overwritten, and the browser package notes live in crates/bdinfo-rs-wasm/web, not the crate directory above it.

No tag is created by this PR.