### PR TITLE
ci(gui): close the driven window when the walk ends instead of idling to the smoke deadline

### DIFF
--- a/.github/scripts/gui-drive-inject-linux.ps1
+++ b/.github/scripts/gui-drive-inject-linux.ps1
@@ -100,8 +100,32 @@ $after = Get-FileHash (Join-Path $Gallery '04-settings-open.png') -ErrorAction S
 $landed = $before -and $after -and ($before.Hash -ne $after.Hash)
 Write-Host "==> settings-click pixel change: $landed"
 
-Write-Host '==> waiting for the smoke-deadline exit'
-$exited = $proc.WaitForExit($SmokeMs)
+# End the app on the walk's clock, not the boot clock — the same change as the
+# Windows leg, with xdotool's windowclose as this platform's close gesture.
+# BDINFO_GUI_SMOKE_MS is a sleep the app starts at BOOT, so waiting it out
+# burns ~100 s of pure sleep after the walk has finished. No new debug hook is
+# needed: `exit_on_close_request` is false and `iced::window::close_requests()`
+# is subscribed unconditionally, so an OS close request routes CloseRequested
+# -> close_with_geometry -> SaveAndClose -> window::close and the process exits
+# 0 once its last window is gone. The smoke deadline stays as the BACKSTOP, so
+# a close that does not land costs exactly what it costs today.
+$CloseGraceMs = 15000
+Write-Host '==> asking the window to close (xdotool windowclose)'
+# Best-effort: a refused close must fall through to the backstop, not abort the
+# run. `$ErrorActionPreference = 'Stop'` plus PowerShell 7.4's native-command
+# error mapping would otherwise make a non-zero xdotool exit terminating here,
+# unlike the walk's own xdotool calls, where a failure genuinely is fatal.
+try { & xdotool windowclose $wid } catch { Write-Host "!! xdotool windowclose failed: $_" }
+$exited = $proc.WaitForExit($CloseGraceMs)
+if ($exited) {
+    Write-Host '==> app ended by: the injected close'
+}
+else {
+    Write-Host '!! the injected close did not land — falling back to the smoke deadline'
+    Write-Host '==> waiting for the smoke-deadline exit'
+    $exited = $proc.WaitForExit($SmokeMs)
+    if ($exited) { Write-Host '==> app ended by: the smoke deadline' }
+}
 if (-not $exited) { Stop-Process -Id $proc.Id -Force; throw 'the app never hit its smoke deadline' }
 Write-Host ("==> app exit code {0}" -f $proc.ExitCode)
 # The app's per-launch diagnostics log rides along in the gallery.

--- a/.github/scripts/gui-drive-inject-macos.ps1
+++ b/.github/scripts/gui-drive-inject-macos.ps1
@@ -119,8 +119,37 @@ else {
     if (-not $landed) { $failures += 'the Settings click changed no pixels (missed or blocked)' }
 }
 
-Write-Host '==> waiting for the smoke-deadline exit'
-$exited = $proc.WaitForExit($SmokeMs)
+# End the app on the walk's clock, not the boot clock — the same change as the
+# other two legs, with System Events' close button as this platform's close
+# gesture. BDINFO_GUI_SMOKE_MS is a sleep the app starts at BOOT, so waiting it
+# out burns ~100 s of pure sleep after the walk has finished. No new debug hook
+# is needed: `exit_on_close_request` is false and
+# `iced::window::close_requests()` is subscribed unconditionally, so an OS
+# close request routes CloseRequested -> close_with_geometry -> SaveAndClose ->
+# window::close and the process exits 0 once its last window is gone.
+#
+# Deliberately OUTSIDE the `$geomOk` block above: that block is skipped
+# whenever the geometry lookup is refused, and this leg still wants its exit
+# shortened when the walk never ran. Best-effort throughout — Accessibility is
+# exactly what this leg exists to probe, so a refused close is expected here
+# and must fall through to the smoke deadline rather than fail the run.
+$CloseGraceMs = 15000
+Write-Host '==> asking the window to close (System Events)'
+try {
+    & osascript -e 'tell application "System Events" to click button 1 of window 1 of (first process whose name is "bdinfo-rs-gui")' 2>&1 |
+        ForEach-Object { Write-Host "    $_" }
+}
+catch { Write-Host "!! the close gesture was refused: $_" }
+$exited = $proc.WaitForExit($CloseGraceMs)
+if ($exited) {
+    Write-Host '==> app ended by: the injected close'
+}
+else {
+    Write-Host '!! the injected close did not land — falling back to the smoke deadline'
+    Write-Host '==> waiting for the smoke-deadline exit'
+    $exited = $proc.WaitForExit($SmokeMs)
+    if ($exited) { Write-Host '==> app ended by: the smoke deadline' }
+}
 if (-not $exited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
 $code = if ($exited) { $proc.ExitCode } else { 'killed' }
 Write-Host "==> app exit code $code"

--- a/.github/scripts/gui-drive-inject-windows.ps1
+++ b/.github/scripts/gui-drive-inject-windows.ps1
@@ -13,8 +13,10 @@
 # probe with a visible effect). PrintWindow screenshots after every event are
 # the evidence; one hard automated assert (the Settings click must change the
 # rendered pixels vs the shot before it) proves input actually reached the
-# app. The app exits by the BDINFO_GUI_SMOKE_MS deadline — exit 0 means the
-# event loop survived the whole injected walk.
+# app. The walk ends by injecting the platform's close gesture and the app
+# exits 0 through its own save-and-close path, with the BDINFO_GUI_SMOKE_MS
+# deadline kept as the backstop — exit 0 either way means the event loop
+# survived the whole injected walk.
 #
 # Every click re-verifies GetForegroundWindow() is still the app first —
 # injected input lands wherever the OS says focus is, never click blind.
@@ -410,8 +412,34 @@ $after = Get-FileHash (Join-Path $Gallery '04-settings-open.png') -ErrorAction S
 $landed = $before -and $after -and ($before.Hash -ne $after.Hash)
 Write-Host "==> settings-click pixel change: $landed"
 
-Write-Host '==> waiting for the smoke-deadline exit'
-$exited = $proc.WaitForExit($SmokeMs)
+# End the app on the walk's clock, not the boot clock. BDINFO_GUI_SMOKE_MS is
+# a sleep the app starts at BOOT, so waiting it out burns ~100 s of pure sleep
+# after the walk has finished. The app is closable without any new debug hook:
+# `exit_on_close_request` is false and `iced::window::close_requests()` is
+# subscribed unconditionally, so an OS close request routes CloseRequested ->
+# close_with_geometry -> SaveAndClose -> window::close, and the process exits 0
+# once its last window is gone. WM_CLOSE is the same primitive Send-Click uses
+# on blocker windows above.
+#
+# The smoke deadline stays as the BACKSTOP: if the close does not land, this
+# falls through to the original wait and the original failure text, so a lost
+# close costs exactly what it costs today and reddens nothing new. Closing this
+# way also exercises the save-and-close path, which writes gui.conf into the
+# isolated config dir the walk provisioned — the log collection below reads the
+# same directory and is unaffected.
+$CloseGraceMs = 15000
+Write-Host '==> asking the window to close (WM_CLOSE)'
+[void][GuiInput]::PostMessage($hwnd, 0x0010, [IntPtr]::Zero, [IntPtr]::Zero)
+$exited = $proc.WaitForExit($CloseGraceMs)
+if ($exited) {
+    Write-Host '==> app ended by: the injected close'
+}
+else {
+    Write-Host '!! the injected close did not land — falling back to the smoke deadline'
+    Write-Host '==> waiting for the smoke-deadline exit'
+    $exited = $proc.WaitForExit($SmokeMs)
+    if ($exited) { Write-Host '==> app ended by: the smoke deadline' }
+}
 if (-not $exited) { Stop-Process -Id $proc.Id -Force; throw 'the app never hit its smoke deadline' }
 Write-Host ("==> app exit code {0}" -f $proc.ExitCode)
 # The app's per-launch diagnostics log (it names the debug hooks the boot

--- a/crates/bdinfo-rs-wasm/web/README.md
+++ b/crates/bdinfo-rs-wasm/web/README.md
@@ -21,10 +21,11 @@ Firefox.
 npm i @bdinfo-rs/wasm
 ```
 
-The published payload is **~501 KB of WebAssembly + ~44 KB of JS**. Only the
-main-thread entry you import (~9 KB) loads up front; the scan Worker (~3 KB)
-and the wasm-bindgen glue (~32 KB) that hosts the `.wasm` are fetched lazily
-inside the Worker, and nothing past the entry loads at all until the first scan.
+The published payload is **~535 KB of WebAssembly + ~51 KB of JS**, measured on
+the optimized build (`wasm-opt -Oz`). Only the main-thread entry you import
+(~12 KB) loads up front; the scan Worker (~4 KB) and the wasm-bindgen glue
+(~34 KB) that hosts the `.wasm` are fetched lazily inside the Worker, and
+nothing past the entry loads at all until the first scan.
 
 ## Usage
 


### PR DESCRIPTION
The three injected drive legs ended by waiting out BDINFO_GUI_SMOKE_MS, which the app starts as a sleep at BOOT rather than at the end of the walk. The walk finishes well inside it, so each leg burned roughly 100 s of pure sleep, three times per gui drive matrix run.

Each leg now injects the platform close gesture after its pixel-change assert and waits a 15 s grace: WM_CLOSE on Windows (the primitive the script already uses on blocker windows), xdotool windowclose on Linux, System Events on macOS. No app code is needed. exit_on_close_request is false and iced::window::close_requests() is subscribed unconditionally, so an OS close request routes CloseRequested to close_with_geometry to SaveAndClose to window::close, and the process exits 0 once its last window is gone; that chain was checked against the current source before writing anything.

The smoke deadline stays as the backstop with its original failure text, so a close that does not land costs exactly what it costs today and no new red is possible. Each leg logs which path ended the app, so a regression is readable in the job log. gui-drive-assisted.ps1 is untouched, being already event-driven.

Two deliberate placements: the macOS gesture sits outside the geometry block, which that leg skips whenever Accessibility refuses the lookup, and the Linux close is wrapped so a refused close falls through to the backstop instead of aborting under the script's ErrorActionPreference.

One behaviour change on the app side: the injected walk now also exercises save-and-close, so the run writes gui.conf into the isolated config directory the walk already provisions. The gallery log collection reads that same directory and is unaffected.

Also in this branch: the npm package README quoted payload sizes that had drifted from the build they describe. The optimized .wasm is ~535 KB, not ~501 KB, and the shipped JS ~51 KB, not ~44 KB; the tracked wasm-size-budget.txt already recorded the larger figure.