### PR TITLE
fix(core): keep the real disc label when a drive-root scan hits a read error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,17 +60,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **core:** a 3D clip whose `BDMV/STREAM/SSIF/<clip>.ssif` will not open is measured from the plain
   `*.m2ts` instead of being abandoned — the base view is reported, the dependent (MVC) row is not,
   and the failure is recorded against the `.ssif` in the `WARNING` block. ([#363](https://github.com/agentjp/bdinfo-rs/issues/363))
-* **core:** three classic-parity corrections — an audio access unit's transfer interval is measured
-  only on a forward PTS (a backwards step no longer drags the interval base back), undecoded
-  MPEG-1/2 and AAC audio rows fall back to the type-derived codec names instead of rendering an
-  empty one, and each clip's share of its playlist is computed against the finished playlist length
-  rather than the part accumulated so far. ([#364](https://github.com/agentjp/bdinfo-rs/issues/364))
-* **core:** the raw-device volume-label read on a Windows drive root is skipped once any io error
-  has been recorded, at any scan stage — one less sector-by-sector grind of a failing drive.
-  ([#341](https://github.com/agentjp/bdinfo-rs/issues/341))
+* **core:** three classic-parity corrections — an access unit's transfer interval is measured only
+  on a forward PTS (a backwards step no longer drags the interval base back), undecoded MPEG-1/2
+  and AAC audio rows fall back to the type-derived codec names instead of rendering an empty one,
+  and each clip's share of its playlist is computed against the finished playlist length rather
+  than the part accumulated so far. The first also reaches the playlist-level bitrate of a video
+  stream, where it moves a short playlist's kbps by a few counts; a feature-length one is
+  unchanged. See DIFFERENCES.md. ([#364](https://github.com/agentjp/bdinfo-rs/issues/364))
+* **core:** the volume label of a disc mounted at a Windows drive root is read from the raw device
+  **before** the scan instead of after it, so a scan that records a read error still names the disc
+  — in the report body, in the `BDINFO.<label>.txt` file name, and in the desktop app's title —
+  rather than degrading to the drive letter. The read is only attempted for an input path that can
+  walk up to a nameless drive root, so an ordinary named folder costs no extra IO.
+  ([#341](https://github.com/agentjp/bdinfo-rs/issues/341), [#378](https://github.com/agentjp/bdinfo-rs/issues/378))
 * **cli:** the progress line repaints about once a second through a stalled read, switching its
-  lead-in to `Still reading` after five seconds, so a hung drive no longer looks like a hung
-  program. ([#366](https://github.com/agentjp/bdinfo-rs/issues/366))
+  lead-in to `Still scanning` after five seconds, so a hung drive no longer looks like a hung
+  program. ([#366](https://github.com/agentjp/bdinfo-rs/issues/366), [#378](https://github.com/agentjp/bdinfo-rs/issues/378))
+* **core:** the remaining-time readout shows `--:--:--` until the first bytes are measured, on both
+  the command line and the desktop app, instead of `00:00:00` — which read as "about to finish" at
+  the moment nothing had been read, and could stand there for minutes beside a stalled read.
+  ([#378](https://github.com/agentjp/bdinfo-rs/issues/378))
+* **gui:** the log records a stall clearing as well as a stall starting, the scan overlay no longer
+  passes clicks and drags through to the table beneath it, the scan-notice modal stops referring to
+  a report below it, and a refused report save names the destination it tried.
+  ([#377](https://github.com/agentjp/bdinfo-rs/issues/377))
 * **gui:** cancelling a scan keeps the values it measured on the grids, the selection stays live
   during a scan so the panes follow the highlighted row, and the remaining-time estimate climbs
   through a stall instead of freezing. ([#365](https://github.com/agentjp/bdinfo-rs/issues/365))

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -27,9 +27,9 @@ actually see on a normal disc.
 | [AVC High 4:4:4 (profile 244)](#avc-high-444-profile-244) | **Yes** — profile token | Rare — Blu-ray video is almost always 4:2:0 |
 | [PGS forced-caption counts](#pgs-forced-caption-counts) | **Yes** — caption tally | Discs with multi-object subtitle compositions |
 | [Playlist attribute selection on short clips](#playlist-attribute-selection-on-short-clips) | **Yes** — which clip's streams are presented | Rare — multi-clip playlists whose early clips are short |
+| [Bitrate under a backwards PTS](#bitrate-under-a-backwards-pts) | **Yes** — bitrate numbers | Short playlists, by a few kbps; feature-length ones are unchanged |
 | [E-AC-3 reduced data-rate](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on non-BD input | Reduced-rate E-AC-3 (24 / 22.05 / 16 kHz) isn't used on Blu-ray |
 | [AC-3 low-sample-rate shift](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on non-BD input | Legacy `bsid` 9/10; conforming Blu-ray AC-3 is always `bsid` 8 |
-| [Audio bitrate under a backwards PTS](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only on non-monotone audio PTS | Damaged or non-conforming streams whose audio PTS steps backwards |
 | [Undecoded MPEG-1/2 and AAC audio names](#correctness-fixes-with-no-effect-on-a-normal-disc) | Only when the stream was never decoded | Damaged discs whose MPA/AAC frames the scan could not read |
 | [HEVC `profile_idc` recovery](#correctness-fixes-with-no-effect-on-a-normal-disc) | Edge case only | Malformed headers with `general_profile_idc == 0` |
 | [VC-1 interlaced-field picture type](#correctness-fixes-with-no-effect-on-a-normal-disc) | **No** — internal only | Never — the picture tag is counted, never printed |
@@ -167,6 +167,26 @@ byte-identical.
 <sub>Source: `crates/bdinfo-rs-core/src/bdrom/mpls.rs` (the post-parse resolution),
 `crates/bdinfo-rs-core/src/bdrom/disc.rs` (`select_reference`).</sub>
 
+### Bitrate under a backwards PTS
+
+BDInfo 0.8 advances a stream's last-seen PTS whenever the value merely *changes*
+(`TSStreamFile`'s PES parse compares `PTS != PTSLast`), so a backwards step measures a
+negative transfer interval — discarding that access unit's bitrate sample — and drags the
+interval base backwards, overstating the next forward unit's interval and understating its
+rate. bdinfo-rs advances only on a forward step, against the running maximum, as BDInfo
+0.7.5.6 did (`PTS > PTSLast`) and as the PTS+DTS path of both tools already does.
+
+The rule governs any stream whose PES headers carry a PTS without a DTS — not audio alone
+— and the same last-seen PTS is what the final playlist-level bitrate pass reads for the
+video streams, so a video row's kbps can move too. What moves is a small **absolute** span
+of the measured timeline, a fraction of a second: enough to clear the printed resolution on
+a short playlist, and lost in the rounding of a feature-length one. That is why every
+committed golden — all feature-length — is byte-identical across the change, while a real
+disc's short playlists shift by a few kbps.
+
+<sub>Source: `crates/bdinfo-rs-core/src/bdrom/m2ts.rs` (the PTS-only PES arm and
+`finish_scan`).</sub>
+
 ---
 
 ## Correctness fixes with no effect on a normal disc
@@ -195,14 +215,6 @@ value is never rendered.
   a PMT whose `table_id` is not 0x02. BDInfo assembles the mislabeled section and adopts
   whatever PMT PID it announces. No conforming disc carries a wrong PAT table id, so the
   report is unchanged for every real disc.
-- **Audio bitrate under a backwards PTS.** BDInfo 0.8 measures an audio access unit's
-  transfer interval whenever the PTS merely *changes* (`TSStreamFile`'s PES parse compares
-  `PTS != PTSLast`): a backwards step measures a negative interval — discarding that
-  unit's bitrate sample — and drags the interval base backwards, so the next forward
-  unit's interval is overstated and its rate understated. bdinfo-rs measures only forward
-  steps against the running maximum, as BDInfo 0.7.5.6 did (`PTS > PTSLast`) and as the
-  PTS+DTS path of both tools already does. Audio PTS within a conforming stream file is
-  monotone, so a healthy disc measures identically.
 - **Undecoded MPEG-1/2 and AAC audio names.** BDInfo derives these four codec names from
   the decoded frame header alone and renders an empty name when no frame was ever decoded
   (the unset `ExtendedData` cast to a null string). bdinfo-rs falls back to the
@@ -259,17 +271,7 @@ deliberately diverge from BDInfo 0.8:
   browse, and ahead of the full pass in a measurement scan that did not already read
   the codec detail — the desktop app's does, and skips it), 256 KiB in the full pass.
 
-A damaged scan of a bare Windows drive root also keeps a degraded disc label: once any
-io error is recorded — at any scan stage, so a metadata-only browse counts too — the
-raw-device read that recovers the UDF volume label is skipped — one more sector-by-sector
-grind of a failing drive for a cosmetic string — so the report and its file name carry
-the bare drive letter. A failure blaming the disc's bytes rather than the device (a
-malformed playlist, a missing clip file) leaves the label read in place. Classic BDInfo
-shows the OS-reported volume label there (it reads it through the filesystem before
-scanning and has no raw-device read to skip).
-
-<sub>Source: `crates/bdinfo-rs-core/src/bdrom/m2ts.rs` (`DATA_SIZE`, `QUICK_DATA_SIZE`),
-`crates/bdinfo-rs-core/src/vfs/volume.rs` (the label-read gate).</sub>
+<sub>Source: `crates/bdinfo-rs-core/src/bdrom/m2ts.rs` (`DATA_SIZE`, `QUICK_DATA_SIZE`).</sub>
 
 ### Read errors: folder input vs `.iso` input
 

--- a/crates/bdinfo-rs-core/src/bdrom/progress.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/progress.rs
@@ -23,7 +23,9 @@ use std::time::Duration;
 /// The percent is the byte ratio; a scan with nothing to read (`total == 0`)
 /// reads 100%, not a division by zero. The remaining estimate scales the
 /// elapsed time by the bytes still to read, and is `0` before the first byte
-/// arrives (`done == 0` gives it nothing to extrapolate from).
+/// arrives (`done == 0` gives it nothing to extrapolate from) — which is a
+/// placeholder value, not a time, so a surface spells it through
+/// [`remaining_hms`] rather than [`hms`].
 ///
 /// The estimate works in **milliseconds**: whole-second math would read zero
 /// for the entire first second, exactly when the first plausible estimate
@@ -57,11 +59,34 @@ pub fn hms(seconds: u64) -> String {
     format!("{h:02}:{m:02}:{s:02}")
 }
 
+/// What the remaining field reads while there is no estimate to show — the
+/// blind window before the first byte is measured.
+///
+/// Punctuation rather than a word, and exactly as wide as an [`hms`] time: both
+/// surfaces lay the progress line out in monospace, and the terminal one
+/// truncates it to a narrow window, so the field has to keep its width. A
+/// placeholder also adds no vocabulary to a line that already spells everything
+/// else as a number.
+pub const NO_ESTIMATE: &str = "--:--:--";
+
+/// The remaining field's spelling: [`hms`] of `remaining_seconds` once bytes
+/// have been measured, and [`NO_ESTIMATE`] before that.
+///
+/// `done` is the same byte count [`progress_stats`] took. At `done == 0` its
+/// estimate has nothing to extrapolate from and reads `0`, which spelled as a
+/// time says `00:00:00` — "about to finish" at the moment nothing has been read
+/// at all. On damaged media that window can stand for minutes beside a stalled
+/// read, so it is spelled as the absence it is.
+#[must_use]
+pub fn remaining_hms(done: u64, remaining_seconds: u64) -> String {
+    if done == 0 { NO_ESTIMATE.to_owned() } else { hms(remaining_seconds) }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
-    use super::{hms, progress_stats};
+    use super::{NO_ESTIMATE, hms, progress_stats, remaining_hms};
 
     #[test]
     fn an_empty_scan_reads_one_hundred_percent() {
@@ -105,6 +130,26 @@ mod tests {
         let (_, _, remaining) =
             progress_stats(1, u64::MAX, Duration::from_secs(u64::from(u32::MAX)));
         assert_eq!(remaining, u64::MAX);
+    }
+
+    #[test]
+    fn the_remaining_field_shows_a_placeholder_until_a_byte_is_measured() {
+        // Before the first byte there is no estimate, however long the clock has
+        // run; from the first byte on the field is an ordinary time again.
+        let (_, _, remaining) = progress_stats(0, 200, Duration::from_secs(190));
+        assert_eq!(remaining_hms(0, remaining), NO_ESTIMATE);
+        let (_, _, remaining) = progress_stats(50, 200, Duration::from_secs(4));
+        assert_eq!(remaining_hms(50, remaining), "00:00:12");
+        // A finished scan reads zero seconds, not the placeholder — bytes were
+        // measured, and none are left.
+        assert_eq!(remaining_hms(200, 0), "00:00:00");
+    }
+
+    #[test]
+    fn the_placeholder_is_as_wide_as_the_time_it_stands_in_for() {
+        // The terminal line is truncated to the window width, so a placeholder
+        // wider or narrower than a time would shift the fields around it.
+        assert_eq!(NO_ESTIMATE.chars().count(), hms(0).chars().count());
     }
 
     #[test]

--- a/crates/bdinfo-rs-core/src/scan.rs
+++ b/crates/bdinfo-rs-core/src/scan.rs
@@ -31,10 +31,10 @@ use crate::vfs::volume;
 ///
 /// The label is the [`volume`] repair's: a folder scan names the disc after
 /// its root directory, which a bare Windows drive root (`J:\`) does not have.
-/// When the scan recorded an io failure at any stage the repair skips its
-/// raw-device read — the device just demonstrated read errors, and another
-/// raw read could stall — so the label degrades to the bare drive letter
-/// there.
+/// The repair's raw-device read runs **before** the scan, on the letter the
+/// input path spells, so a disc whose scan goes on to fail reads still carries
+/// its real name; what that read found is applied only if the finished scan's
+/// own label turned out to be a bare drive root.
 ///
 /// `mode`, `options`, `scan_files` and `observers` are
 /// [`BdRom::open_resilient`]'s, passed through unchanged.
@@ -49,11 +49,18 @@ pub fn open_folder(
     scan_files: Option<&BTreeSet<String>>,
     observers: ScanObservers<'_>,
 ) -> Result<ScanReport, BdError> {
+    // Ahead of the scan, and only for an input path that can walk up to a
+    // nameless drive root: the read grinds the very device the scan is about to
+    // read, and one raw read on damaged media can sit for minutes in the
+    // drive's retries — so it belongs where no read has failed yet. Re-walking
+    // the tree afterwards to recover the same letter is not an option: `FsDir`
+    // shares its error sink across derived handles, so a second walk would
+    // record a damaged listing's failures into the report twice.
+    let probed = volume::drive_root_probe(path).and_then(volume::real_volume_label);
     let root = FsDir::new(path);
     let mut report = BdRom::open_resilient(&root, mode, options, scan_files, observers)?;
     report.errors.extend(root.take_errors());
-    report.bdrom.volume_label =
-        volume::resolve_folder_label_after_scan(&report.bdrom.volume_label, &report.errors);
+    report.bdrom.volume_label = volume::apply_drive_root_probe(&report.bdrom.volume_label, probed);
     Ok(report)
 }
 

--- a/crates/bdinfo-rs-core/src/vfs/volume.rs
+++ b/crates/bdinfo-rs-core/src/vfs/volume.rs
@@ -17,16 +17,25 @@
 //! UDF volume label — read off the raw volume device (`\\.\J:`) through the
 //! same [`UdfSource`](crate::vfs::udf::source::UdfSource) core the `.iso` path
 //! uses, the identical string Windows Explorer and classic `BDInfo` show —
-//! falling back to the drive letter when that read is unavailable. A folder
-//! backend's caller applies it to the scanned label; an `.iso` scan already
-//! reads the genuine UDF label and needs no repair. A scan that recorded io
-//! failures resolves through `resolve_folder_label_after_scan` instead, which
-//! skips the raw-device read outright.
+//! falling back to the drive letter when that read is unavailable. An `.iso`
+//! scan already reads the genuine UDF label and needs no repair.
+//!
+//! A folder scan's caller takes that repair in two halves so the device read
+//! lands **before** the scan: [`drive_root_probe`] picks the drive letter to
+//! read out of the input path, the caller performs the read, and
+//! [`apply_drive_root_probe`] applies the answer to the label the finished scan
+//! derived. Only the scanned label can confirm the disc root really was
+//! nameless, and it does not exist until the walk has run — but reading the
+//! device *after* the scan costs a damaged disc its name, because the drive
+//! that just failed a read is the one this repair must not grind a second time.
+//! Reading first resolves both: the read is over before any failure exists, and
+//! the answer is still only applied to a label that turned out nameless.
 
 #[cfg(any(windows, test))]
 use std::io::{self, Read, Seek, SeekFrom};
+use std::path::Path;
 
-use crate::error::{BdError, ScanError};
+use crate::discovery::BdmvDir;
 #[cfg(any(windows, test))]
 use crate::vfs::ReadSeek;
 #[cfg(windows)]
@@ -57,7 +66,51 @@ fn drive_root_letter(label: &str) -> Option<char> {
 /// a `J:\` scan.
 #[must_use]
 pub fn resolve_folder_label(scanned: &str) -> String {
-    resolve_folder_label_after_scan(scanned, &[])
+    resolve_with(scanned, real_volume_label)
+}
+
+/// The drive letter a scan of `path` may need the volume label of, or `None`
+/// when it cannot need one.
+///
+/// A folder scan names the disc after the root it walked up to, so that name is
+/// a bare drive root only when every directory between `path` and the drive
+/// root is one the walk climbs out of. This decides that **lexically**, from
+/// the input path alone: strip a `<letter>:` prefix, then require every
+/// remaining component to be either empty (a separator) or a `BDMV`-tree
+/// directory name ([`BdmvDir::from_name`]). `J:\`, `J:\BDMV` and
+/// `j:/bdmv/stream` all qualify — the three input spellings a folder scan
+/// accepts — while `J:\Rips\Disc\BDMV` does not, because the walk stops at
+/// `Disc`. No IO and no filesystem lookup, so an ordinary named folder costs
+/// nothing and the verdict is identical on every platform (`std` only parses a
+/// path `Prefix` on Windows).
+///
+/// A `Some` is a *may*, never a *will*: [`apply_drive_root_probe`] still
+/// requires the finished scan's own label to be a bare drive root before it
+/// uses anything read for this letter.
+pub(crate) fn drive_root_probe(path: &Path) -> Option<char> {
+    let text = path.to_string_lossy();
+    let mut chars = text.chars();
+    let letter = chars.next()?;
+    if !letter.is_ascii_alphabetic() || chars.next() != Some(':') {
+        return None;
+    }
+    chars
+        .as_str()
+        .split(['/', '\\'])
+        .all(|part| part.is_empty() || BdmvDir::from_name(part).is_some())
+        .then(|| letter.to_ascii_uppercase())
+}
+
+/// [`resolve_folder_label`] with the raw-device read already taken: `probed` is
+/// the label [`drive_root_probe`]'s letter yielded before the scan started, and
+/// `None` when no probe was owed or the read produced nothing.
+///
+/// A bare drive-root `scanned` resolves to `probed`, or to the drive letter; a
+/// real name resolves to itself, which is what keeps a scan of a named folder
+/// un-renameable by a probe taken on speculation.
+#[must_use]
+pub(crate) fn apply_drive_root_probe(scanned: &str, probed: Option<String>) -> String {
+    resolve_with(scanned, move |_| probed)
 }
 
 /// The label resolution both entry points end in, with the raw-device read
@@ -67,36 +120,6 @@ fn resolve_with(scanned: &str, read: impl FnOnce(char) -> Option<String>) -> Str
         || scanned.to_owned(),
         |letter| read(letter).unwrap_or_else(|| letter.to_string()),
     )
-}
-
-/// [`resolve_folder_label`] for a scan that may have recorded failures: when
-/// `errors` carries an io failure ([`BdError::Io`]) from any stage, the
-/// raw-device read is skipped and a bare drive-root label degrades straight
-/// to the drive letter. The label read grinds the same device that just
-/// failed, sector by sector, and on damaged media one raw read can stall for
-/// minutes inside the drive's retries — a cosmetic label is not worth that
-/// after the device has demonstrated read errors. Every other [`BdError`]
-/// describes the disc's *bytes* — malformed or missing metadata — which is no
-/// evidence against the device, so those leave the read in play. A real name
-/// resolves to itself either way.
-#[must_use]
-pub(crate) fn resolve_folder_label_after_scan(scanned: &str, errors: &[ScanError]) -> String {
-    resolve_after_scan_with(scanned, errors, real_volume_label)
-}
-
-/// The pure core of [`resolve_folder_label_after_scan`], with the raw-device
-/// read injected as `read` so the failure gate is exercised without a real
-/// device.
-fn resolve_after_scan_with(
-    scanned: &str,
-    errors: &[ScanError],
-    read: impl FnOnce(char) -> Option<String>,
-) -> String {
-    if errors.iter().any(|e| matches!(e.reason, BdError::Io(_))) {
-        resolve_with(scanned, |_| None)
-    } else {
-        resolve_with(scanned, read)
-    }
 }
 
 /// How many times to attempt the raw-device read — an optical drive can fail the
@@ -113,14 +136,17 @@ const RAW_READ_RETRY_DELAY: std::time::Duration = std::time::Duration::from_mill
 /// `letter` (Windows `\\.\J:`), or `None` when it cannot — the device is absent,
 /// unreadable, holds no UDF volume, or reports an empty label.
 ///
+/// The one IO in this module, so a folder scan's caller runs it at the moment
+/// it chooses — before the scan, for [`drive_root_probe`]'s letter.
+///
 /// Environment-bound: opening a real volume device cannot run in a deterministic
 /// test, so this is excluded from coverage and mutation. The machinery it drives
-/// — [`AlignedReader`], [`UdfSource::read_label`], and the decision in
-/// [`resolve_with`] — is unit-tested directly, and the live read is validated
-/// end-to-end against a physical disc.
+/// — [`AlignedReader`], [`UdfSource::read_label`], and the decisions in
+/// [`drive_root_probe`] and [`apply_drive_root_probe`] — is unit-tested
+/// directly, and the live read is validated end-to-end against a physical disc.
 #[cfg(windows)]
 #[cfg_attr(coverage_nightly, coverage(off))]
-fn real_volume_label(letter: char) -> Option<String> {
+pub(crate) fn real_volume_label(letter: char) -> Option<String> {
     let iso = RawVolumeIso { device: format!(r"\\.\{letter}:") };
     for attempt in 0..RAW_READ_ATTEMPTS {
         // Pause before each retry (never the first) so a spun-down drive gets a
@@ -143,7 +169,7 @@ fn real_volume_label(letter: char) -> Option<String> {
 /// platform constant, excluded from coverage like its Windows sibling.
 #[cfg(not(windows))]
 #[cfg_attr(coverage_nightly, coverage(off))]
-const fn real_volume_label(_letter: char) -> Option<String> {
+pub(crate) const fn real_volume_label(_letter: char) -> Option<String> {
     None
 }
 
@@ -297,13 +323,12 @@ fn add_signed(base: u64, delta: i64) -> io::Result<u64> {
 )]
 mod tests {
     use std::io::{Cursor, Read as _, Seek as _, SeekFrom};
+    use std::path::Path;
 
     use super::{
-        AlignedReader, BdError, SECTOR, ScanError, add_signed, drive_root_letter,
-        resolve_after_scan_with, resolve_folder_label, resolve_folder_label_after_scan,
-        resolve_with,
+        AlignedReader, SECTOR, add_signed, apply_drive_root_probe, drive_root_letter,
+        drive_root_probe, resolve_folder_label, resolve_with,
     };
-    use crate::error::ScanStage;
 
     #[test]
     fn drive_root_letter_matches_every_bare_drive_root_spelling() {
@@ -344,70 +369,52 @@ mod tests {
         assert_eq!(resolve_folder_label("BigBuckBunny"), "BigBuckBunny");
     }
 
-    /// A recorded device failure at `stage` — the reason that closes the gate.
-    fn io_error_at(stage: ScanStage) -> ScanError {
-        ScanError {
-            file: "00000.m2ts".to_owned(),
-            stage,
-            reason: BdError::Io(std::io::Error::other("read failed")),
-        }
-    }
-
-    /// A recorded failure at `stage` blaming the disc's bytes rather than the
-    /// device, which leaves the gate open.
-    fn parse_error_at(stage: ScanStage) -> ScanError {
-        ScanError { file: "00000.clpi".to_owned(), stage, reason: BdError::UnexpectedEof }
+    #[test]
+    fn a_probe_is_owed_by_every_drive_root_input_spelling() {
+        // The three spellings the CLI accepts for a disc sitting at a drive
+        // root — the root itself, its BDMV directory, and a directory inside
+        // that — each walk up to the nameless root, so each owes a probe.
+        // Separators, letter case and a trailing separator are all immaterial.
+        assert_eq!(drive_root_probe(Path::new(r"J:\")), Some('J'));
+        assert_eq!(drive_root_probe(Path::new("k:/")), Some('K'));
+        assert_eq!(drive_root_probe(Path::new("k:")), Some('K'));
+        assert_eq!(drive_root_probe(Path::new(r"J:\BDMV")), Some('J'));
+        assert_eq!(drive_root_probe(Path::new("j:/bdmv/stream/")), Some('J'));
+        assert_eq!(drive_root_probe(Path::new(r"J:\BDMV\PLAYLIST")), Some('J'));
     }
 
     #[test]
-    fn a_recorded_io_failure_at_any_stage_skips_the_device_read() {
-        // One injected reader for every shape: consulted only when the gate is
-        // open, so its label wins exactly there.
-        let read = |letter: char| Some(format!("VOL{letter}"));
-        // An io failure degrades a drive root straight to the letter, whatever
-        // stage recorded it — a stream read is what a damaged disc trips first,
-        // but a metadata-only scan never reaches that stage at all. These are
-        // the four a folder scan can record; `ScanStage::SectorRead` comes
-        // from the UDF `.iso` reader, and an `.iso` carries a genuine volume
-        // label that never reaches this repair.
-        for stage in
-            [ScanStage::Discovery, ScanStage::ClipInfo, ScanStage::Playlist, ScanStage::StreamFile]
-        {
-            assert_eq!(resolve_after_scan_with(r"J:\", &[io_error_at(stage)], read), "J");
-        }
-        // A parse failure is no evidence against the device, so it leaves the
-        // read in play — as does a clean scan.
-        assert_eq!(
-            resolve_after_scan_with(r"J:\", &[parse_error_at(ScanStage::ClipInfo)], read),
-            "VOLJ"
-        );
-        assert_eq!(resolve_after_scan_with(r"J:\", &[], read), "VOLJ");
-        // One io failure among parse failures still closes the gate.
-        assert_eq!(
-            resolve_after_scan_with(
-                r"J:\",
-                &[parse_error_at(ScanStage::ClipInfo), io_error_at(ScanStage::Playlist)],
-                read
-            ),
-            "J"
-        );
-        // A real name resolves to itself whatever is on record.
-        assert_eq!(
-            resolve_after_scan_with("BigBuckBunny", &[io_error_at(ScanStage::StreamFile)], read),
-            "BigBuckBunny"
-        );
+    fn no_probe_is_owed_where_the_scan_will_find_a_name() {
+        // A named directory anywhere above the BDMV tree is the label the scan
+        // will derive, so probing the drive would be pure wasted IO.
+        assert_eq!(drive_root_probe(Path::new(r"J:\Rips\Disc\BDMV")), None);
+        assert_eq!(drive_root_probe(Path::new(r"J:\BigBuckBunny")), None);
+        // Relative and non-Windows inputs carry no drive letter to probe at all
+        // — a mounted disc names itself through its mount point there.
+        assert_eq!(drive_root_probe(Path::new("BigBuckBunny")), None);
+        assert_eq!(drive_root_probe(Path::new("/media/user/MY_DISC/BDMV")), None);
+        assert_eq!(drive_root_probe(Path::new("")), None);
+        assert_eq!(drive_root_probe(Path::new("1:/")), None); // not a letter
+        assert_eq!(drive_root_probe(Path::new("Jx")), None); // no colon
     }
 
     #[test]
-    fn resolve_folder_label_after_scan_leaves_a_real_name_untouched() {
-        // The wrapper with the real device read behind it, on the shapes that
-        // never touch a device — a real name on both sides of the gate (the
-        // drive-root road is validated end-to-end on real hardware).
-        assert_eq!(resolve_folder_label_after_scan("BigBuckBunny", &[]), "BigBuckBunny");
+    fn a_probed_label_reaches_a_drive_root_scan_whatever_the_scan_recorded() {
+        // The probe is taken before the scan runs, so what the scan went on to
+        // record cannot reach this decision — there is nothing here to consult.
+        // That is the whole repair: a disc whose read failed still gets its
+        // name, where consulting the errors afterwards degraded it to `J`.
+        assert_eq!(apply_drive_root_probe(r"J:\", Some("MY_DISC".to_owned())), "MY_DISC");
+        assert_eq!(apply_drive_root_probe("k:/", Some("MY_DISC".to_owned())), "MY_DISC");
+        // No probe (none owed, or the device read produced nothing) still
+        // degrades to the drive letter, which is all the scan itself has.
+        assert_eq!(apply_drive_root_probe(r"J:\", None), "J");
+        // A real name is never renamed, even by a probe taken on speculation.
         assert_eq!(
-            resolve_folder_label_after_scan("BigBuckBunny", &[io_error_at(ScanStage::StreamFile)]),
+            apply_drive_root_probe("BigBuckBunny", Some("MY_DISC".to_owned())),
             "BigBuckBunny"
         );
+        assert_eq!(apply_drive_root_probe("BigBuckBunny", None), "BigBuckBunny");
     }
 
     /// An inner reader that fails any read whose current position or length is

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -2794,9 +2794,11 @@ impl App {
                 // A stalled scan (no progress event past the threshold —
                 // [`Flow::scan_stalled`]) says the drive is struggling with
                 // the named file; classic BDInfo's bar just freezes silently.
+                // "Still" continues the verb before it, so a line that changes
+                // mid-scan reads as the same activity carrying on.
                 Stage::Scanning if self.flow.scan_stalled() => progress.map_or_else(
                     || "Starting scan…".to_owned(),
-                    |pr| format!("Still reading {}…", pr.file()),
+                    |pr| format!("Still scanning {}…", pr.file()),
                 ),
                 Stage::Scanning => progress.map_or_else(
                     || "Starting scan…".to_owned(),
@@ -4382,7 +4384,11 @@ mod interaction {
             Some("00:01:30".to_owned())
         );
         assert!(app.flow.scan_stalled());
-        assert!(sees(&app, "Still reading A.M2TS…"), "the stall hint names the stuck file");
+        // "Still" continues the measured pass's own verb: `Scanning` above,
+        // `Still scanning` here. (The listing pass reads, and says `Reading` /
+        // `Still reading` for the same reason.)
+        assert!(sees(&app, "Still scanning A.M2TS…"), "the stall hint names the stuck file");
+        assert!(!sees(&app, "Scanning A.M2TS…"), "the plain wording is replaced, not doubled");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/progress.rs
+++ b/crates/bdinfo-rs-gui/src/progress.rs
@@ -10,7 +10,7 @@
 
 use std::time::Duration;
 
-use bdinfo_rs_core::bdrom::progress::{hms, progress_stats};
+use bdinfo_rs_core::bdrom::progress::{hms, progress_stats, remaining_hms};
 
 /// The indeterminate-bar animation period (one full 0→1→0 breath).
 pub const PULSE_PERIOD: u16 = 1000;
@@ -175,10 +175,11 @@ impl ProgressModel {
         hms(self.elapsed_seconds)
     }
 
-    /// The remaining-time estimate as `hh:mm:ss`.
+    /// The remaining-time estimate as `hh:mm:ss`, or the core's no-estimate
+    /// placeholder while nothing has been measured to extrapolate from.
     #[must_use]
     pub fn remaining_hms(&self) -> String {
-        hms(self.remaining_seconds)
+        remaining_hms(self.done, self.remaining_seconds)
     }
 
     /// The progress text line: `NN% - file | Elapsed: hh:mm:ss | Remaining:
@@ -191,7 +192,7 @@ impl ProgressModel {
             self.percent,
             self.file,
             hms(self.elapsed_seconds),
-            hms(self.remaining_seconds)
+            self.remaining_hms()
         )
     }
 }
@@ -259,12 +260,15 @@ mod tests {
     #[test]
     fn a_tick_before_any_bytes_estimates_nothing() {
         // `done == 0` gives the cumulative average nothing to extrapolate from,
-        // so the readout stays at zero however long the clock runs — the same
-        // blind window `progress_stats` defines for the first event.
+        // so the readout shows the core's no-estimate placeholder however long
+        // the clock runs — the same blind window `progress_stats` defines for
+        // the first event, spelled as an absence rather than as `00:00:00`,
+        // which on a stalled read would say "about to finish" for minutes.
         let mut model = ProgressModel::compute("00000.M2TS".to_owned(), 0, 200, Duration::ZERO);
         model.set_elapsed(Duration::from_secs(30));
         assert_eq!(model.elapsed_hms(), "00:00:30");
-        assert_eq!(model.remaining_hms(), "00:00:00");
+        assert_eq!(model.remaining_hms(), "--:--:--");
+        assert_eq!(model.line(), "  0% - 00000.M2TS | Elapsed: 00:00:30 | Remaining: --:--:--");
     }
 
     #[test]

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -37,8 +37,8 @@ pub enum Input {
     /// inside it (the scan walks up to the disc root). The label is the
     /// directory name — or, when the disc root is a nameless Windows drive
     /// root, the real UDF label the [`bdinfo_rs_core::vfs::volume`] repair
-    /// recovers; after a scan that recorded an io error the repair skips its
-    /// raw-device read and the label degrades to the bare drive letter.
+    /// recovers, which it reads before the scan so a disc whose reads fail is
+    /// still named; the bare drive letter only when that read finds nothing.
     Folder(PathBuf),
     /// A single `.iso` image. The label is the real UDF volume label.
     Iso(PathBuf),

--- a/crates/bdinfo-rs/src/main.rs
+++ b/crates/bdinfo-rs/src/main.rs
@@ -36,7 +36,8 @@
 //! draws on stderr. On an ANSI terminal that line repaints about once a second
 //! even while the scan reports nothing, so the elapsed and remaining readouts
 //! keep moving through a read that has not returned; after five seconds of
-//! silence its lead-in reads `Still reading` instead of `Scanning`. The flow
+//! silence its lead-in reads `Still scanning` instead of `Scanning`, and the
+//! remaining readout stays `--:--:--` until the first bytes are measured. The flow
 //! narration (table, picker, analysis preamble,
 //! classic epilogue, saved-report message) prints on stdout. A stream file
 //! measured shorter than the disc declares (a truncated file reads to a clean
@@ -93,7 +94,7 @@ use bdinfo_rs_core::bdrom::order::{
     HiddenRule, PlaylistFilter, hidden_by, named_selection, selection_order,
     selection_stream_files, table_rows,
 };
-use bdinfo_rs_core::bdrom::progress::{hms, progress_stats};
+use bdinfo_rs_core::bdrom::progress::{hms, progress_stats, remaining_hms};
 use bdinfo_rs_core::bdrom::shortfall::ShortStreamFile;
 use bdinfo_rs_core::error::{BdError, ScanError};
 use bdinfo_rs_core::report::text::{self, RenderOptions};
@@ -916,8 +917,10 @@ const STALL_AFTER: Duration = Duration::from_secs(5);
 const LEAD_SCANNING: &str = "Scanning";
 
 /// The lead-in once the reads have gone quiet ([`STALL_AFTER`]) — the same
-/// "still reading" wording the desktop shell shows for a stuck read.
-const LEAD_STALLED: &str = "Still reading";
+/// wording the desktop shell shows for a stuck read. "Still" continues
+/// [`LEAD_SCANNING`]'s verb rather than swapping in another one, so a line that
+/// changes mid-scan reads as the same activity carrying on.
+const LEAD_STALLED: &str = "Still scanning";
 
 /// The lead-in for a quiet or a moving scan.
 const fn lead_in(stalled: bool) -> &'static str {
@@ -1225,7 +1228,7 @@ fn compose_styled_progress(
         "{percent:>3}% - {} | Elapsed: {} | Remaining: {}",
         progress.file,
         hms(elapsed_seconds),
-        hms(remaining_seconds)
+        remaining_hms(progress.done, remaining_seconds)
     );
     // The room the bar gets: the width less one spare cell, the lead-in and its
     // ` [] ` bar frame, and the tail — all measured in display cells.
@@ -1261,7 +1264,7 @@ fn compose_progress(progress: &ScanProgress<'_>, elapsed: Duration, lead: &str) 
         "{lead} {percent:>3}% - {} | Elapsed: {} | Remaining: {}",
         progress.file,
         hms(elapsed_seconds),
-        hms(remaining_seconds)
+        remaining_hms(progress.done, remaining_seconds)
     )
 }
 
@@ -2011,13 +2014,14 @@ Options:
             super::LEAD_SCANNING,
         );
         assert_eq!(line, "Scanning  25% - 00000.M2TS | Elapsed: 00:00:00 | Remaining: 00:00:01");
-        // Nothing read yet → no estimate; an empty scan reads 100%.
+        // Nothing read yet → no estimate, spelled as one; an empty scan reads
+        // 100%.
         let line = compose_progress(
             &ScanProgress { file: "00000.M2TS", done: 0, total: 200 },
             Duration::from_secs(1),
             super::LEAD_SCANNING,
         );
-        assert_eq!(line, "Scanning   0% - 00000.M2TS | Elapsed: 00:00:01 | Remaining: 00:00:00");
+        assert_eq!(line, "Scanning   0% - 00000.M2TS | Elapsed: 00:00:01 | Remaining: --:--:--");
         let line = compose_progress(
             &ScanProgress { file: "00000.M2TS", done: 0, total: 0 },
             Duration::ZERO,
@@ -2033,7 +2037,7 @@ Options:
         );
         assert_eq!(
             line,
-            "Still reading  25% - 00000.M2TS | Elapsed: 00:00:10 | Remaining: 00:00:30"
+            "Still scanning  25% - 00000.M2TS | Elapsed: 00:00:10 | Remaining: 00:00:30"
         );
     }
 
@@ -2571,13 +2575,13 @@ Options:
         // out of the bar's room, never out of the tail.
         let progress = ScanProgress { file: "00000.M2TS", done: 50, total: 200 };
         let line = compose_styled_progress(&progress, Duration::from_secs(10), 120, true);
-        assert!(line.starts_with("Still reading ["), "{line}");
+        assert!(line.starts_with("Still scanning ["), "{line}");
         assert!(line.contains(" 25% - 00000.M2TS | Elapsed: 00:00:10 | Remaining: 00:00:30"));
         assert_eq!(line.matches('█').count(), 6);
         assert_eq!(line.matches('░').count(), 18);
         // The lead-in decision itself.
         assert_eq!(super::lead_in(false), "Scanning");
-        assert_eq!(super::lead_in(true), "Still reading");
+        assert_eq!(super::lead_in(true), "Still scanning");
         // Its trigger: five seconds of silence, inclusive.
         assert!(!super::stalled(Duration::from_millis(4_999)));
         assert!(super::stalled(Duration::from_secs(5)));
@@ -2598,9 +2602,34 @@ Options:
         // The fallback carries the stall wording too — a narrow terminal loses
         // the bar, not the news that the read is stuck.
         let line = compose_styled_progress(&progress, Duration::from_secs(10), 20, true);
-        assert_eq!(line, "Still reading  25% ");
+        assert_eq!(line, "Still scanning  25%");
         // A zero-width terminal draws nothing rather than panicking.
         assert_eq!(compose_styled_progress(&progress, Duration::ZERO, 0, false), "");
+    }
+
+    #[test]
+    fn the_no_estimate_placeholder_costs_the_line_no_width() {
+        // Before the first byte the remaining field is a placeholder, not a
+        // time — and it has to occupy exactly the room a time would, because
+        // the bar is sized from what the tail leaves and the narrow fallback
+        // truncates to the window. Same width in, same line out.
+        let blind = ScanProgress { file: "00000.M2TS", done: 0, total: 200 };
+        let measured = ScanProgress { file: "00000.M2TS", done: 50, total: 200 };
+        let line = compose_progress(&blind, Duration::from_secs(10), super::LEAD_SCANNING);
+        assert!(line.ends_with("Remaining: --:--:--"), "{line}");
+        assert_eq!(
+            line.chars().count(),
+            compose_progress(&measured, Duration::from_secs(10), super::LEAD_SCANNING)
+                .chars()
+                .count()
+        );
+        // The bar keeps every cell it had.
+        let styled = compose_styled_progress(&blind, Duration::from_secs(10), 120, false);
+        assert!(styled.contains("Remaining: --:--:--"), "{styled}");
+        assert_eq!(styled.matches('░').count(), 24);
+        // And the narrow fallback truncates at the same column.
+        let narrow = compose_styled_progress(&blind, Duration::from_secs(10), 20, false);
+        assert_eq!(narrow, "Scanning   0% - 000");
     }
 
     #[test]
@@ -2668,7 +2697,7 @@ Options:
         let after_forty = paints(&painted);
         assert_eq!(after_forty.len(), 3);
         let third = after_forty.get(2).expect("the stalled paint");
-        assert!(third.contains("Still reading ["), "{third}");
+        assert!(third.contains("Still scanning ["), "{third}");
         assert!(third.contains("00011.M2TS | Elapsed: 00:00:40"), "{third}");
         assert!(third.contains(" 25% - "), "the percent cannot move without an event: {third}");
     }
@@ -2724,7 +2753,7 @@ Options:
         let repaints = paints(&painted);
         assert!(repaints.len() >= 2, "the ticker repainted at least once: {repaints:?}");
         let last = repaints.last().expect("a painted line");
-        assert!(last.contains("Still reading ["), "{last}");
+        assert!(last.contains("Still scanning ["), "{last}");
         assert!(last.contains("00011.M2TS | Elapsed: 00:00:4"), "the clock climbed: {last}");
 
         // Stopping really stops it: with the clocks pushed back into the past


### PR DESCRIPTION
On a Windows drive root a single read error cost the disc its name: the report
body read `Disc Label: <letter>`, the file was written as `BDINFO.<letter>.txt`,
and the desktop app's title degraded with it. The raw-device label read was
gated on the finished scan having recorded no io failure, and that gate closed
on exactly the media the label matters most on.

The gate's reason — do not grind a device that has just demonstrated read
errors — only applies once a failure exists, so the read now runs before the
scan. Which drive letter to read is decided lexically from the input path
(strip a `<letter>:` prefix; probe only when every remaining component is a
separator or a BDMV-tree directory name), which covers all three accepted input
spellings and costs an ordinary named folder no IO. The answer is applied
afterwards, and only to a label the finished scan left as a bare drive root.
Re-walking the tree afterwards was rejected: `FsDir` shares its error sink
across derived handles, so a second walk would record a damaged listing's
failures into the report twice.

Two progress-line corrections ride along, both visible for minutes on damaged
media rather than milliseconds:

- Before any bytes are measured the remaining estimate has nothing to
  extrapolate from and read `00:00:00` — "about to finish" at the moment
  nothing had been read. It now reads `--:--:--`, spelled by a new
  `progress::remaining_hms` so the rule lives once in core; the placeholder is
  exactly as wide as a time, so the monospace layout and the terminal line's
  narrow fallback are unmoved. Once a byte is measured both surfaces show a
  time as before.
- The stalled lead-in said `Still reading` under a line that had been saying
  `Scanning`; it now says `Still scanning`. The listing pass keeps `Reading` /
  `Still reading`, which is already its own verb continued.

Documentation: DIFFERENCES.md scoped the forward-PTS bitrate rule to audio and
claimed a healthy disc measures identically. Neither holds — the rule governs
any stream whose PES carries a PTS without a DTS, and the final playlist-level
bitrate pass reads the same field for video streams, so a short playlist's kbps
moves by a few counts while a feature-length one does not. That entry moves out
of the no-effect list into the visible section; the drive-root label paragraph
this PR falsifies is gone. CHANGELOG.md's 4.0.0 section carried both false
statements and the superseded lead-in wording, and gains entries for this
change and for #377.

Verified with `pwsh scripts/compliance.ps1 -All`: root, wasm and GUI gates
green. Root coverage 100% lines/regions/functions, branches 97.70% (floor 97%);
`mt --in-diff` 18 mutants, 17 caught and 1 unviable; `semver` reports no update
required; all 1108 tests pass, so every committed golden is byte-identical.