### PR TITLE
fix(gui): decide an input's kind without touching the filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the command line and the desktop app, instead of `00:00:00` — which read as "about to finish" at
   the moment nothing had been read, and could stand there for minutes beside a stalled read.
   ([#378](https://github.com/agentjp/bdinfo-rs/issues/378))
+* **gui:** deciding whether a path names a disc folder or an `.iso` image no longer reads the
+  filesystem — the kind is taken from the path's spelling, and whether the path can be opened is
+  answered by the listing worker. A source that has stopped answering (an unplugged drive, a share
+  that is gone) therefore no longer freezes the window before it appears when it is the remembered
+  last source, nor freezes a running window when it is dropped onto it; the stall lands on the
+  worker, behind the scan overlay's Cancel. A path that is missing or is not a disc still reaches
+  the same failure screen with the same message. ([#379](https://github.com/agentjp/bdinfo-rs/issues/379))
 * **gui:** the log records a stall clearing as well as a stall starting, the scan overlay no longer
   passes clicks and drags through to the table beneath it, the scan-notice modal stops referring to
   a report below it, and a refused report save names the destination it tried.

--- a/crates/bdinfo-rs-gui/src/diagnostics.rs
+++ b/crates/bdinfo-rs-gui/src/diagnostics.rs
@@ -220,10 +220,10 @@ pub fn install_panic_hook() {
 
 /// Tolerated-`Result` logging.
 ///
-/// Where the code deliberately swallows an error (a settings write, an
-/// autosave destination, a recall of a vanished path), `log_err` records it
-/// with the swallow's own `file:line` before the value flows on unchanged —
-/// the tolerance stays, the invisibility goes.
+/// Where the code deliberately swallows an error (a settings write, the
+/// config directory it needs, the window icon), `log_err` records it with the
+/// swallow's own `file:line` before the value flows on unchanged — the
+/// tolerance stays, the invisibility goes.
 pub trait LogErr {
     /// Logs the `Err` (if any) at Warn, tagged with the caller's `file:line`
     /// and `what` naming the tolerated operation, and returns `self`.

--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -514,19 +514,6 @@ impl Flow {
         }
     }
 
-    /// A path arriving from outside the pickers (a drop or the boot argument)
-    /// was not a disc folder or `.iso` — enter the same fatal state a failed
-    /// pick reaches, carrying the classifier's message. A no-op while a scan
-    /// is in flight ([`Stage::Listing`] / [`Stage::Scanning`]): the shell
-    /// ignores drops while busy, and this transition enforces the same rule.
-    #[must_use]
-    pub fn open_failed(self, message: String) -> Self {
-        match self.inner {
-            Inner::Listing { .. } | Inner::Scanning { .. } => self,
-            _ => Self { inner: Inner::Failed(message) },
-        }
-    }
-
     /// Toggles the checkbox at `index` (only while the table is editable —
     /// [`Stage::Listed`] / [`Stage::Reported`]). The scan set changed, so the
     /// retained pre-scan report refreshes with it.
@@ -1492,28 +1479,6 @@ mod tests {
         );
         assert_eq!(flow.stage(), Stage::Failed);
         assert_eq!(flow.error_message(), Some("no BD"));
-    }
-
-    #[test]
-    fn a_rejected_open_is_fatal_like_a_bad_pick() {
-        // From idle and from a loaded disc alike, the rejection lands in the
-        // same failure state a bad pick reaches.
-        let flow = Flow::idle().open_failed("not a disc".to_owned());
-        assert_eq!(flow.stage(), Stage::Failed);
-        assert_eq!(flow.error_message(), Some("not a disc"));
-        assert_eq!(listed().open_failed("not a disc".to_owned()).stage(), Stage::Failed);
-    }
-
-    #[test]
-    fn a_rejected_open_never_interrupts_a_running_scan() {
-        // While listing, the drop is ignored — the listing continues.
-        let flow = Flow::start_listing(input()).open_failed("nope".to_owned());
-        assert_eq!(flow.stage(), Stage::Listing);
-        // While a measured scan runs, likewise.
-        let mut flow = listed();
-        flow.toggle(0);
-        let flow = flow.start_scanning(1).open_failed("nope".to_owned());
-        assert_eq!(flow.stage(), Stage::Scanning);
     }
 
     #[test]
@@ -2695,7 +2660,7 @@ mod tests {
             Failed(u64),
             Cancel,
             Relist,
-            OpenRejected,
+            RelistRejected,
         }
 
         /// One of a few representative view configurations — a filter change,
@@ -2749,7 +2714,7 @@ mod tests {
                 (0_u64..4).prop_map(Event::Failed),
                 Just(Event::Cancel),
                 Just(Event::Relist),
-                Just(Event::OpenRejected),
+                Just(Event::RelistRejected),
             ]
         }
 
@@ -2826,16 +2791,13 @@ mod tests {
                         }
                         Event::Cancel => flow = flow.cancel(),
                         Event::Relist => flow = Flow::start_listing(input()).listed(&input(), Ok(structural()), ViewSettings::default()),
-                        Event::OpenRejected => {
-                            let before = flow.stage();
-                            flow = flow.open_failed("nope".to_owned());
-                            // A rejected open fails from any settled state but
-                            // never interrupts an in-flight scan.
-                            if matches!(before, Stage::Listing | Stage::Scanning) {
-                                prop_assert_eq!(flow.stage(), before);
-                            } else {
-                                prop_assert_eq!(flow.stage(), Stage::Failed);
-                            }
+                        Event::RelistRejected => {
+                            // The twin of `Relist`: the same open, refused by
+                            // the listing worker (an unopenable path, a disc
+                            // with no structure), which is fatal from wherever
+                            // the flow stood.
+                            flow = Flow::start_listing(input()).listed(&input(), Err("nope".to_owned()), ViewSettings::default());
+                            prop_assert_eq!(flow.stage(), Stage::Failed);
                         }
                     }
                     // The stage is always one of the legal states, and an

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -267,11 +267,15 @@ fn attended_session() -> bool {
 /// Boots the app and fires a one-shot request for the OS theme, so the first
 /// frame matches the desktop's light/dark setting. The persisted state seeds
 /// the launch: the stored theme preference applies, and the last opened source
-/// — when it still exists — shows in the Source field with "Rescan" live
-/// (`BDInfo` seeds its source box from `LastPath` the same way), but nothing
-/// scans until asked; a vanished path starts clean. A command-line path
-/// (`bdinfo-rs-gui <path>`, `BDInfo`'s `args[0]`) opens at boot through the same
-/// classify-and-list road a drop takes — `open` arrives from
+/// shows in the Source field with "Rescan" live (`BDInfo` seeds its source box
+/// from `LastPath` the same way), but nothing scans until asked. The recall
+/// takes the source's kind off the path's spelling and reads nothing
+/// ([`Input::classify`]) — a stat here would run before iced has created the
+/// window, so a source that no longer answers would leave a process with no
+/// window and no way to end it. A source that has gone away is therefore
+/// recalled like any other, and says so when the user rescans it. A
+/// command-line path (`bdinfo-rs-gui <path>`, `BDInfo`'s `args[0]`) opens at
+/// boot through the same road a drop takes — `open` arrives from
 /// [`args::classify`] over the OS-native argv, so a non-UTF-8 path survives
 /// intact. In a **debug** build it also applies the screenshot-harness
 /// environment hooks (see the debug `boot_with`).
@@ -286,13 +290,8 @@ fn boot(
         persisted,
         ..App::default()
     };
-    if let Some(input) = app
-        .persisted
-        .last_path
-        .clone()
-        .and_then(|path| Input::classify(path).log_err("last-path recall").ok())
-    {
-        app.flow = Flow::recall(input);
+    if let Some(path) = app.persisted.last_path.clone() {
+        app.flow = Flow::recall(Input::classify(path));
     }
     let mut tasks = vec![iced::system::theme().map(Message::OsTheme)];
     if let Some(path) = open {
@@ -995,8 +994,8 @@ enum Message {
     FolderPicked(Option<PathBuf>),
     /// The `.iso` file dialog closed.
     IsoPicked(Option<PathBuf>),
-    /// A path arrived from outside the pickers (the boot argument) — classify
-    /// it and open like a pick, or land in the friendly failure state.
+    /// A path arrived from outside the pickers (the boot argument) — read its
+    /// kind off the spelling and open it like a pick.
     OpenPath(PathBuf),
     /// A drag-and-drop payload entered the window (one event per held file).
     FileHovered,
@@ -1902,34 +1901,14 @@ impl App {
         Task::none()
     }
 
-    /// Opens `path` — a dropped item or the boot argument — through the same
-    /// classify-and-list road the pickers take ([`Input::classify`], the one
-    /// classifier both roads share). Ignored while a scan is in flight,
-    /// the same rule that disables the Source buttons; a path that is neither a
-    /// directory nor a `.iso` file lands in the same friendly failure state as
-    /// a bad pick, with the loaded-disc chrome cleared like any new open.
+    /// Opens `path` — a dropped item or the boot argument — like a pick, with
+    /// its kind read off the spelling ([`Input::classify`], the one classifier
+    /// both roads share) so that this, the UI thread, never stats a path that
+    /// may not answer. A path that is not there, or is not the kind of thing
+    /// its name promised, lands in the same friendly failure state as a bad
+    /// pick — from the listing worker, which is where the filesystem is read.
     fn open_path(&mut self, path: PathBuf) -> Task<Message> {
-        if self.is_busy() {
-            return Task::none();
-        }
-        match Input::classify(path) {
-            Ok(input) => self.begin_listing(input),
-            Err(message) => {
-                // The one open road that ends before `begin_listing` — and so
-                // before the "listing …" line — leaving a log in which a drop
-                // or a command-line path the user swears they gave simply
-                // never appears.
-                log::info!("open failed: {message}");
-                self.status = None;
-                self.showing_report = false;
-                self.notice = None;
-                self.hovered = None;
-                self.hovered_header = None;
-                self.pane_selection = None;
-                self.flow = std::mem::take(&mut self.flow).open_failed(message);
-                Task::none()
-            }
-        }
+        self.picked(Input::classify(path))
     }
 
     /// Begins the initial scan of `input` — the bounded `Codecs` pass, which
@@ -4680,14 +4659,25 @@ mod interaction {
 
     #[test]
     fn a_bad_path_lands_in_the_friendly_failure_screen() {
-        // A REAL file that is not an `.iso` (this crate's own manifest), so
-        // the classifier's extension road runs before rejecting it.
+        // A REAL file that is not an `.iso` (this crate's own manifest). The
+        // open reads no filesystem: it takes the path for a folder on its
+        // spelling and hands it to the listing worker, so the rejection
+        // arrives as that worker's result — which is what is injected here,
+        // straight from the seam rather than as a literal.
         let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
         let mut app = App::default();
         let _ = app.update(Message::OpenPath(manifest.clone()));
+        assert_eq!(app.flow.stage(), Stage::Listing, "the open goes to the worker");
+        let input = bdinfo_rs_gui::scan::Input::classify(manifest.clone());
+        let result = bdinfo_rs_gui::scan::scan_structural(
+            &input,
+            &mut bdinfo_rs_gui::scan::no_progress,
+            &std::sync::atomic::AtomicBool::new(false),
+        );
+        let _ = app.update(Message::Listed { generation: app.generation, input, result });
         assert_eq!(app.flow.stage(), Stage::Failed);
         assert!(sees(&app, "Couldn't open the disc"));
-        // The classifier's whole message renders (the selector is exact-text).
+        // The seam's whole message renders (the selector is exact-text).
         assert!(sees(
             &app,
             &format!("Not a Blu-ray disc folder or .iso image: {}", manifest.display())
@@ -4697,16 +4687,20 @@ mod interaction {
     #[test]
     fn only_the_first_dropped_item_opens() {
         // Two files dropped together: winit hovers both, then drops both. The
-        // first drop takes the hover flag and opens (here: fails classify);
-        // the second must be ignored, not clobber the first.
+        // first drop takes the hover flag and opens; the second must be
+        // ignored, not clobber the first.
         let mut app = App::default();
         let _ = app.update(Message::FileHovered);
         let _ = app.update(Message::FileHovered);
         let _ = app.update(Message::FileDropped(PathBuf::from("first.xyz")));
+        assert!(!app.drop_hover, "the first drop consumed the flag both hovers set");
         let _ = app.update(Message::FileDropped(PathBuf::from("second.xyz")));
-        assert_eq!(app.flow.stage(), Stage::Failed);
-        assert!(sees(&app, "The path does not exist: first.xyz"), "the FIRST item won the drop");
-        assert!(!sees(&app, "The path does not exist: second.xyz"));
+        assert_eq!(app.flow.stage(), Stage::Listing);
+        assert_eq!(
+            app.flow.current_input(),
+            Some(&bdinfo_rs_gui::scan::Input::Folder(PathBuf::from("first.xyz"))),
+            "the FIRST item won the drop"
+        );
     }
 
     /// A scratch directory under the crate's target dir (unique per test) for

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -45,30 +45,30 @@ pub enum Input {
 }
 
 impl Input {
-    /// Classifies a path arriving from outside the pickers — a drag-and-drop
-    /// item or a command-line argument — into the input the open flow takes:
-    /// a directory is a [`Input::Folder`], a file with a `.iso` extension
-    /// (case-insensitive) a [`Input::Iso`]. The one classifier both roads
-    /// share, so a dropped disc and `bdinfo-rs-gui <path>` can never diverge.
+    /// Decides which input a path arriving from outside the pickers — a
+    /// drag-and-drop item, a command-line argument, the recalled last source —
+    /// names, **from its spelling alone**: a `.iso` extension (ASCII
+    /// case-insensitive) is an [`Input::Iso`], anything else an
+    /// [`Input::Folder`]. The one classifier every such road shares, so a
+    /// dropped disc and `bdinfo-rs-gui <path>` can never diverge.
+    ///
+    /// It reads nothing, and must not: every caller runs on the UI thread —
+    /// the recall before the window even exists — and a `std::fs` stat of a
+    /// path that does not answer (a dropped network share, an optical drive
+    /// inside its retry storm) blocks in an uninterruptible kernel wait, which
+    /// on Windows leaves a process that cannot be ended. Whether the path is
+    /// there, and is the kind of thing its spelling promised, is
+    /// [`scan_structural`]'s answer — on the worker thread, where a stall
+    /// costs one thread and the user keeps a live Cancel.
     ///
     /// The extension check compares [`std::ffi::OsStr`] bytes directly, so a
-    /// non-UTF-8 path classifies (and fails) without a lossy conversion.
-    ///
-    /// # Errors
-    /// A short user-facing message when the path is neither a directory nor a
-    /// `.iso` file (or does not exist at all) — shown by the same friendly
-    /// failure state a bad pick reaches.
-    pub fn classify(path: PathBuf) -> Result<Self, String> {
-        if path.is_dir() {
-            return Ok(Self::Folder(path));
-        }
-        if path.is_file() && path.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("iso")) {
-            return Ok(Self::Iso(path));
-        }
-        if path.exists() {
-            Err(format!("Not a Blu-ray disc folder or .iso image: {}", path.display()))
+    /// non-UTF-8 path classifies without a lossy conversion.
+    #[must_use]
+    pub fn classify(path: PathBuf) -> Self {
+        if path.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("iso")) {
+            Self::Iso(path)
         } else {
-            Err(format!("The path does not exist: {}", path.display()))
+            Self::Folder(path)
         }
     }
 
@@ -150,6 +150,34 @@ fn open(
 /// holds no readable structure at all.
 type Opened = Result<(BdRom, Vec<ScanError>), String>;
 
+/// Rejects an input the filesystem cannot serve, in the two messages the
+/// friendly failure state shows: a path that is not there, and a path that is
+/// there but is not the kind of thing [`Input::classify`] read off its
+/// spelling (a stray file, or a directory named `*.iso`).
+///
+/// This is the whole of the seam's filesystem validation, and it runs here —
+/// inside the listing, on whatever thread called it — because each of these
+/// stats blocks for as long as the filesystem makes it, and the shell
+/// classifies on its UI thread. Letting the core's own open speak instead is
+/// not equivalent: a folder that is not there reaches
+/// [`BdError::StructureNotFound`], whose "unable to locate BD structure" is
+/// both wrong and less useful than saying the path does not exist.
+fn openable(input: &Input) -> Result<(), String> {
+    let path = input.path();
+    let usable = match input {
+        Input::Folder(_) => path.is_dir(),
+        Input::Iso(_) => path.is_file(),
+    };
+    if usable {
+        return Ok(());
+    }
+    if path.exists() {
+        Err(format!("Not a Blu-ray disc folder or .iso image: {}", path.display()))
+    } else {
+        Err(format!("The path does not exist: {}", path.display()))
+    }
+}
+
 /// Recorded scan failures as display strings, for the UI's warning surfaces.
 fn error_lines(errors: &[ScanError]) -> Vec<String> {
     errors.iter().map(ToString::to_string).collect()
@@ -173,7 +201,9 @@ pub const fn no_progress(_: ScanProgress<'_>) {}
 /// never wait on one to conclude a cancelled listing is over.
 ///
 /// # Errors
-/// A short message when the input holds no readable Blu-ray structure (no
+/// A short message when the path is not there or is not the kind of thing its
+/// spelling promised (the filesystem check [`Input::classify`] leaves to this
+/// road), when the input holds no readable Blu-ray structure (no
 /// `BDMV`/`CLIPINF`/`PLAYLIST`, or a `.iso` that is not a readable UDF
 /// volume), or when `cancel` was set mid-listing.
 pub fn scan_structural(
@@ -181,6 +211,7 @@ pub fn scan_structural(
     progress: &mut dyn FnMut(ScanProgress<'_>),
     cancel: &AtomicBool,
 ) -> Result<Structural, String> {
+    openable(input)?;
     let (bdrom, errors) = listing_scan(|mode, options| {
         // The options come from `listing_scan` (the default plus its AACS
         // verdict reuse), never the user's settings: the partial-retention
@@ -433,45 +464,66 @@ mod tests {
     }
 
     #[test]
-    fn classify_takes_a_directory_as_a_folder() {
+    fn classify_takes_a_path_without_an_iso_extension_as_a_folder() {
         let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        assert_eq!(Input::classify(dir.clone()), Ok(Input::Folder(dir)));
+        assert_eq!(Input::classify(dir.clone()), Input::Folder(dir));
         // A trailing separator classifies the same directory.
         let mut trailing = env!("CARGO_MANIFEST_DIR").to_owned();
         trailing.push(std::path::MAIN_SEPARATOR);
         let trailing = PathBuf::from(trailing);
-        assert_eq!(Input::classify(trailing.clone()), Ok(Input::Folder(trailing)));
+        assert_eq!(Input::classify(trailing.clone()), Input::Folder(trailing));
     }
 
     #[test]
-    fn classify_takes_an_iso_file_by_extension() {
+    fn classify_takes_an_iso_by_extension() {
         let iso = fixture("BigBuckBunny.iso");
-        assert_eq!(Input::classify(iso.clone()), Ok(Input::Iso(iso)));
+        assert_eq!(Input::classify(iso.clone()), Input::Iso(iso));
     }
 
     #[test]
     fn classify_ignores_the_extension_case() {
-        // `.ISO` must classify like `.iso`; the fixture is lower-case, so make a
-        // scratch file (the classifier requires the file to exist).
-        let path = std::env::temp_dir().join("bdinfo-rs-gui-classify-case.ISO");
-        std::fs::write(&path, b"x").expect("the scratch file writes");
-        let result = Input::classify(path.clone());
-        let _ = std::fs::remove_file(&path);
-        assert_eq!(result, Ok(Input::Iso(path)));
+        // `.ISO` classifies like `.iso`.
+        let shouting = PathBuf::from("DISC.ISO");
+        assert_eq!(Input::classify(shouting.clone()), Input::Iso(shouting));
     }
 
     #[test]
-    fn classify_rejects_a_file_that_is_not_an_iso() {
+    fn classify_answers_for_a_path_that_is_not_there() {
+        // The no-IO contract, observable in-process: NEITHER path exists, so a
+        // classifier that consulted the filesystem could not return a variant
+        // for either — and on a path that never answers, the stat it would
+        // take never returns at all.
+        let folder = fixture("no-such-thing");
+        assert_eq!(Input::classify(folder.clone()), Input::Folder(folder));
+        let iso = fixture("no-such-thing.iso");
+        assert_eq!(Input::classify(iso.clone()), Input::Iso(iso));
+    }
+
+    #[test]
+    fn a_path_that_is_not_there_fails_the_listing_by_name() {
+        // The message the friendly failure state shows, whole: the core's own
+        // "unable to locate BD structure" would be both wrong and less useful.
+        let missing = fixture("no-such-thing");
+        let message = scan_structural(&Input::classify(missing.clone()))
+            .expect_err("a missing path lists nothing");
+        assert_eq!(message, format!("The path does not exist: {}", missing.display()));
+    }
+
+    #[test]
+    fn a_path_that_is_not_what_its_name_promises_fails_the_listing() {
+        // A real file with no `.iso` extension classifies as a folder, and a
+        // real directory named `*.iso` classifies as an image: both are there,
+        // and neither can be opened as what it was taken for.
         let file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
-        let message = Input::classify(file).expect_err("a stray file is rejected");
-        assert!(message.contains("Not a Blu-ray disc folder or .iso image"));
-    }
-
-    #[test]
-    fn classify_rejects_a_nonexistent_path() {
         let message =
-            Input::classify(fixture("no-such-thing.iso")).expect_err("a missing path is rejected");
-        assert!(message.contains("does not exist"));
+            scan_structural(&Input::classify(file.clone())).expect_err("a stray file is rejected");
+        assert_eq!(message, format!("Not a Blu-ray disc folder or .iso image: {}", file.display()));
+
+        let dir = scratch("dir-named-iso").join("disc.iso");
+        std::fs::create_dir_all(&dir).expect("the scratch dir creates");
+        let message = scan_structural(&Input::classify(dir.clone()))
+            .expect_err("a directory is no .iso image");
+        assert_eq!(message, format!("Not a Blu-ray disc folder or .iso image: {}", dir.display()));
     }
 
     #[test]
@@ -944,9 +996,12 @@ mod tests {
     fn classify_survives_a_non_utf8_path() {
         use std::os::windows::ffi::OsStringExt;
 
-        // An unpaired surrogate — representable in a Windows path, not in UTF-8.
+        // An unpaired surrogate — representable in a Windows path, not in
+        // UTF-8 — ending in `.iso`: the extension is compared as bytes, so it
+        // still reads as an image rather than tripping over the conversion.
         let bogus = std::ffi::OsString::from_wide(&[0xD800, 0x002E, 0x0069, 0x0073, 0x006F]);
-        assert!(Input::classify(PathBuf::from(bogus)).is_err());
+        let bogus = PathBuf::from(bogus);
+        assert_eq!(Input::classify(bogus.clone()), Input::Iso(bogus));
     }
 
     #[cfg(unix)]
@@ -954,8 +1009,11 @@ mod tests {
     fn classify_survives_a_non_utf8_path() {
         use std::os::unix::ffi::OsStringExt;
 
-        // Raw bytes that are not UTF-8, ending in `.iso`.
+        // Raw bytes that are not UTF-8, ending in `.iso`: the extension is
+        // compared as bytes, so it still reads as an image rather than
+        // tripping over the conversion.
         let bogus = std::ffi::OsString::from_vec(vec![0xFF, 0xFE, b'.', b'i', b's', b'o']);
-        assert!(Input::classify(PathBuf::from(bogus)).is_err());
+        let bogus = PathBuf::from(bogus);
+        assert_eq!(Input::classify(bogus.clone()), Input::Iso(bogus));
     }
 }


### PR DESCRIPTION
The desktop app could hang before it had a window. `boot()` recalled the last
opened path and classified it on the main thread, before iced created the
window, and the classifier opened with `path.is_dir()`. On a path that does not
answer — a share that is gone, an optical drive inside a retry storm — that stat
blocks in an uninterruptible kernel wait: no window appears, the log stops after
its startup lines, and the process cannot be ended. `open_path`, which serves
command-line paths and drag-and-drop, carried the same call, so a dropped dead
path froze a window that was already up.

The Folder-vs-Iso decision is now lexical: a `.iso` extension is an image,
anything else a folder. The existence and shape check moves into
`scan_structural`, which already runs on the listing worker, behind the scan
overlay's Cancel. Both of the existing messages live on that road, so a missing
path and a non-disc path still reach the same failure screen in the same words —
letting the core answer instead would report "unable to locate BD structure" for
a path that is not there.

A recalled source that has since gone away is now recalled and reports the
failure when the user acts on it, rather than being dropped in silence at boot.
`Flow::open_failed` goes with the caller it existed for: a rejected open is a
listing failure, which `Flow::listed` already routes to the same fatal state.

This does not make a stalled read cancellable; it makes the stall survivable,
off the drawing thread and behind an action the user chose.