### PR TITLE
feat(wasm): add a light theme with an auto, light and dark setting to the demo

### DIFF
--- a/crates/bdinfo-rs-wasm/web/_headers
+++ b/crates/bdinfo-rs-wasm/web/_headers
@@ -21,7 +21,15 @@
 # scripts), data: images, and blob: for the in-page report download
 # (URL.createObjectURL). No COOP/COEP (single-threaded FileReaderSync, no
 # SharedArrayBuffer) — see the note above.
+#
+# The 'sha256-…' entry allowlists index.html's inline theme-boot script — the
+# page's one attribute-less <script> tag. It hashes the EXACT bytes between the
+# script tags, so regenerate after ANY edit to them (run in this directory):
+#   node -e "const s=require('fs').readFileSync('index.html','utf8').match(/<script>([^]*?)<\/script>/)[1];console.log('sha256-'+require('crypto').createHash('sha256').update(s).digest('base64'))"
+# A stale hash fails SILENTLY — the page loads, the blocked script never sets
+# data-theme, and a stored Light/Dark choice paints wrong on cold start.
+# test/parity.chrome.mjs serves this CSP on index.html and asserts the boot.
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-bIG7TV9pFGN301DjW68tzbgy2dQfI+ZZrLEEXZdjvsM='; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -24,6 +24,22 @@
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ccircle cx='64' cy='64' r='54.4' fill='none' stroke='%23F2A65A' stroke-width='16.64'/%3E%3Ccircle cx='64' cy='64' r='20.48' fill='%23F2A65A'/%3E%3C/svg%3E"
     />
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+    <!-- Applies a stored manual theme choice before first paint; Auto leaves
+         the attribute off and the prefers-color-scheme blocks below decide.
+         Inline so it runs during parse: the CSP in _headers allowlists exactly
+         these bytes by SHA-256 hash, so any edit between the script tags must
+         regenerate the hash (the command is beside it in _headers) — a stale
+         hash blocks the script SILENTLY and a stored choice paints wrong on
+         cold start. The storage key mirrors SETTINGS_KEY in src/state.ts,
+         which an inline script cannot import. -->
+    <script>
+      try {
+        const theme = JSON.parse(localStorage.getItem("bdinfo-rs.settings")).theme;
+        if (theme === "light" || theme === "dark") {
+          document.documentElement.dataset.theme = theme;
+        }
+      } catch {}
+    </script>
     <style>
       :root {
         --bg: #0b0d10;
@@ -633,6 +649,32 @@
         border-radius: 6px;
         padding: 0.25rem 0.4rem;
       }
+      /* The Auto/Light/Dark theme chips: one segmented control built from the
+         button idiom — outer corners only, segments fused by a 1px overlap.
+         The pressed chip is accent-tinted and sits above its neighbors so its
+         accent border wins the overlap. */
+      .chips {
+        margin-left: auto;
+        display: inline-flex;
+      }
+      .chips .btn {
+        border-radius: 0;
+      }
+      .chips .btn:first-child {
+        border-radius: 9px 0 0 9px;
+      }
+      .chips .btn:last-child {
+        border-radius: 0 9px 9px 0;
+      }
+      .chips .btn + .btn {
+        margin-left: -1px;
+      }
+      .chips .btn[aria-pressed="true"] {
+        position: relative;
+        color: var(--accent);
+        border-color: var(--accent);
+        background: var(--accent-dim);
+      }
       /* the hairline separating the display settings from the report ones */
       .settings hr {
         border: none;
@@ -1035,6 +1077,17 @@
       <!-- settings: a native modal dialog (Esc closes, the backdrop dims) -->
       <dialog class="settings" id="settings-dialog" aria-labelledby="settings-title">
         <h2 id="settings-title">Settings</h2>
+        <!-- Instant-apply: each chip is its own live preview, so there is no
+             draft state and nothing to cancel. -->
+        <div class="setting-row">
+          <span>Theme</span>
+          <span class="chips" id="theme-chips" role="group" aria-label="Theme">
+            <button class="btn small" type="button" data-theme-choice="auto" aria-pressed="false">Auto</button>
+            <button class="btn small" type="button" data-theme-choice="light" aria-pressed="false">Light</button>
+            <button class="btn small" type="button" data-theme-choice="dark" aria-pressed="false">Dark</button>
+          </span>
+        </div>
+        <hr />
         <div class="setting-row">
           <label class="setting">
             <input type="checkbox" id="opt-short" />

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -36,6 +36,19 @@
         --danger: #ff6b6b;
         --warn: #f7b955;
         --ok: #46d18a;
+        --accent-ink: #06121b;
+        --link-hover: #7ad2ff;
+        --error-text: #ffd7d7;
+        --error-bg: rgba(255, 107, 107, 0.08);
+        --error-border: rgba(255, 107, 107, 0.35);
+        --warning-text: #ffe6bd;
+        --warning-bg: rgba(247, 185, 85, 0.08);
+        --warning-border: rgba(247, 185, 85, 0.35);
+        --shadow: rgba(0, 0, 0, 0.55);
+        --backdrop: rgba(4, 6, 9, 0.62);
+        --logo-glow: rgba(76, 194, 255, 0.35);
+        --report-bg: #08090b;
+        --report-text: #cdd3da;
         --radius: 12px;
         --mono: ui-monospace, "Cascadia Code", "JetBrains Mono", "SF Mono", Consolas, monospace;
         --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, sans-serif;
@@ -67,7 +80,7 @@
         text-decoration: none;
       }
       a:hover {
-        color: #7ad2ff;
+        color: var(--link-hover);
       }
 
       .wrap {
@@ -94,7 +107,7 @@
       }
       .brand .logo {
         color: var(--accent);
-        filter: drop-shadow(0 0 10px rgba(76, 194, 255, 0.35));
+        filter: drop-shadow(0 0 10px var(--logo-glow));
       }
       .brand h1 {
         margin: 0;
@@ -161,13 +174,13 @@
       .btn.primary {
         background: var(--accent);
         border-color: var(--accent);
-        color: #06121b;
+        color: var(--accent-ink);
         font-weight: 650;
       }
       .btn.primary:hover:not(:disabled) {
         background: var(--accent-strong);
         border-color: var(--accent-strong);
-        color: #06121b;
+        color: var(--accent-ink);
       }
       .btn.small {
         padding: 0.35rem 0.6rem;
@@ -492,10 +505,10 @@
         background: var(--surface);
         border: 1px solid var(--border-strong);
         border-radius: var(--radius);
-        box-shadow: 0 18px 50px rgba(0, 0, 0, 0.55);
+        box-shadow: 0 18px 50px var(--shadow);
       }
       .settings::backdrop {
-        background: rgba(4, 6, 9, 0.62);
+        background: var(--backdrop);
       }
       .settings h2 {
         margin: 0 0 0.9rem;
@@ -617,11 +630,11 @@
         font-family: var(--mono);
         font-size: 0.8rem;
         line-height: 1.5;
-        color: #cdd3da;
+        color: var(--report-text);
         white-space: pre;
         overflow: auto;
         max-height: 60vh;
-        background: #08090b;
+        background: var(--report-bg);
       }
       .copied {
         color: var(--ok) !important;
@@ -636,9 +649,9 @@
         padding: 0.8rem 1rem;
         margin-bottom: 1.1rem;
         font-size: 0.88rem;
-        color: #ffd7d7;
-        background: rgba(255, 107, 107, 0.08);
-        border: 1px solid rgba(255, 107, 107, 0.35);
+        color: var(--error-text);
+        background: var(--error-bg);
+        border: 1px solid var(--error-border);
         border-radius: 10px;
       }
       .error svg {
@@ -652,9 +665,9 @@
         padding: 0.8rem 1rem;
         margin-bottom: 0.9rem;
         font-size: 0.88rem;
-        color: #ffe6bd;
-        background: rgba(247, 185, 85, 0.08);
-        border: 1px solid rgba(247, 185, 85, 0.35);
+        color: var(--warning-text);
+        background: var(--warning-bg);
+        border: 1px solid var(--warning-border);
         border-radius: 10px;
       }
       .warning svg {

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -99,7 +99,7 @@
           --border-strong: #c0c9d4;
           --text: #1b222b;
           --muted: #57626f;
-          --faint: #6d7885;
+          --faint: #8a93a0;
           --accent: #0270a8;
           --accent-strong: #015d8c;
           --accent-dim: rgba(2, 112, 168, 0.12);
@@ -129,7 +129,7 @@
         --border-strong: #c0c9d4;
         --text: #1b222b;
         --muted: #57626f;
-        --faint: #6d7885;
+        --faint: #8a93a0;
         --accent: #0270a8;
         --accent-strong: #015d8c;
         --accent-dim: rgba(2, 112, 168, 0.12);

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -8,6 +8,11 @@
       name="description"
       content="Analyze a Blu-ray disc (BDMV) entirely in your browser. No upload — the bdinfo-rs measured scan, compiled to WebAssembly."
     />
+    <!-- Each content mirrors --bg in its palette. The media form only tracks
+         the OS, so a manual Light/Dark choice rewrites both contents from the
+         settings module. -->
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0b0d10" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f4f6f9" />
     <!-- The bdinfo-rs aperture mark (crates/bdinfo-rs-gui/assets/icon.svg is
          the vector source of truth): PNG for browsers without SVG favicon
          support (Safari), the inline SVG for everything newer, and the
@@ -52,6 +57,81 @@
         --radius: 12px;
         --mono: ui-monospace, "Cascadia Code", "JetBrains Mono", "SF Mono", Consolas, monospace;
         --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, sans-serif;
+        color-scheme: dark;
+      }
+
+      /* The dark palette above is the fixed reference; the light palette below
+         is derived from it — the same hues with the lightness flipped, and
+         WCAG AA contrast for text, muted and accent against the light grounds.
+         It appears twice because the two states cannot share one selector:
+         the media-guarded block themes Auto (no data-theme attribute — the OS
+         decides), the attribute block an explicit Light choice on any OS; an
+         explicit Dark choice needs no block of its own, since data-theme="dark"
+         defeats the media guard and leaves the :root reference in force. Keep
+         the two copies identical. --report-bg/--report-text are deliberately
+         absent from both: the report well keeps its dark ground in either
+         theme, a terminal artifact on its own ground. Per-block color-scheme
+         is what flips the native widgets (scrollbars, checkbox and spinner
+         chrome, the dialog) with the palette. */
+      @media (prefers-color-scheme: light) {
+        :root:not([data-theme="dark"]) {
+          --bg: #f4f6f9;
+          --bg-glow: #e7edf5;
+          --surface: #ffffff;
+          --surface-2: #eef1f6;
+          --border: #d9dee7;
+          --border-strong: #c0c9d4;
+          --text: #1b222b;
+          --muted: #57626f;
+          --faint: #6d7885;
+          --accent: #0270a8;
+          --accent-strong: #015d8c;
+          --accent-dim: rgba(2, 112, 168, 0.12);
+          --danger: #c92a2a;
+          --warn: #a4720f;
+          --ok: #178a4e;
+          --accent-ink: #ffffff;
+          --link-hover: #015d8c;
+          --error-text: #942222;
+          --error-bg: rgba(201, 42, 42, 0.06);
+          --error-border: rgba(201, 42, 42, 0.35);
+          --warning-text: #7c5a10;
+          --warning-bg: rgba(164, 114, 15, 0.08);
+          --warning-border: rgba(164, 114, 15, 0.35);
+          --shadow: rgba(9, 14, 20, 0.18);
+          --backdrop: rgba(9, 14, 20, 0.35);
+          --logo-glow: rgba(2, 112, 168, 0.25);
+          color-scheme: light;
+        }
+      }
+      :root[data-theme="light"] {
+        --bg: #f4f6f9;
+        --bg-glow: #e7edf5;
+        --surface: #ffffff;
+        --surface-2: #eef1f6;
+        --border: #d9dee7;
+        --border-strong: #c0c9d4;
+        --text: #1b222b;
+        --muted: #57626f;
+        --faint: #6d7885;
+        --accent: #0270a8;
+        --accent-strong: #015d8c;
+        --accent-dim: rgba(2, 112, 168, 0.12);
+        --danger: #c92a2a;
+        --warn: #a4720f;
+        --ok: #178a4e;
+        --accent-ink: #ffffff;
+        --link-hover: #015d8c;
+        --error-text: #942222;
+        --error-bg: rgba(201, 42, 42, 0.06);
+        --error-border: rgba(201, 42, 42, 0.35);
+        --warning-text: #7c5a10;
+        --warning-bg: rgba(164, 114, 15, 0.08);
+        --warning-border: rgba(164, 114, 15, 0.35);
+        --shadow: rgba(9, 14, 20, 0.18);
+        --backdrop: rgba(9, 14, 20, 0.35);
+        --logo-glow: rgba(2, 112, 168, 0.25);
+        color-scheme: light;
       }
 
       * {

--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -757,6 +757,9 @@
         overflow: auto;
         max-height: 60vh;
         background: var(--report-bg);
+        /* The well keeps its dark ground in the light theme, so its own
+           scrollbars must stay dark while the page around them goes light. */
+        color-scheme: dark;
       }
       .copied {
         color: var(--ok) !important;

--- a/crates/bdinfo-rs-wasm/web/src/settings.ts
+++ b/crates/bdinfo-rs-wasm/web/src/settings.ts
@@ -9,6 +9,7 @@ import {
   errMessage,
   hide,
   MAX_SHORT_SECONDS,
+  type Settings,
   saveSettings,
   showError,
   state,
@@ -32,6 +33,42 @@ const optChapters = el<HTMLInputElement>("opt-chapters");
 const optDiagnostics = el<HTMLInputElement>("opt-diagnostics");
 const optSummary = el<HTMLInputElement>("opt-summary");
 const optKeepPartial = el<HTMLInputElement>("opt-keep-partial");
+const themeChips = Array.from(
+  el("theme-chips").querySelectorAll<HTMLButtonElement>("button[data-theme-choice]"),
+);
+
+/** What each palette paints the page ground, mirroring --bg in index.html. */
+const THEME_COLORS = { light: "#f4f6f9", dark: "#0b0d10" };
+
+/**
+ * Puts the stored theme choice into effect: the data-theme attribute for a
+ * manual choice (Auto removes it, and the prefers-color-scheme blocks in
+ * index.html decide), the pressed state on the dialog's chips, and the
+ * theme-color metas. The metas get the EFFECTIVE palette's color written into
+ * both of them: their media form tracks only the OS, so it cannot follow a
+ * manual override — and once overwritten, an Auto page needs the
+ * matchMedia listener below to keep them in step with an OS flip.
+ */
+function applyTheme(): void {
+  const choice = state.settings.theme;
+  if (choice === "auto") {
+    delete document.documentElement.dataset.theme;
+  } else {
+    document.documentElement.dataset.theme = choice;
+  }
+  for (const chip of themeChips) {
+    chip.setAttribute("aria-pressed", String(chip.dataset.themeChoice === choice));
+  }
+  const effective =
+    choice === "auto"
+      ? window.matchMedia("(prefers-color-scheme: light)").matches
+        ? "light"
+        : "dark"
+      : choice;
+  for (const meta of document.querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]')) {
+    meta.content = THEME_COLORS[effective];
+  }
+}
 
 /**
  * Applies a committed threshold value — the one setting that still costs a
@@ -78,6 +115,21 @@ async function applyThreshold(): Promise<void> {
 
 /** Puts the held settings in the dialog's controls and wires their changes. */
 export function initSettings(): void {
+  // The boot script in index.html already set the manual attribute before
+  // first paint; this pass adds what it could not — the chips and the metas.
+  applyTheme();
+  for (const chip of themeChips) {
+    chip.addEventListener("click", () => {
+      state.settings.theme = chip.dataset.themeChoice as Settings["theme"];
+      saveSettings();
+      applyTheme();
+    });
+  }
+  window.matchMedia("(prefers-color-scheme: light)").addEventListener("change", () => {
+    if (state.settings.theme === "auto") {
+      applyTheme();
+    }
+  });
   optShort.checked = state.settings.showShortPlaylists;
   optLooping.checked = state.settings.showLoopingPlaylists;
   optShortSeconds.value = String(state.settings.shortPlaylistSeconds);

--- a/crates/bdinfo-rs-wasm/web/src/state.ts
+++ b/crates/bdinfo-rs-wasm/web/src/state.ts
@@ -18,8 +18,10 @@ export type Source =
   | { kind: "folder"; files: BdmvFile[]; label: string }
   | { kind: "iso"; file: File; label: string };
 
-/** The dialog's settings, mirroring the desktop app's eight browser-relevant ones. */
+/** The dialog's settings, mirroring the desktop app's browser-relevant ones. */
 export interface Settings {
+  /** The page palette: follow the OS (`"auto"`), or force one side. */
+  theme: "auto" | "light" | "dark";
   showShortPlaylists: boolean;
   showLoopingPlaylists: boolean;
   /** What "short" means, in whole seconds — the one setting that re-runs `inspect`. */
@@ -40,7 +42,12 @@ export interface Settings {
   keepPartialScans: boolean;
 }
 
-/** Where the settings persist between visits. */
+/**
+ * Where the settings persist between visits. index.html's inline theme-boot
+ * script reads the same key as a literal — an inline script can import
+ * nothing — so renaming it means changing both (and regenerating the boot
+ * script's CSP hash).
+ */
 const SETTINGS_KEY = "bdinfo-rs.settings";
 
 /** The default short-playlist threshold, matching the CLI flag's default. */
@@ -74,7 +81,9 @@ function loadSettings(): Settings {
     stored = {};
   }
   const seconds = stored.shortPlaylistSeconds;
+  const theme = stored.theme;
   return {
+    theme: theme === "light" || theme === "dark" ? theme : "auto",
     showShortPlaylists: stored.showShortPlaylists === true,
     showLoopingPlaylists: stored.showLoopingPlaylists === true,
     shortPlaylistSeconds:

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -38,6 +38,11 @@ const goldenPath = resolve(here, "../../tests/golden_report.txt");
 // that the page `fetch`es into a `File` — no multi-MB base64 round-trip.
 const isoPath = resolve(here, "../../../bdinfo-rs/tests/fixtures/BigBuckBunny.iso");
 const isoGoldenPath = resolve(here, "../../../bdinfo-rs/tests/fixtures/golden/iso.txt");
+// The deployed CSP, served on the demo page below so its inline theme-boot
+// script runs (or is blocked) exactly as deployed: a stale script hash in
+// _headers is a silent wrong-theme-on-cold-start in production, but a hard
+// failure of the boot assertions here.
+const headersPath = resolve(here, "../_headers");
 
 // The fixture's six files at the synthetic disc paths the in-memory golden was
 // built from: root `WASMDISC` → disc label `WASMDISC`. `bdmt_eng.xml` is empty,
@@ -59,7 +64,7 @@ const MIME = {
   ".json": "application/json; charset=utf-8",
 };
 
-function startServer() {
+function startServer(csp) {
   const server = createServer(async (req, res) => {
     try {
       const urlPath = decodeURIComponent((req.url ?? "/").split("?")[0]);
@@ -75,7 +80,13 @@ function startServer() {
         return;
       }
       const body = await readFile(safe);
-      res.writeHead(200, { "content-type": MIME[extname(safe)] ?? "application/octet-stream" });
+      const headers = { "content-type": MIME[extname(safe)] ?? "application/octet-stream" };
+      // Only the demo page: the harness page's inline module script is a test
+      // fixture the deployed policy never covers.
+      if (urlPath === "/index.html") {
+        headers["content-security-policy"] = csp;
+      }
+      res.writeHead(200, headers);
       res.end(body);
     } catch {
       res.writeHead(404).end();
@@ -97,7 +108,10 @@ async function main() {
     entries.push({ path: item.path, b64: bytes.toString("base64") });
   }
 
-  const server = await startServer();
+  const csp = (await readFile(headersPath, "utf8")).match(
+    /^\s*Content-Security-Policy: (.+)$/m,
+  )[1];
+  const server = await startServer(csp);
   const { port } = server.address();
   const base = `http://127.0.0.1:${port}`;
 
@@ -502,6 +516,67 @@ async function main() {
       keepPartial: document.getElementById("opt-keep-partial").checked,
     }));
 
+    // The theme. Headless Chrome runs OS-light by default, so the OS side is
+    // pinned explicitly: Auto (nothing stored yet) follows an emulated OS flip
+    // live, a manual chip beats the OS and rewrites both theme-color metas,
+    // and the settings dialog closes and reopens with the stored chip pressed.
+    const pageBg = () => demoPage.evaluate(() => getComputedStyle(document.body).backgroundColor);
+    const pressedChips = () =>
+      demoPage.evaluate(() =>
+        [...document.querySelectorAll("#theme-chips .btn")].map((chip) =>
+          chip.getAttribute("aria-pressed"),
+        ),
+      );
+    await demoPage.emulateMedia({ colorScheme: "dark" });
+    const autoDark = await pageBg();
+    await demoPage.emulateMedia({ colorScheme: "light" });
+    const autoLight = await pageBg();
+    await demoPage.click("#settings-btn");
+    await demoPage.click('#theme-chips button[data-theme-choice="dark"]');
+    const overrideDark = {
+      bg: await pageBg(),
+      pressed: await pressedChips(),
+      metas: await demoPage.evaluate(() =>
+        [...document.querySelectorAll('meta[name="theme-color"]')].map((meta) => meta.content),
+      ),
+    };
+    await demoPage.click('#theme-chips button[data-theme-choice="light"]');
+    const overrideLight = await pageBg();
+    await demoPage.click("#settings-close");
+
+    // The boot: reload with a stored Light choice under a dark OS. The init
+    // script records what data-theme was the moment the page's <style> element
+    // appeared — mutation callbacks flush before the module scripts run, so
+    // only the parser-run inline boot script can have set it by then. Light
+    // ground despite the dark OS = the stored override, applied with no dark
+    // flash; the CSP served above is what would block a stale-hashed script.
+    await demoPage.addInitScript(() => {
+      window.__themeAtStyle = "pending";
+      const observer = new MutationObserver(() => {
+        if (document.head?.querySelector("style") && window.__themeAtStyle === "pending") {
+          window.__themeAtStyle = document.documentElement.dataset.theme ?? "absent";
+          observer.disconnect();
+        }
+      });
+      observer.observe(document, { childList: true, subtree: true });
+    });
+    await demoPage.reload();
+    const booted = await demoPage.evaluate(() => ({
+      atStyle: window.__themeAtStyle,
+      attr: document.documentElement.dataset.theme ?? null,
+      bg: getComputedStyle(document.body).backgroundColor,
+      reportBg: getComputedStyle(document.getElementById("report")).backgroundColor,
+    }));
+    await demoPage.click("#settings-btn");
+    const reopened = {
+      open: await demoPage.evaluate(() => document.getElementById("settings-dialog").open),
+      pressed: await pressedChips(),
+    };
+    await demoPage.click("#settings-close");
+    const closedAgain = await demoPage.evaluate(
+      () => document.getElementById("settings-dialog").open,
+    );
+
     demo = {
       initial,
       positionSorted,
@@ -529,6 +604,7 @@ async function main() {
       pageScrolls,
       damagedListing,
       persisted,
+      theme: { autoDark, autoLight, overrideDark, overrideLight, booted, reopened, closedAgain },
     };
   } finally {
     await browser.close();
@@ -891,6 +967,40 @@ async function main() {
     summary: true,
     keepPartial: false,
   });
+  // The theme: Auto follows the emulated OS both ways; a manual chip beats a
+  // light OS, tints its own chip, and writes its ground into both theme-color
+  // metas; a reload under a dark OS with a stored Light choice still boots
+  // light — the attribute is already set when the page's <style> appears, so
+  // there is no dark flash — while the report well keeps its dark ground; and
+  // the settings dialog reopens with the stored chip pressed, then closes.
+  demoOk &= demoEq("auto follows a dark OS", demo.theme.autoDark, "rgb(11, 13, 16)");
+  demoOk &= demoEq("auto follows an OS flip to light", demo.theme.autoLight, "rgb(244, 246, 249)");
+  demoOk &= demoEq("the dark chip beats the light OS", demo.theme.overrideDark.bg, "rgb(11, 13, 16)");
+  demoOk &= demoEq("the pressed chip is the choice", demo.theme.overrideDark.pressed, [
+    "false",
+    "false",
+    "true",
+  ]);
+  demoOk &= demoEq("a manual choice rewrites both metas", demo.theme.overrideDark.metas, [
+    "#0b0d10",
+    "#0b0d10",
+  ]);
+  demoOk &= demoEq(
+    "the light chip repaints the ground",
+    demo.theme.overrideLight,
+    "rgb(244, 246, 249)",
+  );
+  demoOk &= demoEq("the stored choice is applied before the style exists", demo.theme.booted, {
+    atStyle: "light",
+    attr: "light",
+    bg: "rgb(244, 246, 249)",
+    reportBg: "rgb(8, 9, 11)",
+  });
+  demoOk &= demoEq("the dialog reopens with the stored chip pressed", demo.theme.reopened, {
+    open: true,
+    pressed: ["false", "true", "false"],
+  });
+  demoOk &= demoEq("the dialog closes again", demo.theme.closedAgain, false);
   demoOk = Boolean(demoOk);
 
   process.exit(listOk && inspectOk && scanOk && surfaceOk && isoStructuredOk && demoOk ? 0 : 1);

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -108,9 +108,7 @@ async function main() {
     entries.push({ path: item.path, b64: bytes.toString("base64") });
   }
 
-  const csp = (await readFile(headersPath, "utf8")).match(
-    /^\s*Content-Security-Policy: (.+)$/m,
-  )[1];
+  const csp = (await readFile(headersPath, "utf8")).match(/^\s*Content-Security-Policy: (.+)$/m)[1];
   const server = await startServer(csp);
   const { port } = server.address();
   const base = `http://127.0.0.1:${port}`;
@@ -975,7 +973,11 @@ async function main() {
   // the settings dialog reopens with the stored chip pressed, then closes.
   demoOk &= demoEq("auto follows a dark OS", demo.theme.autoDark, "rgb(11, 13, 16)");
   demoOk &= demoEq("auto follows an OS flip to light", demo.theme.autoLight, "rgb(244, 246, 249)");
-  demoOk &= demoEq("the dark chip beats the light OS", demo.theme.overrideDark.bg, "rgb(11, 13, 16)");
+  demoOk &= demoEq(
+    "the dark chip beats the light OS",
+    demo.theme.overrideDark.bg,
+    "rgb(11, 13, 16)",
+  );
   demoOk &= demoEq("the pressed chip is the choice", demo.theme.overrideDark.pressed, [
     "false",
     "false",


### PR DESCRIPTION
The demo page was dark-only. This adds a light theme derived from the existing dark palette — same hues, lightness flipped, WCAG AA contrast for text, muted and accent against the light grounds — behind an Auto/Light/Dark setting. The dark theme's rendered values are unchanged: a computed-style diff of every element against the previous page confirmed the token indirection alone changed nothing.

- Every hard-coded color (report well, primary-button ink, link hover, error and warning trios, shadow, backdrop, logo glow) is now a custom property, so light mode is exactly one alternate token block.
- The light block appears twice per the standard pattern: `@media (prefers-color-scheme: light)` guarded by `:not([data-theme="dark"])` for Auto, and an explicit `[data-theme="light"]` for the manual choice. Per-theme `color-scheme` themes the native widgets; the report well keeps its dark ground (and dark scrollbars) in both themes.
- `theme: "auto" | "light" | "dark"` joins the persisted settings (default auto). Auto/Light/Dark segmented chips in the settings dialog apply instantly; a `matchMedia` listener keeps the `theme-color` metas in step with OS flips while in Auto, since a manual override has to rewrite both metas (the media form only tracks the OS).
- A tiny inline script in `<head>` applies a stored manual choice before first paint, allowlisted in `_headers` by SHA-256 hash with the regeneration command beside it.
- `test/parity.chrome.mjs` now serves the production CSP on the demo page, so a stale boot-script hash fails the suite instead of silently mis-theming cold starts (verified by breaking the hash: the suite goes red). New assertions pin OS-follow in Auto, manual override, meta rewriting, chip state, the pre-paint boot, and the dialog open/close cycle.