### PR TITLE
feat(wasm): align the demo scan semantics with the desktop app

### DIFF
--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -498,13 +498,23 @@
         accent-color: var(--accent);
         cursor: pointer;
       }
+      input[type="checkbox"]:disabled {
+        cursor: not-allowed;
+        opacity: 0.45;
+      }
       /* sortable playlist-table headers: click to sort, arrow shows direction */
       th[data-sort] {
         cursor: pointer;
         user-select: none;
       }
-      th[data-sort]:hover {
+      th[data-sort]:not(.frozen):hover {
         color: var(--text);
+      }
+      /* a running scan freezes the scan set, so the headers read inert until it
+         ends — the arrow keeps showing the sort the scan is reporting in */
+      th[data-sort].frozen {
+        cursor: not-allowed;
+        color: var(--faint);
       }
       th .arrow {
         display: inline-block;
@@ -704,9 +714,12 @@
         display: flex;
         align-items: center;
         gap: 0.85rem;
+        /* the times readout is a whole line of its own on a phone: let it wrap
+           under the bar rather than squeeze it */
+        flex-wrap: wrap;
       }
       progress {
-        flex: 1;
+        flex: 1 1 12rem;
         appearance: none;
         height: 8px;
         border: none;
@@ -734,6 +747,14 @@
         color: var(--text);
         min-width: 2.8rem;
         text-align: right;
+      }
+      .times {
+        font-family: var(--mono);
+        font-variant-numeric: tabular-nums;
+        font-size: 0.8rem;
+        color: var(--muted);
+        margin-left: auto;
+        white-space: nowrap;
       }
       .progress-text {
         margin: 0.7rem 0 0;
@@ -1034,6 +1055,10 @@
             <div class="progress-row">
               <progress id="bar" max="100" value="0"></progress>
               <span class="pct" id="pct">0%</span>
+              <!-- Elapsed + the remaining estimate; blank until the scan's
+                   first progress event gives the estimate something to work
+                   from. -->
+              <span class="times" id="progress-times"></span>
               <button class="btn small" id="cancel-btn" type="button">Cancel</button>
             </div>
             <p class="progress-text" id="progress-text">Preparing…</p>

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -32,13 +32,18 @@ import {
 } from "./scan.js";
 import { initSettings } from "./settings.js";
 import { el, errMessage, showError, state } from "./state.js";
-import { clickSort, playlistsCard, type SortColumn, setAll } from "./table.js";
+import {
+  clearBtn,
+  clickSort,
+  playlistsCard,
+  type SortColumn,
+  selectAllBtn,
+  setAll,
+} from "./table.js";
 
 const dropzone = el<HTMLLabelElement>("dropzone");
 const picker = el<HTMLInputElement>("picker");
 const isoPicker = el<HTMLInputElement>("iso-picker");
-const selectAllBtn = el<HTMLButtonElement>("select-all");
-const clearBtn = el<HTMLButtonElement>("clear-sel");
 const cancelBtn = el<HTMLButtonElement>("cancel-btn");
 
 picker.addEventListener("change", () => {

--- a/crates/bdinfo-rs-wasm/web/src/format.ts
+++ b/crates/bdinfo-rs-wasm/web/src/format.ts
@@ -79,6 +79,44 @@ export function errorReason(reason: ScanErrorReason): string {
   }
 }
 
+/** What the remaining field reads while nothing has been measured to extrapolate from. */
+const NO_ESTIMATE = "--:--:--";
+
+/**
+ * `hh:mm:ss` from whole seconds, hours ACCUMULATING — a scan past a day reads
+ * `25:01:01`. Deliberately unlike the table's `tableLength`, which wraps at 24
+ * because a playlist runtime never legitimately exceeds a day and a wall-clock
+ * estimate can.
+ */
+function hms(seconds: number): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${pad(Math.trunc(seconds / 3600))}:${pad(Math.trunc(seconds / 60) % 60)}:${pad(seconds % 60)}`;
+}
+
+/**
+ * The progress card's `Elapsed hh:mm:ss · Remaining hh:mm:ss`, from the byte
+ * counts the last progress event reported and the wall time since the scan
+ * started.
+ *
+ * The estimate scales the elapsed time by the bytes still to read, so
+ * re-deriving it from RETAINED counts at a later `elapsedMs` makes it climb —
+ * which is what a caller ticking this on a wall clock wants a stalled read to
+ * look like. Before the first byte is measured there is nothing to extrapolate
+ * from, and the field reads {@link NO_ESTIMATE} rather than `00:00:00`, which
+ * would say "about to finish" for however long the stall lasts.
+ *
+ * The arithmetic is the library's `bdrom::progress::progress_stats` +
+ * `remaining_hms` (Rust), hand-written a second time here because a browser
+ * page cannot call it; the vectors in `test/parity.node.mjs` are the ones that
+ * module's own unit tests assert, so a change to either side that is not
+ * mirrored fails a test.
+ */
+export function elapsedRemaining(done: number, total: number, elapsedMs: number): string {
+  const left = Math.max(0, total - done);
+  const remaining = done === 0 ? NO_ESTIMATE : hms(Math.trunc((elapsedMs * left) / (done * 1000)));
+  return `Elapsed ${hms(Math.trunc(elapsedMs / 1000))} · Remaining ${remaining}`;
+}
+
 /**
  * The disc label a saved report is named after: the disc's own volume label,
  * falling back to `picked` — the name of the folder or file the user chose —

--- a/crates/bdinfo-rs-wasm/web/src/scan.ts
+++ b/crates/bdinfo-rs-wasm/web/src/scan.ts
@@ -12,11 +12,11 @@ import {
   type ScanError,
   scan,
 } from "./analyze.js";
-import { counted, errorLine, reportLabel } from "./format.js";
+import { counted, elapsedRemaining, errorLine, reportLabel } from "./format.js";
 import { applyMeasured } from "./panes.js";
 import { discardNote } from "./settings.js";
 import { el, errMessage, errorBox, hide, type Source, show, showError, state } from "./state.js";
-import { playlistRows, playlistsCard, renderRows, selectedNames } from "./table.js";
+import { playlistRows, playlistsCard, renderRows, scanNames } from "./table.js";
 
 const pickedBox = el("picked");
 const pickedName = el("picked-name");
@@ -26,6 +26,7 @@ export const scanBtn = el<HTMLButtonElement>("scan-btn");
 const progressCard = el("progress-card");
 const bar = el<HTMLProgressElement>("bar");
 const pctLabel = el("pct");
+const progressTimes = el("progress-times");
 const progressText = el("progress-text");
 export const reportCard = el("report-card");
 const reportPre = el("report");
@@ -235,24 +236,54 @@ export async function runScan(): Promise<void> {
   if (state.source === null || !scanOffered()) {
     return;
   }
-  const selection = selectedNames();
+  const selection = scanNames();
+  // An empty scan set means an empty table, not an empty selection — the
+  // button is disabled there, and a scan started any other way is refused on
+  // the same terms.
   if (selection.length === 0) {
     return;
   }
   const src = state.source;
   const controller = new AbortController();
   state.scanController = controller;
+  const gen = ++state.generation;
   hide(errorBox);
   hide(reportCard);
   hide(discardNote);
   show(progressCard);
   setProgress(0, "Preparing…");
-  scanBtn.disabled = true;
+  // This pass starts its tallies from zero, so whatever a cancelled or failed
+  // scan left ticked goes now rather than being overwritten row by row. The
+  // redraw is also what freezes the controls that name the scan set.
+  state.live.clear();
+  renderRows();
+  const started = performance.now();
+  // The last progress event's byte counts, retained so a wall-clock tick can
+  // re-derive the estimate from them. Null until the first event — the blind
+  // window the readout spends blank.
+  let counts: { done: number; total: number } | null = null;
+  const showTimes = () => {
+    progressTimes.textContent =
+      counts === null
+        ? ""
+        : elapsedRemaining(counts.done, counts.total, performance.now() - started);
+  };
+  showTimes();
   const onProgress = ({ file, done, total }: { file: string; done: number; total: number }) => {
     const percent = total > 0 ? Math.floor((done / total) * 100) : 0;
     setProgress(percent, `Scanning ${file}`);
+    counts = { done, total };
+    showTimes();
   };
-  const gen = ++state.generation;
+  // The estimate is re-derived from the retained counts on every tick, so a
+  // read that stalls makes Remaining climb each second instead of holding the
+  // value a now-stale event computed. Stamped like every other completion: a
+  // tick belonging to a scan the page has moved on from writes nothing.
+  const ticker = window.setInterval(() => {
+    if (gen === state.generation) {
+      showTimes();
+    }
+  }, 1000);
   const threshold = state.settings.shortPlaylistSeconds;
   const sections = {
     streamDiagnostics: state.settings.reportStreamDiagnostics,
@@ -292,14 +323,14 @@ export async function runScan(): Promise<void> {
       showError(errMessage(error));
     }
   } finally {
+    window.clearInterval(ticker);
     state.scanController = null;
     hide(progressCard);
-    scanBtn.disabled = selectedNames().length === 0 || !scanOffered();
-    // The overlay dies with the scan that fed it. A finished scan cleared it
-    // already, adopting the measured disc; a cancelled or failed one clears it
-    // here, and the redraw puts back what the held disc knows — partial numbers
-    // beside a report that does not carry them would be the worse half-state.
-    state.live.clear();
+    // A finished scan already dropped the overlay, adopting the measured disc.
+    // A cancelled or failed one KEEPS it: what the scan did measure before it
+    // stopped is real, and the desktop app leaves the same cells standing. The
+    // report is not made from it — a cancel still renders none — so the redraw
+    // only releases the controls and puts the cells back as they stand.
     renderRows();
   }
   // A report switch flipped while the scan ran was deferred (the disc it would

--- a/crates/bdinfo-rs-wasm/web/src/state.ts
+++ b/crates/bdinfo-rs-wasm/web/src/state.ts
@@ -158,10 +158,12 @@ export const state = {
    * It is an overlay rather than a patch of the held disc for the reason the
    * desktop app keeps one too: the disc the page holds is what the report, the
    * sort keys and the row set are derived from, so writing half-measured numbers
-   * into it would make those disagree with the report beside them. Clearing the
-   * map is therefore all a scan's end takes — {@link adoptDisc} does it when the
-   * measured disc arrives, and a cancelled scan does it to return the cells to
-   * what the held disc knows.
+   * into it would make those disagree with the report beside them.
+   *
+   * It outlives the scan that filled it: a cancelled or failed scan leaves its
+   * partial numbers on the cells, and the NEXT scan clears them as it starts.
+   * A finished scan clears it too, but by adopting the measured disc — whose
+   * numbers are the final form of the very cells the overlay was raising.
    */
   live: new Map<string, MeasuredPlaylist>(),
   /** The playlist whose details the panes show; null before the first draw. */

--- a/crates/bdinfo-rs-wasm/web/src/table.ts
+++ b/crates/bdinfo-rs-wasm/web/src/table.ts
@@ -43,8 +43,20 @@ export const PACKET_BYTES = 192;
 
 export const playlistsCard = el("playlists-card");
 export const playlistBody = el<HTMLTableSectionElement>("playlist-body");
+export const selectAllBtn = el<HTMLButtonElement>("select-all");
+export const clearBtn = el<HTMLButtonElement>("clear-sel");
 const selCount = el("sel-count");
 const hiddenHint = el("hidden-hint");
+
+/**
+ * Whether the scan set is frozen: a running scan measures the playlists it
+ * started with, so what names them cannot move under it. The active row and the
+ * measured cells are not part of the scan set and stay live — they show the
+ * running scan rather than change it.
+ */
+function frozen(): boolean {
+  return state.scanController !== null;
+}
 
 /** A row per playlist, in the table order `position` records. */
 export function playlistRows(playlists: Playlist[]): PlaylistRow[] {
@@ -141,8 +153,15 @@ function isAscending(rows: PlaylistRow[], column: SortColumn): boolean {
  * its direction; a click on any other column starts it ascending — unless the
  * rows already read ascending by that column, in which case it starts
  * descending. That keeps every click a visible re-order.
+ *
+ * Inert while the scan set is {@link frozen}: the report prints the scan set in
+ * table order, so a re-sort under a running scan would re-order a report that
+ * scan is still producing.
  */
 export function clickSort(column: SortColumn): void {
+  if (frozen()) {
+    return;
+  }
   const ascending =
     state.sort?.column === column ? !state.sort.ascending : !isAscending(state.displayed, column);
   state.sort = { column, ascending };
@@ -195,6 +214,7 @@ export function renderRows(): void {
   renderHint();
   ensureActive();
   updateSelection();
+  applyFreeze();
 }
 
 /** How many playlist names a hint line spells out before it counts the rest. */
@@ -292,10 +312,12 @@ function playlistRow(row: PlaylistRow, position: number, group: number): HTMLTab
   // playlist and fills the detail panes, like the desktop table.
   tr.addEventListener("click", (event) => {
     if (event.target === check || event.target === checkCell) {
-      if (event.target === checkCell) {
+      // The cell stands in for the box, so it has to refuse what the disabled
+      // box already refuses while the scan set is frozen.
+      if (event.target === checkCell && !frozen()) {
         check.checked = !check.checked;
+        updateSelection();
       }
-      updateSelection();
       return;
     }
     state.activeName = row.name;
@@ -328,8 +350,30 @@ export function updateSelection(): void {
       count += 1;
     }
   }
-  selCount.textContent = `${count} selected`;
-  scanBtn.disabled = count === 0 || !scanOffered();
+  // Nothing ticked is a whole-disc scan, not a refusal to scan, so the count
+  // says what the button will do rather than reading as an empty selection.
+  selCount.textContent = count === 0 ? "0 selected — scans all" : `${count} selected`;
+  // The only unscannable table is one with no rows in it: the settings can
+  // withhold every playlist the disc has, and there is then nothing to measure.
+  scanBtn.disabled = state.displayed.length === 0 || !scanOffered() || frozen();
+}
+
+/**
+ * Puts the freeze into effect on the controls that name the scan set — the row
+ * checkboxes, the two selection buttons and the sortable headers. Disabled
+ * rather than hidden: the user can still read what the running scan is
+ * measuring.
+ */
+export function applyFreeze(): void {
+  const scanning = frozen();
+  for (const box of rowBoxes()) {
+    box.disabled = scanning;
+  }
+  selectAllBtn.disabled = scanning;
+  clearBtn.disabled = scanning;
+  for (const th of playlistsCard.querySelectorAll<HTMLTableCellElement>("th[data-sort]")) {
+    th.classList.toggle("frozen", scanning);
+  }
 }
 
 export function selectedNames(): string[] {
@@ -343,7 +387,25 @@ export function selectedNames(): string[] {
   return names;
 }
 
+/**
+ * The playlists a measured scan covers: the ticked rows, or — with nothing
+ * ticked — every listed row, in table order. That is the desktop app's and the
+ * command line's whole-disc rule, so the filter settings widen and narrow what
+ * a whole-disc scan measures exactly as they widen and narrow the table.
+ *
+ * Always a list of names, never the empty list the module reads as "the
+ * standard set": that set is classified against the library's own default
+ * threshold and filter, which is not what this page is showing.
+ */
+export function scanNames(): string[] {
+  const selected = selectedNames();
+  return selected.length > 0 ? selected : state.displayed.map((row) => row.name);
+}
+
 export function setAll(checked: boolean): void {
+  if (frozen()) {
+    return;
+  }
   for (const box of rowBoxes()) {
     box.checked = checked;
   }

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -257,15 +257,43 @@ async function main() {
     await demoPage.goto(`${base}/index.html`);
     await demoPage.evaluate((items) => {
       // Record every request the page posts to a scan Worker, so the checks
-      // below can assert which settings cost a wasm call and which cost none.
+      // below can assert which settings cost a wasm call and which cost none,
+      // and which playlists each measured scan was asked for.
       const NativeWorker = window.Worker;
       window.__calls = [];
+      window.__selections = [];
+      // Cancels the running scan from inside the page, one message after its
+      // first measured snapshot has been applied. The fixture disc scans in
+      // well under a second, so a cancel driven from the test process would
+      // race the completion; this cannot.
+      window.__cancelOnMeasured = false;
       window.Worker = class extends NativeWorker {
+        #handler = null;
         postMessage(message, ...rest) {
           if (typeof message === "object" && message !== null && "kind" in message) {
             window.__calls.push(message.kind);
+            if ("selection" in message) {
+              window.__selections.push(message.selection);
+            }
           }
           super.postMessage(message, ...rest);
+        }
+        get onmessage() {
+          return this.#handler;
+        }
+        set onmessage(handler) {
+          this.#handler = handler;
+          super.onmessage = (event) => {
+            handler(event);
+            if (
+              window.__cancelOnMeasured &&
+              event.data?.type === "measured" &&
+              event.data.measured.playlists.some((playlist) => playlist.measuredBytes > 0)
+            ) {
+              window.__cancelOnMeasured = false;
+              document.getElementById("cancel-btn").click();
+            }
+          };
         }
       };
       const decode = (b64) => {
@@ -355,6 +383,16 @@ async function main() {
           reportHidden: document.getElementById("report-card").hidden,
           progressHidden: document.getElementById("progress-card").hidden,
           discardHidden: document.getElementById("discard-note").hidden,
+          selCount: document.getElementById("sel-count").textContent,
+          times: document.getElementById("progress-times").textContent,
+          // The scan-set controls: live between scans, inert while one runs.
+          scanDisabled: document.getElementById("scan-btn").disabled,
+          boxesDisabled: [...document.querySelectorAll("#playlist-body input[type=checkbox]")].map(
+            (box) => box.disabled,
+          ),
+          sortFrozen: [...document.querySelectorAll("th[data-sort]")].map((th) =>
+            th.classList.contains("frozen"),
+          ),
           calls: window.__calls.slice(),
         };
       });
@@ -406,9 +444,55 @@ async function main() {
     // report below comparable to the scan's own, byte for byte.
     await demoPage.click('th[data-sort="position"]');
 
+    // Nothing ticked is a whole-disc scan, not a refusal to scan: the button
+    // stays live and the count says what pressing it will do.
+    await demoPage.click("#clear-sel");
+    const cleared = await readDemo();
+    await demoPage.click("#select-all");
+    const reselected = await readDemo();
+
     // The measured scan through the page (both shown rows are ticked): the
     // report card appears and the panes' measured cells fill in place.
-    await demoPage.click("#scan-btn");
+    //
+    // `runScan` installs the scan and redraws the table synchronously, so
+    // everything read after the click below is genuinely mid-scan state — no
+    // polling, and no race with a fixture that finishes in under a second.
+    const midScan = await demoPage.evaluate(() => {
+      const read = () => ({
+        names: [...document.querySelectorAll("#playlist-body td.name")].map((td) => td.textContent),
+        selCount: document.getElementById("sel-count").textContent,
+        boxesDisabled: [...document.querySelectorAll("#playlist-body input[type=checkbox]")].map(
+          (box) => box.disabled,
+        ),
+        sortFrozen: [...document.querySelectorAll("th[data-sort]")].map((th) =>
+          th.classList.contains("frozen"),
+        ),
+        selectAllDisabled: document.getElementById("select-all").disabled,
+        clearDisabled: document.getElementById("clear-sel").disabled,
+        scanDisabled: document.getElementById("scan-btn").disabled,
+        progressHidden: document.getElementById("progress-card").hidden,
+        times: document.getElementById("progress-times").textContent,
+      });
+      document.getElementById("scan-btn").click();
+      const frozen = read();
+      // Every edit to the scan set is inert while the scan runs — the header
+      // sort, both selection buttons, and the check cell that stands in for a
+      // row's (now disabled) box.
+      document.querySelector('th[data-sort="name"]').click();
+      document.getElementById("select-all").click();
+      document.getElementById("clear-sel").click();
+      document.querySelector("#playlist-body td.col-check").click();
+      const afterEdits = read();
+      // The active row is not part of the scan set and stays live: clicking the
+      // other row re-targets the panes under the running scan.
+      document.querySelector('#playlist-body tr[data-name="00001.MPLS"] td.name').click();
+      const activated = {
+        active: document.querySelector("#playlist-body tr.active")?.dataset.name ?? null,
+        paneLabel: document.getElementById("pane-playlist").textContent,
+      };
+      document.querySelector('#playlist-body tr[data-name="00000.MPLS"] td.name').click();
+      return { frozen, afterEdits, activated };
+    });
     await demoPage.waitForFunction(() => !document.getElementById("report-card").hidden, {
       timeout: 120000,
     });
@@ -468,6 +552,25 @@ async function main() {
     );
     const zeroThreshold = await readDemo();
     await demoPage.click("#settings-close");
+
+    // A cancelled whole-disc scan. Nothing is ticked, so the scan set is every
+    // listed row — which the recorded request proves — and the page cancels
+    // itself the moment the first measured snapshot has been applied. What that
+    // snapshot ticked must still be standing afterwards, beside no report: a
+    // cancel measures something real and renders nothing.
+    await demoPage.click("#clear-sel");
+    const beforeCancel = await readDemo();
+    await demoPage.evaluate(() => {
+      window.__cancelOnMeasured = true;
+      document.getElementById("scan-btn").click();
+    });
+    await demoPage.waitForFunction(
+      () => document.getElementById("progress-card").hidden,
+      undefined,
+      { timeout: 120000 },
+    );
+    const cancelled = await readDemo();
+    const cancelledSelection = await demoPage.evaluate(() => window.__selections.at(-1));
 
     // A phone-width viewport must not scroll the page sideways — wide tables
     // scroll inside their own wrapper instead.
@@ -585,6 +688,9 @@ async function main() {
       grouped,
       noSuffix,
       preScan,
+      cleared,
+      reselected,
+      midScan,
       scanned,
       report,
       sdOff,
@@ -599,6 +705,9 @@ async function main() {
       thresholdApplied,
       retentionOff,
       zeroThreshold,
+      beforeCancel,
+      cancelled,
+      cancelledSelection,
       pageScrolls,
       damagedListing,
       persisted,
@@ -827,6 +936,81 @@ async function main() {
     "10.63 MB",
   ]);
   demoOk &= demoEq("display settings cost no wasm call", demo.preScan.calls, ["inspect"]);
+
+  // The empty selection: the button is live and the count says the scan covers
+  // everything, and ticking the rows again returns the plain count.
+  demoOk &= demoEq(
+    "an empty selection still scans",
+    demo.cleared.selCount,
+    "0 selected — scans all",
+  );
+  demoOk &= demoEq("the button is live at nothing selected", demo.cleared.scanDisabled, false);
+  demoOk &= demoEq("a selection counts itself", demo.reselected.selCount, "2 selected");
+  demoOk &= demoEq("the controls are live between scans", demo.preScan.sortFrozen, [
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+  ]);
+  demoOk &= demoEq("the boxes are live between scans", demo.preScan.boxesDisabled, [false, false]);
+
+  // The mid-scan freeze: the scan set cannot move under the running scan, the
+  // readout waits for the first progress event, and the active row stays live.
+  demoOk &= demoEq("a running scan disables the boxes", demo.midScan.frozen.boxesDisabled, [
+    true,
+    true,
+  ]);
+  demoOk &= demoEq("a running scan freezes every sort header", demo.midScan.frozen.sortFrozen, [
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+  ]);
+  demoOk &= demoEq(
+    "a running scan disables the selection buttons",
+    [
+      demo.midScan.frozen.selectAllDisabled,
+      demo.midScan.frozen.clearDisabled,
+      demo.midScan.frozen.scanDisabled,
+    ],
+    [true, true, true],
+  );
+  demoOk &= demoEq("the progress card is up", demo.midScan.frozen.progressHidden, false);
+  demoOk &= demoEq("the readout is blank before the first event", demo.midScan.frozen.times, "");
+  demoOk &= demoEq("a frozen sort header does not re-order", demo.midScan.afterEdits.names, [
+    "00001.MPLS [02 Chapters]",
+    "00000.MPLS",
+  ]);
+  demoOk &= demoEq(
+    "frozen selection edits change nothing",
+    demo.midScan.afterEdits.selCount,
+    "2 selected",
+  );
+  demoOk &= demoEq("the active row stays live mid-scan", demo.midScan.activated, {
+    active: "00001.MPLS",
+    paneLabel: "00001.MPLS",
+  });
+  demoOk &= demoEq("the scan releases the controls", demo.scanned.boxesDisabled, [false, false]);
+  demoOk &= demoEq("the scan releases the headers", demo.scanned.sortFrozen, [
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+  ]);
+  // Digits normalized: the times themselves depend on how long the scan took,
+  // the shape does not — and it is a real estimate, not the `--:--:--` of a
+  // scan that never measured a byte.
+  demoOk &= demoEq(
+    "the readout keeps the last elapsed and remaining",
+    demo.scanned.times.replace(/\d/g, "0"),
+    "Elapsed 00:00:00 · Remaining 00:00:00",
+  );
   demoOk &= demoEq("scan keeps the active row", demo.scanned.active, "00000.MPLS");
   demoOk &= demoEq("measured size fills after the scan", demo.scanned.files, [
     ["00000.M2TS", "1", "00:00:30", "10.63 MB", "10.55 MB"],
@@ -937,6 +1121,31 @@ async function main() {
     "00002.MPLS",
   ]);
   demoOk &= demoEq("a zero threshold shows no short hint", demo.zeroThreshold.hintHidden, true);
+
+  // The cancelled whole-disc scan: the request named every listed row without a
+  // tick anywhere, the cells it managed to tick are still standing, and no
+  // report was rendered from them. The controls are released again.
+  demoOk &= demoEq("nothing measured before the cancelled scan", demo.beforeCancel.measured, [
+    "—",
+    "—",
+    "—",
+  ]);
+  demoOk &= demoEq("an empty selection asks for every listed row", demo.cancelledSelection, [
+    "00001.MPLS",
+    "00000.MPLS",
+    "00002.MPLS",
+  ]);
+  demoOk &= demoEq(
+    "a cancelled scan keeps what it measured",
+    demo.cancelled.measured.every((text) => text !== "—"),
+    true,
+  );
+  demoOk &= demoEq("a cancelled scan renders no report", demo.cancelled.reportHidden, true);
+  demoOk &= demoEq("a cancelled scan releases the boxes", demo.cancelled.boxesDisabled, [
+    false,
+    false,
+    false,
+  ]);
 
   demoOk &= demoEq("no sideways page scroll at phone width", demo.pageScrolls, false);
 

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -246,6 +246,35 @@ async function main() {
     );
   }
 
+  // The demo's Elapsed/Remaining readout against the vectors the library's own
+  // `bdrom::progress` unit tests assert — the arithmetic is written once per
+  // language and cannot be shared, so these rows are what keep the two from
+  // drifting. Reading the same byte counts at a LATER wall time must lengthen
+  // the estimate rather than hold it: that is what makes a stalled read visible
+  // instead of frozen.
+  const { elapsedRemaining } = await import("../dist/format.js");
+  const progressVectors = [
+    // 50 of 200 B after 4 s: a quarter read, so three times the elapsed to go.
+    [[50, 200, 4_000], "Elapsed 00:00:04 · Remaining 00:00:12"],
+    // The same event re-read 62 s later: both fields climb, nothing else moves.
+    [[50, 200, 65_999], "Elapsed 00:01:05 · Remaining 00:03:17"],
+    // Nothing measured yet — the estimate has nothing to extrapolate from, and
+    // says so rather than reading "about to finish" through a whole stall.
+    [[0, 200, 30_000], "Elapsed 00:00:30 · Remaining --:--:--"],
+    // A finished pass: bytes were measured and none are left.
+    [[200, 200, 7_000], "Elapsed 00:00:07 · Remaining 00:00:00"],
+    // Hours accumulate past a day instead of wrapping at 24 like a playlist runtime.
+    [[1, 2, 90_061_000], "Elapsed 25:01:01 · Remaining 25:01:01"],
+  ];
+  const progressMismatches = progressVectors.flatMap(([args, want]) => {
+    const got = elapsedRemaining(...args);
+    return got === want ? [] : [`${JSON.stringify(args)}: got "${got}", want "${want}"`];
+  });
+  const progressOk = progressMismatches.length === 0;
+  if (!progressOk) {
+    console.error(`FAIL — progress readout diverged: ${progressMismatches.join("; ")}`);
+  }
+
   // The report save-file name, sanitized by the core rule.
   const fileNameOk =
     report_file_name("WASMDISC") === "BDINFO.WASMDISC.txt" &&
@@ -416,6 +445,7 @@ async function main() {
     rejectionOk &&
     codecsOk &&
     sizeOk &&
+    progressOk &&
     fileNameOk &&
     fullOk &&
     keepPartialOk &&
@@ -427,7 +457,7 @@ async function main() {
     downloadNameOk
   ) {
     console.log(
-      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + rejection + codecs + size vectors + file name + download name + selection + round trip + retention + short-stream notices + .iso OK.`,
+      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + rejection + codecs + size vectors + progress readout + file name + download name + selection + round trip + retention + short-stream notices + .iso OK.`,
     );
     process.exit(0);
   }


### PR DESCRIPTION
Four scan-lifecycle behaviours the browser demo did differently from the desktop app, all moved to the desktop app's rule.

**Whole-disc scan on an empty selection.** Nothing ticked now scans every listed playlist instead of refusing to scan, so the button is live at zero and the count reads `0 selected - scans all`. The request names the rows explicitly rather than sending the module's empty selection, whose whole-disc set is classified against the library's own default filter instead of the one the page is showing - so the filter settings widen and narrow a whole-disc scan exactly as they widen and narrow the table. The one unscannable table is one with no rows in it.

**A cancelled or failed scan keeps its partial cells.** What the scan measured before it stopped is real and stays on the grids; the next scan clears them as it starts. The report path is unchanged - a cancel still renders none.

**Mid-scan freeze.** While a scan runs, the row checkboxes, both selection buttons and the sort headers read disabled. The active-row click and the live measured cells stay live: they show the running scan rather than change it.

**Elapsed / Remaining.** The progress row gains a mono readout, re-derived from the last progress event's byte counts on every wall-clock tick, so a stalled read makes the estimate climb instead of holding a stale value. Blank before the first event, and `--:--:--` while no byte has been measured to extrapolate from. Hours accumulate rather than wrapping at 24.

Display and interaction only: no change to the package's option surface, the worker protocol, the wasm crate, or the report bytes.

## Verification

`test:chrome` goes from 76 to 97 assertions. The freeze and the cancel are pinned without polling: the scan installs itself and redraws synchronously, so state read straight after the click is genuinely mid-scan, and the cancel is driven from inside the Worker message hook one message after the first measured snapshot lands. Teeth checked - restoring the clear-on-cancel, neutering the freeze, and dropping the whole-disc fallback each turn the matching assertions red. The elapsed/remaining arithmetic is pinned in `parity.node.mjs` against the vectors the library's `bdrom::progress` unit tests assert.

Driven live in Chrome against a genuinely defective 22 GB disc in an optical drive: the first read stalled for 49 s with no bytes, where the readout showed a climbing Elapsed beside `--:--:--`; once bytes arrived the estimate went live and 36 consecutive wall-clock ticks lengthened it while the percent stood still. Mid-scan the four checkboxes and six headers read disabled while a row click still re-targeted the panes; cancelling left 294.84 MB / 435.00 MB / 4.81 MB standing with no report, and starting the next scan cleared them.