### PR TITLE
feat(wasm): add disc info, pre-scan report and copy affordances to the demo

### DIFF
--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -377,13 +377,20 @@
         font-size: 0.82em;
         color: var(--text);
       }
+      /* The post-pick source bar: the slim line that stands in for the whole
+         dropzone once a disc is loaded, with the action that brings the
+         dropzone back. */
       .picked {
         display: flex;
         align-items: center;
+        flex-wrap: wrap;
         gap: 0.5rem;
-        padding: 0 1.1rem 0.6rem;
+        padding: 0.85rem 1.1rem;
         color: var(--muted);
         font-size: 0.85rem;
+      }
+      .picked .btn {
+        margin-left: auto;
       }
       .picked svg {
         color: var(--ok);
@@ -523,13 +530,19 @@
         font-size: 0.62rem;
         color: var(--accent);
       }
-      /* the active (master-detail) row driving the panes below the table */
+      /* the active (master-detail) row driving the panes below the table, and
+         the highlighted pane row Ctrl+C copies the path of */
       tbody tr.active {
         box-shadow: inset 2px 0 0 var(--accent);
         background: var(--surface-2);
       }
       tbody tr.active.sel {
         background: var(--accent-dim);
+      }
+      /* the row whose disc path Ctrl+C just copied: the copy button's own
+         "copied" affordance, where a table row has no label to relabel */
+      tbody tr.copied-row td {
+        color: var(--ok);
       }
 
       /* ── detail panes (stream files + codecs of the active playlist) ── */
@@ -576,12 +589,6 @@
       .pane .table-wrap {
         max-height: 16rem;
       }
-      .pane tbody tr {
-        cursor: default;
-      }
-      .pane tbody tr:hover {
-        background: transparent;
-      }
 
       .card-foot {
         display: flex;
@@ -601,6 +608,69 @@
         color: var(--muted);
         font-size: 0.82rem;
         white-space: pre-line;
+      }
+      /* the same hint carrying the transient Show/Hide reveal beside it */
+      .hint-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+      .hint-row p {
+        margin: 0;
+      }
+      .hint-row .btn {
+        margin-left: auto;
+        flex: none;
+      }
+
+      /* ── disc-info strip (under the panes) ───────────────────── */
+      /* The detected-disc block the classic report prints as its footer, in the
+         desktop app's order: title, features, size, then the notes. */
+      .disc-info {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.75rem;
+        padding: 0.7rem 1.1rem;
+        border-top: 1px solid var(--border);
+        background: var(--surface-2);
+        font-size: 0.8rem;
+      }
+      .info-lines {
+        min-width: 0;
+      }
+      .info-line,
+      .info-note {
+        margin: 0;
+        overflow-wrap: anywhere;
+      }
+      .info-line {
+        color: var(--text);
+      }
+      .info-note {
+        color: var(--muted);
+      }
+      .info-line + .info-line,
+      .info-note {
+        margin-top: 0.2rem;
+      }
+      .info-label {
+        color: var(--muted);
+        margin-right: 0.4rem;
+      }
+      .info-line .mono {
+        font-family: var(--mono);
+      }
+      /* The AACS indicator: one line tall, in the slack right of the lines, so
+         a disc with it and one without lay out identically everywhere else. */
+      .badge {
+        margin-left: auto;
+        flex: none;
+        white-space: nowrap;
+        padding: 0.1rem 0.45rem;
+        border-radius: 6px;
+        color: var(--warning-text);
+        background: var(--warning-bg);
+        border: 1px solid var(--warning-border);
       }
 
       /* ── settings dialog ─────────────────────────────────────── */
@@ -928,23 +998,27 @@
             <span class="dz-hint">or the disc root — drop it (or an <code>.iso</code>) here, or click to browse</span>
             <input id="picker" type="file" webkitdirectory multiple hidden />
           </label>
-          <div class="or-iso">
+          <div class="or-iso" id="or-iso">
             <label class="iso-link" id="iso-link">
               or analyze a single <code>.iso</code> image
               <input id="iso-picker" type="file" accept=".iso,application/x-iso9660-image" hidden />
             </label>
           </div>
+          <!-- The source bar a loaded disc replaces the dropzone with: what was
+               picked, and the way back to picking. The dropzone itself is
+               untouched — "Change disc…" simply puts it back. -->
           <div class="picked" id="picked" hidden>
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M20 6 9 17l-5-5" />
             </svg>
             <span><span class="pill" id="picked-name">disc</span> — <span id="picked-count">0 files</span></span>
+            <button class="btn small" id="change-disc" type="button">Change disc…</button>
           </div>
           <div class="listing" id="listing" hidden>
             <span class="spinner" aria-hidden="true"></span>
             Reading playlists…
           </div>
-          <p class="privacy">
+          <p class="privacy" id="privacy">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
               <path d="m9 12 2 2 4-4" />
@@ -1016,11 +1090,30 @@
               </div>
             </div>
           </div>
-          <p class="hint" id="encrypted-note" hidden>
-            This disc is AACS-encrypted — its stream data cannot be analyzed, so
-            the measured scan is unavailable. Everything above is read from the
-            disc's own metadata and is correct.
-          </p>
+          <!-- The detected-disc strip the desktop app draws under its panes,
+               carrying the same lines the classic report's footer prints. The
+               hidden-tracks note is shown rather than left to the `*` marker's
+               hover title, which a touch screen has no way to reach. -->
+          <div class="disc-info" id="disc-info">
+            <div class="info-lines">
+              <p class="info-line" id="info-title" hidden>
+                <span class="info-label">Disc Title:</span> <span id="info-title-value"></span>
+              </p>
+              <p class="info-line" id="info-features" hidden>
+                <span class="info-label">Detected Features:</span> <span id="info-features-value"></span>
+              </p>
+              <p class="info-line" id="info-size" hidden>
+                <span class="info-label">Disc Size:</span> <span class="mono" id="info-size-value"></span>
+              </p>
+              <!-- The wording of bdrom::disc::HIDDEN_STREAMS_NOTE, which the
+                   command line prints under the same table: the `*` marker and
+                   this sentence are one contract, so a surface showing the
+                   marker shows this text verbatim. -->
+              <p class="info-note" id="hidden-tracks-note" hidden>(*) Some playlists on this disc have hidden tracks. These tracks are marked with an asterisk.</p>
+              <p class="info-note" id="encrypted-note" hidden>This disc is AACS-encrypted — its stream data cannot be analyzed, so the measured scan is unavailable. Everything above is read from the disc's own metadata and is correct.</p>
+            </div>
+            <span class="badge" id="encrypted-badge" hidden>⚠ AACS-encrypted</span>
+          </div>
           <!-- Files the scan could not read or parse and continued past. It
                sits in this card rather than beside the report because a
                structural listing records them too, and that listing renders no
@@ -1037,15 +1130,26 @@
               <ul id="scan-errors-list"></ul>
             </div>
           </div>
-          <p class="hint" id="hidden-hint" hidden></p>
+          <!-- The filter hint, with the session-only reveal beside it: Show
+               puts the withheld playlists in the table without touching the
+               stored settings, which is what makes it transient. -->
+          <div class="hint hint-row" id="hidden-row" hidden>
+            <p id="hidden-hint" hidden></p>
+            <button class="btn small" id="reveal-btn" type="button">Show</button>
+          </div>
           <div class="card-foot">
             <span class="muted" id="sel-count">0 selected</span>
-            <button class="btn primary" id="scan-btn" type="button" disabled>
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-              </svg>
-              Scan selected
-            </button>
+            <div class="toolbar">
+              <!-- The report before any measured scan: the same render, over a
+                   disc whose measured values are all zero. -->
+              <button class="btn small" id="view-report-btn" type="button" disabled>View report</button>
+              <button class="btn primary" id="scan-btn" type="button" disabled>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+                </svg>
+                Scan selected
+              </button>
+            </div>
           </div>
         </section>
 

--- a/crates/bdinfo-rs-wasm/web/src/demo.ts
+++ b/crates/bdinfo-rs-wasm/web/src/demo.ts
@@ -18,7 +18,10 @@
 //
 // This module is the page's composition root: it owns the pick controls and
 // wires every listener the feature modules beside it export.
+import { copyRowPath } from "./panes.js";
 import {
+  changeDisc,
+  changeDiscBtn,
   collectAndLoad,
   copyBtn,
   copyReport,
@@ -29,6 +32,8 @@ import {
   loadIso,
   runScan,
   scanBtn,
+  viewReport,
+  viewReportBtn,
 } from "./scan.js";
 import { initSettings } from "./settings.js";
 import { el, errMessage, showError, state } from "./state.js";
@@ -36,9 +41,11 @@ import {
   clearBtn,
   clickSort,
   playlistsCard,
+  revealBtn,
   type SortColumn,
   selectAllBtn,
   setAll,
+  toggleReveal,
 } from "./table.js";
 
 const dropzone = el<HTMLLabelElement>("dropzone");
@@ -120,4 +127,27 @@ copyBtn.addEventListener("click", () => {
 });
 downloadBtn.addEventListener("click", () => {
   void downloadReport();
+});
+changeDiscBtn.addEventListener("click", changeDisc);
+viewReportBtn.addEventListener("click", () => {
+  void viewReport();
+});
+revealBtn.addEventListener("click", toggleReveal);
+
+// Ctrl+C (⌘C) copies the highlighted row's disc path, like the desktop app and
+// the classic tool before it — but only when it would otherwise copy nothing:
+// a text selection is what the user meant to copy, and a focused field owns its
+// own selection, which `getSelection` does not report.
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "c" || !(event.ctrlKey || event.metaKey) || event.altKey) {
+    return;
+  }
+  const focused = document.activeElement;
+  if (focused instanceof HTMLInputElement || focused instanceof HTMLTextAreaElement) {
+    return;
+  }
+  if (window.getSelection()?.isCollapsed === false) {
+    return;
+  }
+  void copyRowPath();
 });

--- a/crates/bdinfo-rs-wasm/web/src/format.ts
+++ b/crates/bdinfo-rs-wasm/web/src/format.ts
@@ -9,7 +9,7 @@
 // assert every row of it, so a change here that is not mirrored there fails a
 // test on both.
 
-import type { ScanError, ScanErrorReason } from "./analyze.js";
+import type { Disc, ScanError, ScanErrorReason } from "./analyze.js";
 
 /**
  * The count with its noun's number agreed — `"1 error"`, `"0 errors"`,
@@ -40,6 +40,30 @@ export function sizeCell(bytes: number | null, humanReadable: boolean): string {
     unit += 1;
   }
   return `${value.toFixed(unit === 0 ? 0 : 2)} ${units[unit]}`;
+}
+
+/**
+ * The disc's detected-feature labels, in presentation order — the `Extras:`
+ * line the report prints, and the disc-info strip's `Detected Features`.
+ *
+ * The labels and their order are the library's `BdRom::extra_features`
+ * (`crates/bdinfo-rs-core/src/bdrom/disc.rs`), written a second time here
+ * because a browser page cannot call it: the mirror carries the six flags, not
+ * the strings they stand for. `test/parity.node.mjs` renders a disc with every
+ * flag set and compares this list against the report's own `Extras:` line, so a
+ * label or an order that moves on the Rust side fails there rather than
+ * drifting quietly.
+ */
+export function featureLabels(disc: Disc): string[] {
+  const flags: [boolean, string][] = [
+    [disc.isUhd, "Ultra HD"],
+    [disc.isBdJava, "BD-Java"],
+    [disc.is50hz, "50Hz Content"],
+    [disc.is3d, "Blu-ray 3D"],
+    [disc.isDbox, "D-BOX Motion Code"],
+    [disc.isPsp, "PSP Digital Copy"],
+  ];
+  return flags.filter(([set]) => set).map(([, label]) => label);
 }
 
 /**

--- a/crates/bdinfo-rs-wasm/web/src/panes.ts
+++ b/crates/bdinfo-rs-wasm/web/src/panes.ts
@@ -1,9 +1,10 @@
 // The two detail panes under the playlist table — the active playlist's stream
 // files and its codecs — and the in-place cell writes that let all three tables
-// tick while a scan runs.
-import type { Clip, MeasuredPlaylist, MeasuredSnapshot, Stream } from "./analyze.js";
+// tick while a scan runs. A pane row can also be highlighted, which is what
+// aims the Ctrl+C path copy at it.
+import type { MeasuredPlaylist, MeasuredSnapshot, Playlist, Stream } from "./analyze.js";
 import { sizeCell } from "./settings.js";
-import { el, hide, show, state } from "./state.js";
+import { el, hide, show, showError, state } from "./state.js";
 import {
   cell,
   PACKET_BYTES,
@@ -14,10 +15,26 @@ import {
   textCell,
 } from "./table.js";
 
+/**
+ * A highlighted detail-pane row — the Ctrl+C copy target while it stands.
+ *
+ * It names the playlist it was picked in: the rows are rebuilt from whichever
+ * playlist is active, so an index alone would point at a row of a different
+ * playlist as soon as the active row moves.
+ */
+export interface PaneRow {
+  playlist: string;
+  region: "files" | "codecs";
+  index: number;
+}
+
 const panesBox = el("detail-panes");
 const paneLabel = el("pane-playlist");
 const filesBody = el<HTMLTableSectionElement>("files-body");
 const codecsBody = el<HTMLTableSectionElement>("codecs-body");
+
+/** How long a copied row stays flagged, matching the Copy button's label. */
+const COPIED_MS = 1500;
 
 /**
  * Keeps a row active and the panes filled: when the settings hide the active
@@ -49,8 +66,43 @@ function renderPanes(): void {
   show(panesBox);
   paneLabel.textContent = playlist.name;
   const measured = state.live.get(playlist.name);
-  filesBody.replaceChildren(...streamFileRows(playlist.clips, measured));
-  codecsBody.replaceChildren(...playlist.streams.map((stream) => codecRow(stream, measured)));
+  filesBody.replaceChildren(...streamFileRows(playlist, measured));
+  codecsBody.replaceChildren(
+    ...playlist.streams.map((stream, index) => codecRow(playlist, stream, index, measured)),
+  );
+  applyPanePick();
+}
+
+/**
+ * Highlights the picked pane row, and only while it still describes the
+ * playlist it was picked in — a pick made in another playlist's panes stands
+ * for a row that is no longer on screen.
+ */
+function applyPanePick(): void {
+  const pick = state.paneRow?.playlist === state.activeName ? state.paneRow : null;
+  for (const [region, body] of [
+    ["files", filesBody],
+    ["codecs", codecsBody],
+  ] as const) {
+    Array.from(body.rows).forEach((tr, index) => {
+      tr.classList.toggle(
+        "active",
+        pick !== null && pick.region === region && pick.index === index,
+      );
+    });
+  }
+}
+
+/** Makes `tr` the picked pane row (or drops the pick when it is picked again). */
+function pickPaneRow(row: PaneRow): void {
+  const pick = state.paneRow;
+  const same =
+    pick !== null &&
+    pick.playlist === row.playlist &&
+    pick.region === row.region &&
+    pick.index === row.index;
+  state.paneRow = same ? null : row;
+  applyPanePick();
 }
 
 /**
@@ -64,9 +116,9 @@ function renderPanes(): void {
  * rows line up with `clips` one for one; without it the cells come from the
  * held disc.
  */
-function streamFileRows(clips: Clip[], measured?: MeasuredPlaylist): HTMLTableRowElement[] {
+function streamFileRows(playlist: Playlist, measured?: MeasuredPlaylist): HTMLTableRowElement[] {
   let index = 0;
-  return clips.map((clip, position) => {
+  return playlist.clips.map((clip, position) => {
     if (clip.angleIndex === 0) {
       index += 1;
     }
@@ -87,6 +139,9 @@ function streamFileRows(clips: Clip[], measured?: MeasuredPlaylist): HTMLTableRo
     const packets = textCell(sizeCell(bytes > 0 ? bytes : null), "num");
     packets.dataset.cell = "clip-measured";
     tr.appendChild(packets);
+    tr.addEventListener("click", () => {
+      pickPaneRow({ playlist: playlist.name, region: "files", index: position });
+    });
     return tr;
   });
 }
@@ -101,8 +156,16 @@ function streamFileRows(clips: Clip[], measured?: MeasuredPlaylist): HTMLTableRo
  * row records the pair that names it, since the snapshot orders its streams
  * differently and can only be matched by `(pid, angleIndex)`.
  */
-function codecRow(stream: Stream, measured?: MeasuredPlaylist): HTMLTableRowElement {
+function codecRow(
+  playlist: Playlist,
+  stream: Stream,
+  index: number,
+  measured?: MeasuredPlaylist,
+): HTMLTableRowElement {
   const tr = document.createElement("tr");
+  tr.addEventListener("click", () => {
+    pickPaneRow({ playlist: playlist.name, region: "codecs", index });
+  });
   tr.dataset.pid = String(stream.pid);
   tr.dataset.angle = String(stream.angleIndex);
   const codecCell = cell();
@@ -130,6 +193,68 @@ function liveRate(measured: MeasuredPlaylist | undefined, stream: Stream): numbe
 function bitrateCell(bitsPerSecond: number): string {
   const kbps = Math.trunc(bitsPerSecond / 1000);
   return kbps > 0 ? `${kbps.toLocaleString("en-US")} kbps` : "—";
+}
+
+// ── Ctrl+C: the highlighted row's disc path ──────────────────────────────────
+
+/**
+ * The disc-relative path of the highlighted row, in the desktop app's
+ * precedence: a highlighted Stream File row wins (its clip's `BDMV/STREAM/…`),
+ * otherwise the active playlist's `BDMV/PLAYLIST/…`. A highlighted Codec row
+ * copies nothing, which is the scope the classic tool's Ctrl+C has.
+ *
+ * Disc-relative rather than a real path: the desktop app copies the picked
+ * folder's path or the image's virtual `iso::BDMV/…` form, and a browser page
+ * is given neither — a picked `File` carries a name, never a location.
+ *
+ * `null` for a target there is nothing to name: no active playlist, a Codec
+ * row, or a Stream File row whose clip the redraw has already replaced.
+ */
+export function copyTargetPath(): string | null {
+  const active = state.activeName;
+  if (active === null) {
+    return null;
+  }
+  const pick = state.paneRow?.playlist === active ? state.paneRow : null;
+  if (pick === null) {
+    return `BDMV/PLAYLIST/${active}`;
+  }
+  if (pick.region === "codecs") {
+    return null;
+  }
+  const clip = state.playlists.find((entry) => entry.name === active)?.clips.at(pick.index);
+  // The real `xxxxx.M2TS` stream file, never the row's display name: an
+  // interleaved clip shows its `*.ssif` there, which is a different file.
+  return clip === undefined ? null : `BDMV/STREAM/${clip.name}`;
+}
+
+/**
+ * Copies {@link copyTargetPath} to the clipboard and marks the row it came
+ * from — the row is the only label a copied path has, so it stands in for the
+ * Copy button's "Copied!" here.
+ */
+export async function copyRowPath(): Promise<void> {
+  const path = copyTargetPath();
+  if (path === null) {
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(path);
+  } catch {
+    showError("Could not copy to the clipboard.");
+    return;
+  }
+  const pick = state.paneRow?.playlist === state.activeName ? state.paneRow : null;
+  const row =
+    pick?.region === "files"
+      ? filesBody.rows.item(pick.index)
+      : playlistBody.querySelector<HTMLTableRowElement>("tr.active");
+  if (row !== null) {
+    row.classList.add("copied-row");
+    window.setTimeout(() => {
+      row.classList.remove("copied-row");
+    }, COPIED_MS);
+  }
 }
 
 // ── live measured cells ──────────────────────────────────────────────────────

--- a/crates/bdinfo-rs-wasm/web/src/scan.ts
+++ b/crates/bdinfo-rs-wasm/web/src/scan.ts
@@ -395,6 +395,11 @@ async function renderPreview(): Promise<void> {
   }
   const sections = reportSections();
   const selection = scanNames();
+  // Recorded as the render is REQUESTED, not when it lands: it says which
+  // selection the page is rendering, so a change made during the round trip is
+  // judged against that one rather than against the older order still on
+  // screen — which would ask again for the render already on its way.
+  state.previewOrder = selection;
   const gen = ++state.generation;
   try {
     const text = await renderReport({ ...held, reportOrder: selection }, sections);
@@ -403,7 +408,6 @@ async function renderPreview(): Promise<void> {
     }
     state.reportText = text;
     state.renderedWith = sections;
-    state.previewOrder = selection;
     reportPre.textContent = text;
     show(reportCard);
   } catch (error) {

--- a/crates/bdinfo-rs-wasm/web/src/scan.ts
+++ b/crates/bdinfo-rs-wasm/web/src/scan.ts
@@ -18,11 +18,16 @@ import { discardNote } from "./settings.js";
 import { el, errMessage, errorBox, hide, type Source, show, showError, state } from "./state.js";
 import { playlistRows, playlistsCard, renderRows, scanNames } from "./table.js";
 
+const dropzone = el("dropzone");
+const orIso = el("or-iso");
+const privacy = el("privacy");
 const pickedBox = el("picked");
 const pickedName = el("picked-name");
 const pickedCount = el("picked-count");
+export const changeDiscBtn = el<HTMLButtonElement>("change-disc");
 const discLabel = el("disc-label");
 export const scanBtn = el<HTMLButtonElement>("scan-btn");
+export const viewReportBtn = el<HTMLButtonElement>("view-report-btn");
 const progressCard = el("progress-card");
 const bar = el<HTMLProgressElement>("bar");
 const pctLabel = el("pct");
@@ -40,7 +45,6 @@ const scanErrorsCount = el("scan-errors-count");
 const scanErrorsList = el("scan-errors-list");
 const mainEl = el("main");
 const listingBox = el("listing");
-const encryptedNote = el("encrypted-note");
 
 export function fileListToBdmv(list: FileList): BdmvFile[] {
   return Array.from(list, (file) => ({ path: file.webkitRelativePath || file.name, file }));
@@ -104,6 +108,27 @@ export async function loadIso(file: File): Promise<void> {
   await loadSource({ kind: "iso", file, label });
 }
 
+/**
+ * Swaps the source card between its two shapes: the dropzone that lands the
+ * user, and the slim bar naming what is loaded. The dropzone itself is
+ * unchanged either way — {@link changeDisc} simply brings it back.
+ */
+function showSourceBar(loaded: boolean): void {
+  dropzone.hidden = loaded;
+  orIso.hidden = loaded;
+  privacy.hidden = loaded;
+  pickedBox.hidden = !loaded;
+}
+
+/**
+ * Puts the dropzone back. The loaded disc is left exactly as it stands — the
+ * page keeps listing it until a new pick replaces it, so a user who opens the
+ * picker and changes their mind loses nothing.
+ */
+export function changeDisc(): void {
+  showSourceBar(false);
+}
+
 async function loadSource(src: Source): Promise<void> {
   state.source = src;
   state.discName = src.label;
@@ -111,19 +136,20 @@ async function loadSource(src: Source): Promise<void> {
   pickedCount.textContent =
     src.kind === "folder" ? counted(src.files.length, "file") : "disc image (.iso)";
   mainEl.classList.remove("landing");
-  show(pickedBox);
+  showSourceBar(true);
   hide(errorBox);
   hide(reportCard);
   hide(progressCard);
   hide(playlistsCard);
   hide(discardNote);
-  hide(encryptedNote);
   show(listingBox);
   // A fresh pick discards everything held for the previous one.
   state.scanController?.abort();
   state.disc = null;
   state.reportText = "";
   state.renderedWith = null;
+  state.previewing = false;
+  state.paneRow = null;
   const gen = ++state.generation;
   const threshold = state.settings.shortPlaylistSeconds;
   try {
@@ -164,13 +190,15 @@ async function loadSource(src: Source): Promise<void> {
  */
 export function adoptDisc(next: Disc, threshold: number): void {
   // A new disc supersedes whatever a scan was ticking: its numbers are the
-  // final form of the very cells the overlay was raising.
+  // final form of the very cells the overlay was raising. A shown pre-scan
+  // report was rendered from the disc being replaced, so it is re-rendered even
+  // when the selection names come out identical.
   state.live.clear();
+  state.previewOrder = null;
   state.disc = next;
   state.discThreshold = threshold;
   state.playlists = next.playlists;
   state.allRows = playlistRows(next.playlists);
-  encryptedNote.hidden = !next.isAacsEncrypted;
   // Only a measured scan can carry short-stream notices, so a re-inspected
   // (structural) disc clears the strip along with everything else measured.
   const notices = next.shortStreamNotices ?? [];
@@ -250,6 +278,8 @@ export async function runScan(): Promise<void> {
   hide(errorBox);
   hide(reportCard);
   hide(discardNote);
+  // Whatever this scan reports supersedes a pre-scan report of the same disc.
+  state.previewing = false;
   show(progressCard);
   setProgress(0, "Preparing…");
   // This pass starts its tallies from zero, so whatever a cancelled or failed
@@ -285,10 +315,7 @@ export async function runScan(): Promise<void> {
     }
   }, 1000);
   const threshold = state.settings.shortPlaylistSeconds;
-  const sections = {
-    streamDiagnostics: state.settings.reportStreamDiagnostics,
-    quickSummary: state.settings.reportQuickSummary,
-  };
+  const sections = reportSections();
   // The live cells: guarded by the same stamp the completion is, so a snapshot
   // from a scan the page has already moved on from writes nothing.
   const onMeasured = (snapshot: MeasuredSnapshot) => {
@@ -339,6 +366,82 @@ export async function runScan(): Promise<void> {
   void applyReportSections();
 }
 
+/** The report sections the settings currently ask for. */
+function reportSections(): { streamDiagnostics: boolean; quickSummary: boolean } {
+  return {
+    streamDiagnostics: state.settings.reportStreamDiagnostics,
+    quickSummary: state.settings.reportQuickSummary,
+  };
+}
+
+/**
+ * Renders the report over the held disc BEFORE any measured scan: the same
+ * render the desktop app serves from the moment a disc is listed, over a disc
+ * whose measured values are all zero because nothing has measured them yet.
+ *
+ * It prints the scan set the button would measure — the ticked rows, or every
+ * listed row — by handing the module that selection as the disc's
+ * `reportOrder`, which is the documented way to name what a render prints. The
+ * disc's own order would print the library's default whole-disc set instead:
+ * not the set this page is showing, and not the one a scan from here would
+ * measure.
+ */
+async function renderPreview(): Promise<void> {
+  const held = state.disc;
+  // Mid-scan the held disc is about to be replaced by the measured one, whose
+  // completion renders the real report over it.
+  if (held === null || state.scanController !== null) {
+    return;
+  }
+  const sections = reportSections();
+  const selection = scanNames();
+  const gen = ++state.generation;
+  try {
+    const text = await renderReport({ ...held, reportOrder: selection }, sections);
+    if (gen !== state.generation) {
+      return;
+    }
+    state.reportText = text;
+    state.renderedWith = sections;
+    state.previewOrder = selection;
+    reportPre.textContent = text;
+    show(reportCard);
+  } catch (error) {
+    showError(errMessage(error));
+  }
+}
+
+/** The View report button: renders the pre-scan report and keeps it shown. */
+export async function viewReport(): Promise<void> {
+  state.previewing = true;
+  await renderPreview();
+  reportCard.scrollIntoView({ behavior: "smooth", block: "nearest" });
+}
+
+/**
+ * Re-renders a shown pre-scan report when the scan set it prints has moved.
+ *
+ * A no-op unless one is shown — a measured report is not re-derived from a
+ * selection — and a no-op while the set is the one already on screen: a redraw
+ * for a display setting changes what the TABLE shows, and the report is not
+ * rendered from that.
+ */
+export function refreshPreview(): void {
+  if (!state.previewing) {
+    return;
+  }
+  const selection = scanNames();
+  const shown = state.previewOrder;
+  if (
+    shown !== null &&
+    shown.length === selection.length &&
+    shown.every((n, i) => n === selection[i])
+  ) {
+    return;
+  }
+  void renderPreview();
+}
+
 /**
  * Applies the report-section switches: a `renderReport` over the held measured
  * disc, replacing the held report text only — never a rescan. Without a
@@ -347,6 +450,12 @@ export async function runScan(): Promise<void> {
  * nothing at all.
  */
 export async function applyReportSections(): Promise<void> {
+  // A shown pre-scan report renders under the switches too — it is the same
+  // render, over a disc nothing has measured.
+  if (state.previewing) {
+    await renderPreview();
+    return;
+  }
   if (state.disc === null || !state.disc.measured) {
     return;
   }
@@ -355,10 +464,7 @@ export async function applyReportSections(): Promise<void> {
   if (state.scanController !== null) {
     return;
   }
-  const wanted = {
-    streamDiagnostics: state.settings.reportStreamDiagnostics,
-    quickSummary: state.settings.reportQuickSummary,
-  };
+  const wanted = reportSections();
   if (
     state.renderedWith !== null &&
     state.renderedWith.streamDiagnostics === wanted.streamDiagnostics &&

--- a/crates/bdinfo-rs-wasm/web/src/scan.ts
+++ b/crates/bdinfo-rs-wasm/web/src/scan.ts
@@ -395,6 +395,17 @@ async function renderPreview(): Promise<void> {
   }
   const sections = reportSections();
   const selection = scanNames();
+  // The settings can withhold every playlist the disc has. There is then
+  // nothing to report on — the button that offers the report is disabled on the
+  // same terms — so the shown one is withdrawn rather than re-rendered into a
+  // report with no playlist in it.
+  if (selection.length === 0) {
+    state.previewing = false;
+    state.previewOrder = null;
+    state.reportText = "";
+    hide(reportCard);
+    return;
+  }
   // Recorded as the render is REQUESTED, not when it lands: it says which
   // selection the page is rendering, so a change made during the round trip is
   // judged against that one rather than against the older order still on

--- a/crates/bdinfo-rs-wasm/web/src/settings.ts
+++ b/crates/bdinfo-rs-wasm/web/src/settings.ts
@@ -14,7 +14,7 @@ import {
   showError,
   state,
 } from "./state.js";
-import { renderRows } from "./table.js";
+import { dropReveal, renderRows } from "./table.js";
 
 /** {@link formatSize} under the page's current size-format setting. */
 export function sizeCell(bytes: number | null): string {
@@ -106,6 +106,9 @@ async function applyThreshold(): Promise<void> {
     state.reportText = "";
     state.renderedWith = null;
     hide(reportCard);
+    // A re-classified table is the settings' own view of the disc, so the
+    // transient reveal over the old classification goes with it.
+    dropReveal();
     adoptDisc(next, parsed);
     discardNote.hidden = !discarding;
   } catch (error) {
@@ -146,7 +149,9 @@ export function initSettings(): void {
     settingsDialog.close();
   });
   // The four display settings are pure re-projections of the held disc: redraw
-  // the table and panes from what the page holds, no WebAssembly call.
+  // the table and panes from what the page holds, no WebAssembly call. Each one
+  // also drops the transient reveal — the settings are now saying what the
+  // table shows, which is what the reveal was standing in for.
   for (const box of [optShort, optLooping, optHumanSizes, optChapters]) {
     box.addEventListener("change", () => {
       state.settings.showShortPlaylists = optShort.checked;
@@ -154,6 +159,7 @@ export function initSettings(): void {
       state.settings.humanReadableSizes = optHumanSizes.checked;
       state.settings.displayChapterCount = optChapters.checked;
       saveSettings();
+      dropReveal();
       renderRows();
     });
   }

--- a/crates/bdinfo-rs-wasm/web/src/state.ts
+++ b/crates/bdinfo-rs-wasm/web/src/state.ts
@@ -11,6 +11,7 @@
 // uninitialized `const` — which is why the stored settings are read here rather
 // than by a call back into the settings module.
 import type { BdmvFile, Disc, MeasuredPlaylist, Playlist } from "./analyze.js";
+import type { PaneRow } from "./panes.js";
 import type { PlaylistRow, Sort } from "./table.js";
 
 /** The picked disc — a `webkitdirectory` BDMV folder, or a single `.iso`. */
@@ -168,6 +169,33 @@ export const state = {
   live: new Map<string, MeasuredPlaylist>(),
   /** The playlist whose details the panes show; null before the first draw. */
   activeName: null as string | null,
+  /**
+   * The highlighted detail-pane row — Ctrl+C's copy target while it stands, and
+   * null when no pane row has been clicked. Cleared whenever the panes are
+   * redrawn: a row index means nothing once the rows under it change.
+   */
+  paneRow: null as PaneRow | null,
+  /**
+   * Whether the transient reveal is on: the playlists the filters withhold sit
+   * in the table as ordinary rows. Session-only and deliberately outside
+   * {@link Settings} — it is never stored, and any settings change drops it,
+   * which is what keeps it from reading as a fourth filter switch.
+   */
+  revealing: false,
+  /**
+   * Whether the shown report is the PRE-SCAN structural render rather than a
+   * measured scan's. It is re-rendered whenever the selection or the settings
+   * behind it move, so what is on screen always describes the current
+   * selection; a measured scan replaces it with the report it produced.
+   */
+  previewing: false,
+  /**
+   * The playlist selection the shown pre-scan report was rendered over, by
+   * name; null while none is shown. It is what tells a selection change (a
+   * re-render) from a redraw that left the scan set exactly as it was — a
+   * display setting, say, which the report is not derived from at all.
+   */
+  previewOrder: null as string[] | null,
   /** The active sort; null draws the CLI's table order (by `position`). */
   sort: null as Sort | null,
   settings: loadSettings(),

--- a/crates/bdinfo-rs-wasm/web/src/table.ts
+++ b/crates/bdinfo-rs-wasm/web/src/table.ts
@@ -2,8 +2,9 @@
 // held disc, the settings filter and the renumbering, the sort, the selection
 // ticks, and the hint naming what the filters withheld.
 import type { HiddenRule, Playlist } from "./analyze.js";
+import { featureLabels, sizeCell as formatSize } from "./format.js";
 import { applyActive, ensureActive } from "./panes.js";
-import { scanBtn, scanOffered } from "./scan.js";
+import { refreshPreview, scanBtn, scanOffered, viewReportBtn } from "./scan.js";
 import { sizeCell } from "./settings.js";
 import { el, state } from "./state.js";
 
@@ -46,7 +47,18 @@ export const playlistBody = el<HTMLTableSectionElement>("playlist-body");
 export const selectAllBtn = el<HTMLButtonElement>("select-all");
 export const clearBtn = el<HTMLButtonElement>("clear-sel");
 const selCount = el("sel-count");
+const hiddenRow = el("hidden-row");
 const hiddenHint = el("hidden-hint");
+export const revealBtn = el<HTMLButtonElement>("reveal-btn");
+const infoTitle = el("info-title");
+const infoTitleValue = el("info-title-value");
+const infoFeatures = el("info-features");
+const infoFeaturesValue = el("info-features-value");
+const infoSize = el("info-size");
+const infoSizeValue = el("info-size-value");
+const hiddenTracksNote = el("hidden-tracks-note");
+const encryptedNote = el("encrypted-note");
+const encryptedBadge = el("encrypted-badge");
 
 /**
  * Whether the scan set is frozen: a running scan measures the playlists it
@@ -88,12 +100,38 @@ export function tableLength(ticks: number): string {
 
 /**
  * Whether the settings list `row`: every rule that classifies it as withheld
- * must be switched on.
+ * must be switched on. The transient reveal lists every row instead — a rule
+ * that withheld nothing has nothing to reveal, so revealing "all" and revealing
+ * "the rules that withheld something" are the same set.
  */
 function isShown(row: PlaylistRow): boolean {
-  return row.hiddenBy.every((rule) =>
-    rule === "short" ? state.settings.showShortPlaylists : state.settings.showLoopingPlaylists,
+  return (
+    state.revealing ||
+    row.hiddenBy.every((rule) =>
+      rule === "short" ? state.settings.showShortPlaylists : state.settings.showLoopingPlaylists,
+    )
   );
+}
+
+/**
+ * Flips the transient reveal. It writes no setting and saves nothing: the rows
+ * come and go for this session only, exactly like the desktop app's Show/Hide,
+ * and the next settings change drops it (see {@link dropReveal}).
+ *
+ * Inert while the scan set is frozen, like the selection controls: revealing
+ * rows under a running scan would widen the set it is measuring.
+ */
+export function toggleReveal(): void {
+  if (frozen()) {
+    return;
+  }
+  state.revealing = !state.revealing;
+  renderRows();
+}
+
+/** Drops the reveal — what every settings change does to it. */
+export function dropReveal(): void {
+  state.revealing = false;
 }
 
 // ── sorting ──────────────────────────────────────────────────────────────────
@@ -212,6 +250,7 @@ export function renderRows(): void {
   );
   renderSortIndicators();
   renderHint();
+  renderDiscInfo();
   ensureActive();
   updateSelection();
   applyFreeze();
@@ -226,6 +265,10 @@ const HINT_NAMES = 3;
  * disc, mirroring the CLI's `Hidden by filters (…)` block — a playlist that is
  * both short and looping is named on both lines and takes both settings to
  * reveal.
+ *
+ * The lines describe the SETTINGS, so the transient reveal changes their
+ * wording rather than retiring them: the rows it puts in the table are still
+ * the ones the settings withhold, and the line is where its Show/Hide lives.
  */
 function renderHint(): void {
   const lines: string[] = [];
@@ -237,6 +280,8 @@ function renderHint(): void {
   }
   hiddenHint.textContent = lines.join("\n");
   hiddenHint.hidden = lines.length === 0;
+  hiddenRow.hidden = lines.length === 0;
+  revealBtn.textContent = state.revealing ? "Hide" : "Show";
 }
 
 /** The hint line for `rule`, or nothing when the rule withheld no playlist. */
@@ -247,9 +292,44 @@ function hintLine(rule: "short" | "looping"): string[] {
   }
   const rest = names.length - HINT_NAMES;
   const more = rest > 0 ? ` and ${rest} more` : "";
+  const listed = `(${rule}): ${names.slice(0, HINT_NAMES).join(", ")}${more}`;
   return [
-    `Hidden by filters (${rule}): ${names.slice(0, HINT_NAMES).join(", ")}${more} - enable in settings`,
+    state.revealing
+      ? `Showing filtered playlists ${listed} - enable in settings to keep`
+      : `Hidden by filters ${listed} - enable in settings`,
   ];
+}
+
+/**
+ * The disc-info strip under the panes: the block the classic report prints as
+ * its footer — the disc title when the disc declares one, the detected features
+ * when it has any, its size in both the report's exact bytes and human-readable
+ * form, and the two notes. The desktop app draws the same lines in the same
+ * order.
+ *
+ * The hidden-tracks note is judged over the DISPLAYED rows, like the desktop
+ * app's: it explains the `*` markers the table is showing, so a disc whose only
+ * marked playlist the filters withhold has no marker to explain.
+ */
+function renderDiscInfo(): void {
+  const disc = state.disc;
+  const title = disc?.discTitle ?? "";
+  infoTitleValue.textContent = title;
+  infoTitle.hidden = title === "";
+  const features = disc === null ? [] : featureLabels(disc);
+  infoFeaturesValue.textContent = features.join(", ");
+  infoFeatures.hidden = features.length === 0;
+  // The report's own `Disc Size:` — the whole tree, so the interleaved *.ssif
+  // bytes that `sizeBytes` leaves out are counted in (see the mirror's two size
+  // fields). Both forms are shown whatever the size-format setting says, which
+  // is the one place the exact byte count is always readable.
+  const bytes = (disc?.sizeBytes ?? 0) + (disc?.interleavedSizeBytes ?? 0);
+  infoSizeValue.textContent = `${formatSize(bytes, false)} bytes (${formatSize(bytes, true)})`;
+  infoSize.hidden = bytes <= 0;
+  hiddenTracksNote.hidden = !state.displayed.some((row) => row.hasHidden);
+  const encrypted = disc?.isAacsEncrypted === true;
+  encryptedNote.hidden = !encrypted;
+  encryptedBadge.hidden = !encrypted;
 }
 
 export function cell(className?: string): HTMLTableCellElement {
@@ -356,12 +436,20 @@ export function updateSelection(): void {
   // The only unscannable table is one with no rows in it: the settings can
   // withhold every playlist the disc has, and there is then nothing to measure.
   scanBtn.disabled = state.displayed.length === 0 || !scanOffered() || frozen();
+  // The structural report needs no measurable stream data, so it is offered for
+  // an encrypted disc too — its structure is read from cleartext metadata and
+  // is correct, which is exactly what that report prints.
+  viewReportBtn.disabled = state.disc === null || state.displayed.length === 0 || frozen();
+  // A shown pre-scan report describes the selection, so a changed selection
+  // re-renders it — the same way a report-section switch re-renders a measured
+  // one rather than leaving a stale report on screen.
+  refreshPreview();
 }
 
 /**
  * Puts the freeze into effect on the controls that name the scan set — the row
- * checkboxes, the two selection buttons and the sortable headers. Disabled
- * rather than hidden: the user can still read what the running scan is
+ * checkboxes, the two selection buttons, the reveal and the sortable headers.
+ * Disabled rather than hidden: the user can still read what the running scan is
  * measuring.
  */
 export function applyFreeze(): void {
@@ -371,6 +459,7 @@ export function applyFreeze(): void {
   }
   selectAllBtn.disabled = scanning;
   clearBtn.disabled = scanning;
+  revealBtn.disabled = scanning;
   for (const th of playlistsCard.querySelectorAll<HTMLTableCellElement>("th[data-sort]")) {
     th.classList.toggle("frozen", scanning);
   }

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -683,6 +683,29 @@ async function main() {
     const cancelled = await readDemo();
     const cancelledSelection = await demoPage.evaluate(() => window.__selections.at(-1));
 
+    // The settings can withhold every playlist the disc has: there is then
+    // nothing to report on, and a shown pre-scan report is withdrawn instead of
+    // re-rendered into a report with no playlist in it. The threshold goes back
+    // to 0 afterwards — the reload below reads the stored value.
+    await demoPage.click("#view-report-btn");
+    await demoPage.waitForFunction(
+      () => !document.getElementById("report-card").hidden,
+      undefined,
+      {
+        timeout: 60000,
+      },
+    );
+    const previewAgain = await readDemo();
+    await demoPage.click("#settings-btn");
+    await demoPage.fill("#opt-short-seconds", "60");
+    await demoPage.locator("#opt-short-seconds").blur();
+    await rowCountIs(0);
+    const emptied = await readDemo();
+    await demoPage.fill("#opt-short-seconds", "0");
+    await demoPage.locator("#opt-short-seconds").blur();
+    await rowCountIs(3);
+    await demoPage.click("#settings-close");
+
     // A phone-width viewport must not scroll the page sideways — wide tables
     // scroll inside their own wrapper instead.
     await demoPage.setViewportSize({ width: 390, height: 844 });
@@ -838,6 +861,8 @@ async function main() {
       beforeCancel,
       cancelled,
       cancelledSelection,
+      previewAgain,
+      emptied,
       pageScrolls,
       damagedListing,
       persisted,
@@ -1381,6 +1406,24 @@ async function main() {
     false,
     false,
     false,
+  ]);
+
+  // Withholding every playlist: the report and the button that offers it both
+  // go, and the withdrawal costs no render — the threshold's own inspect is the
+  // only request the step makes.
+  demoOk &= demoEq(
+    "the report is offered again after a scan",
+    demo.previewAgain.viewDisabled,
+    false,
+  );
+  demoOk &= demoEq(
+    "an empty table withdraws the report and its button",
+    [demo.emptied.reportHidden, demo.emptied.viewDisabled, demo.emptied.scanDisabled],
+    [true, true, true],
+  );
+  demoOk &= demoEq("withdrawing it renders nothing", demo.emptied.calls, [
+    ...demo.previewAgain.calls,
+    "inspect",
   ]);
 
   demoOk &= demoEq("no sideways page scroll at phone width", demo.pageScrolls, false);

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -377,6 +377,19 @@ async function main() {
           codecs: grid("#codecs-body tr"),
           hintHidden: document.getElementById("hidden-hint").hidden,
           hintText: document.getElementById("hidden-hint").textContent,
+          revealLabel: document.getElementById("reveal-btn").textContent,
+          // The disc-info strip: the lines it shows, and what it says on them.
+          info: [...document.querySelectorAll("#disc-info p")]
+            .filter((line) => !line.hidden)
+            .map((line) => line.textContent.replace(/\s+/g, " ").trim()),
+          badgeHidden: document.getElementById("encrypted-badge").hidden,
+          // The source card: the slim bar names what is loaded, and the
+          // dropzone is only up while there is nothing loaded to name.
+          picked: document.getElementById("picked").hidden
+            ? null
+            : document.getElementById("picked-name").textContent,
+          dropzoneHidden: document.getElementById("dropzone").hidden,
+          viewDisabled: document.getElementById("view-report-btn").disabled,
           errorsHidden: document.getElementById("scan-errors").hidden,
           errorsCount: document.getElementById("scan-errors-count").textContent,
           errorLines: texts("#scan-errors-list li"),
@@ -439,13 +452,72 @@ async function main() {
     await demoPage.click("#settings-close");
     const preScan = await readDemo();
 
+    // The transient reveal: Show puts the withheld playlist in the table and
+    // Hide takes it back out, with the stored settings untouched throughout —
+    // it is session state, not a fourth filter switch.
+    const storedShort = () =>
+      demoPage.evaluate(
+        () => JSON.parse(window.localStorage.getItem("bdinfo-rs.settings")).showShortPlaylists,
+      );
+    await demoPage.click("#reveal-btn");
+    await rowCountIs(3);
+    const revealed = { ...(await readDemo()), stored: await storedShort() };
+    await demoPage.click("#reveal-btn");
+    await rowCountIs(2);
+    const rehidden = await readDemo();
+    // A settings change drops it: the settings are then saying what the table
+    // shows, and a reveal over the old view would be describing nothing.
+    await demoPage.click("#reveal-btn");
+    await rowCountIs(3);
+    await demoPage.click("#settings-btn");
+    await demoPage.click("#opt-chapters");
+    await rowCountIs(2);
+    const revealDropped = await readDemo();
+    await demoPage.click("#opt-chapters");
+    await demoPage.click("#settings-close");
+
+    const reportNow = () => demoPage.evaluate(() => document.getElementById("report").textContent);
+
+    // The report BEFORE any measured scan: the same render over a disc whose
+    // measured values are all zero. It prints the scan set the button would
+    // measure — the table's own rows, in the table's own order, which the
+    // name-ascending sort in force here makes visible — and it is re-rendered
+    // when that set changes rather than left describing a stale selection.
+    const uncheck = (name) =>
+      demoPage.evaluate((playlist) => {
+        document
+          .querySelector(`#playlist-body tr[data-name="${playlist}"] input[type=checkbox]`)
+          .click();
+      }, name);
+    const reportChanges = async (act) => {
+      const before = await reportNow();
+      await act();
+      await demoPage.waitForFunction(
+        (prev) => document.getElementById("report").textContent !== prev,
+        before,
+        { timeout: 60000 },
+      );
+      return reportNow();
+    };
+    const preview = await reportChanges(() => demoPage.click("#view-report-btn"));
+    const previewUnchecked = await reportChanges(() => uncheck("00000.MPLS"));
+    const previewRestored = await reportChanges(() => uncheck("00000.MPLS"));
+    const previewState = await readDemo();
+
     // Back to the table order before scanning, so the page's selection order is
     // the disc's presentation order — which is what makes the re-rendered
-    // report below comparable to the scan's own, byte for byte.
+    // report below comparable to the scan's own, byte for byte. Re-ordering the
+    // table re-orders the report the pre-scan render is showing, so this one
+    // costs a render; a request is logged as the click makes it, so the counts
+    // below need no waiting.
     await demoPage.click('th[data-sort="position"]');
+    const resorted = await readDemo();
 
     // Nothing ticked is a whole-disc scan, not a refusal to scan: the button
-    // stays live and the count says what pressing it will do.
+    // stays live and the count says what pressing it will do. Neither click
+    // moves the scan SET here — every row was ticked, and unticking them all
+    // falls back to the same rows in the same order — so the shown report is
+    // already the right one and no render is asked for.
     await demoPage.click("#clear-sel");
     const cleared = await readDemo();
     await demoPage.click("#select-all");
@@ -470,6 +542,8 @@ async function main() {
         selectAllDisabled: document.getElementById("select-all").disabled,
         clearDisabled: document.getElementById("clear-sel").disabled,
         scanDisabled: document.getElementById("scan-btn").disabled,
+        viewDisabled: document.getElementById("view-report-btn").disabled,
+        revealDisabled: document.getElementById("reveal-btn").disabled,
         progressHidden: document.getElementById("progress-card").hidden,
         times: document.getElementById("progress-times").textContent,
       });
@@ -499,11 +573,48 @@ async function main() {
     const scanned = await readDemo();
     const report = await demoPage.evaluate(() => document.getElementById("report").textContent);
 
+    // Ctrl+C copies the highlighted row's disc path, in the desktop app's
+    // precedence. The clipboard write is stubbed rather than read back: what the
+    // page copies is the assertion, and a headless run has no clipboard
+    // permission to lean on.
+    const copied = await demoPage.evaluate(async () => {
+      const paths = [];
+      navigator.clipboard.writeText = (text) => {
+        paths.push(text);
+        return Promise.resolve();
+      };
+      const press = () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "c", ctrlKey: true, bubbles: true }),
+        );
+        // The copy awaits the clipboard write, so let the microtasks run.
+        return new Promise((done) => setTimeout(done, 0));
+      };
+      const firstFile = () => document.querySelector("#files-body tr");
+      // Nothing picked in the panes: the active playlist row is the target.
+      await press();
+      // A highlighted Stream File row wins, and carries its clip's real name.
+      firstFile().click();
+      await press();
+      const flagged = firstFile().classList.contains("copied-row");
+      // A highlighted Codec row copies nothing — the scope the classic tool has.
+      document.querySelector("#codecs-body tr").click();
+      await press();
+      // A text selection is the user's own copy; the shortcut stands aside.
+      document.querySelector("#codecs-body tr").click();
+      const range = document.createRange();
+      range.selectNodeContents(document.getElementById("sel-count"));
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+      await press();
+      window.getSelection().removeAllRanges();
+      return { paths, flagged };
+    });
+
     // The report-section switches: every flip re-renders the held disc through
     // the package — the displayed text changes while the request log gains only
     // `render` kinds and the progress card never shows. Both orders of turning
     // the two sections off are walked, so the switches' composition is pinned.
-    const reportNow = () => demoPage.evaluate(() => document.getElementById("report").textContent);
     const toggleSection = async (selector) => {
       const before = await reportNow();
       await demoPage.click(selector);
@@ -578,6 +689,14 @@ async function main() {
     const pageScrolls = await demoPage.evaluate(
       () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
     );
+
+    // The post-pick source bar: a loaded disc replaces the dropzone with the
+    // slim bar naming it, and "Change disc…" puts the dropzone back without
+    // disturbing the disc the page is showing — the re-pick below lands on the
+    // bar again.
+    const barLoaded = await readDemo();
+    await demoPage.click("#change-disc");
+    const barChanging = await readDemo();
 
     // A damaged disc through the page: the same folder plus a file in PLAYLIST
     // that is not a playlist, which the structural listing records and reads
@@ -688,11 +807,22 @@ async function main() {
       grouped,
       noSuffix,
       preScan,
+      revealed,
+      rehidden,
+      revealDropped,
+      preview,
+      previewUnchecked,
+      previewRestored,
+      previewState,
+      resorted,
       cleared,
       reselected,
       midScan,
       scanned,
       report,
+      copied,
+      barLoaded,
+      barChanging,
       sdOff,
       bothOff1,
       qsOff,
@@ -884,6 +1014,26 @@ async function main() {
     ["Hidden by filters (short): 00002.MPLS - enable in settings"].join("\n"),
   );
   demoOk &= demoEq("load cost one inspect", demo.initial.calls, ["inspect"]);
+  // The disc-info strip. This disc declares no title and carries no feature
+  // flag, and none of its playlists hides a stream, so the size line is the
+  // whole strip — and it counts every file the page was handed, the six of the
+  // fixture plus the two patched playlists above.
+  const discBytes = entries.reduce(
+    (total, item) => total + Buffer.from(item.b64, "base64").length,
+    0,
+  );
+  const mplsBytes = Buffer.from(
+    entries.find((item) => item.path.endsWith("00000.mpls")).b64,
+    "base64",
+  ).length;
+  const strip = `Disc Size: ${(discBytes + mplsBytes * 2 + 14).toLocaleString("en-US")} bytes (10.63 MB)`;
+  demoOk &= demoEq("the disc-info strip carries the size line alone", demo.initial.info, [strip]);
+  demoOk &= demoEq("an unencrypted disc shows no badge", demo.initial.badgeHidden, true);
+  // The source card: a loaded disc is named by the slim bar, and the dropzone
+  // it replaces is put away until "Change disc…" asks for it.
+  demoOk &= demoEq("a loaded disc shows the source bar", demo.initial.picked, "WASMDISC");
+  demoOk &= demoEq("the dropzone stands down while loaded", demo.initial.dropzoneHidden, true);
+  demoOk &= demoEq("the report is offered before any scan", demo.initial.viewDisabled, false);
   demoOk &= demoEq("stream-file pane (unmeasured)", demo.initial.files, [
     ["00000.M2TS", "1", "00:00:40", "10.63 MB", "—"],
   ]);
@@ -937,6 +1087,75 @@ async function main() {
   ]);
   demoOk &= demoEq("display settings cost no wasm call", demo.preScan.calls, ["inspect"]);
 
+  // The transient reveal: the withheld playlist joins the table as an ordinary
+  // row, the line says so and offers the way back, and the stored setting that
+  // withheld it is untouched — which is what makes the reveal transient rather
+  // than a fourth filter switch. A settings change then drops it.
+  demoOk &= demoEq("Show reveals the withheld playlist", demo.revealed.names, [
+    "00000.MPLS",
+    "00001.MPLS [02 Chapters]",
+    "00002.MPLS",
+  ]);
+  demoOk &= demoEq(
+    "the revealed line says so and offers Hide",
+    [demo.revealed.hintText, demo.revealed.revealLabel],
+    ["Showing filtered playlists (short): 00002.MPLS - enable in settings to keep", "Hide"],
+  );
+  demoOk &= demoEq("the reveal never touched the stored setting", demo.revealed.stored, false);
+  demoOk &= demoEq(
+    "Hide takes the playlist back out",
+    [demo.rehidden.names.length, demo.rehidden.revealLabel, demo.rehidden.hintText],
+    [2, "Show", "Hidden by filters (short): 00002.MPLS - enable in settings"],
+  );
+  demoOk &= demoEq(
+    "a settings change drops the reveal",
+    [demo.revealDropped.names.length, demo.revealDropped.revealLabel],
+    [2, "Show"],
+  );
+
+  // The pre-scan report: the same render over a disc nothing has measured. It
+  // prints the rows the table is showing, in the table's own order — the
+  // name-ascending sort in force here, not the disc's presentation order, which
+  // would have put the 40 s playlist first — and it follows the selection while
+  // it is shown, at the cost of one render each time that selection moves.
+  const blocks = (text) => text.split("\r\n").filter((line) => line.startsWith("PLAYLIST: "));
+  demoOk &= demoEq(
+    "the pre-scan report prints the table's rows in its order",
+    blocks(demo.preview),
+    ["PLAYLIST: 00000.MPLS", "PLAYLIST: 00001.MPLS"],
+  );
+  // The measured Movie Size of this clip: in the scan's report, and in nothing
+  // a render before it could know.
+  demoOk &= demoEq(
+    "the pre-scan report measures nothing",
+    [demo.preview.includes("11,064,384"), demo.report.includes("11,064,384")],
+    [false, true],
+  );
+  demoOk &= demoEq("unticking a row drops its block", blocks(demo.previewUnchecked), [
+    "PLAYLIST: 00001.MPLS",
+  ]);
+  demoOk &= compare(
+    "restoring the selection renders the same report again",
+    demo.previewRestored,
+    Buffer.from(demo.preview),
+  );
+  demoOk &= demoEq("the pre-scan report cost renders only", demo.previewState.calls, [
+    ...demo.preScan.calls,
+    "render",
+    "render",
+    "render",
+  ]);
+  demoOk &= demoEq("no scan ran for it", demo.previewState.progressHidden, true);
+  demoOk &= demoEq("re-ordering the table re-renders it", demo.resorted.calls, [
+    ...demo.previewState.calls,
+    "render",
+  ]);
+  demoOk &= demoEq(
+    "a selection change that leaves the scan set alone renders nothing",
+    [demo.cleared.calls, demo.reselected.calls],
+    [demo.resorted.calls, demo.resorted.calls],
+  );
+
   // The empty selection: the button is live and the count says the scan covers
   // everything, and ticking the rows again returns the plain count.
   demoOk &= demoEq(
@@ -978,6 +1197,13 @@ async function main() {
       demo.midScan.frozen.scanDisabled,
     ],
     [true, true, true],
+  );
+  // The reveal and the pre-scan report name the scan set too, so they are
+  // frozen with the rest of it.
+  demoOk &= demoEq(
+    "a running scan disables the reveal and the report button",
+    [demo.midScan.frozen.revealDisabled, demo.midScan.frozen.viewDisabled],
+    [true, true],
   );
   demoOk &= demoEq("the progress card is up", demo.midScan.frozen.progressHidden, false);
   demoOk &= demoEq("the readout is blank before the first event", demo.midScan.frozen.times, "");
@@ -1032,7 +1258,20 @@ async function main() {
     ["973 kbps", "1,536 kbps"],
   );
   demoOk &= demoEq("the demo report renders", demo.report.includes("QUICK SUMMARY:"), true);
-  demoOk &= demoEq("the scan cost one scan call", demo.scanned.calls, ["inspect", "scan"]);
+  demoOk &= demoEq("the scan cost one scan call", demo.scanned.calls, [
+    ...demo.reselected.calls,
+    "scan",
+  ]);
+
+  // Ctrl+C, in the desktop app's precedence: a highlighted Stream File row wins
+  // and names its clip's real stream file, an unhighlighted pane falls back to
+  // the active playlist, and a Codec row copies nothing. The paths are
+  // disc-relative — a browser page is given no location for what it was handed.
+  demoOk &= demoEq("Ctrl+C copies the highlighted row's disc path", demo.copied.paths, [
+    "BDMV/PLAYLIST/00000.MPLS",
+    "BDMV/STREAM/00000.M2TS",
+  ]);
+  demoOk &= demoEq("the copied row is marked", demo.copied.flagged, true);
 
   // The section switches: eight flips, eight `render` requests, no scan and no
   // progress bar; every rendering equals the scan's own report minus exactly
@@ -1061,8 +1300,7 @@ async function main() {
   );
   demoOk &= compare("demo render: restored again", demo.restored2, Buffer.from(demo.report));
   demoOk &= demoEq("section flips cost renders only", demo.afterRenders.calls, [
-    "inspect",
-    "scan",
+    ...demo.scanned.calls,
     ...Array(8).fill("render"),
   ]);
   demoOk &= demoEq("no scan ran while re-rendering", demo.afterRenders.progressHidden, true);
@@ -1074,9 +1312,7 @@ async function main() {
   // `inspect` (one request), re-classified the 10 s playlist into the table,
   // and visibly discarded the measured results and the held report.
   demoOk &= demoEq("threshold change cost one inspect", demo.thresholdApplied.calls, [
-    "inspect",
-    "scan",
-    ...Array(8).fill("render"),
+    ...demo.afterRenders.calls,
     "inspect",
   ]);
   demoOk &= demoEq("threshold re-classifies the table", demo.thresholdApplied.names, [
@@ -1148,6 +1384,21 @@ async function main() {
   ]);
 
   demoOk &= demoEq("no sideways page scroll at phone width", demo.pageScrolls, false);
+
+  // "Change disc…" is the way back to the dropzone, and it is only that: the
+  // disc the page is showing stays exactly where it is until a new pick
+  // replaces it, and that pick lands on the source bar again.
+  demoOk &= demoEq(
+    "Change disc… puts the dropzone back",
+    [demo.barChanging.picked, demo.barChanging.dropzoneHidden],
+    [null, false],
+  );
+  demoOk &= demoEq("it leaves the loaded disc alone", demo.barChanging.names, demo.barLoaded.names);
+  demoOk &= demoEq(
+    "a fresh pick lands on the source bar again",
+    [demo.damagedListing.picked, demo.damagedListing.dropzoneHidden],
+    ["WASMDISC", true],
+  );
 
   // The failure strip: absent for healthy media, and on a damaged listing it
   // names the file and says what was wrong with it, in the report's wording.

--- a/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.node.mjs
@@ -275,6 +275,40 @@ async function main() {
     console.error(`FAIL — progress readout diverged: ${progressMismatches.join("; ")}`);
   }
 
+  // The demo's Detected Features list against the report's own `Extras:` line.
+  // The labels and their order are the library's (`BdRom::extra_features`) and
+  // are written a second time in TypeScript, because the mirror carries the six
+  // flags rather than the strings they stand for — so this renders a disc with
+  // every flag set and requires the demo to spell that line exactly. A label or
+  // an order that moves on the Rust side fails here.
+  const { featureLabels } = await import("../dist/format.js");
+  const featured = {
+    ...inspected,
+    isUhd: true,
+    isBdJava: true,
+    is50hz: true,
+    is3d: true,
+    isDbox: true,
+    isPsp: true,
+  };
+  const extrasLine = render_report(featured)
+    .split("\r\n")
+    .find((line) => line.startsWith("Extras:"));
+  const labels = featureLabels(featured);
+  // The report pads its labels to column 16; the value is what follows.
+  const featuresOk =
+    labels.length === 6 &&
+    extrasLine !== undefined &&
+    extrasLine.slice(16) === labels.join(", ") &&
+    // A disc with no feature flags has no Extras line and no labels either.
+    featureLabels(inspected).length === 0 &&
+    !render_report(inspected).includes("Extras:");
+  if (!featuresOk) {
+    console.error(
+      `FAIL — detected features diverged: labels ${JSON.stringify(labels)}, report line ${JSON.stringify(extrasLine)}.`,
+    );
+  }
+
   // The report save-file name, sanitized by the core rule.
   const fileNameOk =
     report_file_name("WASMDISC") === "BDINFO.WASMDISC.txt" &&
@@ -446,6 +480,7 @@ async function main() {
     codecsOk &&
     sizeOk &&
     progressOk &&
+    featuresOk &&
     fileNameOk &&
     fullOk &&
     keepPartialOk &&
@@ -457,7 +492,7 @@ async function main() {
     downloadNameOk
   ) {
     console.log(
-      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + rejection + codecs + size vectors + progress readout + file name + download name + selection + round trip + retention + short-stream notices + .iso OK.`,
+      `PASS — Node measured scan matches the golden (${golden.length} bytes); inspect + table fields + classification + rejection + codecs + size vectors + progress readout + detected features + file name + download name + selection + round trip + retention + short-stream notices + .iso OK.`,
     );
     process.exit(0);
   }


### PR DESCRIPTION
Five display-only additions the desktop app has and the browser demo lacked, all off data the wasm mirror already exports. No Rust, no wasm rebuild, no mirror change; everything is under `crates/bdinfo-rs-wasm/web/`.

- **Disc-info strip** under the panes: disc title when the disc declares one, detected features, the disc size in exact bytes and human-readable form, the hidden-tracks note the `*` marker previously carried only as a hover title, and the AACS indicator relocated there as a badge beside its explanation.
- **View report** before any measured scan: the structural zero-bitrate render over the checked-or-all selection, printing the table rows in table order, and re-rendered whenever that selection moves. Withdrawn when the filters withhold every playlist, like the button that offers it.
- **Post-pick source bar** naming the loaded disc, with `Change disc...` putting the dropzone back and leaving the listing alone.
- **Session-only Show/Hide reveal** on the filter hint: it writes no setting and the next settings change drops it.
- **Ctrl+C** copies the highlighted row disc-relative path, a Stream File row ahead of the active playlist, a Codec row copying nothing, and standing aside for a text selection or a focused field.

The features list ports `BdRom::extra_features` label for label. Because the mirror carries the six flags rather than the strings, `test/parity.node.mjs` renders a disc with every flag set and pins the list against the report `Extras:` line.

`test/parity.chrome.mjs` grows from 97 to 124 assertions covering the strip, the pre-scan render and its re-render, the reveal, the source bar and the copy precedence; no assertion was removed.