### PR TITLE
fix(gui): say the report was generated, not written, when errors were recorded

### DIFF
--- a/crates/bdinfo-rs-gui/src/flow.rs
+++ b/crates/bdinfo-rs-gui/src/flow.rs
@@ -338,14 +338,17 @@ impl Listing {
 /// The scan-complete confirmation text for a scan that recorded `errors`
 /// failures.
 ///
-/// A clean success, or a note that the resilient scan still wrote the report
+/// A clean success, or a note that the resilient scan still generated the report
 /// — the message the shell shows in its completion modal.
 #[must_use]
 pub fn scan_notice(errors: usize) -> String {
     if errors == 0 {
         "Scan completed successfully.".to_owned()
     } else {
-        format!("Scan completed with {}.\nThe report was still written.", counted(errors, "error"))
+        format!(
+            "Scan completed with {}.\nThe report was still generated.",
+            counted(errors, "error")
+        )
     }
 }
 
@@ -1369,11 +1372,11 @@ mod tests {
         assert_eq!(super::scan_notice(0), "Scan completed successfully.");
         assert_eq!(
             super::scan_notice(1),
-            "Scan completed with 1 error.\nThe report was still written."
+            "Scan completed with 1 error.\nThe report was still generated."
         );
         assert_eq!(
             super::scan_notice(2),
-            "Scan completed with 2 errors.\nThe report was still written."
+            "Scan completed with 2 errors.\nThe report was still generated."
         );
     }
 

--- a/crates/bdinfo-rs-gui/src/main.rs
+++ b/crates/bdinfo-rs-gui/src/main.rs
@@ -2711,7 +2711,7 @@ impl App {
                 p,
                 p.warning,
                 &format!(
-                    "Completed with {} — the report below was still written.",
+                    "Completed with {} — the report was still generated.",
                     report::counted(errors.len(), "error")
                 ),
             ));


### PR DESCRIPTION
The scan-complete modal and the report view's error banner both claimed the report "was still written". The verb collides with the file save: the modal is shown before autosave runs, autosave may be off, and on read-only media (a physical disc's own root as the autosave destination) the save fails — leaving the modal claiming a write while the status line reports "Save failed". "Written"/"saved" stays reserved for the status line, which is the one surface that knows the save outcome.

- `flow::scan_notice`: "The report was still written." → "The report was still generated." (error case only; a clean scan still says "Scan completed successfully.")
- report view banner: "the report below was still written" → "the report was still generated"