### PR TITLE
feat(wasm): show an indeterminate progress state before the first scan event

### DIFF
--- a/crates/bdinfo-rs-wasm/web/index.html
+++ b/crates/bdinfo-rs-wasm/web/index.html
@@ -810,6 +810,61 @@
         background: var(--accent);
         border-radius: 99px;
       }
+      /* Before the scan's first progress event nothing has been measured, so
+         the bar sweeps instead of standing flat at zero. Firefox paints the
+         element's own background as the track (::-moz-progress-bar is the
+         value, which has no width at zero); Chrome paints ::-webkit-progress-bar
+         over it. Hence two SEPARATE rules — a selector list carrying a
+         pseudo-element one engine cannot parse would invalidate the whole
+         rule, and with it the animation on the engine that can. */
+      progress.indeterminate {
+        background-image: linear-gradient(
+          90deg,
+          var(--surface-2) 0%,
+          var(--accent-dim) 50%,
+          var(--surface-2) 100%
+        );
+        background-size: 200% 100%;
+        background-repeat: repeat-x;
+        animation: sweep 1.4s linear infinite;
+      }
+      progress.indeterminate::-webkit-progress-bar {
+        background-image: linear-gradient(
+          90deg,
+          var(--surface-2) 0%,
+          var(--accent-dim) 50%,
+          var(--surface-2) 100%
+        );
+        background-size: 200% 100%;
+        background-repeat: repeat-x;
+        animation: sweep 1.4s linear infinite;
+      }
+      /* One tile of travel per cycle, so the loop restarts where it ended. */
+      @keyframes sweep {
+        from {
+          background-position-x: 200%;
+        }
+        to {
+          background-position-x: 0%;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        /* The gradient goes with the animation: a highlight parked mid-bar
+           would read as a measurement rather than as "not measured yet". */
+        progress.indeterminate {
+          background-image: none;
+          animation: none;
+        }
+        progress.indeterminate::-webkit-progress-bar {
+          background-image: none;
+          animation: none;
+        }
+      }
+      .progress-row .spinner {
+        /* Sits in the percentage's reserved slot, so swapping the wheel for the
+           number at the first event does not resize the bar. */
+        margin: 0 calc((2.8rem - 14px) / 2);
+      }
       .pct {
         font-family: var(--mono);
         font-variant-numeric: tabular-nums;
@@ -1158,6 +1213,11 @@
           <div class="body">
             <div class="progress-row">
               <progress id="bar" max="100" value="0"></progress>
+              <!-- The same wheel the listing box shows: until the first progress
+                   event there is nothing measured to put a number on, so the
+                   percentage stands down and this takes its reserved space.
+                   `aria-hidden` because "Preparing…" below already says it. -->
+              <span class="spinner" id="progress-spinner" aria-hidden="true" hidden></span>
               <span class="pct" id="pct">0%</span>
               <!-- Elapsed + the remaining estimate; blank until the scan's
                    first progress event gives the estimate something to work

--- a/crates/bdinfo-rs-wasm/web/src/scan.ts
+++ b/crates/bdinfo-rs-wasm/web/src/scan.ts
@@ -30,6 +30,7 @@ export const scanBtn = el<HTMLButtonElement>("scan-btn");
 export const viewReportBtn = el<HTMLButtonElement>("view-report-btn");
 const progressCard = el("progress-card");
 const bar = el<HTMLProgressElement>("bar");
+const progressSpinner = el("progress-spinner");
 const pctLabel = el("pct");
 const progressTimes = el("progress-times");
 const progressText = el("progress-text");
@@ -292,11 +293,21 @@ export async function runScan(): Promise<void> {
   // re-derive the estimate from them. Null until the first event — the blind
   // window the readout spends blank.
   let counts: { done: number; total: number } | null = null;
+  // The whole blind window hangs off that one value: no estimate, no
+  // percentage, and a sweeping bar instead of a flat one. On a defective disc
+  // the first read can stall for the better part of a minute, and a `0%` beside
+  // a motionless bar claims a measurement that has not been made.
   const showTimes = () => {
+    // Read once into a local: the counts are written from another closure, so
+    // only a snapshot narrows for the estimate below.
+    const measured = counts;
+    progressSpinner.hidden = measured !== null;
+    pctLabel.hidden = measured === null;
+    bar.classList.toggle("indeterminate", measured === null);
     progressTimes.textContent =
-      counts === null
+      measured === null
         ? ""
-        : elapsedRemaining(counts.done, counts.total, performance.now() - started);
+        : elapsedRemaining(measured.done, measured.total, performance.now() - started);
   };
   showTimes();
   const onProgress = ({ file, done, total }: { file: string; done: number; total: number }) => {

--- a/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
+++ b/crates/bdinfo-rs-wasm/web/test/parity.chrome.mjs
@@ -398,6 +398,11 @@ async function main() {
           discardHidden: document.getElementById("discard-note").hidden,
           selCount: document.getElementById("sel-count").textContent,
           times: document.getElementById("progress-times").textContent,
+          // The blind window before the first progress event: sweeping bar,
+          // wheel where the percentage goes, no number.
+          indeterminate: document.getElementById("bar").classList.contains("indeterminate"),
+          spinnerHidden: document.getElementById("progress-spinner").hidden,
+          pctHidden: document.getElementById("pct").hidden,
           // The scan-set controls: live between scans, inert while one runs.
           scanDisabled: document.getElementById("scan-btn").disabled,
           boxesDisabled: [...document.querySelectorAll("#playlist-body input[type=checkbox]")].map(
@@ -546,6 +551,9 @@ async function main() {
         revealDisabled: document.getElementById("reveal-btn").disabled,
         progressHidden: document.getElementById("progress-card").hidden,
         times: document.getElementById("progress-times").textContent,
+        indeterminate: document.getElementById("bar").classList.contains("indeterminate"),
+        spinnerHidden: document.getElementById("progress-spinner").hidden,
+        pctHidden: document.getElementById("pct").hidden,
       });
       document.getElementById("scan-btn").click();
       const frozen = read();
@@ -1232,6 +1240,17 @@ async function main() {
   );
   demoOk &= demoEq("the progress card is up", demo.midScan.frozen.progressHidden, false);
   demoOk &= demoEq("the readout is blank before the first event", demo.midScan.frozen.times, "");
+  // Before the first event nothing is measured, so the strip says so: the bar
+  // sweeps, the wheel is up, and no percentage claims a measurement.
+  demoOk &= demoEq(
+    "the bar is indeterminate before the first event",
+    [
+      demo.midScan.frozen.indeterminate,
+      demo.midScan.frozen.spinnerHidden,
+      demo.midScan.frozen.pctHidden,
+    ],
+    [true, false, true],
+  );
   demoOk &= demoEq("a frozen sort header does not re-order", demo.midScan.afterEdits.names, [
     "00001.MPLS [02 Chapters]",
     "00000.MPLS",
@@ -1261,6 +1280,13 @@ async function main() {
     "the readout keeps the last elapsed and remaining",
     demo.scanned.times.replace(/\d/g, "0"),
     "Elapsed 00:00:00 · Remaining 00:00:00",
+  );
+  // The last progress event leaves the measuring state behind when the card
+  // hides: the sweep is off, the wheel is down, the percentage is back.
+  demoOk &= demoEq(
+    "a measured scan leaves the strip determinate",
+    [demo.scanned.indeterminate, demo.scanned.spinnerHidden, demo.scanned.pctHidden],
+    [false, true, false],
   );
   demoOk &= demoEq("scan keeps the active row", demo.scanned.active, "00000.MPLS");
   demoOk &= demoEq("measured size fills after the scan", demo.scanned.files, [


### PR DESCRIPTION
Between pressing Scan and the scan's first progress event nothing has been measured, yet the progress strip showed a flat bar and `0%` — a number claiming a measurement that has not happened. On healthy media that window is a blink; on defective media it can stand for the better part of a minute, where the page reads as frozen.

That window now says what it is:

- the bar sweeps a highlight across the track (`progress.indeterminate`)
- the listing box's spinner appears in the percentage's reserved slot
- the percentage is withheld until the first event brings it back

All three hang off `counts === null` in `runScan` — the retained byte counts that already drive the Elapsed/Remaining readout — set in `showTimes()`, which already runs at scan start, on every progress event and on every 1 Hz tick. No new state, no new timer, no animation loop.

The element rule and the `::-webkit-progress-bar` rule are separate: a selector list carrying a vendor pseudo-element one engine cannot parse would invalidate the whole rule. Firefox is served by the element background (its `::-moz-progress-bar` is the value, which has no width at zero); Chrome overpaints it with the track pseudo-element. Under `prefers-reduced-motion: reduce` both the animation and the gradient go, leaving the plain track rather than a highlight parked mid-bar.

Colours are the existing tokens (`--accent-dim` over `--surface-2`).

`test/parity.chrome.mjs` pins all three flags in the mid-scan snapshot and their opposites after the report lands: 124 to 126 assertions, none deleted.