### PR TITLE
ci(release): publish the gui crate from its own tag-triggered workflow

### DIFF
--- a/.github/scripts/check-trusted-publishing-triggers.ps1
+++ b/.github/scripts/check-trusted-publishing-triggers.ps1
@@ -1,0 +1,192 @@
+#!/usr/bin/env pwsh
+# Trusted-publishing trigger gate: no workflow may mint a registry token from a
+# `workflow_run` trigger.
+#
+# crates.io answers an OIDC token request made from a `workflow_run` run with
+# HTTP 400 — "Trusted Publishing does not support the `workflow_run` event
+# trigger due to security concerns. Please use a different trigger such as
+# `push`, `release`, or `workflow_dispatch`." npm's trusted publishing rejects
+# the same trigger. The failure is invisible until a real release: the token is
+# only requested at publish time, and a `cargo publish --dry-run` earlier in the
+# same workflow needs no token and passes.
+#
+# This is not the same thing as `id-token: write` under `workflow_run`, which is
+# legitimate and used here — GitHub's own attestation service (docker.yml) has no
+# such restriction. So the check matches the two registry mints by name rather
+# than the permission.
+#
+# No per-file linter catches this: it is a relationship between a trigger and a
+# step, and both are individually valid.
+#
+# Usage:
+#   pwsh check-trusted-publishing-triggers.ps1 [-Path <workflow dir>]
+#   pwsh check-trusted-publishing-triggers.ps1 -SelfTest
+# Exit code: 0 = no workflow mints from a workflow_run trigger, 1 = at least one
+# does (or a self-test case failed).
+
+[CmdletBinding()]
+param(
+    [string] $Path,
+    [switch] $SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# The registry mints. Each is the exact spelling that requests a trusted-publishing
+# token, so a workflow can name the mechanism in prose without matching.
+$script:Mints = @(
+    @{ Pattern = 'rust-lang/crates-io-auth-action'; What = 'crates.io OIDC mint' }
+    @{ Pattern = 'npm\s+(stage\s+)?publish'; What = 'npm publish' }
+)
+
+# True when the file's top-level `on:` block declares a workflow_run trigger.
+# Anchored to the block so that `github.event.workflow_run.conclusion` in a job
+# condition — which every workflow_run consumer uses — is never mistaken for the
+# trigger itself.
+function Test-WorkflowRunTrigger {
+    param([string[]] $Lines)
+
+    $inOn = $false
+    foreach ($line in $Lines) {
+        if ($line -match '^\s*#') { continue }
+        if ($line -match '^["'']?on["'']?\s*:') { $inOn = $true; continue }
+        if (-not $inOn) { continue }
+        # The block ends at the next top-level key.
+        if ($line -match '^\S') { break }
+        if ($line -match '^\s{1,4}workflow_run\s*:') { return $true }
+    }
+    return $false
+}
+
+# The mints a file requests, ignoring comment lines so that a header explaining
+# this very rule does not trip it.
+function Get-MintsRequested {
+    param([string[]] $Lines)
+
+    $hits = @()
+    foreach ($line in $Lines) {
+        if ($line -match '^\s*#') { continue }
+        foreach ($mint in $script:Mints) {
+            if ($line -match $mint.Pattern -and $hits -notcontains $mint.What) { $hits += $mint.What }
+        }
+    }
+    return $hits
+}
+
+function Test-TrustedPublishingTriggers {
+    param([string] $Dir)
+
+    $found = @()
+    foreach ($file in Get-ChildItem -LiteralPath $Dir -Filter '*.yml' | Sort-Object Name) {
+        $lines = Get-Content -LiteralPath $file.FullName
+        if (-not (Test-WorkflowRunTrigger $lines)) { continue }
+        foreach ($what in Get-MintsRequested $lines) {
+            $found += "$($file.Name): $what runs under a workflow_run trigger"
+        }
+    }
+    return $found
+}
+
+# --- self-test --------------------------------------------------------------
+
+if ($SelfTest) {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) "tpt-selftest-$([System.Guid]::NewGuid())"
+    $cases = @(
+        @{ Name = 'workflow_run + crates mint'; Expect = 1; Body = @'
+on:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+jobs:
+  publish:
+    steps:
+      - uses: rust-lang/crates-io-auth-action@abc # v1.0.5
+'@ }
+        @{ Name = 'tag push + crates mint'; Expect = 0; Body = @'
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  publish:
+    steps:
+      - uses: rust-lang/crates-io-auth-action@abc # v1.0.5
+'@ }
+        @{ Name = 'workflow_run, no mint'; Expect = 0; Body = @'
+on:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+jobs:
+  ship:
+    steps:
+      - run: echo hello
+'@ }
+        @{ Name = 'dispatch + mint, workflow_run only in an expression'; Expect = 0; Body = @'
+on:
+  workflow_dispatch:
+jobs:
+  publish:
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: rust-lang/crates-io-auth-action@abc # v1.0.5
+'@ }
+        @{ Name = 'workflow_run + npm publish'; Expect = 1; Body = @'
+on:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+jobs:
+  publish:
+    steps:
+      - run: npm stage publish --provenance
+'@ }
+        @{ Name = 'workflow_run + mint named only in a comment'; Expect = 0; Body = @'
+on:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+jobs:
+  ship:
+    # rust-lang/crates-io-auth-action cannot be used here; see the header.
+    steps:
+      - run: echo hello
+'@ }
+    )
+
+    $failures = @()
+    foreach ($case in $cases) {
+        $dir = Join-Path $root ($case.Name -replace '[^A-Za-z0-9]', '-')
+        New-Item -ItemType Directory -Force $dir | Out-Null
+        Set-Content -LiteralPath (Join-Path $dir 'case.yml') -Value $case.Body
+        $found = @(Test-TrustedPublishingTriggers $dir)
+        if ($found.Count -ne $case.Expect) {
+            $failures += "  '$($case.Name)': expected $($case.Expect) failure(s), got $($found.Count)$(if ($found.Count) { " — $($found -join '; ')" })"
+        }
+    }
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+
+    if ($failures.Count) {
+        Write-Host 'trusted-publishing trigger self-test FAILED:' -ForegroundColor Red
+        $failures | ForEach-Object { Write-Host $_ -ForegroundColor Red }
+        exit 1
+    }
+    Write-Host "trusted-publishing trigger self-test passed ($($cases.Count) cases)." -ForegroundColor Green
+    exit 0
+}
+
+# --- normal mode ------------------------------------------------------------
+
+if (-not $Path) {
+    $Path = Join-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) '.github/workflows'
+}
+
+$found = @(Test-TrustedPublishingTriggers $Path)
+if ($found.Count) {
+    Write-Host 'FAILED: a registry token is minted from a workflow_run trigger:' -ForegroundColor Red
+    $found | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+    Write-Host '    Move the publish to a workflow triggered by the tag push (or a dispatch).' -ForegroundColor DarkGray
+    exit 1
+}
+Write-Host 'trusted publishing: no registry mint runs under a workflow_run trigger.' -ForegroundColor Green
+exit 0

--- a/.github/scripts/classify-diff.ps1
+++ b/.github/scripts/classify-diff.ps1
@@ -477,6 +477,13 @@ begin {
             Match      = { param($f) $f -eq '.github/scripts/check-workflow-permissions.ps1' }
         },
         @{
+            Name       = 'trusted-publishing trigger checker'
+            Areas      = @('yaml', 'workflows')
+            Structural = $true
+            Why        = 'The lint YAML job runs it beside the permission checker, over the same .github/workflows tree.'
+            Match      = { param($f) $f -eq '.github/scripts/check-trusted-publishing-triggers.ps1' }
+        },
+        @{
             Name       = 'packaging templates'
             Areas      = @()
             Structural = $true

--- a/.github/scripts/publish-gui-crates.ps1
+++ b/.github/scripts/publish-gui-crates.ps1
@@ -1,39 +1,37 @@
 #!/usr/bin/env pwsh
-# The crates.io channel leg of gui-publish.yml: publish bdinfo-rs-gui from
-# the tagged source (-SrcDir is a checkout of the gui-v* tag — the release's
-# bytes were built from that same commit, and the attested release is what
-# admitted the tag into this workflow).
+# Publish bdinfo-rs-gui to crates.io from a checkout of the gui-v* tag it is
+# given — the crates.io leg of gui-publish-crates.yml.
 #
-#   -Mode prepare  guard tag == crate version, then `cargo package --locked`:
-#                  packages the crate and verify-builds it against the
-#                  registry, which is also where the sequencing rule
-#                  bites — bdinfo-rs-gui depends on bdinfo-rs-core at the
-#                  same version, so this fails cleanly until the CLI
-#                  release's publish-crates.yml run has put that core version
-#                  on crates.io. The built .crate lands in -Payload.
-#                  `package`, not `publish --dry-run`: the latter stages the
-#                  .crate under target/package/tmp-crate/ and only a real
-#                  publish promotes it (observed with cargo 1.96), while
-#                  `package` finalizes target/package/<name>-<ver>.crate.
-#   -Mode publish  the same guard, then `cargo publish --locked`, tolerating
-#                  "already uploaded" as success — crates.io versions are
-#                  immutable, so that error IS the idempotent re-dispatch
-#                  path, and a registry pre-check would only add an API call
-#                  a transient failure could kill the job on (the
-#                  publish-crates.yml idiom). CARGO_REGISTRY_TOKEN arrives
-#                  from the OIDC mint (Trusted Publishing); the crate must
-#                  already exist on crates.io for that trust rule to apply,
-#                  so the FIRST publish is manual, like the CLI crates'.
+# The tag is guarded against the crate's own manifest version first: cargo
+# publishes what the manifest carries, not what the tag says.
+#
+# `cargo publish` runs from the crate's own directory because bdinfo-rs-gui is
+# an independent workspace (the root Cargo.toml lists it under `exclude`), so
+# `-p bdinfo-rs-gui` from the repository root does not reach it.
+#
+# An "already uploaded" failure counts as success: crates.io versions are
+# immutable, so that error is exactly what re-running an already-published
+# version produces, and tolerating it is what lets a failed release be healed
+# by re-dispatching this workflow. There is deliberately no registry
+# pre-check — it would add a crates.io API call that a transient 503 could
+# fail the job on, which is the reasoning publish-crates.yml records for the
+# same decision.
+#
+# bdinfo-rs-gui depends on bdinfo-rs-core at the same version, so this publish
+# cannot resolve until the matching vX.Y.Z tag's publish-crates.yml run has put
+# that core version on crates.io. Push vX.Y.Z and let it finish before pushing
+# gui-vX.Y.Z.
+#
+# CARGO_REGISTRY_TOKEN comes from the caller's OIDC mint (crates.io Trusted
+# Publishing). That trust rule only applies to a crate that already exists on
+# crates.io, so a new crate's first publish is done by hand.
 
 [CmdletBinding()]
 param(
     # The gui-v* tag being published.
     [Parameter(Mandatory)] [string] $Tag,
-    # A checkout of that tag.
-    [Parameter(Mandatory)] [string] $SrcDir,
-    [Parameter(Mandatory)] [ValidateSet('prepare', 'publish')] [string] $Mode,
-    # prepare: directory the packaged .crate is staged in.
-    [string] $Payload
+    # A checkout of that tag; defaults to the working directory.
+    [string] $SrcDir = '.'
 )
 
 Set-StrictMode -Version Latest
@@ -43,43 +41,25 @@ $PSNativeCommandUseErrorActionPreference = $false
 . "$PSScriptRoot/_common.ps1"
 
 $tagVersion = Get-GuiTagVersion $Tag
-if ($Mode -eq 'prepare' -and -not $Payload) { Stop-Leg 'prepare needs -Payload' }
 
 $crate = Join-Path $SrcDir 'crates/bdinfo-rs-gui'
 if (-not (Test-Path -LiteralPath (Join-Path $crate 'Cargo.toml'))) { Stop-Leg "no gui crate under $SrcDir" }
 
-# cargo publishes whatever version the manifest carries, not the tag — fail
-# fast on a mismatch (the publish-crates.yml guard, on the gui crate).
 $crateVersion = Get-CrateVersion -Name 'bdinfo-rs-gui' -ManifestPath (Join-Path $crate 'Cargo.toml')
 if ($crateVersion -ne $tagVersion) { Stop-Leg "tag $Tag does not match the gui crate version $crateVersion" }
 
 Push-Location -LiteralPath $crate
 $code = 1
 try {
-    if ($Mode -eq 'prepare') {
-        cargo package --locked -p bdinfo-rs-gui
-        $code = $LASTEXITCODE
-    }
-    else {
-        $out = cargo publish --locked -p bdinfo-rs-gui 2>&1 | Out-String
-        Write-Host $out
-        $code = $LASTEXITCODE
-        if ($code -ne 0 -and $out -match 'already (uploaded|exists)') {
-            Write-Host "bdinfo-rs-gui@$crateVersion is already on crates.io - treating as success"
-            $code = 0
-        }
+    $out = cargo publish --locked -p bdinfo-rs-gui 2>&1 | Out-String
+    Write-Host $out
+    $code = $LASTEXITCODE
+    if ($code -ne 0 -and $out -match 'already (uploaded|exists)') {
+        Write-Host "bdinfo-rs-gui@$crateVersion is already on crates.io - treating as success"
+        $code = 0
     }
 }
 finally { Pop-Location }
-if ($code -ne 0) { Stop-Leg "cargo publish ($Mode) exit $code" }
+if ($code -ne 0) { Stop-Leg "cargo publish exit $code" }
 
-if ($Mode -eq 'prepare') {
-    New-Item -ItemType Directory -Force $Payload | Out-Null
-    $built = @(Get-ChildItem (Join-Path $crate 'target/package') -Filter '*.crate')
-    if ($built.Count -ne 1) { Stop-Leg "expected exactly one packaged .crate, found $($built.Count)" }
-    Copy-Item $built[0].FullName $Payload
-    Write-Host "prepared + verify-built $($built[0].Name)"
-}
-else {
-    Write-Host "published bdinfo-rs-gui@$crateVersion to crates.io"
-}
+Write-Host "published bdinfo-rs-gui@$crateVersion to crates.io"

--- a/.github/scripts/publish-gui-verify.ps1
+++ b/.github/scripts/publish-gui-verify.ps1
@@ -25,7 +25,7 @@ param(
     [Parameter(Mandatory)] [string] $Tag,
     # The dispatch's channel selection: `all` or one channel name.
     [Parameter(Mandatory)]
-    [ValidateSet('all', 'winget', 'homebrew', 'aur', 'cloudsmith', 'crates')]
+    [ValidateSet('all', 'winget', 'homebrew', 'aur', 'cloudsmith')]
     [string] $Channels,
     # Where the release assets are downloaded for verification.
     [Parameter(Mandatory)] [string] $OutDir
@@ -100,7 +100,7 @@ foreach ($name in $expected) {
 
 # Channel matrix. AUR is armed by the AUR_ENABLED repo variable, like the
 # packages.yml aur job.
-$selected = if ($Channels -eq 'all') { @('winget', 'homebrew', 'aur', 'cloudsmith', 'crates') } else { @($Channels) }
+$selected = if ($Channels -eq 'all') { @('winget', 'homebrew', 'aur', 'cloudsmith') } else { @($Channels) }
 if ($env:AUR_ENABLED -ne 'true' -and $selected -contains 'aur') {
     if ($Channels -eq 'aur') {
         Stop-Leg 'AUR publishing is paused (repo variable AUR_ENABLED is not true); set it before an explicit aur dispatch'

--- a/.github/workflows/gui-publish-crates.yml
+++ b/.github/workflows/gui-publish-crates.yml
@@ -1,0 +1,108 @@
+name: gui-publish-crates
+
+# Publish bdinfo-rs-gui to crates.io on a gui-vX.Y.Z tag, using crates.io
+# Trusted Publishing (OIDC): a short-lived, repo/workflow-scoped token is minted
+# at run time, so no long-lived CARGO_REGISTRY_TOKEN is stored. This is the
+# gui-v* twin of publish-crates.yml, which does the same for the two root
+# crates on a v* tag.
+#
+# It is a workflow of its own rather than a channel of gui-publish.yml because
+# that workflow is driven by `workflow_run`, and crates.io refuses to mint a
+# token for one, answering the request with HTTP 400: "Trusted Publishing does
+# not support the `workflow_run` event trigger due to security concerns. Please
+# use a different trigger such as `push`, `release`, or `workflow_dispatch`."
+# A tag push is such a trigger. The resulting split matches the CLI's, where
+# publish-crates.yml and publish-npm.yml ride the tag while the channels that
+# consume built release assets ride workflow_run.
+#
+# The publish job binds the `crates-io` environment, which holds NO secrets and
+# exists only as a publishing gate: GitHub emits the environment in the token's
+# OIDC claim and refuses the job outright on a ref the environment does not
+# admit (its rules are the `master` branch and the `v*` and `gui-v*` tags). So
+# the crates.io trusted publisher for bdinfo-rs-gui records repository
+# agentjp/bdinfo-rs, workflow `gui-publish-crates.yml` AND environment
+# `crates-io` — a second lock, which the filename alone is not: anyone who can
+# push a workflow could otherwise mint a token, while changing an environment
+# takes repository-settings access. publish-crates.yml binds the same
+# environment for the two root crates.
+#
+# This is NOT the `release` environment gui-publish.yml binds: that one holds
+# four stored channel secrets this has no business reading, and its deployment
+# rules admit `master` and `v*` — not `gui-v*`.
+#
+# Bootstrap: Trusted Publishing applies only to a crate that already exists on
+# crates.io, so a new crate's first publish is done by hand; this workflow takes
+# over for every tag afterwards.
+
+on:
+  push:
+    tags: ["gui-v*"]
+  # Re-publish without re-tagging: re-pushing a tag is refused by the immutable
+  # release ruleset and would re-fire gui-release.yml, so a failed or skipped
+  # crates publish is healed from here. The leg is idempotent, so a dispatch
+  # against an already-published version is a no-op that still exercises the
+  # OIDC mint.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The gui-v* tag to publish, e.g. gui-v4.0.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gui-publish-crates-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Refuse to publish a tag that is not on master — the ancestry gate
+  # publish-crates.yml, publish-npm.yml and gui-release.yml share. It checks the
+  # commit the run was triggered on, so on the tag-push path it checks the
+  # tagged commit; a workflow_dispatch runs on the default branch and the check
+  # is trivially satisfied there, exactly as it is for publish-npm.yml's
+  # dispatch. crates.io publishing is live and irreversible (a version can be
+  # yanked but never re-uploaded), so the off-master guard matters here.
+  guard-ancestor:
+    uses: ./.github/workflows/guard-ancestor.yml
+    # No `secrets: inherit` — guard-ancestor takes no secrets, so inheriting
+    # them is needless privilege (and zizmor's secrets-inherit audit flags it).
+    permissions:
+      contents: read
+
+  publish:
+    name: cargo publish bdinfo-rs-gui (crates.io)
+    needs: guard-ancestor
+    runs-on: ubuntu-latest
+    # Holds no secrets — see the header. Its deployment rules admit the gui-v*
+    # tag this runs on and the master branch a dispatch resolves to.
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write # mint the short-lived crates.io OIDC token
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
+    steps:
+      # The tag's own source: on the dispatch path `github.ref` is the default
+      # branch, so the ref is taken from the input instead.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+          persist-credentials: false
+
+      # No build cache here: this workflow publishes to crates.io, so a cache
+      # poisoned in a less-trusted context could taint a published crate
+      # (zizmor cache-poisoning). cargo publish builds fresh.
+
+      - name: Authenticate to crates.io (Trusted Publishing / OIDC)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      # The tag/version guard and the tolerate-already-uploaded rule live in the
+      # script, with the reasoning for both.
+      - name: Publish bdinfo-rs-gui, tolerating a version already on crates.io
+        shell: pwsh
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: ./.github/scripts/publish-gui-crates.ps1 -Tag $env:TAG

--- a/.github/workflows/gui-publish.yml
+++ b/.github/workflows/gui-publish.yml
@@ -1,9 +1,12 @@
 name: gui-publish
 
 # The GUI's package-manager fan-out — the counterpart of the CLI's
-# packages.yml / homebrew.yml / publish-crates.yml, publishing an EXISTING
-# immutable gui-v* release's attested bytes to winget, the Homebrew tap
-# (cask), the AUR, Cloudsmith, and crates.io. Two ways in:
+# packages.yml / homebrew.yml, publishing an EXISTING immutable gui-v*
+# release's attested bytes to winget, the Homebrew tap (cask), the AUR and
+# Cloudsmith. The crate itself goes to crates.io from gui-publish-crates.yml
+# instead, because crates.io Trusted Publishing rejects the `workflow_run`
+# trigger this workflow is driven by; that file records the reasoning. Two
+# ways in:
 #
 #   workflow_dispatch  the deliberate rollout: per channel for a staged
 #                      first release, `all` at steady state, and the
@@ -13,11 +16,10 @@ name: gui-publish
 #                      gui-release run (its dry-run dispatches never
 #                      qualify) publishes every channel of that release.
 #                      Variable-gated because the first release must stay
-#                      staged — until the two manual bootstraps below
-#                      (crates.io first publish, winget `komac new`) the
-#                      winget and crates legs can only fail. Once they are
-#                      done, set the variable and a gui-v* tag push carries
-#                      all the way to the channels on its own.
+#                      staged — until the winget bootstrap below, the winget
+#                      leg can only fail. Once it is done, set the variable
+#                      and a gui-v* tag push carries all the way to the
+#                      channels on its own.
 #
 # Nothing is rebuilt here; every leg consumes (or points komac / the AUR at)
 # release assets the verify job proved complete, checksum-exact, and
@@ -31,9 +33,9 @@ name: gui-publish
 #             attestation verifies; resolves the channel matrix.
 #   prepare   fail-fast matrix: each leg builds + validates its payload
 #             (komac --dry-run manifests, the rendered cask, the PKGBUILD in
-#             an Arch container, package-metadata assertions, cargo publish
-#             --dry-run) and uploads it as a workflow artifact. Nothing has
-#             been pushed anywhere when this phase fails.
+#             an Arch container, package-metadata assertions) and uploads it
+#             as a workflow artifact. Nothing has been pushed anywhere when
+#             this phase fails.
 #   publish   gated on ALL of prepare (and mode == publish): pushes the
 #             pre-validated payloads. fail-fast is OFF here — cancelling a
 #             sibling mid-push is worse than letting it finish — and every
@@ -47,11 +49,6 @@ name: gui-publish
 #
 # Sequencing the legs enforce loudly rather than assume (details in the
 # .github/scripts/publish-gui-*.ps1 headers):
-#   - crates: bdinfo-rs-gui depends on bdinfo-rs-core at the same version, so
-#     the leg needs the CLI release's publish-crates.yml run to have put that
-#     core version on crates.io; until then the dry-run fails in prepare. The
-#     crate must also already exist on crates.io for Trusted Publishing, so
-#     the FIRST publish is manual (the publish-crates.yml bootstrap rule).
 #   - winget: komac cannot create a package id headlessly, so a package's
 #     FIRST submission is a manual interactive komac run — done for
 #     agentjp.bdinfo-rs-gui via winget-pkgs#405038; the leg auto-submits
@@ -60,9 +57,7 @@ name: gui-publish
 # Secrets (all on the `release` ENVIRONMENT, like packages.yml — its
 # deployment rules admit `master`, which is what both a workflow_dispatch
 # from the default branch and a workflow_run resolve to):
-# WINGET_TOKEN, HOMEBREW_TAP_TOKEN, AUR_SSH_KEY,
-# CLOUDSMITH_API_KEY. crates.io needs no stored secret (OIDC Trusted
-# Publishing, configured on crates.io for THIS workflow file). Only the
+# WINGET_TOKEN, HOMEBREW_TAP_TOKEN, AUR_SSH_KEY, CLOUDSMITH_API_KEY. Only the
 # publish job binds the environment; verify + prepare run with the read-only
 # default token, so phase 1/2 cannot touch any external registry even in
 # principle.
@@ -82,7 +77,7 @@ on:  # zizmor: ignore[dangerous-triggers] runs only after our own tag-triggered 
         required: true
         default: all
         type: choice
-        options: [all, winget, homebrew, aur, cloudsmith, crates]
+        options: [all, winget, homebrew, aur, cloudsmith]
       mode:
         description: publish, or prepare-only (validate + stage payloads, push nothing)
         required: true
@@ -236,27 +231,6 @@ jobs:
           .github/scripts/publish-gui-cloudsmith.ps1
           -Version $env:VERSION -Tag $env:TAG -Mode prepare -Sums sums/SHA256SUMS -Payload payload
 
-      # The crates leg works on the tagged source — the same commit the
-      # attested release was built from (gui-release.yml's guards admitted
-      # the tag onto master before anything was published from it).
-      - name: crates — check out the tagged source
-        if: matrix.channel == 'crates'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.resolve.outputs.tag }}
-          path: tag-src
-          persist-credentials: false
-
-      # No build cache, deliberately: this builds what publish ships, and a
-      # cache poisoned in a less-trusted context must not taint it (the
-      # publish-crates.yml discipline).
-      - name: crates — cargo publish --dry-run at the tag
-        if: matrix.channel == 'crates'
-        shell: pwsh
-        run: >-
-          .github/scripts/publish-gui-crates.ps1
-          -Tag $env:TAG -SrcDir tag-src -Mode prepare -Payload payload
-
       - name: Upload the validated payload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -276,7 +250,6 @@ jobs:
     environment: release
     permissions:
       contents: read
-      id-token: write # the crates leg's OIDC mint (crates.io Trusted Publishing)
     strategy:
       # DELIBERATELY not fail-fast: cancelling a sibling mid-push could
       # strand a channel half-published; a failed leg is healed by
@@ -361,24 +334,3 @@ jobs:
           .github/scripts/publish-gui-cloudsmith.ps1
           -Version $env:VERSION -Tag $env:TAG -Mode publish -Payload payload
 
-      - name: crates — check out the tagged source
-        if: matrix.channel == 'crates'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.resolve.outputs.tag }}
-          path: tag-src
-          persist-credentials: false
-
-      - name: crates — authenticate (Trusted Publishing / OIDC)
-        if: matrix.channel == 'crates'
-        id: auth
-        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
-
-      - name: crates — cargo publish
-        if: matrix.channel == 'crates'
-        shell: pwsh
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: >-
-          .github/scripts/publish-gui-crates.ps1
-          -Tag $env:TAG -SrcDir tag-src -Mode publish

--- a/.github/workflows/gui-publish.yml
+++ b/.github/workflows/gui-publish.yml
@@ -333,4 +333,3 @@ jobs:
         run: >-
           .github/scripts/publish-gui-cloudsmith.ps1
           -Version $env:VERSION -Tag $env:TAG -Mode publish -Payload payload
-

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -16,10 +16,12 @@ name: install-smoke-test
 # Out of scope by design: Scoop, WinGet, and cargo install/binstall ship the bare
 # executable only (no man/completions), so there is nothing to verify there. The
 # .deb/.rpm/Cloudsmith man+completions contract is verified per-release in packages.yml.
-# The GUI's other channels (crates.io, winget, AUR, Cloudsmith) are likewise
+# The GUI's other package channels (winget, AUR, Cloudsmith) are likewise
 # checksum- and attestation-verified per release by gui-publish.yml's
-# verify/prepare phases; for both binaries Homebrew is the one rolling channel
-# worth re-probing between releases.
+# verify/prepare phases, and its crate is published from source by
+# gui-publish-crates.yml, which carries no release asset to verify; for both
+# binaries Homebrew is the one rolling channel worth re-probing between
+# releases.
 
 on:  # zizmor: ignore[dangerous-triggers] only installs the published formula/cask; never checks out untrusted PR code
   workflow_run:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -8,14 +8,37 @@ name: publish-crates
 # after a partial failure finishes the release instead of erroring — see the publish
 # step for why `cargo publish --workspace` (one command for both) can't do this.
 #
+# The publish job binds the `crates-io` environment, which holds NO secrets and
+# exists only as a publishing gate: GitHub emits the environment in the token's
+# OIDC claim and refuses the job outright on a ref the environment does not
+# admit (its rules are the `master` branch and the `v*` and `gui-v*` tags). So
+# the trusted publisher records repository agentjp/bdinfo-rs, workflow
+# `publish-crates.yml` AND environment `crates-io` — a second lock, which the
+# filename alone is not: anyone who can push a workflow could otherwise mint a
+# token, while changing an environment takes repository-settings access.
+# gui-publish-crates.yml binds the same environment for bdinfo-rs-gui.
+#
 # Bootstrap: Trusted Publishing requires the crate to already exist, so the FIRST
 # publish of each crate is done by hand; this workflow takes over for every tag
 # afterwards. Configure the trusted publisher on crates.io for BOTH crates ->
-# repository agentjp/bdinfo-rs, workflow `publish-crates.yml`.
+# repository agentjp/bdinfo-rs, workflow `publish-crates.yml`, environment
+# `crates-io`.
 
 on:
   push:
     tags: ["v*"]
+  # Re-publish without re-tagging: re-pushing a tag is refused by the immutable
+  # release ruleset and would re-fire v-release.yml, which errors on a release
+  # that already exists. Re-running the original tag run is not equivalent —
+  # that re-executes the workflow file as it stood at the TAG, not master's. The
+  # publish is idempotent, so a dispatch against a fully-published version is a
+  # no-op that still exercises the OIDC mint.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The v* tag to publish, e.g. v4.0.0
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -44,17 +67,25 @@ jobs:
     name: cargo publish --workspace (crates.io)
     needs: guard-ancestor
     runs-on: ubuntu-latest
+    # Holds no secrets — see the header. Its deployment rules admit the v* tag
+    # this runs on and the master branch a dispatch resolves to.
+    environment: crates-io
     permissions:
       contents: read
       id-token: write # mint the short-lived crates.io OIDC token
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
     steps:
+      # The tag's own source: on the dispatch path `github.ref` is the default
+      # branch, so the ref is taken from the input instead.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.tag || github.ref_name }}
           persist-credentials: false
 
-      # No build cache here: this workflow runs only on a release tag and publishes
-      # to crates.io, so a cache poisoned in a less-trusted context could taint a
-      # published crate (zizmor cache-poisoning). cargo publish builds fresh.
+      # No build cache here: this workflow publishes to crates.io, so a cache
+      # poisoned in a less-trusted context could taint a published crate
+      # (zizmor cache-poisoning). cargo publish builds fresh.
 
       # cargo publishes whatever version is in Cargo.toml, not the tag — fail fast
       # if a tag was cut that does not match (mirrors the guard in docker.yml).
@@ -69,7 +100,7 @@ jobs:
           $PSNativeCommandUseErrorActionPreference = $false
           . ./.github/scripts/_common.ps1
 
-          $tag = $env:GITHUB_REF_NAME
+          $tag = $env:TAG
           $base = Get-ReleaseTagBase $tag
           # Both crates inherit the version from [workspace.package], so either
           # one reports it.

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -137,6 +137,14 @@ jobs:
           ./.github/scripts/check-workflow-permissions.ps1 -SelfTest
           ./.github/scripts/check-workflow-permissions.ps1
 
+      # A registry mint under a workflow_run trigger is refused by crates.io and
+      # npm, and nothing reveals it until a real release — see the script.
+      - name: Check trusted-publishing triggers
+        shell: pwsh
+        run: |
+          ./.github/scripts/check-trusted-publishing-triggers.ps1 -SelfTest
+          ./.github/scripts/check-trusted-publishing-triggers.ps1
+
   # TOML formatting + lint gate (taplo): every tracked TOML — the Cargo manifests,
   # the gate configs (clippy/deny/nextest/mutants/typos), dist-workspace.toml — must
   # match `taplo fmt` and pass `taplo lint`, against the committed taplo.toml. Mirrors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,6 +263,16 @@ The desktop app releases through its own hand-rolled lane (`gui-release.yml`), n
 macOS `.dmg`, Linux AppImage + `.deb` + `.rpm`), and publishes a GitHub Release marked not-latest.
 cargo-dist's `v` tag-namespace keeps the two lanes from ever firing each other.
 
+The publishing that follows is split by how each channel authenticates, mirroring the command-line
+lane. `gui-publish-crates.yml` puts the crate on crates.io from the tag push, because crates.io
+Trusted Publishing refuses to mint a token for a `workflow_run` trigger; `gui-publish.yml` then
+pushes the release's attested bytes to WinGet, the Homebrew cask, the AUR and Cloudsmith on
+`workflow_run`, using stored secrets. Both crates.io lanes bind the `crates-io` GitHub environment,
+which holds no secrets and exists so the minted token's OIDC claim names it — the trusted publisher
+records the workflow filename *and* that environment, so pushing a workflow is not by itself enough
+to publish a crate. `.github/scripts/check-trusted-publishing-triggers.ps1` fails CI if any
+`workflow_run` workflow tries to mint a registry token.
+
 **Versioning: two lanes, one version.** The library, the command line, the browser package and the
 desktop app move in lock-step: every surface carries the same `X.Y.Z`, and a release tags both
 lanes at it (`vX.Y.Z` and `gui-vX.Y.Z`). The lanes are separate because they build and publish


### PR DESCRIPTION
crates.io Trusted Publishing answers a token request made from a workflow_run run with HTTP 400,
saying the workflow_run event trigger is not supported and naming push, release and
workflow_dispatch as alternatives. gui-publish.yml is driven by workflow_run, so its crates leg
could never publish bdinfo-rs-gui: it failed at the authenticate step on the one release where the
run reached the publish phase at all, and earlier releases only hid it because the run died in the
prepare phase first.

gui-publish-crates.yml takes the crate over on the gui-v tag push, the twin of publish-crates.yml
for the two root crates. gui-publish.yml keeps the four channels that consume release assets and
authenticate with stored secrets. That split is the one the command-line lane already uses.

Both crates.io lanes now bind a crates-io GitHub environment that holds no secrets and exists only
as a publishing gate: GitHub emits it in the token OIDC claim and refuses the job on a ref the
environment does not admit, so a trusted publisher can require the workflow filename and the
environment together rather than the filename alone. publish-crates.yml also gains a
workflow_dispatch, giving the crates lane a heal path that does not need a re-pushed tag; re-running
the original tag run is not equivalent, since that re-executes the workflow file as it stood at the
tag.

check-trusted-publishing-triggers.ps1 fails the build if a workflow_run workflow mints a registry
token, which is the shape of the defect. It is deliberately narrower than flagging id-token under
workflow_run, which is legitimate and in use here for build attestations. Verified against the
pre-fix workflow, where it reports the failure.