### PR TITLE
ci: bump the wrangler and cloudsmith-cli pins

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -86,7 +86,7 @@ NPM=12.0.2
 
 # wrangler, invoked with npx to deploy the demo site. Pinned because it runs with
 # the Cloudflare Pages deploy token.
-WRANGLER=4.123.0
+WRANGLER=4.124.0
 
 # komac, fetched over curl to submit the WinGet manifests. winget-releaser wraps
 # the same tool but bootstraps it through cargo-bins/cargo-binstall@main, which
@@ -94,4 +94,4 @@ WRANGLER=4.123.0
 KOMAC=2.16.0
 
 # cloudsmith-cli, installed with pipx by the package push legs.
-CLOUDSMITH_CLI=1.23.0
+CLOUDSMITH_CLI=1.24.0


### PR DESCRIPTION
wrangler 4.123.0 -> 4.124.0, cloudsmith-cli 1.23.0 -> 1.24.0. Both pins live only in .github/pins.env; neither is cargo-dist, so DIST_SHA256 is unchanged.

Closes #401