### PR TITLE
ci(deps): bump rust stable, wrangler and cloudsmith-cli pins

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -86,7 +86,7 @@ NPM=12.0.2
 
 # wrangler, invoked with npx to deploy the demo site. Pinned because it runs with
 # the Cloudflare Pages deploy token.
-WRANGLER=4.124.0
+WRANGLER=4.125.0
 
 # komac, fetched over curl to submit the WinGet manifests. winget-releaser wraps
 # the same tool but bootstraps it through cargo-bins/cargo-binstall@main, which
@@ -94,4 +94,4 @@ WRANGLER=4.124.0
 KOMAC=2.16.0
 
 # cloudsmith-cli, installed with pipx by the package push legs.
-CLOUDSMITH_CLI=1.24.0
+CLOUDSMITH_CLI=1.25.0

--- a/crates/bdinfo-rs-core/src/bdrom/disc.rs
+++ b/crates/bdinfo-rs-core/src/bdrom/disc.rs
@@ -1458,7 +1458,7 @@ fn file_head_encrypted(file: &dyn BdFile) -> bool {
 /// this fingerprint and reads `false`.
 fn unit_shows_encryption(unit: &[u8; ALIGNED_UNIT_BYTES]) -> bool {
     let mut syncs =
-        unit.chunks_exact(SOURCE_PACKET_BYTES).map(|packet| packet.get(4) == Some(&0x47));
+        unit.as_chunks::<SOURCE_PACKET_BYTES>().0.iter().map(|packet| packet.get(4) == Some(&0x47));
     let first = syncs.next() == Some(true);
     let strays = syncs.filter(|&hit| hit).count();
     first && strays <= MAX_STRAY_SYNCS
@@ -3698,7 +3698,8 @@ mod tests {
     /// (packet 0 first), `0xAA` everywhere else.
     fn unit_with_syncs(present: &[bool; 32]) -> [u8; ALIGNED_UNIT_BYTES] {
         let mut unit = [0xAA_u8; ALIGNED_UNIT_BYTES];
-        for (packet, &sync) in unit.chunks_exact_mut(SOURCE_PACKET_BYTES).zip(present) {
+        for (packet, &sync) in unit.as_chunks_mut::<SOURCE_PACKET_BYTES>().0.iter_mut().zip(present)
+        {
             if sync && let Some(byte) = packet.get_mut(4) {
                 *byte = 0x47;
             }

--- a/crates/bdinfo-rs-core/src/vfs/udf/cs0.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/cs0.rs
@@ -33,11 +33,7 @@ pub fn decode_dchars(data: &[u8]) -> String {
         16 => {
             // 16-bit code units, big-endian; pair up the bytes (an odd trailing
             // byte is dropped) and decode as UTF-16 so surrogate pairs join.
-            let units = body.chunks_exact(2).map(|pair| {
-                let hi = pair.first().copied().unwrap_or(0);
-                let lo = pair.get(1).copied().unwrap_or(0);
-                u16::from_be_bytes([hi, lo])
-            });
+            let units = body.as_chunks::<2>().0.iter().map(|&pair| u16::from_be_bytes(pair));
             char::decode_utf16(units).map(|r| r.unwrap_or(char::REPLACEMENT_CHARACTER)).collect()
         }
         // UDF only defines 8 and 16 here (254/255 carry no characters); anything

--- a/crates/bdinfo-rs-core/src/vfs/udf/source.rs
+++ b/crates/bdinfo-rs-core/src/vfs/udf/source.rs
@@ -2116,7 +2116,7 @@ mod tests {
     /// alone otherwise (the encryption fingerprint), `0xAA` filler elsewhere.
     fn aligned_unit(clear: bool) -> Vec<u8> {
         let mut unit = vec![0xAA_u8; 6144];
-        for (index, packet) in unit.chunks_exact_mut(192).enumerate() {
+        for (index, packet) in unit.as_chunks_mut::<192>().0.iter_mut().enumerate() {
             if (clear || index == 0)
                 && let Some(byte) = packet.get_mut(4)
             {

--- a/crates/bdinfo-rs-gui/src/icon.rs
+++ b/crates/bdinfo-rs-gui/src/icon.rs
@@ -212,7 +212,7 @@ mod tests {
         let buf = rgba(size);
         // Every pixel carries the same amber RGB, whatever its alpha — the
         // three channels in their exact order.
-        for pixel in buf.chunks_exact(4) {
+        for pixel in buf.as_chunks::<4>().0 {
             assert_eq!(pixel.first().copied(), Some(242));
             assert_eq!(pixel.get(1).copied(), Some(166));
             assert_eq!(pixel.get(2).copied(), Some(90));

--- a/crates/bdinfo-rs-gui/src/scan.rs
+++ b/crates/bdinfo-rs-gui/src/scan.rs
@@ -631,7 +631,7 @@ mod tests {
         // 0xA5 fills the ciphertext: any byte but the 0x47 sync the probe
         // counts. Each unit then gets its one leading sync back.
         let mut bytes = vec![0xA5_u8; UNIT.checked_mul(2).expect("two units fit")];
-        for unit in bytes.chunks_exact_mut(UNIT) {
+        for unit in bytes.as_chunks_mut::<UNIT>().0 {
             let sync = unit.get_mut(4).expect("a unit holds a first packet header");
             *sync = 0x47;
         }

--- a/crates/bdinfo-rs-gui/src/selection.rs
+++ b/crates/bdinfo-rs-gui/src/selection.rs
@@ -59,16 +59,12 @@ impl Selection {
 
     /// Checks every row ("Select all").
     pub fn set_all(&mut self) {
-        for flag in &mut self.checked {
-            *flag = true;
-        }
+        self.checked.fill(true);
     }
 
     /// Unchecks every row ("Select none").
     pub fn clear(&mut self) {
-        for flag in &mut self.checked {
-            *flag = false;
-        }
+        self.checked.fill(false);
     }
 
     /// Whether the row at `index` is checked (`false` for an out-of-range index).

--- a/crates/bdinfo-rs-gui/src/winres.rs
+++ b/crates/bdinfo-rs-gui/src/winres.rs
@@ -94,7 +94,7 @@ pub fn dib(size: u32, rgba: &[u8]) -> Option<Vec<u8>> {
 
     // The XOR image: rows bottom-up, each RGBA pixel re-ordered to BGRA.
     for row in rgba.chunks_exact(row_len).rev() {
-        for px in row.chunks_exact(4) {
+        for px in row.as_chunks::<4>().0 {
             out.push(px.get(2).copied().unwrap_or_default()); // B
             out.push(px.get(1).copied().unwrap_or_default()); // G
             out.push(px.first().copied().unwrap_or_default()); // R

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 # compiler — reproducible gate across machines and CI. rustup reads this and
 # installs the version + components on demand. Bump deliberately.
 [toolchain]
-channel = "1.97.1" # latest stable
+channel = "1.98.0" # latest stable
 # clippy + rustfmt for the lint/format gate; llvm-tools-preview ships the
 # profdata/profcov binaries cargo-llvm-cov shells out to (the `cov` alias
 # fails on a fresh machine without it).


### PR DESCRIPTION
Rust stable 1.97.1 -> 1.98.0, wrangler 4.124.0 -> 4.125.0, cloudsmith-cli 1.24.0 -> 1.25.0.

Closes #410