### PR TITLE
refactor(wasm): take mirror types across the boundary as tsify Ts<T>

### DIFF
--- a/crates/bdinfo-rs-wasm/.cargo/mutants.toml
+++ b/crates/bdinfo-rs-wasm/.cargo/mutants.toml
@@ -28,6 +28,8 @@ exclude_re = [
     "inspect_files", # the #[wasm_bindgen] structural disc-model export
     "inspect_iso", # the #[wasm_bindgen] .iso structural disc-model export
     "render_report", # the #[wasm_bindgen] re-render-from-a-disc export
+    "scan_options_arg", # the wasm32 options deserialization those five exports share
+    "mirror_conversion", # the wasm32 tsify::Error -> JsValue message shim
 ]
 
 # Enforce the committed lockfile on every mutant build (mirrors CI).

--- a/crates/bdinfo-rs-wasm/Cargo.lock
+++ b/crates/bdinfo-rs-wasm/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -77,9 +77,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -449,7 +449,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -540,14 +540,14 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "tsify"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
+checksum = "7a1a69a9adf75b6573e392dda05bbda166c7675006f6f77c20150751df4efad0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "tsify-macros"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
+checksum = "ef1e2e93369379d0a527c7d6632b58c55d52db7a106d8afbde3b354f3a57a9f1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/bdinfo-rs-wasm/Cargo.toml
+++ b/crates/bdinfo-rs-wasm/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1", features = ["derive"] }
 # published types. `default-features = false, features = ["js"]` selects the
 # serde-wasm-bindgen backend: mirror values cross the boundary as real
 # JavaScript objects rather than a JSON string the consumer must parse.
-tsify = { version = "=0.5.6", default-features = false, features = ["js"] }
+tsify = { version = "=0.5.7", default-features = false, features = ["js"] }
 
 # js-sys / web-sys are referenced ONLY under #[cfg(target_arch = "wasm32")] (the
 # WebReader/WebFile FileReaderSync seam + scan_files/build_web_tree), so they are

--- a/crates/bdinfo-rs-wasm/src/lib.rs
+++ b/crates/bdinfo-rs-wasm/src/lib.rs
@@ -82,10 +82,12 @@ use bdinfo_rs_core::vfs::{BdFile, SearchOption};
 #[cfg(target_arch = "wasm32")]
 use bdinfo_rs_core::vfs::{ReadSeek, extension_of_name};
 // `Tsify` is named for its `into_js`, which turns a mirror value into the
-// JavaScript object a callback takes — the conversion the `#[wasm_bindgen]`
-// return path performs implicitly for a value an export returns.
+// JavaScript object a callback takes. `Ts` is the wrapper an export names in
+// place of a bare mirror type: it keeps the wasm-bindgen boundary infallible
+// and moves the serde conversion into the body, where a malformed value is an
+// ordinary `Err` instead of a thrown string that skips destructors.
 #[cfg(target_arch = "wasm32")]
-use tsify::Tsify;
+use tsify::{Ts, Tsify};
 use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::{JsCast, JsValue};
@@ -696,6 +698,28 @@ fn classification_filter(short_seconds: Option<f64>) -> Result<PlaylistFilter, T
     Ok(PlaylistFilter { short_playlist_seconds, ..standard })
 }
 
+/// Deserializes the optional options object, for each of the five exports that
+/// takes one, before that export does any work.
+///
+/// A value that is not a [`ScanOptions`] is rejected here rather than at the
+/// wasm-bindgen boundary, so it costs an ordinary `Err` and not a thrown string
+/// that unwinds past the destructors of whatever the call had already built.
+#[cfg(target_arch = "wasm32")]
+fn scan_options_arg(options: Option<Ts<ScanOptions>>) -> Result<Option<ScanOptions>, JsValue> {
+    options.map(|options| options.to_rust()).transpose().map_err(mirror_conversion)
+}
+
+/// The JavaScript exception a mirror value's conversion failure raises.
+///
+/// [`tsify::Error`] carries the `serde_wasm_bindgen` message naming the field
+/// that did not fit, which is what a caller needs to fix the call. An export
+/// cannot return a typed error across the boundary, so this arrives as a thrown
+/// string, the same shape as an export's other rejections.
+#[cfg(target_arch = "wasm32")]
+fn mirror_conversion(err: tsify::Error) -> JsValue {
+    JsValue::from_str(&err.to_string())
+}
+
 /// How deep `options` asks an inspect to read: the bounded codec pass
 /// ([`ScanMode::Codecs`]) when `codecs` is on, else the metadata-only scan.
 /// An absent option — or no options object at all — means metadata-only, the
@@ -1171,21 +1195,24 @@ pub fn report_file_name(label: &str) -> String {
 /// full codec detail — profile, level, HDR — while `measured` stays false.
 ///
 /// # Errors
-/// An out-of-domain `shortPlaylistSeconds`, and then as [`scan_files`]:
-/// `paths`/`files` length mismatch, a non-`File` entry, an incoherent
-/// selection, or no readable Blu-ray structure.
+/// An `options` value that is not a `ScanOptions`, an out-of-domain
+/// `shortPlaylistSeconds`, and then as [`scan_files`]: `paths`/`files` length
+/// mismatch, a non-`File` entry, an incoherent selection, or no readable
+/// Blu-ray structure.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn inspect_files(
     paths: Vec<String>,
     files: js_sys::Array,
-    options: Option<ScanOptions>,
-) -> Result<Disc, JsValue> {
+    options: Option<Ts<ScanOptions>>,
+) -> Result<Ts<Disc>, JsValue> {
+    let options = scan_options_arg(options)?;
     let filter = classification_filter(options.and_then(|options| options.short_playlist_seconds))
         .map_err(|err| JsValue::from_str(&err.to_string()))?;
     let root = build_web_tree(&paths, &files)?;
-    inspect_disc(&root, inspect_mode(options.as_ref()), &filter)
-        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))
+    let disc = inspect_disc(&root, inspect_mode(options.as_ref()), &filter)
+        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
+    disc.into_ts().map_err(mirror_conversion)
 }
 
 /// The structural-scan `.iso` entry point for the whole disc model: a single
@@ -1197,18 +1224,24 @@ pub fn inspect_files(
 /// meaning for every option.
 ///
 /// # Errors
-/// An out-of-domain `shortPlaylistSeconds`; a `JsValue` if the image is not a
-/// readable UDF `.iso`, or holds no readable Blu-ray structure.
+/// An `options` value that is not a `ScanOptions`, an out-of-domain
+/// `shortPlaylistSeconds`; a `JsValue` if the image is not a readable UDF
+/// `.iso`, or holds no readable Blu-ray structure.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn inspect_iso(file: web_sys::File, options: Option<ScanOptions>) -> Result<Disc, JsValue> {
+pub fn inspect_iso(
+    file: web_sys::File,
+    options: Option<Ts<ScanOptions>>,
+) -> Result<Ts<Disc>, JsValue> {
+    let options = scan_options_arg(options)?;
     let filter = classification_filter(options.and_then(|options| options.short_playlist_seconds))
         .map_err(|err| JsValue::from_str(&err.to_string()))?;
     let length = file.size() as u64;
     let source = UdfSource::open_resilient(Box::new(WebIso { file, length }))
         .map_err(|err| JsValue::from_str(&format!("not a readable Blu-ray .iso ({err})")))?;
-    inspect_disc(&source.root(), inspect_mode(options.as_ref()), &filter)
-        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))
+    let disc = inspect_disc(&source.root(), inspect_mode(options.as_ref()), &filter)
+        .map_err(|err| JsValue::from_str(&format!("no readable Blu-ray structure ({err})")))?;
+    disc.into_ts().map_err(mirror_conversion)
 }
 
 /// Renders the classic disc report from a [`Disc`] — no media, no rescan.
@@ -1233,14 +1266,19 @@ pub fn inspect_iso(file: web_sys::File, options: Option<ScanOptions>) -> Result<
 /// disc's presentation order instead — the standard `--whole` set, grouped by
 /// shared clip files and longest first — every value of it zero, because an
 /// inspect measures none.
+///
+/// # Errors
+/// A `disc` or `options` value that is not the shape its type declares. Nothing
+/// is read here, so these are the only failures.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-#[must_use]
-pub fn render_report(mut disc: Disc, options: Option<ScanOptions>) -> String {
+pub fn render_report(disc: Ts<Disc>, options: Option<Ts<ScanOptions>>) -> Result<String, JsValue> {
+    let options = scan_options_arg(options)?;
+    let mut disc: Disc = disc.to_rust().map_err(mirror_conversion)?;
     let printed = disc.report_order.take();
     let (bdrom, errors) = disc.into_scan();
     let order = render_order(&bdrom, printed.as_deref());
-    text::render_with(&bdrom, &order, &errors, render_options(options.as_ref()))
+    Ok(text::render_with(&bdrom, &order, &errors, render_options(options.as_ref())))
 }
 
 /// The measured-scan entry point: a `webkitdirectory`-selected BDMV folder in,
@@ -1271,11 +1309,12 @@ pub fn render_report(mut disc: Disc, options: Option<ScanOptions>) -> String {
 /// [`render_report`] without scanning again.
 ///
 /// # Errors
-/// Returns a `JsValue` if `paths` and `files` differ in length, any `files`
-/// entry is not a `File`, the paths do not form one coherent disc selection,
-/// no readable Blu-ray structure is found (so a wrong folder pick is reported
-/// rather than silently returning an empty report), or a non-empty `selection`
-/// names no playlist on the disc (the CLI's "No matching playlists found on BD").
+/// Returns a `JsValue` if `options` is not a `ScanOptions`, `paths` and `files`
+/// differ in length, any `files` entry is not a `File`, the paths do not form
+/// one coherent disc selection, no readable Blu-ray structure is found (so a
+/// wrong folder pick is reported rather than silently returning an empty
+/// report), or a non-empty `selection` names no playlist on the disc (the CLI's
+/// "No matching playlists found on BD").
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn scan_files(
@@ -1283,9 +1322,10 @@ pub fn scan_files(
     files: js_sys::Array,
     selection: Vec<String>,
     on_progress: Option<js_sys::Function>,
-    options: Option<ScanOptions>,
+    options: Option<Ts<ScanOptions>>,
     on_measured: Option<js_sys::Function>,
-) -> Result<ScanResult, JsValue> {
+) -> Result<Ts<ScanResult>, JsValue> {
+    let options = scan_options_arg(options)?;
     // Validated before the scan: an out-of-domain threshold rejects up front
     // rather than after a multi-GB demux.
     let filter = classification_filter(options.and_then(|options| options.short_playlist_seconds))
@@ -1298,7 +1338,9 @@ pub fn scan_files(
         on_progress.as_ref(),
         on_measured.as_ref(),
     )?;
-    Ok(measured_result(&scan, render_options(options.as_ref()), &filter))
+    measured_result(&scan, render_options(options.as_ref()), &filter)
+        .into_ts()
+        .map_err(mirror_conversion)
 }
 
 /// The measured-scan `.iso` entry point: a single OS-picked Blu-ray `.iso`
@@ -1318,18 +1360,20 @@ pub fn scan_files(
 /// file instead (see `DIFFERENCES.md`).
 ///
 /// # Errors
-/// Returns a `JsValue` if the image is not a readable UDF `.iso`, no readable
-/// Blu-ray structure is found inside it, or a non-empty `selection` names no
-/// playlist on the disc (the CLI's "No matching playlists found on BD").
+/// Returns a `JsValue` if `options` is not a `ScanOptions`, the image is not a
+/// readable UDF `.iso`, no readable Blu-ray structure is found inside it, or a
+/// non-empty `selection` names no playlist on the disc (the CLI's "No matching
+/// playlists found on BD").
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn scan_iso(
     file: web_sys::File,
     selection: Vec<String>,
     on_progress: Option<js_sys::Function>,
-    options: Option<ScanOptions>,
+    options: Option<Ts<ScanOptions>>,
     on_measured: Option<js_sys::Function>,
-) -> Result<ScanResult, JsValue> {
+) -> Result<Ts<ScanResult>, JsValue> {
+    let options = scan_options_arg(options)?;
     // Validated before the scan, as in `scan_files`.
     let filter = classification_filter(options.and_then(|options| options.short_playlist_seconds))
         .map_err(|err| JsValue::from_str(&err.to_string()))?;
@@ -1347,7 +1391,9 @@ pub fn scan_iso(
     // demux, and reported nowhere unless drained here (as `run_iso_report` and
     // the command line's `open_iso` both drain them).
     scan.merge_errors(source.take_errors());
-    Ok(measured_result(&scan, render_options(options.as_ref()), &filter))
+    measured_result(&scan, render_options(options.as_ref()), &filter)
+        .into_ts()
+        .map_err(mirror_conversion)
 }
 
 #[cfg(test)]

--- a/crates/bdinfo-rs-wasm/src/mirror.rs
+++ b/crates/bdinfo-rs-wasm/src/mirror.rs
@@ -37,9 +37,8 @@
 //!
 //! `tsify` copies the doc comment of each type and field below into the generated TypeScript
 //! declaration as `JSDoc`, so those lines are what a consumer reads in an editor. Write them for
-//! that reader, and note three things `tsify` 0.5.6 does to them on the way out:
+//! that reader, and note two things `tsify` 0.5.7 does to them on the way out:
 //!
-//! * An apostrophe is emitted escaped, as `\'` — so avoid it.
 //! * A rustdoc intra-doc link is emitted verbatim, brackets and path and all, which resolves to
 //!   nothing in TypeScript. Name a sibling field in plain backticks instead, under its published
 //!   camelCase name.
@@ -85,7 +84,6 @@ use tsify::Tsify;
 /// from the other: the report is rendered straight from the scan, and the disc
 /// mirrors that same scan.
 #[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[tsify(into_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct ScanResult {
     /// The classic disc report, rendered with the sections the scan was asked
@@ -104,11 +102,10 @@ pub struct ScanResult {
 /// Each option says which calls read it, and a call ignores the rest:
 /// `render_report` re-renders a disc a scan already produced, so the options
 /// governing what a scan reads mean nothing to it.
-// Only `from_wasm_abi`: this type crosses INTO the module as a parameter and is
-// never returned, so it needs the inverse of the `Disc` conversion and not the
-// forward one.
+// `Deserialize` only: this type crosses INTO the module as a parameter and is
+// never returned, so an export names it as `Ts<ScanOptions>` and calls
+// `to_rust`, never `into_ts`.
 #[derive(Tsify, Deserialize, Debug, Clone, Copy, PartialEq)]
-#[tsify(from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct ScanOptions {
     /// Render the report `STREAM DIAGNOSTICS:` section, on unless switched off.
@@ -157,13 +154,12 @@ pub struct ScanOptions {
 }
 
 /// A scanned Blu-ray disc: the disc-level properties and every playlist on it.
-// `into_wasm_abi` is what lets an export return a `Disc` by value: it implements
-// wasm-bindgen's `IntoWasmAbi` over `serde_wasm_bindgen`, so the value crosses as a real
-// JavaScript object. `from_wasm_abi` is its inverse, letting an export take one back as a
-// parameter. Only the type an export names needs them; the types below are reached
-// through this one.
+// An export names this type as `tsify::Ts<Disc>`, whose `into_ts` / `to_rust`
+// convert it over `serde_wasm_bindgen`, so the value crosses as a real
+// JavaScript object rather than a JSON string. Both directions are used: a
+// scan returns a `Disc`, and `render_report` takes one back. The types below
+// are reached through this one and cross with it.
 #[derive(Tsify, Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 #[expect(
     clippy::struct_excessive_bools,
@@ -534,8 +530,10 @@ pub struct Chapter {
 /// display keeps its last known numbers for every other playlist; and within
 /// one scan the byte tallies only grow, so a cell one snapshot raises is never
 /// walked back by a later one.
+// No wasm-bindgen conversion: this type never appears in an export's signature.
+// It reaches JavaScript only as the argument `notify_measured` hands the
+// caller's callback, built with the `Tsify::into_js` the `js` feature provides.
 #[derive(Tsify, Serialize, Debug, Clone, PartialEq, Eq)]
-#[tsify(into_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct MeasuredSnapshot {
     /// The stream file the scan was demuxing when it took this snapshot, in

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
 dependencies = [
  "async-channel",
  "async-task",
@@ -396,7 +396,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -709,7 +709,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -788,7 +788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75382bc7392ef10aad10935f92fc3db36d2d4dad0e5d96d8d65e04f89a07ec39"
+checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
 dependencies = [
  "bytemuck",
 ]
@@ -919,7 +919,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1006,7 +1006,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1492,9 +1492,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1689,7 +1689,7 @@ dependencies = [
  "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.9.2",
+ "redox_syscall 0.9.3",
 ]
 
 [[package]]
@@ -1742,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
@@ -2301,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
 ]
@@ -2601,7 +2601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
- "font-types 0.12.3",
+ "font-types 0.12.4",
  "once_cell",
 ]
 
@@ -2625,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
+checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -2721,7 +2721,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2814,7 +2814,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2849,7 +2849,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3004,7 +3004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3095,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3131,10 +3131,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3183,7 +3183,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3329,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "tsify"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
+checksum = "7a1a69a9adf75b6573e392dda05bbda166c7675006f6f77c20150751df4efad0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -3341,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "tsify-macros"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
+checksum = "ef1e2e93369379d0a527c7d6632b58c55d52db7a106d8afbde3b354f3a57a9f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3368,7 +3368,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3434,9 +3434,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -3476,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3489,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3499,9 +3499,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3509,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3522,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -3680,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3855,7 +3855,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4421,7 +4421,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -4507,9 +4507,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4524,7 +4524,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4535,9 +4535,9 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zvariant"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
@@ -4551,14 +4551,14 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
  "zvariant_utils",
 ]
 
@@ -4571,6 +4571,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 3.0.3",
+ "syn 3.0.4",
  "winnow",
 ]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,8 @@
 #
 # Formatting is checked/applied with the PINNED NIGHTLY rustfmt (see
 # `scripts/_common.ps1` $Nightly) so the unstable options below take effect; the
-# rest of the gate stays on stable 1.96.1. Apply: `pwsh scripts/fmt.ps1`.
+# rest of the gate stays on the stable channel `rust-toolchain.toml` pins.
+# Apply: `pwsh scripts/fmt.ps1`.
 # The gate checks with `cargo +<nightly> fmt --check`.
 
 # --- stable ---


### PR DESCRIPTION
Bumps tsify to 0.5.7, which deprecates `into_wasm_abi`/`from_wasm_abi`, and moves the five exports that name a mirror type to the `Ts<T>` wrapper. The boundary stays infallible and the serde conversion happens in the function body, so a malformed value from JavaScript is an ordinary `Err` rather than a thrown string that skips destructors.

The published TypeScript is unchanged: all 136 declarations in the generated `.d.ts` match the previous build byte for byte. Only JSDoc prose differs, because 0.5.7 stops escaping apostrophes and quotation marks.

`render_report` returns `Result<String, JsValue>`; wasm-bindgen maps that to the same `: string` declaration and throws on error, as its siblings already did.

Refreshes both the wasm and fuzz lockfiles, superseding #415 and #420.