### PR TITLE
ci(deps): refresh the wrangler pin and the biome schema url

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -86,7 +86,7 @@ NPM=12.0.2
 
 # wrangler, invoked with npx to deploy the demo site. Pinned because it runs with
 # the Cloudflare Pages deploy token.
-WRANGLER=4.125.0
+WRANGLER=4.127.0
 
 # komac, fetched over curl to submit the WinGet manifests. winget-releaser wraps
 # the same tool but bootstraps it through cargo-bins/cargo-binstall@main, which

--- a/crates/bdinfo-rs-wasm/web/biome.json
+++ b/crates/bdinfo-rs-wasm/web/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
Bumps wrangler 4.125.0 to 4.127.0 and points the biome schema URL at 2.5.10, the version the web lockfile installs.

Closes #425