### PR TITLE
ci(deps): refresh the cloudsmith-cli and node pins

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -76,7 +76,7 @@ WASM_BINDGEN_CLI=0.2.127
 
 # The Node line the browser package builds and tests on: 26 reaches LTS in
 # October 2026. Odd majors are never LTS and are not adopted.
-NODE=26.7.0
+NODE=26.8.1
 
 # npm, pinned independently of whichever npm a given Node 26.x bundles: `npm
 # stage publish` needs >= 11.15.0 and `--provenance` needs a working bundled
@@ -94,4 +94,4 @@ WRANGLER=4.127.0
 KOMAC=2.16.0
 
 # cloudsmith-cli, installed with pipx by the package push legs.
-CLOUDSMITH_CLI=1.25.0
+CLOUDSMITH_CLI=1.26.0


### PR DESCRIPTION
Bumps cloudsmith-cli 1.25.0 to 1.26.0 and the Node pin 26.7.0 to 26.8.1.

Closes #436