### PR TITLE
ci(deps): bump the wrangler pin to 4.127.1

### DIFF
--- a/.github/pins.env
+++ b/.github/pins.env
@@ -86,7 +86,7 @@ NPM=12.0.2
 
 # wrangler, invoked with npx to deploy the demo site. Pinned because it runs with
 # the Cloudflare Pages deploy token.
-WRANGLER=4.127.0
+WRANGLER=4.127.1
 
 # komac, fetched over curl to submit the WinGet manifests. winget-releaser wraps
 # the same tool but bootstraps it through cargo-bins/cargo-binstall@main, which


### PR DESCRIPTION
Bumps the pinned wrangler version in .github/pins.env from 4.127.0 to 4.127.1.

Closes #438